### PR TITLE
fix(cloudflare): recover from partially-created Worker state

### DIFF
--- a/alchemy-effect/src/Cloudflare/Workers/Worker.ts
+++ b/alchemy-effect/src/Cloudflare/Workers/Worker.ts
@@ -451,12 +451,30 @@ export const WorkerProvider = () =>
         `alchemy:id:${id}`,
       ];
 
-      const hasAlchemyWorkerTags = (
+      const isOwnedByDifferentStack = (
         id: string,
         tags: readonly string[] | undefined,
       ) => {
-        const actualTags = new Set(tags ?? []);
-        return createAlchemyWorkerTags(id).every((tag) => actualTags.has(tag));
+        const actualTags = (tags ?? []).filter((t) =>
+          t.startsWith("alchemy:"),
+        );
+        if (actualTags.length === 0) {
+          // No alchemy tags — likely created by us in a partially-failed
+          // deploy where the settings API didn't persist/return tags, or
+          // an unmanaged worker whose deterministic name collided.  Treat
+          // as adoptable so we can recover from "creating" state.
+          return false;
+        }
+        // Has alchemy tags — verify they match *this* stack/stage/resource.
+        const expected = new Set(createAlchemyWorkerTags(id));
+        return !actualTags
+          .filter(
+            (t) =>
+              t.startsWith("alchemy:stack:") ||
+              t.startsWith("alchemy:stage:") ||
+              t.startsWith("alchemy:id:"),
+          )
+          .every((tag) => expected.has(tag));
       };
 
       const prepareAssets = Effect.fnUntraced(function* (
@@ -1169,13 +1187,13 @@ ${[
             yield* Effect.logInfo(
               `Cloudflare Worker create: ${name} already exists`,
             );
-            if (!hasAlchemyWorkerTags(id, existingSettings.tags ?? [])) {
+            if (isOwnedByDifferentStack(id, existingSettings.tags ?? [])) {
               return yield* Effect.die(
-                `Worker "${name}" already exists but is not owned by this stack/stage/resource`,
+                `Worker "${name}" already exists but is owned by a different stack/stage/resource`,
               );
             }
             yield* Effect.logInfo(
-              `Cloudflare Worker create: adopting existing ${name} owned by this stack/stage/resource`,
+              `Cloudflare Worker create: adopting existing ${name}`,
             );
           }
           return yield* putWorker(

--- a/alchemy-effect/test/Cloudflare/Workers/Worker.test.ts
+++ b/alchemy-effect/test/Cloudflare/Workers/Worker.test.ts
@@ -2,6 +2,7 @@ import { Account } from "@/Cloudflare/Account";
 import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as R2 from "@/Cloudflare/R2";
 import { destroy } from "@/Destroy";
+import * as State from "@/State/index.ts";
 import { test } from "@/Test/Vitest";
 import * as workers from "@distilled.cloud/cloudflare/workers";
 import { expect } from "@effect/vitest";
@@ -212,6 +213,71 @@ test(
     );
 
     expect(updatedWorker.workerName).toEqual(worker.workerName);
+
+    yield* destroy();
+
+    yield* waitForWorkerToBeDeleted(worker.workerName, accountId);
+  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+);
+
+test(
+  "recover from partially-created state",
+  Effect.gen(function* () {
+    const accountId = yield* Account;
+    const stack = yield* Stack;
+
+    yield* destroy();
+
+    const workerEffect = Effect.gen(function* () {
+      return yield* Cloudflare.Worker("RecoverWorker", {
+        main,
+        subdomain: { enabled: true, previewsEnabled: true },
+        compatibility: {
+          date: "2024-01-01",
+        },
+      });
+    });
+
+    // Deploy the worker normally so it exists on Cloudflare
+    const worker = yield* test.deploy(workerEffect);
+
+    const actualWorker = yield* findWorker(worker.workerName, accountId);
+    expect(actualWorker?.scriptName).toEqual(worker.workerName);
+
+    // Simulate a partially-failed first deploy by resetting state to "creating"
+    // with no output attributes (attr), as would happen if the deploy succeeded
+    // on Cloudflare but state persistence failed before marking "created".
+    const state = yield* State.State.asEffect();
+    const existing = yield* state.get({
+      stack: stack.name,
+      stage: stack.stage,
+      fqn: "RecoverWorker",
+    });
+    expect(existing).toBeDefined();
+    yield* state.set({
+      stack: stack.name,
+      stage: stack.stage,
+      fqn: "RecoverWorker",
+      value: {
+        resourceType: existing!.resourceType,
+        namespace: existing!.namespace,
+        fqn: existing!.fqn,
+        logicalId: existing!.logicalId,
+        instanceId: existing!.instanceId,
+        providerVersion: existing!.providerVersion,
+        downstream: existing!.downstream,
+        bindings: existing!.bindings,
+        removalPolicy: existing!.removalPolicy,
+        status: "creating" as const,
+        props: existing!.props ?? {},
+      },
+    });
+
+    // Redeploy — should recover by adopting the existing worker instead of
+    // failing with "already exists but is not owned by this stack/stage/resource"
+    const recovered = yield* test.deploy(workerEffect);
+
+    expect(recovered.workerName).toEqual(worker.workerName);
 
     yield* destroy();
 


### PR DESCRIPTION
## Summary
- When a Worker deploy partially succeeds (uploaded to Cloudflare but state not persisted as "created"), the next deploy fails with "already exists but is not owned by this stack/stage/resource"
- The Cloudflare settings API returns empty/null tags, so the ownership check incorrectly rejects the worker we created
- Changed the ownership check to only reject workers with alchemy tags belonging to a *different* stack/stage/resource, rather than rejecting when no tags are present

## Test plan
- [ ] Deploy a Cloudflare Worker, interrupt mid-deploy to leave state as "creating"
- [ ] Re-deploy and verify it recovers by adopting the existing worker
- [ ] Verify a worker owned by a different stack/stage is still rejected