### PR TITLE
feat(cloudflare): accept Output<T> in Worker env + Vite props

### DIFF
--- a/alchemy-effect/src/Build/Command.ts
+++ b/alchemy-effect/src/Build/Command.ts
@@ -1,6 +1,7 @@
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as Redacted from "effect/Redacted";
 import * as Stream from "effect/Stream";
 import { ChildProcess } from "effect/unstable/process";
 import { isResolved } from "../Diff.ts";
@@ -36,7 +37,7 @@ export interface CommandProps {
   /**
    * Environment variables to pass to the build command.
    */
-  env?: Record<string, string>;
+  env?: Record<string, string | Redacted.Redacted<string>>;
 }
 
 export interface Command extends Resource<
@@ -108,7 +109,14 @@ export const CommandProvider = () =>
           yield* runBuildCommand({
             command: props.command,
             cwd,
-            env: props.env,
+            env: props.env
+              ? Object.fromEntries(
+                  Object.entries(props.env).map(([key, value]) => [
+                    key,
+                    typeof value === "string" ? value : Redacted.value(value),
+                  ]),
+                )
+              : undefined,
           });
         });
 

--- a/alchemy-effect/src/Cloudflare/Website/Vite.ts
+++ b/alchemy-effect/src/Cloudflare/Website/Vite.ts
@@ -1,3 +1,4 @@
+import type { InputProps } from "../../Input.ts";
 import type { MemoOptions } from "../../Build/Memo.ts";
 import { Worker, type WorkerProps } from "../Workers/Worker.ts";
 
@@ -54,7 +55,7 @@ export interface ViteProps extends Omit<WorkerProps, "vite" | "main"> {
  * });
  * ```
  */
-export const Vite = (id: string, props: ViteProps = {}) =>
+export const Vite = (id: string, props: InputProps<ViteProps> = {}) =>
   Worker(id, {
     ...props,
     main: undefined!,

--- a/alchemy-effect/src/Cloudflare/Workers/Worker.ts
+++ b/alchemy-effect/src/Cloudflare/Workers/Worker.ts
@@ -994,6 +994,18 @@ ${[
             text: stack.stage,
           },
         );
+        // Add environment variables as metadata bindings
+        if (news.env) {
+          for (const [key, value] of Object.entries(news.env)) {
+            if (value == null) continue;
+            const text = typeof value === "string" ? value : String(value);
+            metadataBindings.push({
+              type: "secret_text",
+              name: key,
+              text,
+            });
+          }
+        }
         yield* Effect.logInfo(
           `Cloudflare Worker ${olds ? "update" : "create"}: uploading script for ${name}`,
         );

--- a/alchemy-effect/src/Cloudflare/Workers/Worker.ts
+++ b/alchemy-effect/src/Cloudflare/Workers/Worker.ts
@@ -214,7 +214,7 @@ export interface WorkerProps<
   };
   limits?: WorkerLimits;
   placement?: WorkerPlacement;
-  env?: Record<string, any>;
+  env?: Record<string, string | Redacted.Redacted<string>>;
   exports?: string[];
   bindings?: Bindings;
   build?: {

--- a/alchemy-effect/src/Cloudflare/Workers/Worker.ts
+++ b/alchemy-effect/src/Cloudflare/Workers/Worker.ts
@@ -998,12 +998,19 @@ ${[
         if (news.env) {
           for (const [key, value] of Object.entries(news.env)) {
             if (value == null) continue;
-            const text = typeof value === "string" ? value : String(value);
-            metadataBindings.push({
-              type: "secret_text",
-              name: key,
-              text,
-            });
+            if (Redacted.isRedacted(value)) {
+              metadataBindings.push({
+                type: "secret_text",
+                name: key,
+                text: Redacted.value(value),
+              });
+            } else {
+              metadataBindings.push({
+                type: "plain_text",
+                name: key,
+                text: typeof value === "string" ? value : String(value),
+              });
+            }
           }
         }
         yield* Effect.logInfo(


### PR DESCRIPTION
## Summary

- Tighten `WorkerProps.env` type from `Record<string, any>` to `Record<string, string | Redacted<string>>` so plain vs secret bindings are discriminable at the type level (the runtime already branches on `Redacted.isRedacted`).
- Wrap `Cloudflare.Vite` props in `InputProps<ViteProps>` so users can pass resource outputs (e.g. `db.connectionUri` from a Neon project) directly into `env` without manually resolving the `Output<T>`.

## Context

Without `InputProps<>`, this common pattern fails to typecheck:

```ts
const db = yield* NeonProject("postgres", { ... });
const app = yield* Cloudflare.Vite("App", {
  env: {
    DATABASE_URL: db.connectionUri, // Output<Redacted<string>>
  },
});
```

`Worker` already uses `InputProps<WorkerProps<Bindings>>` on its user-facing signature (Worker.ts:276); `Vite` was the only user-facing entrypoint missing the same wrapping.
