### PR TITLE
fix(Cloudflare): install external deps in container Dockerfile

### DIFF
--- a/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
+++ b/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
@@ -103,6 +103,32 @@ export interface ContainerApplicationProps extends PlatformProps {
    */
   runtime?: "bun" | "node";
   /**
+   * Module specifiers that Rolldown should mark as external when bundling
+   * the container entrypoint. The matching packages are installed inside the
+   * image via the runtime's package manager (`bun add` for `runtime: "bun"`,
+   * `npm install` for `runtime: "node"`) before the entrypoint runs.
+   *
+   * Use this for native dependencies that must not be bundled (e.g. `sharp`,
+   * `impit`) or for packages that intentionally ship in the base image.
+   *
+   * Install inside the image is controlled by {@link autoInstallExternals}
+   * (default `true`); set it to `false` if your custom `dockerfile` already
+   * installs these packages and you want to avoid the redundant step.
+   */
+  external?: string[];
+  /**
+   * Whether to auto-install the packages listed in {@link external} inside
+   * the container image (via `bun add` or `npm install`) before running the
+   * entrypoint.
+   *
+   * @default true
+   *
+   * Set to `false` when your custom `dockerfile` already installs these
+   * packages (for example, via a base image that pre-installs `sharp`), to
+   * avoid the redundant install step.
+   */
+  autoInstallExternals?: boolean;
+  /**
    * Human-readable application name. If omitted, Alchemy derives a deterministic
    * physical name from the stack, stage, and logical ID.
    */
@@ -418,7 +444,12 @@ export const ContainerProvider = () =>
           isExternal: props.isExternal,
         });
 
-        const finalDockerfile = buildFinalDockerfile(props.dockerfile, runtime, props.external);
+        const finalDockerfile = buildFinalDockerfile(
+          props.dockerfile,
+          runtime,
+          props.external,
+          props.autoInstallExternals,
+        );
         const imageHash = (yield* sha256Object({
           bundleHash,
           dockerfile: finalDockerfile,
@@ -562,14 +593,16 @@ await Effect.runPromise(serverEffect).catch((err) => {
         userDockerfile: string | undefined,
         runtime: "bun" | "node",
         external: string[] = [],
+        autoInstallExternals = true,
       ): string => {
         const base =
           userDockerfile?.trim() ??
           (runtime === "bun" ? "FROM oven/bun:1" : "FROM node:22-slim");
         const runtimeBin = runtime === "bun" ? "bun" : "node";
+        const installCmd = runtime === "bun" ? "bun add" : "npm install";
         const installStep =
-          external.length > 0 && runtime === "bun"
-            ? `RUN bun add ${external.join(" ")}`
+          autoInstallExternals && external.length > 0
+            ? `RUN ${installCmd} ${external.join(" ")}`
             : "";
         return [
           base,
@@ -603,7 +636,12 @@ await Effect.runPromise(serverEffect).catch((err) => {
           dotAlchemy,
           `${id}-container`,
         );
-        const finalDockerfile = buildFinalDockerfile(props.dockerfile, runtime, props.external);
+        const finalDockerfile = buildFinalDockerfile(
+          props.dockerfile,
+          runtime,
+          props.external,
+          props.autoInstallExternals,
+        );
         yield* materializeDockerfile(finalDockerfile, contextDir);
         yield* writeContextFiles(contextDir, [
           { path: "index.mjs", content: code },

--- a/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
+++ b/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
@@ -418,7 +418,7 @@ export const ContainerProvider = () =>
           isExternal: props.isExternal,
         });
 
-        const finalDockerfile = buildFinalDockerfile(props.dockerfile, runtime);
+        const finalDockerfile = buildFinalDockerfile(props.dockerfile, runtime, props.external);
         const imageHash = (yield* sha256Object({
           bundleHash,
           dockerfile: finalDockerfile,
@@ -561,15 +561,21 @@ await Effect.runPromise(serverEffect).catch((err) => {
       const buildFinalDockerfile = (
         userDockerfile: string | undefined,
         runtime: "bun" | "node",
+        external: string[] = [],
       ): string => {
         const base =
           userDockerfile?.trim() ??
           (runtime === "bun" ? "FROM oven/bun:1" : "FROM node:22-slim");
         const runtimeBin = runtime === "bun" ? "bun" : "node";
+        const installStep =
+          external.length > 0 && runtime === "bun"
+            ? `RUN bun add ${external.join(" ")}`
+            : "";
         return [
           base,
           "",
           "WORKDIR /app",
+          ...installStep ? [installStep, ""] : [],
           "COPY index.mjs /app/index.mjs",
           `ENTRYPOINT ["${runtimeBin}", "/app/index.mjs"]`,
           "",
@@ -597,7 +603,7 @@ await Effect.runPromise(serverEffect).catch((err) => {
           dotAlchemy,
           `${id}-container`,
         );
-        const finalDockerfile = buildFinalDockerfile(props.dockerfile, runtime);
+        const finalDockerfile = buildFinalDockerfile(props.dockerfile, runtime, props.external);
         yield* materializeDockerfile(finalDockerfile, contextDir);
         yield* writeContextFiles(contextDir, [
           { path: "index.mjs", content: code },


### PR DESCRIPTION
## Summary

When a Container is declared with `external: ["impit", "tough-cookie"]`, the bundler correctly excludes these packages from the bundle. However, the generated Dockerfile only copies `index.mjs` into the image — it does **NOT** run `bun add` to install the external packages.

At container runtime (Firecracker VM), Bun encounters bare `import` statements for the external packages and fails to resolve the module because it isn't in `node_modules`. The container process **crashes before any Effect code runs**, producing zero stdout and causing `port.fetch()` to hang indefinitely with `outcome: canceled`.

## Fix

`buildFinalDockerfile` now accepts an `external: string[]` parameter. When external packages exist and runtime is "bun", it injects a `RUN bun add <deps>` step between `WORKDIR` and `COPY`. Both call sites (`computeImageHash` and `buildAndPushImage`) now pass `props.external`.

### Example generated Dockerfile

```dockerfile
FROM oven/bun:1

WORKDIR /app
RUN bun add impit tough-cookie

COPY index.mjs /app/index.mjs
ENTRYPOINT ["bun", "/app/index.mjs"]
```

## Verification

Deployed to Cloudflare Workers with a DeviceContainer (Bun runtime). After the fix:
- Container image contains `node_modules/impit/` and `node_modules/tough-cookie/`
- `package.json` and `bun.lock` are generated in the image
- Container process no longer crashes on startup (no zero-stdout issue)
- `port.fetch()` connects successfully

<!--

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

-->