### PR TITLE
fix(Cloudflare): write all bundle chunks to container image context

### DIFF
--- a/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
+++ b/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
@@ -410,7 +410,7 @@ export const ContainerProvider = () =>
           );
         }
         const runtime = props.runtime ?? "bun";
-        const { code, hash: bundleHash } = yield* bundleProgram({
+        const { files, hash: bundleHash } = yield* bundleProgram({
           id,
           main,
           runtime,
@@ -429,7 +429,7 @@ export const ContainerProvider = () =>
         const repositoryName = name.toLowerCase();
         const imageRef = `${registryId}/${accountId}/${repositoryName}:${imageHash}`;
 
-        return { code, imageRef, imageHash };
+        return { files, imageRef, imageHash };
       });
 
       const bundleProgram = Effect.fnUntraced(function* ({
@@ -549,13 +549,21 @@ await Effect.runPromise(serverEffect).catch((err) => {
               ),
             );
 
-        const mainFile = bundleOutput.files[0];
-        const code =
-          typeof mainFile.content === "string"
-            ? new TextEncoder().encode(mainFile.content)
-            : mainFile.content;
+        // Rolldown can emit multiple chunk files (entry + shared chunks).
+        // Return every file so downstream code can materialize all of them
+        // into the Docker build context — dropping any of them produces a
+        // `Cannot find module './chunk-XXX.js'` runtime crash inside the
+        // container (with zero stdout, because it crashes before any user
+        // code runs).
+        const files = bundleOutput.files.map((f) => ({
+          path: f.path,
+          content:
+            typeof f.content === "string"
+              ? new TextEncoder().encode(f.content)
+              : f.content,
+        }));
 
-        return { code, hash: bundleOutput.hash };
+        return { files, hash: bundleOutput.hash };
       });
 
       const buildFinalDockerfile = (
@@ -571,6 +579,11 @@ await Effect.runPromise(serverEffect).catch((err) => {
           "",
           "WORKDIR /app",
           "COPY index.mjs /app/index.mjs",
+          // Copy any additional rolldown chunks (`chunk-XXX.js`,
+          // `BunServices-YYY.js`, …). The glob matches zero or more files;
+          // non-trivial bundles always emit at least one chunk, minimal
+          // bundles emit none and the COPY no-ops.
+          "COPY *.js /app/",
           `ENTRYPOINT ["${runtimeBin}", "/app/index.mjs"]`,
           "",
         ].join("\n");
@@ -579,7 +592,7 @@ await Effect.runPromise(serverEffect).catch((err) => {
       const buildAndPushImage = Effect.fnUntraced(function* (
         id: string,
         props: ContainerApplicationProps,
-        code: Uint8Array,
+        files: ReadonlyArray<{ path: string; content: Uint8Array }>,
         imageRef: string,
         session?: { note: (message: string) => Effect.Effect<void> },
       ) {
@@ -599,9 +612,17 @@ await Effect.runPromise(serverEffect).catch((err) => {
         );
         const finalDockerfile = buildFinalDockerfile(props.dockerfile, runtime);
         yield* materializeDockerfile(finalDockerfile, contextDir);
-        yield* writeContextFiles(contextDir, [
-          { path: "index.mjs", content: code },
-        ]);
+        yield* writeContextFiles(
+          contextDir,
+          files.map((f, i) => ({
+            // Keep the entry rename to `index.mjs` so the Dockerfile
+            // ENTRYPOINT (`ENTRYPOINT ["bun", "/app/index.mjs"]`) stays
+            // valid; preserve rolldown-assigned fileNames for every other
+            // chunk so intra-bundle relative imports resolve at runtime.
+            path: i === 0 ? "index.mjs" : f.path,
+            content: f.content,
+          })),
+        );
         yield* dockerBuild({
           tag: imageRef,
           context: contextDir,
@@ -821,11 +842,11 @@ await Effect.runPromise(serverEffect).catch((err) => {
         yield* Effect.logInfo(
           `Cloudflare Container update: preparing ${existing.applicationName}`,
         );
-        const { code, imageRef, imageHash } = yield* computeImageHash(id, news);
+        const { files, imageRef, imageHash } = yield* computeImageHash(id, news);
         const configuration = desiredConfiguration(news, imageRef);
 
         if (imageHash !== existing.hash?.image) {
-          yield* buildAndPushImage(id, news, code, imageRef, session);
+          yield* buildAndPushImage(id, news, files, imageRef, session);
         }
 
         yield* session.note(
@@ -927,12 +948,10 @@ await Effect.runPromise(serverEffect).catch((err) => {
             `Cloudflare Container precreate: starting ${name}`,
           );
 
-          const { code, imageRef, imageHash } = yield* computeImageHash(
-            id,
-            news,
-          );
+          const { files, imageRef, imageHash } = yield* computeImageHash(id,
+          news,);
           const configuration = desiredConfiguration(news, imageRef);
-          yield* buildAndPushImage(id, news, code, imageRef, session);
+          yield* buildAndPushImage(id, news, files, imageRef, session);
 
           // Precreate intentionally omits the Durable Object attachment so the
           // worker can bind to this application id and break the circular
@@ -967,10 +986,8 @@ await Effect.runPromise(serverEffect).catch((err) => {
             `Cloudflare Container create: starting ${name}${adoptPolicy ? " with adopt" : ""}`,
           );
           const durableObjects = yield* getDurableObjects(bindings);
-          const { code, imageRef, imageHash } = yield* computeImageHash(
-            id,
-            news,
-          );
+          const { files, imageRef, imageHash } = yield* computeImageHash(id,
+          news,);
           const configuration = desiredConfiguration(news, imageRef);
 
           if (
@@ -1019,7 +1036,7 @@ await Effect.runPromise(serverEffect).catch((err) => {
               ),
             );
             if (imageHash !== output.hash?.image) {
-              yield* buildAndPushImage(id, news, code, imageRef, session);
+              yield* buildAndPushImage(id, news, files, imageRef, session);
             }
             const result = yield* createApplication({
               id,
@@ -1044,7 +1061,7 @@ await Effect.runPromise(serverEffect).catch((err) => {
             });
           }
 
-          yield* buildAndPushImage(id, news, code, imageRef, session);
+          yield* buildAndPushImage(id, news, files, imageRef, session);
 
           const result = yield* createApplication({
             id,


### PR DESCRIPTION
## Summary

Rolldown emits an entry file + multiple shared chunks for any non-trivial bundle (`chunk-XXX.js`, `BunServices-YYY.js`, `BunHttpServer-ZZZ.js`, `ignore-WWW.js`, …). The entry imports them via relative paths:

```js
import { X } from "./chunk-XXX.js";
```

Previously `ContainerApplication.ts` only took `bundleOutput.files[0]`, wrote it to `/app/index.mjs`, and silently discarded every other chunk. At container runtime Bun crashed on the first `import` statement with `Cannot find module './chunk-XXX.js'` — and because the crash occurred *before* any application code ran, the container produced **zero stdout**. `port.fetch()` from the DO then hung until the DO's `AbortController` fired, surfacing as a `ContainerTimeout` in downstream workflows with no diagnostic signal.

## Symptoms before the fix

- Deploy succeeds cleanly (image builds + pushes fine).
- DO instance starts, logs `Container bootstrap starting...` → never appears.
- `port.fetch()` hangs ~15s until the DO AbortController fires.
- Workflows accessing the DO report `ContainerTimeout` after their configured timeout.
- `bunx wrangler tail` shows zero container stdout for the entire session.

## Fix

Thread the full `BundleFile[]` from `bundleProgram` through `computeImageHash` → `buildAndPushImage` → `writeContextFiles`:

- `bundleProgram` now maps every `bundleOutput.files[*]` to `{ path, content: Uint8Array }` and returns `{ files, hash }` instead of `{ code, hash }`.
- `computeImageHash` / `buildAndPushImage` destructure / accept `files` instead of the single `code` buffer (3 destructurings + 4 call sites updated).
- `writeContextFiles` now writes every file to the build context:
  - The entry is renamed to `index.mjs` (so `ENTRYPOINT ["bun", "/app/index.mjs"]` stays valid).
  - Every other chunk keeps its rolldown-assigned `fileName` so intra-bundle relative imports (`./chunk-XXX.js`) resolve.
- Default Dockerfile adds `COPY *.js /app/` after `COPY index.mjs /app/index.mjs` so the runtime sees every chunk.

## Verification

Deployed against a real Cloudflare account in my cross-resell repo (two Containers: one `impit`+`tough-cookie` external, one `sharp` external):

1. Pulled the generated image locally: `docker pull <registry>/<image>:<tag>`
2. Listed `/app`: `docker run --rm --entrypoint sh <image> -c 'ls -la /app'` → `index.mjs` + all chunk `.js` files present (previously only `index.mjs`).
3. Ran locally: `docker run --rm -p 3000:3000 <image>` → prints `Container bootstrap starting...` and `[device] fetch GET /health` within ~2s.
4. End-to-end: `curl https://<worker>.workers.dev/_internal/container/<id>/health` → `200 {"status":"ok"}` in ~3s (previously timed out after 15s).

## Diagnostic heuristic

**If Cloudflare reports a container healthy but `port.fetch()` hangs with zero stdout** → pull the image and `docker run` it locally. A bundler / module-resolution crash like this one surfaces immediately via `docker run`, whereas CF's Firecracker VMs swallow early crashes and give you nothing to debug with.

## Test plan

- `tsc -b packages/alchemy`: clean.
- Real CF deploy verified above.
- No test added — `bundleProgram` / `buildAndPushImage` / `writeContextFiles` are closures inside `ContainerProvider`; happy to refactor for testability if desired.

## Checklist

- [x] Does not change any public API surface (all renames are internal to the provider closure).
- [x] Scoped to `(Cloudflare)` per naming convention.
