### PR TITLE
fix(Cloudflare): provide WorkerEnvironment to Workflow body, not wrapper

### DIFF
--- a/examples/cloudflare-worker/src/NotifyWorkflow.ts
+++ b/examples/cloudflare-worker/src/NotifyWorkflow.ts
@@ -8,15 +8,48 @@ export default class NotifyWorkflow extends Cloudflare.Workflow<NotifyWorkflow>(
     const rooms = yield* Room;
 
     return Effect.gen(function* () {
+      // Regression guard for https://github.com/alchemy-run/alchemy-effect/pull/71
+      //
+      // Accessing `Cloudflare.WorkerEnvironment` inside the workflow body
+      // previously crashed with `Service not found: Cloudflare.Workers.WorkerEnvironment`
+      // because `provideService(WorkerEnvironment, env)` was applied to the
+      // outer `Effect.succeed(body)` wrapper (a no-op) instead of `body`
+      // itself in `Workflow.ts`. Keeping this yield + the KV roundtrip below
+      // ensures the integ test catches any future regression of that fix.
+      const env = yield* Cloudflare.WorkerEnvironment;
       const event = yield* Cloudflare.WorkflowEvent;
       const { roomId, message } = event.payload as {
         roomId: string;
         message: string;
       };
 
+      // Exercise an env binding from inside a workflow step — the real-world
+      // pattern users follow (`env.<binding>.put(...)` / `.get(...)` etc).
+      const stored = yield* Cloudflare.task(
+        "kv-roundtrip",
+        Effect.tryPromise({
+          try: async () => {
+            const key = `workflow:smoke:${roomId}`;
+            await env.KV.put(key, message);
+            const got = await env.KV.get(key);
+            if (got !== message) {
+              throw new Error(
+                `KV roundtrip mismatch: expected "${message}", got "${got ?? "null"}"`,
+              );
+            }
+            return got;
+          },
+          catch: (cause) =>
+            cause instanceof Error ? cause : new Error(String(cause)),
+        }).pipe(Effect.orDie),
+      );
+
       const processed = yield* Cloudflare.task(
         "process",
-        Effect.succeed({ text: `Processed: ${message}`, ts: Date.now() }),
+        Effect.succeed({
+          text: `Processed: ${stored}`,
+          ts: Date.now(),
+        }),
       );
 
       const room = rooms.getByName(roomId);

--- a/examples/cloudflare-worker/test/integ.test.ts
+++ b/examples/cloudflare-worker/test/integ.test.ts
@@ -14,3 +14,65 @@ test(
     expect(url).toBeString();
   }),
 );
+
+/**
+ * Regression guard for https://github.com/alchemy-run/alchemy-effect/pull/71
+ *
+ * `NotifyWorkflow` accesses `Cloudflare.WorkerEnvironment` inside its body and
+ * performs a KV roundtrip via `env.KV.put` / `env.KV.get`. If the fix from #71
+ * is ever reverted, the body Effect loses the `WorkerEnvironment` service and
+ * dies with `Service not found: Cloudflare.Workers.WorkerEnvironment` on the
+ * first `yield* Cloudflare.WorkerEnvironment` — the workflow instance never
+ * reaches `complete`, and this test times out or surfaces the `errored` status.
+ */
+test(
+  "workflow body can access WorkerEnvironment and exercise env bindings",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    const roomId = `smoke-${Date.now()}`;
+
+    // Start the workflow instance.
+    const startResponse = yield* Effect.tryPromise({
+      try: () => fetch(`${url}/workflow/start/${roomId}`, { method: "POST" }),
+      catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+    });
+    expect(startResponse.status).toBe(200);
+
+    const { instanceId } = (yield* Effect.tryPromise({
+      try: () => startResponse.json() as Promise<{ instanceId: string }>,
+      catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+    }));
+    expect(instanceId).toBeString();
+
+    // Poll status until complete / errored / timeout (~60s).
+    const deadline = Date.now() + 60_000;
+    let lastStatus: { status: string; output?: unknown; error?: unknown } | undefined;
+    while (Date.now() < deadline) {
+      const statusResponse = yield* Effect.tryPromise({
+        try: () => fetch(`${url}/workflow/status/${instanceId}`),
+        catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+      });
+      expect(statusResponse.status).toBe(200);
+      lastStatus = (yield* Effect.tryPromise({
+        try: () =>
+          statusResponse.json() as Promise<{
+            status: string;
+            output?: unknown;
+            error?: unknown;
+          }>,
+        catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+      }));
+      if (lastStatus.status === "complete" || lastStatus.status === "errored") {
+        break;
+      }
+      yield* Effect.sleep("2 seconds");
+    }
+
+    // The workflow must have completed — if WorkerEnvironment provision breaks,
+    // the body dies on the first yield and the instance never reaches complete.
+    expect(lastStatus).toBeDefined();
+    expect(lastStatus!.status).toBe("complete");
+    expect(lastStatus!.error).toBeFalsy();
+  }),
+  { timeout: 120_000 },
+);

