### PR TITLE
fix(core): unexpected plan result with bindings

### DIFF
--- a/alchemy-effect/src/plan.ts
+++ b/alchemy-effect/src/plan.ts
@@ -1,6 +1,7 @@
 import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import { omit } from "effect/Struct";
 import type {
   AnyBinding,
   BindingDiffProps,
@@ -433,8 +434,13 @@ class DeleteResourceHasDownstreamDependencies extends Data.TaggedError(
 
 const arePropsChanged = <R extends Resource>(
   oldState: ResourceState | undefined,
-  newState: R["props"],
-) => JSON.stringify(oldState?.props) !== JSON.stringify(newState);
+  newProps: R["props"],
+) => {
+  return (
+    JSON.stringify(omit(oldState?.props ?? {}, "bindings")) !==
+    JSON.stringify(omit((newProps ?? {}) as any, "bindings"))
+  );
+};
 
 const diffBindings = Effect.fn(function* ({
   oldState,
@@ -504,7 +510,7 @@ const diffBindings = Effect.fn(function* ({
       return {
         action: "noop",
         binding,
-        attr: undefined,
+        attr: oldBinding.attr,
       } satisfies NoopBind<AnyBinding>;
     },
   );


### PR DESCRIPTION
Two changes:
1. The `arePropsChanged` function should exclude bindings from the comparison. These are diffed separately; including them in `arePropsChanged` results in extraneous updates.
2. The `diffBindings` function should include attributes when returning a `NoopBind` type. Otherwise, if a downstream resource updates, it will not have access to existing binding data.