### PR TITLE
fix(Cloudflare/Container): await monitor() Promise instead of discarding it

### DIFF
--- a/packages/alchemy/src/Cloudflare/Container/ContainerBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Container/ContainerBinding.ts
@@ -70,7 +70,8 @@ export const bindContainer = Effect.fnUntraced(function* <Shape, Req = never>(
             state.container!.interceptAllOutboundHttp(binding),
           ),
         ),
-      monitor: () => Effect.sync(() => state.container?.monitor()),
+      monitor: () =>
+        Effect.promise(() => state.container?.monitor() ?? Promise.resolve()),
       start: (options?: ContainerStartupOptions) =>
         Effect.sync(() => state.container!.start(options)),
     } satisfies Container as Shape;


### PR DESCRIPTION
## Summary

`state.container.monitor()` returns `Promise<void>` that resolves when the container process exits. Wrapping it in `Effect.sync()` creates a synchronous effect that discards the return value, so the Promise is never awaited.

The monitor fiber completes instantly (logging "monitor exited" at the same ms as "started") and never detects container process death. This causes `container.running` to stay stale (`true`) when the process dies, `ensureRunning` skips restart, and `port.fetch` hangs on a dead process.

## Fix

Use `Effect.promise()` to properly await the monitor Promise:

```ts
// Before (broken):
monitor: () => Effect.sync(() => state.container?.monitor()),

// After (fixed):
monitor: () =>
  Effect.promise(() => state.container?.monitor() ?? Promise.resolve()),
```

Note: `start()` remains `Effect.sync()` since `Container.start()` returns `void` per `@cloudflare/workers-types` (synchronous).

## Testing

Deployed to Cloudflare Workers with a DeviceContainer (Bun runtime). After the fix:
- Monitor fiber stays alive (logs "monitor started" persists, no instant "monitor exited")
- Dead container processes are properly detected
- `port.fetch()` no longer hangs indefinitely on dead processes

<!--

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

-->