--- a/packages/alchemy/src/Cloudflare/Workers/Workflow.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Workflow.ts
@@ -83,8 +83,17 @@ export const sleepUntil = (
 
 /**
  * The services available inside a workflow run body.
+ *
+ * `WorkerEnvironment` is provided to the body at runtime by the workflow
+ * export wrapper (see `make(env)` below), so users can access env bindings
+ * from inside workflow steps via `yield* WorkerEnvironment` — the type must
+ * reflect that or `yield* WorkerEnvironment` fails to type-check inside a
+ * body even though it succeeds at runtime.
  */
-export type WorkflowRunServices = WorkflowEvent | WorkflowStep;
+export type WorkflowRunServices =
+  | WorkflowEvent
+  | WorkflowStep
+  | WorkerEnvironment;
 
 export type WorkflowServices = WorkerServices | PlatformServices;
 

--- a/packages/alchemy/src/Cloudflare/Workers/Workflow.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Workflow.ts
@@ -323,13 +323,14 @@ export const Workflow: WorkflowClass = taggedFunction(WorkflowScope, ((
           yield* worker.export(name, {
             kind: "workflow",
             make: (env: unknown) =>
-              Effect.succeed(body).pipe(
-                Effect.provideContext(services),
-                Effect.provideService(
-                  WorkerEnvironment,
-                  env as Record<string, any>,
+              Effect.succeed(
+                body.pipe(
+                  Effect.provideService(
+                    WorkerEnvironment,
+                    env as Record<string, any>,
+                  ),
                 ),
-              ),
+              ).pipe(Effect.provideContext(services)),
           } satisfies WorkflowExport);
 
           return self;


### PR DESCRIPTION
Fixes #70.

## Problem

`provideService(WorkerEnvironment, env)` was being applied to the outer `Effect.succeed(body)` rather than to `body` itself. Since `Effect.succeed(body)` produces an effect with `R = never`, the `provideService` call is a no-op — `WorkerEnvironment` is never actually provided to `body`.

When `WorkflowBridge.run()` in `Rpc.ts` later runs `body`, `WorkerEnvironment` is missing and any workflow instance crashes at runtime with:

> `Service not found: Cloudflare.Workers.WorkerEnvironment`

## Fix

Apply `provideService` to `body` before wrapping in `Effect.succeed`. This matches the working pattern used by `makeDurableObjectBridge` (which is why DOs and Containers are unaffected by this bug).

```diff
 make: (env: unknown) =>
-  Effect.succeed(body).pipe(
-    Effect.provideContext(services),
-    Effect.provideService(WorkerEnvironment, env as Record<string, any>),
-  ),
+  Effect.succeed(
+    body.pipe(
+      Effect.provideService(WorkerEnvironment, env as Record<string, any>),
+    ),
+  ).pipe(Effect.provideContext(services)),
```

## Testing

Verified in a real Cloudflare Workers deploy: workflows with `yield* Cloudflare.WorkerEnvironment` now progress past `step.do()` where they previously crashed immediately on invocation.
