### PR TITLE
docs(home): restructure landing flow to lead with Effect-native features

### DIFF
--- a/website/src/components/marketing-islands/BindingsToIAM.tsx
+++ b/website/src/components/marketing-islands/BindingsToIAM.tsx
@@ -33,8 +33,8 @@ const ROWS: BindRow[] = [
     id: "get",
     call: (
       <>
-        <K>const</K> get = <K>yield</K>* <V>S3</V>.<V>GetObject</V>.<F>bind</F>(
-        <T>Photos</T>);
+        <K>const</K> getPhoto = <K>yield</K>* <V>S3</V>.<V>GetObject</V>.
+        <F>bind</F>(<T>Photos</T>);
       </>
     ),
     resource: { label: "Photos", sub: "S3.Bucket", kind: "s3" },
@@ -44,7 +44,7 @@ const ROWS: BindRow[] = [
     id: "put",
     call: (
       <>
-        <K>const</K> put = <K>yield</K>* <V>DynamoDB</V>.<V>PutItem</V>.
+        <K>const</K> putJob = <K>yield</K>* <V>DynamoDB</V>.<V>PutItem</V>.
         <F>bind</F>(<T>Jobs</T>);
       </>
     ),
@@ -184,7 +184,23 @@ export default function BindingsToIAM() {
               {"\n    "}
             </span>
           ))}
-          <C>{"// handler uses get / put / stream …"}</C>
+          {"\n    "}
+          <K>return</K> {"{"}
+          {"\n      "}
+          <V>fetch</V>: (<V>req</V>) {"=>"} <V>Effect</V>.<F>gen</F>(
+          <K>function</K>* () {"{"}
+          {"\n        "}
+          <K>const</K> photo = <K>yield</K>* <F>getPhoto</F>({"{ "}
+          <V>key</V>: <V>req</V>.<V>key</V> {"}"});
+          {"\n        "}
+          <K>yield</K>* <F>putJob</F>({"{ "}
+          <V>id</V>: <V>req</V>.<V>id</V>, <V>photo</V> {"}"});
+          {"\n        "}
+          <K>return</K> <K>new</K> <T>Response</T>(<S>"ok"</S>);
+          {"\n      "}
+          {"}),"}
+          {"\n    "}
+          {"};"}
           {"\n  "}
           {"}),"}
           {"\n"}

--- a/website/src/components/marketing-islands/DeployTerminal.tsx
+++ b/website/src/components/marketing-islands/DeployTerminal.tsx
@@ -45,8 +45,10 @@ interface Row extends Resource {
 
 export default function DeployTerminal({
   title = "~/my-app",
+  bare,
 }: {
   title?: string;
+  bare?: boolean;
 }) {
   const [mode, setMode] = useState<"idle" | "plan" | "deploy" | "destroy">(
     "idle",
@@ -300,6 +302,7 @@ export default function DeployTerminal({
       badge={mode !== "idle" ? MODE_LABEL[mode] : undefined}
       badgeColor={accent}
       bodyMinHeight={296}
+      bare={bare}
     >
       <Line>
         <span style={{ color: accent, transition: "color 280ms ease" }}>

--- a/website/src/components/marketing-islands/StackDeployMobile.tsx
+++ b/website/src/components/marketing-islands/StackDeployMobile.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useRef, useState } from "react";
+import DeployTerminal from "./DeployTerminal";
+import { highlightTS } from "../marketing/highlightTS";
+
+/**
+ * Mobile-only combined view for the "Stand up your cloud / Tear it down" section.
+ *
+ * Shows ONE terminal-styled card with two tabs in the header chrome:
+ *   - alchemy.run.ts   → highlighted source (the input)
+ *   - $ alchemy deploy → live DeployTerminal animation (the output)
+ *
+ * Auto-cycles between the two tabs every CYCLE_MS. The cycle pauses as soon
+ * as the user taps a tab so they can read at their own pace. We also pause
+ * when the card is offscreen so we don't burn cycles in the background.
+ */
+
+type Tab = "code" | "deploy";
+
+const CYCLE_MS = 7000;
+
+export default function StackDeployMobile({ code }: { code: string }) {
+  const [tab, setTab] = useState<Tab>("code");
+  const [pinned, setPinned] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  // Auto-advance until the user pins a tab. Restarts on every tab change so
+  // the dwell time is consistent whether a switch was automatic or manual.
+  useEffect(() => {
+    if (pinned) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const schedule = () => {
+      timer = setTimeout(() => {
+        if (cancelled) return;
+        setTab((t) => (t === "code" ? "deploy" : "code"));
+      }, CYCLE_MS);
+    };
+
+    // Only run while the card is in view.
+    const obs = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          if (e.isIntersecting) {
+            schedule();
+          } else if (timer) {
+            clearTimeout(timer);
+            timer = null;
+          }
+        }
+      },
+      { threshold: 0.3 },
+    );
+    if (wrapRef.current) obs.observe(wrapRef.current);
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      obs.disconnect();
+    };
+  }, [tab, pinned]);
+
+  const onTab = (next: Tab) => {
+    setPinned(true);
+    setTab(next);
+  };
+
+  const codeHtml = highlightTS(code);
+
+  return (
+    <div ref={wrapRef} className="stack-mobile">
+      <div className="stack-mobile__chrome">
+        <div className="stack-mobile__header">
+          <span
+            className="alc-code-block__dot"
+            style={{ background: "var(--alc-danger)" }}
+          />
+          <span
+            className="alc-code-block__dot"
+            style={{ background: "var(--alc-warn)" }}
+          />
+          <span
+            className="alc-code-block__dot"
+            style={{ background: "var(--alc-accent-bright)" }}
+          />
+          <div className="stack-mobile__tabs" role="tablist">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === "code"}
+              className="stack-mobile__tab"
+              data-active={tab === "code"}
+              onClick={() => onTab("code")}
+            >
+              alchemy.run.ts
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === "deploy"}
+              className="stack-mobile__tab"
+              data-active={tab === "deploy"}
+              onClick={() => onTab("deploy")}
+            >
+              $ alchemy deploy
+            </button>
+          </div>
+        </div>
+        <div className="stack-mobile__body">
+          {/* Both panels stay mounted so the DeployTerminal animation keeps
+              running across tab switches — feels alive when you flip back. */}
+          <div className="stack-mobile__panel" hidden={tab !== "code"}>
+            <pre
+              className="alc-code-block__pre stack-mobile__pre"
+              dangerouslySetInnerHTML={{ __html: codeHtml }}
+            />
+          </div>
+          <div className="stack-mobile__panel" hidden={tab !== "deploy"}>
+            <DeployTerminal bare />
+          </div>
+        </div>
+      </div>
+      <div className="stack-mobile__hint" aria-hidden>
+        {pinned ? (
+          <span>tap a tab to switch</span>
+        ) : (
+          <span>cycling · tap to pin</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/website/src/components/marketing-islands/_terminal.tsx
+++ b/website/src/components/marketing-islands/_terminal.tsx
@@ -65,13 +65,30 @@ export function TermChrome({
   badgeColor,
   children,
   bodyMinHeight,
+  bare,
 }: {
   title: string;
   badge?: string;
   badgeColor?: string;
   children: ReactNode;
   bodyMinHeight?: number;
+  /**
+   * When true, omit the outer `.alc-term` wrapper and the dots/title header.
+   * Useful when this terminal is embedded inside another chrome (e.g. the
+   * mobile tab toggle that combines code + deploy into one card).
+   */
+  bare?: boolean;
 }) {
+  if (bare) {
+    return (
+      <pre
+        className="alc-term__body"
+        style={bodyMinHeight ? { minHeight: bodyMinHeight } : undefined}
+      >
+        {children}
+      </pre>
+    );
+  }
   return (
     <div className="alc-term">
       <div className="alc-term__header">

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -150,36 +150,32 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
   <StackDeployMobile client:visible code={STACK_SRC} />
 </Section>
 
-{/* ───── 2 · TYPE IAM + ENV VARS ───── */}
+{/* ───── 2 · EFFECT-PILLED MODE ───── */}
 
-<Section padding="80px 32px" id="bindings-iam">
+<Section padding="80px 32px" id="effect-pilled">
   <div style="text-align:center;margin-bottom:36px;">
-    <Eyebrow>typed bindings · least-privilege permissions</Eyebrow>
+    <Eyebrow>effect-pilled · type-checked bindings</Eyebrow>
     <h2 class="alc-h2" style="margin:10px 0 12px;">
-      Type-checked IAM policies and env vars. <span style="color:var(--alc-accent-deep);font-style:italic;">Never forget another permission.</span>
+      <span style="color:var(--alc-accent-deep);font-style:italic;">Effect-pilled</span> mode.
     </h2>
     <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:760px;margin:0 auto;">
-      Bind a resource to a function. Alchemy generates the exact IAM policy and env vars it actually uses — nothing more, nothing missing. <a class="alc-learn-more" href="/concepts/binding">Learn more &rarr;</a>
-    </p>
-  </div>
-
-  <div class="alc-mode-head" style="text-align:center;max-width:760px;margin:0 auto 28px;">
-    <h3 class="alc-h3">
-      <span style="color:var(--alc-accent-deep);font-style:italic;">Effect-pilled</span> mode.
-    </h3>
-    <p class="alc-mode__lede" style="text-align:center;margin-top:10px;">
-      Combine infra and app code into a single type-safe program. Bindings carry through the type system, so a missing policy or env var is a compile error — not a 3am page.
+      Combine infra and app code into a single type-safe program. Bindings carry through the type system, so a missing policy or env var is a compile error — not a 3am page. <a class="alc-learn-more" href="/concepts/binding">Learn more &rarr;</a>
     </p>
   </div>
 
   <BindingsToIAM client:visible />
+</Section>
 
-  <div class="alc-mode-head" style="text-align:center;max-width:760px;margin:64px auto 18px;">
-    <h3 class="alc-h3">
+{/* ───── 3 · ASYNC FETCH ESCAPE HATCH ───── */}
+
+<Section padding="80px 32px" id="async-fetch">
+  <div style="text-align:center;margin-bottom:36px;">
+    <Eyebrow>async fetch · plain handlers · typed bindings</Eyebrow>
+    <h2 class="alc-h2" style="margin:10px 0 12px;">
       Don't worry — you can still <code class="alc-code-inline" style="color:var(--alc-accent-deep);">export&nbsp;default&nbsp;{"{"} async&nbsp;fetch {"}"}</code>.
-    </h3>
-    <p class="alc-mode__lede" style="text-align:center;margin-top:10px;">
-      It's just Infrastructure as Code, after all. Declare resources, attach them as bindings, and your handler stays the plain async function you already know. Bindings stay fully typed in <code class="alc-code-inline">env</code>.
+    </h2>
+    <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:760px;margin:0 auto;">
+      It's just Infrastructure as Code, after all. Declare resources, attach them as bindings, and your handler stays the plain async function you already know — bindings stay fully typed in <code class="alc-code-inline">env</code>. <a class="alc-learn-more" href="/guides/migrating-from-v1">Learn more &rarr;</a>
     </p>
   </div>
 

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -158,8 +158,8 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
     <h2 class="alc-section-statement">
       Compose <span style="color:var(--alc-accent-deep);font-style:italic;">Effects</span> and <span style="color:var(--alc-accent-deep);font-style:italic;">Layers</span> into type-safe cloud applications.
     </h2>
-    <p style="font-size:14px;line-height:1.6;color:var(--alc-fg-3);max-width:680px;margin:18px auto 0;">
-      <a class="alc-learn-more" href="/concepts/binding" style="margin:0;">Learn more &rarr;</a>
+    <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:760px;margin:20px auto 0;">
+      Every <code class="alc-code-inline" style="color:var(--alc-accent-deep);">.bind()</code> generates the exact IAM policy and environment variables your function actually uses — nothing more, nothing missing. <span style="color:var(--alc-fg-1);font-weight:500;">Never forget another IAM policy or env var.</span> <a class="alc-learn-more" href="/concepts/binding">Learn more &rarr;</a>
     </p>
   </div>
 

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../layouts/Marketing.astro
 title: "alchemy — zero to production. TypeScript IaC on Effect."
-description: "Alchemy is the IaC tool that's actually TypeScript. Deploy frontends, ship backends, and define the cloud they run on — all from one typed program on Effect. Bindings are the IAM policy. Run locally against real resources. Spin up isolated stacks per test. Preview every PR. Watch it in production."
+description: "Alchemy is the IaC tool that's actually TypeScript. Stand up your whole cloud in one program, type the IAM, hot-reload it locally, run tests against the real cloud, preview every PR, and ship dashboards & alarms in the same file."
 ---
 
 import Section from "../components/marketing/Section.astro";
@@ -13,12 +13,13 @@ import CodeBlock from "../components/marketing/CodeBlock.astro";
 import SketchLabel from "../components/marketing/SketchLabel.astro";
 import DeployTerminal from "../components/marketing-islands/DeployTerminal.tsx";
 import BindingsToIAM from "../components/marketing-islands/BindingsToIAM.tsx";
-import DevTestTerminal from "../components/marketing-islands/DevTestTerminal.tsx";
+import DevTerminal from "../components/marketing-islands/DevTerminal.tsx";
+import TestTerminal from "../components/marketing-islands/TestTerminal.tsx";
 import PRLifecycle from "../components/marketing-islands/PRLifecycle.tsx";
 import CopyForAgent from "../components/marketing-islands/CopyForAgent.tsx";
 import HeroCta from "../components/marketing-islands/HeroCta.tsx";
 
-export const STACK_SRC = `// alchemy.run.ts — the entrypoint
+export const STACK_SRC = `// alchemy.run.ts — your whole cloud, one program.
 export default Alchemy.Stack(
   "MyApp",
   { providers: Layer.mergeAll(AWS.providers(), Cloudflare.providers()) },
@@ -31,6 +32,21 @@ export default Alchemy.Stack(
     return { url: api.url };
   }),
 );`;
+
+export const EFFECT_PILLED_SRC = `// alchemy.run.ts — infra + runtime in one program.
+const Photos = yield* Cloudflare.R2Bucket("Photos");
+
+yield* Cloudflare.Worker("Api", Effect.gen(function* () {
+  const photos = yield* R2.GetObject.bind(Photos);   // ← typed handle
+  return {
+    fetch: (req) => Effect.gen(function* () {
+      const obj = yield* photos({ key: "hello.txt" });
+      return new Response(obj?.body ?? "Not found");
+    }),
+  };
+}));
+// Alchemy infers IAM + bindings from .bind() calls.
+// Forget a permission? It won't compile.`;
 
 export const ASYNC_RUN_SRC = `// alchemy.run.ts — declare resources, attach as bindings.
 export const Bucket = Cloudflare.R2Bucket("Bucket");
@@ -52,12 +68,14 @@ export default {
   },
 };`;
 
-export const TEST_SRC = `const stack = beforeAll(deploy(Stack));
+export const TEST_SRC = `// test/api.test.ts — isolated stack per suite.
+const stack = beforeAll(deploy(Stack));   // real R2, real DynamoDB
+afterAll(destroy(stack));                 // torn down at the end
 
 test("PUT + GET round-trips through R2", Effect.gen(function* () {
-const { url } = yield* stack;
-const res = yield* HttpClient.get(\`\${url}/object/hello.txt\`);
-expect(yield* res.text).toBe("hi!");
+  const { url } = yield* stack;
+  const res = yield* HttpClient.get(\`\${url}/object/hello.txt\`);
+  expect(yield* res.text).toBe("hi!");
 }));`;
 
 export const OTEL_SRC = `// src/Api.ts — Effect emits OpenTelemetry. Exporter is a Layer.
@@ -101,24 +119,21 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
       &rarr; production.
     </h1>
     <h2 class="alc-hero__subtitle">
-      Infrastructure as code in pure TypeScript. Move fast in dev; operate at
-      scale{" "}
-      <span style="color:var(--alc-accent-deep);font-style:italic;">
-        without compromise
-      </span>
-      .
+      Infrastructure as code in pure TypeScript. Optimized for{" "}
+      <span style="color:var(--alc-accent-deep);font-style:italic;">rapid development</span>{" "}
+      without compromising production readiness.
     </h2>
     <HeroCta client:load />
   </div>
 </Section>
 
-{/* ───── 1 · PLAN · DEPLOY · DESTROY ───── */}
+{/* ───── 1 · STAND UP / TEAR DOWN ───── */}
 
 <Section padding="40px 32px 96px" id="plan-deploy-destroy">
   <div style="text-align:center;margin-bottom:36px;">
-    <Eyebrow>diff · deploy · destroy</Eyebrow>
+    <Eyebrow>plan · deploy · destroy</Eyebrow>
     <h2 class="alc-h2" style="margin:10px 0 12px;">Stand up your cloud. <span style="color:var(--alc-accent-deep);font-style:italic;">Tear it down just as fast.</span></h2>
-    <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:680px;margin:0 auto;">
+    <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:720px;margin:0 auto;">
       Your whole cloud in one TypeScript program. <code class="alc-code-inline" style="color:var(--alc-accent-deep);">plan</code> shows the diff, <code class="alc-code-inline" style="color:var(--alc-accent-deep);">deploy</code> applies it, <code class="alc-code-inline" style="color:var(--alc-accent-deep);">destroy</code> reverses it. <a class="alc-learn-more" href="/concepts/deploy-and-destroy">Learn more &rarr;</a>
     </p>
   </div>
@@ -146,56 +161,68 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
   </div>
 </Section>
 
-{/* ───── 2 · BINDINGS = IAM ───── */}
+{/* ───── 2 · TYPE IAM + ENV VARS ───── */}
 
 <Section padding="80px 32px" id="bindings-iam">
   <div style="text-align:center;margin-bottom:36px;">
-    <Eyebrow>bindings · least-privilege permissions</Eyebrow>
+    <Eyebrow>typed bindings · least-privilege permissions</Eyebrow>
     <h2 class="alc-h2" style="margin:10px 0 12px;">
-      Bindings <span style="color:var(--alc-accent-deep);font-style:italic;">are</span> the IAM policy.
+      Type IAM policies and env vars. <span style="color:var(--alc-accent-deep);font-style:italic;">Never forget another permission.</span>
     </h2>
-    <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:720px;margin:0 auto;">
-      Bind a resource to a function. Alchemy generates the exact IAM and Worker bindings it actually uses. Nothing more. <a class="alc-learn-more" href="/concepts/binding">Learn more &rarr;</a>
+    <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:760px;margin:0 auto;">
+      Bind a resource to a function. Alchemy generates the exact IAM policy and env vars it actually uses — nothing more, nothing missing. <a class="alc-learn-more" href="/concepts/binding">Learn more &rarr;</a>
     </p>
   </div>
 
   <BindingsToIAM client:visible />
+
+  {/* Two sub-sections: Effect-pilled (recommended) + async fetch (escape hatch). */}
+  <div class="alc-modes" style="margin-top:64px;">
+    <div class="alc-mode">
+      <div class="alc-mode__head">
+        <SketchLabel>Recommended</SketchLabel>
+        <h3 class="alc-h3">
+          <span style="color:var(--alc-accent-deep);font-style:italic;">Effect-pilled</span> mode.
+        </h3>
+        <p class="alc-mode__lede">
+          Combine infra and app code into a single type-safe program. Bindings carry through the type system, so a missing policy or env var is a compile error — not a 3am page.
+        </p>
+      </div>
+      <CodeBlock filename="alchemy.run.ts" code={EFFECT_PILLED_SRC} compact />
+    </div>
+
+    <div class="alc-mode alc-mode--escape">
+      <div class="alc-mode__head">
+        <SketchLabel>Escape hatch</SketchLabel>
+        <h3 class="alc-h3">
+          Don't worry — you can still <code class="alc-code-inline" style="color:var(--alc-accent-deep);">export&nbsp;default&nbsp;{"{"} async&nbsp;fetch {"}"}</code>.
+        </h3>
+        <p class="alc-mode__lede">
+          It's just Infrastructure as Code, after all. Declare resources, attach them as bindings, and your handler stays the plain async function you already know. Bindings stay fully typed in <code class="alc-code-inline">env</code>.
+        </p>
+      </div>
+      <div class="alc-split-2">
+        <CodeBlock filename="alchemy.run.ts" code={ASYNC_RUN_SRC} compact />
+        <CodeBlock filename="src/worker.ts" code={ASYNC_WORKER_SRC} compact />
+      </div>
+    </div>
+  </div>
 </Section>
 
-{/* ───── 3 · EFFECT-NATIVE, ASYNC-COMPATIBLE ───── */}
+{/* ───── 3 · HOT RELOAD AS YOU DEVELOP ───── */}
 
-<Section padding="64px 32px" id="effect-and-async">
+<Section padding="80px 32px" background="var(--alc-bg-nav)" id="hot-reload">
   <div style="text-align:center;margin-bottom:32px;">
-    <Eyebrow>effect-native · async-compatible</Eyebrow>
-    <h2 class="alc-h2" style="margin:10px 0 12px;">
-      Effect <span style="color:var(--alc-accent-deep);font-style:italic;">when you want it</span>. <code class="alc-code-inline">async fetch</code> when you don't.
-    </h2>
+    <Eyebrow>alchemy dev · live cloud · hot reload</Eyebrow>
+    <h2 class="alc-h2" style="margin:10px 0 12px;">Hot reload your cloud resources <span style="color:var(--alc-accent-deep);font-style:italic;">as you develop</span>.</h2>
     <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:720px;margin:0 auto;">
-      Use Effect for typed errors and composition. Or stick with <code class="alc-code-inline" style="color:var(--alc-accent-deep);">async fetch(req, env)</code>. Bindings stay fully typed either way. <a class="alc-learn-more" href="/guides/migrating-from-v1">Learn more &rarr;</a>
+      Iterate on your frontend and backend at the same time. Both your infrastructure and application update in real-time — add a queue in <code class="alc-code-inline" style="color:var(--alc-accent-deep);">alchemy.run.ts</code>, the worker reloads with the binding already wired. <a class="alc-learn-more" href="/concepts/local-development">Learn more &rarr;</a>
     </p>
   </div>
 
-  <div class="alc-split-2">
-    <CodeBlock filename="alchemy.run.ts" code={ASYNC_RUN_SRC} compact />
-    <CodeBlock filename="src/worker.ts" code={ASYNC_WORKER_SRC} compact />
+  <div class="alc-dev-stage">
+    <DevTerminal client:visible />
   </div>
-</Section>
-
-{/* ───── 4 · DEV + TEST (merged) ───── */}
-
-<Section padding="80px 32px" background="var(--alc-bg-nav)" id="dev-and-test">
-  <div style="text-align:center;margin-bottom:32px;">
-    <Eyebrow>alchemy dev · alchemy test · no mocks, isolated stages</Eyebrow>
-    <h2 class="alc-h2" style="margin:10px 0 12px;">Dev hot-reloads. Tests run against live cloud resources.</h2>
-    <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:680px;margin:0 auto;">
-      A <code class="alc-code-inline" style="color:var(--alc-accent-deep);">Stack</code> is just an Effect. <code class="alc-code-inline" style="color:var(--alc-accent-deep);">alchemy dev</code> hot-reloads against your live cloud. Tests yield the same stack into an isolated stage. <a class="alc-learn-more" href="/concepts/local-development">Learn more &rarr;</a>
-    </p>
-  </div>
-
-<div class="alc-split-2 alc-split-2--wide-left">
-  <DevTestTerminal client:visible />
-  <CodeBlock filename="test/api.test.ts" code={TEST_SRC} compact />
-</div>
 
   <div class="alc-stat-strip">
     <span class="alc-stat-strip__item"><strong>workerd</strong> locally</span>
@@ -204,34 +231,59 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
     <span class="alc-stat-strip__sep">·</span>
     <span class="alc-stat-strip__item">live <strong>R2 / KV / D1</strong></span>
     <span class="alc-stat-strip__sep">·</span>
-    <span class="alc-stat-strip__item"><strong>per-suite</strong> stages</span>
-    <span class="alc-stat-strip__sep">·</span>
-    <span class="alc-stat-strip__item">vitest + bun, <strong>Effect-aware</strong></span>
+    <span class="alc-stat-strip__item">infra + app in <strong>one watcher</strong></span>
   </div>
 </Section>
 
-{/* ───── 4 · CI · PREVIEW ENVIRONMENTS ───── */}
+{/* ───── 4 · TEST AGAINST LIVE CLOUD ───── */}
+
+<Section padding="80px 32px" id="live-tests">
+  <div style="text-align:center;margin-bottom:32px;">
+    <Eyebrow>alchemy test · isolated stages · no mocks</Eyebrow>
+    <h2 class="alc-h2" style="margin:10px 0 12px;">Run tests against <span style="color:var(--alc-accent-deep);font-style:italic;">live cloud resources</span>.</h2>
+    <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:720px;margin:0 auto;">
+      Have agents write tests against your real API and run them against the actual cloud — every suite gets its own isolated stack, deployed and destroyed automatically. <a class="alc-learn-more" href="/concepts/testing">Learn more &rarr;</a>
+    </p>
+  </div>
+
+  <div class="alc-split-2 alc-split-2--wide-left">
+    <TestTerminal client:visible />
+    <CodeBlock filename="test/api.test.ts" code={TEST_SRC} compact />
+  </div>
+
+  <div class="alc-stat-strip">
+    <span class="alc-stat-strip__item"><strong>per-suite</strong> stages</span>
+    <span class="alc-stat-strip__sep">·</span>
+    <span class="alc-stat-strip__item">vitest + bun, <strong>Effect-aware</strong></span>
+    <span class="alc-stat-strip__sep">·</span>
+    <span class="alc-stat-strip__item">deploy → assert → <strong>destroy</strong></span>
+    <span class="alc-stat-strip__sep">·</span>
+    <span class="alc-stat-strip__item"><strong>no mocks</strong>, no fakes</span>
+  </div>
+</Section>
+
+{/* ───── 5 · PR PREVIEW ENVIRONMENTS ───── */}
 
 <Section padding="80px 32px" background="var(--alc-bg-nav)" id="ci-previews">
   <div style="text-align:center;margin-bottom:32px;">
-    <Eyebrow>continuous integration · preview environments</Eyebrow>
-    <h2 class="alc-h2" style="margin:10px 0 12px;">Every PR gets an <span style="color:var(--alc-accent-deep);font-style:italic;">ephemeral</span> preview environment.</h2>
-    <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:680px;margin:0 auto;">
-      One workflow file. The stage name comes from the event (<code class="alc-code-inline" style="color:var(--alc-accent-deep);">pr-{`{`}n{`}`}</code>, <code class="alc-code-inline" style="color:var(--alc-accent-deep);">prod</code>, branch), and prod refuses to be destroyed. <a class="alc-learn-more" href="/guides/ci">Learn more &rarr;</a>
+    <Eyebrow>github actions · preview environments</Eyebrow>
+    <h2 class="alc-h2" style="margin:10px 0 12px;">Preview every PR with an <span style="color:var(--alc-accent-deep);font-style:italic;">ephemeral</span> environment.</h2>
+    <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:720px;margin:0 auto;">
+      Alchemy programs run anywhere. Drop one into GitHub Actions to deploy a real environment per PR for testing — and tear it down when the PR merges or closes. <a class="alc-learn-more" href="/guides/ci">Learn more &rarr;</a>
     </p>
   </div>
 
   <PRLifecycle client:visible />
 </Section>
 
-{/* ───── 5 · OPERATIONAL READINESS ───── */}
+{/* ───── 6 · PRODUCTIONIZE FROM DAY ONE ───── */}
 
 <Section padding="80px 32px" id="operational-readiness">
   <div style="text-align:center;margin-bottom:32px;">
-    <Eyebrow>operational readiness · observability as iac</Eyebrow>
-    <h2 class="alc-h2" style="margin:10px 0 12px;">Dashboards and alarms <span style="color:var(--alc-accent-deep);font-style:italic;">ship with</span> the resources.</h2>
-    <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:680px;margin:0 auto;">
-      Dashboards, alarms, and OTel exporters sit in the same <code class="alc-code-inline" style="color:var(--alc-accent-deep);">alchemy.run.ts</code> as the workers they watch. Ship the system and operate it from one program. <a class="alc-learn-more" href="/concepts/observability">Learn more &rarr;</a>
+    <Eyebrow>observability as iac · effect-native otel</Eyebrow>
+    <h2 class="alc-h2" style="margin:10px 0 12px;">Don't forget to productionize. <span style="color:var(--alc-accent-deep);font-style:italic;">Dashboards, alarms, and metrics</span> from day one.</h2>
+    <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:760px;margin:0 auto;">
+      Metrics and dashboards shouldn't be an afterthought. Record metrics and spans with Effect's built-in OpenTelemetry, then export them to your favorite analytics tool — all declared next to the resources they watch. <a class="alc-learn-more" href="/concepts/observability">Learn more &rarr;</a>
     </p>
   </div>
 
@@ -239,7 +291,7 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
     <div class="alc-ops-col">
       <SketchLabel>OTel from Effect</SketchLabel>
       <CodeBlock filename="src/Api.ts" code={OTEL_SRC} compact />
-      <p class="alc-ops-caption">Effect already emits logs, spans, and metrics. Swap the OTLP Layer to ship them to <strong>Axiom</strong>, <strong>Datadog</strong>, <strong>CloudWatch</strong>, or any OTLP endpoint. Your Worker code doesn't change.</p>
+      <p class="alc-ops-caption">Effect already emits logs, spans, and metrics. Swap the OTLP Layer to ship them to <strong>Axiom</strong>, <strong>Datadog</strong>, <strong>CloudWatch</strong>, or any OTLP endpoint. Your worker code doesn't change.</p>
     </div>
     <div class="alc-ops-col">
       <SketchLabel>Dashboards &amp; alarms</SketchLabel>

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -154,12 +154,12 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
 
 <Section padding="80px 32px" id="effect-pilled">
   <div style="text-align:center;margin-bottom:36px;">
-    <Eyebrow>effect-pilled · bindings as iam</Eyebrow>
-    <h2 class="alc-h2" style="margin:10px 0 12px;">
-      <span style="color:var(--alc-accent-deep);font-style:italic;">Effect-pilled</span> mode.
+    <Eyebrow>effect-pilled mode</Eyebrow>
+    <h2 class="alc-section-statement">
+      Compose <span style="color:var(--alc-accent-deep);font-style:italic;">Effects</span> and <span style="color:var(--alc-accent-deep);font-style:italic;">Layers</span> into type-safe cloud applications.
     </h2>
-    <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:760px;margin:0 auto;">
-      Compose Effects and Layers into type-safe cloud applications. <a class="alc-learn-more" href="/concepts/binding">Learn more &rarr;</a>
+    <p style="font-size:14px;line-height:1.6;color:var(--alc-fg-3);max-width:680px;margin:18px auto 0;">
+      <a class="alc-learn-more" href="/concepts/binding" style="margin:0;">Learn more &rarr;</a>
     </p>
   </div>
 

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -170,7 +170,7 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
 
 <Section padding="80px 32px" id="async-fetch">
   <div style="text-align:center;margin-bottom:36px;">
-    <Eyebrow>async fetch · plain handlers · same typed bindings</Eyebrow>
+    <Eyebrow>no effect required · still fully typed</Eyebrow>
     <h2 class="alc-h2" style="margin:10px 0 12px;">
       Don't worry — you can still <code class="alc-code-inline" style="color:var(--alc-accent-deep);">async&nbsp;fetch</code>.
     </h2>

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -172,7 +172,7 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
   <div style="text-align:center;margin-bottom:36px;">
     <Eyebrow>async fetch · plain handlers · typed bindings</Eyebrow>
     <h2 class="alc-h2" style="margin:10px 0 12px;">
-      Don't worry — you can still <code class="alc-code-inline" style="color:var(--alc-accent-deep);">export&nbsp;default&nbsp;{"{"} async&nbsp;fetch {"}"}</code>.
+      Don't worry — you can still <code class="alc-code-inline" style="color:var(--alc-accent-deep);">async&nbsp;fetch</code>.
     </h2>
     <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:760px;margin:0 auto;">
       It's just Infrastructure as Code, after all. Declare resources, attach them as bindings, and your handler stays the plain async function you already know — bindings stay fully typed in <code class="alc-code-inline">env</code>. <a class="alc-learn-more" href="/guides/migrating-from-v1">Learn more &rarr;</a>

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -159,7 +159,7 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
       <span style="color:var(--alc-accent-deep);font-style:italic;">Effect-pilled</span> mode.
     </h2>
     <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:760px;margin:0 auto;">
-      Infra and app code in one type-safe program. Bindings flow through the type system, so a missing IAM policy or env var is a compile error — not a 3am page. <a class="alc-learn-more" href="/concepts/binding">Learn more &rarr;</a>
+      Compose Effects and Layers into type-safe cloud applications. <a class="alc-learn-more" href="/concepts/binding">Learn more &rarr;</a>
     </p>
   </div>
 

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -12,6 +12,7 @@ import DiscordCallout from "../components/marketing/DiscordCallout.astro";
 import CodeBlock from "../components/marketing/CodeBlock.astro";
 import SketchLabel from "../components/marketing/SketchLabel.astro";
 import DeployTerminal from "../components/marketing-islands/DeployTerminal.tsx";
+import StackDeployMobile from "../components/marketing-islands/StackDeployMobile.tsx";
 import BindingsToIAM from "../components/marketing-islands/BindingsToIAM.tsx";
 import DevTerminal from "../components/marketing-islands/DevTerminal.tsx";
 import TestTerminal from "../components/marketing-islands/TestTerminal.tsx";
@@ -144,6 +145,9 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
       </div>
     </div>
   </div>
+
+  {/* Mobile-only: combined card with tabbed code/deploy that auto-cycles. */}
+  <StackDeployMobile client:visible code={STACK_SRC} />
 </Section>
 
 {/* ───── 2 · TYPE IAM + ENV VARS ───── */}

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -120,7 +120,7 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
     <Eyebrow>plan · deploy · destroy</Eyebrow>
     <h2 class="alc-h2" style="margin:10px 0 12px;">Stand up your cloud. <span style="color:var(--alc-accent-deep);font-style:italic;">Tear it down just as fast.</span></h2>
     <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:720px;margin:0 auto;">
-      Your whole cloud in one TypeScript program. <code class="alc-code-inline" style="color:var(--alc-accent-deep);">plan</code> shows the diff, <code class="alc-code-inline" style="color:var(--alc-accent-deep);">deploy</code> applies it, <code class="alc-code-inline" style="color:var(--alc-accent-deep);">destroy</code> reverses it. <a class="alc-learn-more" href="/concepts/deploy-and-destroy">Learn more &rarr;</a>
+      Your whole cloud as one TypeScript program. <code class="alc-code-inline" style="color:var(--alc-accent-deep);">plan</code> previews the diff, <code class="alc-code-inline" style="color:var(--alc-accent-deep);">deploy</code> applies it, <code class="alc-code-inline" style="color:var(--alc-accent-deep);">destroy</code> unwinds it — predictably, every time. <a class="alc-learn-more" href="/concepts/deploy-and-destroy">Learn more &rarr;</a>
     </p>
   </div>
 
@@ -154,12 +154,12 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
 
 <Section padding="80px 32px" id="effect-pilled">
   <div style="text-align:center;margin-bottom:36px;">
-    <Eyebrow>effect-pilled · type-checked bindings</Eyebrow>
+    <Eyebrow>effect-pilled · bindings as iam</Eyebrow>
     <h2 class="alc-h2" style="margin:10px 0 12px;">
       <span style="color:var(--alc-accent-deep);font-style:italic;">Effect-pilled</span> mode.
     </h2>
     <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:760px;margin:0 auto;">
-      Combine infra and app code into a single type-safe program. Bindings carry through the type system, so a missing policy or env var is a compile error — not a 3am page. <a class="alc-learn-more" href="/concepts/binding">Learn more &rarr;</a>
+      Infra and app code in one type-safe program. Bindings flow through the type system, so a missing IAM policy or env var is a compile error — not a 3am page. <a class="alc-learn-more" href="/concepts/binding">Learn more &rarr;</a>
     </p>
   </div>
 
@@ -170,12 +170,12 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
 
 <Section padding="80px 32px" id="async-fetch">
   <div style="text-align:center;margin-bottom:36px;">
-    <Eyebrow>async fetch · plain handlers · typed bindings</Eyebrow>
+    <Eyebrow>async fetch · plain handlers · same typed bindings</Eyebrow>
     <h2 class="alc-h2" style="margin:10px 0 12px;">
       Don't worry — you can still <code class="alc-code-inline" style="color:var(--alc-accent-deep);">async&nbsp;fetch</code>.
     </h2>
     <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:760px;margin:0 auto;">
-      It's just Infrastructure as Code, after all. Declare resources, attach them as bindings, and your handler stays the plain async function you already know — bindings stay fully typed in <code class="alc-code-inline">env</code>. <a class="alc-learn-more" href="/guides/migrating-from-v1">Learn more &rarr;</a>
+      Effect's optional. Declare resources, wire them as bindings, and your handler stays the plain async function you already wrote — <code class="alc-code-inline">env</code> stays fully typed either way. <a class="alc-learn-more" href="/guides/migrating-from-v1">Learn more &rarr;</a>
     </p>
   </div>
 
@@ -189,10 +189,10 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
 
 <Section padding="80px 32px" background="var(--alc-bg-nav)" id="hot-reload">
   <div style="text-align:center;margin-bottom:32px;">
-    <Eyebrow>alchemy dev · live cloud · hot reload</Eyebrow>
-    <h2 class="alc-h2" style="margin:10px 0 12px;">Hot reload your cloud resources <span style="color:var(--alc-accent-deep);font-style:italic;">as you develop</span>.</h2>
+    <Eyebrow>alchemy dev · live cloud · ~100ms reloads</Eyebrow>
+    <h2 class="alc-h2" style="margin:10px 0 12px;">Hot-reload your cloud, <span style="color:var(--alc-accent-deep);font-style:italic;">not just your code</span>.</h2>
     <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:720px;margin:0 auto;">
-      Iterate on your frontend and backend at the same time. Both your infrastructure and application update in real-time — add a queue in <code class="alc-code-inline" style="color:var(--alc-accent-deep);">alchemy.run.ts</code>, the worker reloads with the binding already wired. <a class="alc-learn-more" href="/concepts/local-development">Learn more &rarr;</a>
+      Add a queue in <code class="alc-code-inline" style="color:var(--alc-accent-deep);">alchemy.run.ts</code> and the worker reloads with the binding already wired. Frontend and backend together, against real R2 / KV / D1. <a class="alc-learn-more" href="/concepts/local-development">Learn more &rarr;</a>
     </p>
   </div>
 
@@ -215,10 +215,10 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
 
 <Section padding="80px 32px" id="live-tests">
   <div style="text-align:center;margin-bottom:32px;">
-    <Eyebrow>alchemy test · isolated stages · no mocks</Eyebrow>
-    <h2 class="alc-h2" style="margin:10px 0 12px;">Run tests against <span style="color:var(--alc-accent-deep);font-style:italic;">live cloud resources</span>.</h2>
+    <Eyebrow>alchemy test · isolated stages · live cloud</Eyebrow>
+    <h2 class="alc-h2" style="margin:10px 0 12px;">Test against the real cloud. <span style="color:var(--alc-accent-deep);font-style:italic;">Not a fake of it.</span></h2>
     <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:720px;margin:0 auto;">
-      Have agents write tests against your real API and run them against the actual cloud — every suite gets its own isolated stack, deployed and destroyed automatically. <a class="alc-learn-more" href="/concepts/testing">Learn more &rarr;</a>
+      Each suite spins up its own isolated stack — real R2, real DynamoDB, real Workers — runs your assertions, and tears it back down. No mocks to babysit, no drift between fixture and production. <a class="alc-learn-more" href="/concepts/testing">Learn more &rarr;</a>
     </p>
   </div>
 
@@ -242,10 +242,10 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
 
 <Section padding="80px 32px" background="var(--alc-bg-nav)" id="ci-previews">
   <div style="text-align:center;margin-bottom:32px;">
-    <Eyebrow>github actions · preview environments</Eyebrow>
-    <h2 class="alc-h2" style="margin:10px 0 12px;">Preview every PR with an <span style="color:var(--alc-accent-deep);font-style:italic;">ephemeral</span> environment.</h2>
+    <Eyebrow>github actions · per-pr environments</Eyebrow>
+    <h2 class="alc-h2" style="margin:10px 0 12px;">Every PR gets a <span style="color:var(--alc-accent-deep);font-style:italic;">real</span> environment.</h2>
     <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:720px;margin:0 auto;">
-      Alchemy programs run anywhere. Drop one into GitHub Actions to deploy a real environment per PR for testing — and tear it down when the PR merges or closes. <a class="alc-learn-more" href="/guides/ci">Learn more &rarr;</a>
+      An Alchemy program is just TypeScript — drop one into GitHub Actions to deploy a per-PR stack for review, then let merge or close tear it down. <a class="alc-learn-more" href="/guides/ci">Learn more &rarr;</a>
     </p>
   </div>
 
@@ -256,10 +256,10 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
 
 <Section padding="80px 32px" id="operational-readiness">
   <div style="text-align:center;margin-bottom:32px;">
-    <Eyebrow>observability as iac · effect-native otel</Eyebrow>
-    <h2 class="alc-h2" style="margin:10px 0 12px;">Don't forget to productionize. <span style="color:var(--alc-accent-deep);font-style:italic;">Dashboards, alarms, and metrics</span> from day one.</h2>
+    <Eyebrow>observability as iac · otel from effect</Eyebrow>
+    <h2 class="alc-h2" style="margin:10px 0 12px;">Dashboards and alarms <span style="color:var(--alc-accent-deep);font-style:italic;">ship with the resources</span>.</h2>
     <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:760px;margin:0 auto;">
-      Metrics and dashboards shouldn't be an afterthought. Record metrics and spans with Effect's built-in OpenTelemetry, then export them to your favorite analytics tool — all declared next to the resources they watch. <a class="alc-learn-more" href="/concepts/observability">Learn more &rarr;</a>
+      Effect emits logs, spans, and metrics by default. Wire dashboards and alarms in the same <code class="alc-code-inline" style="color:var(--alc-accent-deep);">alchemy.run.ts</code> as the workers they watch — swap the OTLP exporter for Axiom, Datadog, or anywhere else. <a class="alc-learn-more" href="/concepts/observability">Learn more &rarr;</a>
     </p>
   </div>
 

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -282,13 +282,7 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
 <Section padding="56px 32px 64px" id="outro">
   <DiscordCallout />
   <div class="alc-cta" style="margin-top:48px;text-align:center;">
-    <h2 class="alc-h2">
-      Paste this into your coding agent{" "}
-      <span style="color:var(--alc-accent-deep);font-style:italic;">
-        to get started
-      </span>
-      .
-    </h2>
+    <h2 class="alc-h2">Paste this into your coding agent <span style="color:var(--alc-accent-deep);font-style:italic;">to get started</span>.</h2>
     <CopyForAgent client:load />
     <div style="display:flex;gap:10px;justify-content:center;flex-wrap:wrap;margin-top:24px;">
       <Button variant="secondary" href="/getting-started">

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../layouts/Marketing.astro
 title: "alchemy — zero to production. TypeScript IaC on Effect."
-description: "Alchemy is the IaC tool that's actually TypeScript. Stand up your whole cloud in one program, type the IAM, hot-reload it locally, run tests against the real cloud, preview every PR, and ship dashboards & alarms in the same file."
+description: "Alchemy is the IaC tool that's actually TypeScript. Stand up your whole cloud in one program, type-check the IAM, hot-reload it locally, run tests against the real cloud, preview every PR, and ship dashboards & alarms in the same file."
 ---
 
 import Section from "../components/marketing/Section.astro";
@@ -167,7 +167,7 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
   <div style="text-align:center;margin-bottom:36px;">
     <Eyebrow>typed bindings · least-privilege permissions</Eyebrow>
     <h2 class="alc-h2" style="margin:10px 0 12px;">
-      Type IAM policies and env vars. <span style="color:var(--alc-accent-deep);font-style:italic;">Never forget another permission.</span>
+      Type-checked IAM policies and env vars. <span style="color:var(--alc-accent-deep);font-style:italic;">Never forget another permission.</span>
     </h2>
     <p style="font-size:15.5px;line-height:1.6;color:var(--alc-fg-2);max-width:760px;margin:0 auto;">
       Bind a resource to a function. Alchemy generates the exact IAM policy and env vars it actually uses — nothing more, nothing missing. <a class="alc-learn-more" href="/concepts/binding">Learn more &rarr;</a>
@@ -180,7 +180,6 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
   <div class="alc-modes" style="margin-top:64px;">
     <div class="alc-mode">
       <div class="alc-mode__head">
-        <SketchLabel>Recommended</SketchLabel>
         <h3 class="alc-h3">
           <span style="color:var(--alc-accent-deep);font-style:italic;">Effect-pilled</span> mode.
         </h3>
@@ -193,7 +192,6 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
 
     <div class="alc-mode alc-mode--escape">
       <div class="alc-mode__head">
-        <SketchLabel>Escape hatch</SketchLabel>
         <h3 class="alc-h3">
           Don't worry — you can still <code class="alc-code-inline" style="color:var(--alc-accent-deep);">export&nbsp;default&nbsp;{"{"} async&nbsp;fetch {"}"}</code>.
         </h3>

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -33,21 +33,6 @@ export default Alchemy.Stack(
   }),
 );`;
 
-export const EFFECT_PILLED_SRC = `// alchemy.run.ts — infra + runtime in one program.
-const Photos = yield* Cloudflare.R2Bucket("Photos");
-
-yield* Cloudflare.Worker("Api", Effect.gen(function* () {
-  const photos = yield* R2.GetObject.bind(Photos);   // ← typed handle
-  return {
-    fetch: (req) => Effect.gen(function* () {
-      const obj = yield* photos({ key: "hello.txt" });
-      return new Response(obj?.body ?? "Not found");
-    }),
-  };
-}));
-// Alchemy infers IAM + bindings from .bind() calls.
-// Forget a permission? It won't compile.`;
-
 export const ASYNC_RUN_SRC = `// alchemy.run.ts — declare resources, attach as bindings.
 export const Bucket = Cloudflare.R2Bucket("Bucket");
 
@@ -174,36 +159,29 @@ export const P99Alarm = AWS.CloudWatch.Alarm("p99Latency", {
     </p>
   </div>
 
+  <div class="alc-mode-head" style="text-align:center;max-width:760px;margin:0 auto 28px;">
+    <h3 class="alc-h3">
+      <span style="color:var(--alc-accent-deep);font-style:italic;">Effect-pilled</span> mode.
+    </h3>
+    <p class="alc-mode__lede" style="text-align:center;margin-top:10px;">
+      Combine infra and app code into a single type-safe program. Bindings carry through the type system, so a missing policy or env var is a compile error — not a 3am page.
+    </p>
+  </div>
+
   <BindingsToIAM client:visible />
 
-  {/* Two sub-sections: Effect-pilled (recommended) + async fetch (escape hatch). */}
-  <div class="alc-modes" style="margin-top:64px;">
-    <div class="alc-mode">
-      <div class="alc-mode__head">
-        <h3 class="alc-h3">
-          <span style="color:var(--alc-accent-deep);font-style:italic;">Effect-pilled</span> mode.
-        </h3>
-        <p class="alc-mode__lede">
-          Combine infra and app code into a single type-safe program. Bindings carry through the type system, so a missing policy or env var is a compile error — not a 3am page.
-        </p>
-      </div>
-      <CodeBlock filename="alchemy.run.ts" code={EFFECT_PILLED_SRC} compact />
-    </div>
+  <div class="alc-mode-head" style="text-align:center;max-width:760px;margin:64px auto 18px;">
+    <h3 class="alc-h3">
+      Don't worry — you can still <code class="alc-code-inline" style="color:var(--alc-accent-deep);">export&nbsp;default&nbsp;{"{"} async&nbsp;fetch {"}"}</code>.
+    </h3>
+    <p class="alc-mode__lede" style="text-align:center;margin-top:10px;">
+      It's just Infrastructure as Code, after all. Declare resources, attach them as bindings, and your handler stays the plain async function you already know. Bindings stay fully typed in <code class="alc-code-inline">env</code>.
+    </p>
+  </div>
 
-    <div class="alc-mode alc-mode--escape">
-      <div class="alc-mode__head">
-        <h3 class="alc-h3">
-          Don't worry — you can still <code class="alc-code-inline" style="color:var(--alc-accent-deep);">export&nbsp;default&nbsp;{"{"} async&nbsp;fetch {"}"}</code>.
-        </h3>
-        <p class="alc-mode__lede">
-          It's just Infrastructure as Code, after all. Declare resources, attach them as bindings, and your handler stays the plain async function you already know. Bindings stay fully typed in <code class="alc-code-inline">env</code>.
-        </p>
-      </div>
-      <div class="alc-split-2">
-        <CodeBlock filename="alchemy.run.ts" code={ASYNC_RUN_SRC} compact />
-        <CodeBlock filename="src/worker.ts" code={ASYNC_WORKER_SRC} compact />
-      </div>
-    </div>
+  <div class="alc-split-2">
+    <CodeBlock filename="alchemy.run.ts" code={ASYNC_RUN_SRC} compact />
+    <CodeBlock filename="src/worker.ts" code={ASYNC_WORKER_SRC} compact />
   </div>
 </Section>
 

--- a/website/src/styles/marketing.css
+++ b/website/src/styles/marketing.css
@@ -1758,6 +1758,19 @@ body.alc-root,
   font-size: clamp(26px, 4.8vw, 34px);
 }
 
+/* Hero-scale serif statement used in place of an .alc-h2 + small lede
+   when a section's value-prop reads better as one big sentence. */
+.alc-section-statement {
+  font-family: var(--alc-font-serif);
+  font-weight: 400;
+  font-size: clamp(22px, 3.6vw, 34px);
+  line-height: 1.25;
+  letter-spacing: -0.005em;
+  color: var(--alc-fg-1);
+  max-width: 820px;
+  margin: 12px auto 0;
+}
+
 /* Sub-section heading inside a section (e.g. Effect-pilled / async fetch
    modes inside the bindings-iam section). */
 .alc-h3 {

--- a/website/src/styles/marketing.css
+++ b/website/src/styles/marketing.css
@@ -1647,6 +1647,94 @@ body.alc-root,
   font-size: clamp(26px, 4.8vw, 34px);
 }
 
+/* Sub-section heading inside a section (e.g. Effect-pilled / async fetch
+   modes inside the bindings-iam section). */
+.alc-h3 {
+  font-family: var(--alc-font-serif);
+  font-weight: 500;
+  font-size: clamp(20px, 2.6vw, 24px);
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: var(--alc-fg-1);
+  margin: 6px 0 0;
+}
+
+/* ============================================================
+   Modes stack — used inside the "Type IAM + env vars" section
+   to present the Effect-pilled (recommended) and async-fetch
+   (escape hatch) sub-sections one above the other. The escape
+   hatch is visually softened so the recommended path leads.
+   ============================================================ */
+
+.alc-modes {
+  display: flex;
+  flex-direction: column;
+  gap: 56px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+.alc-mode {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  gap: 28px;
+  align-items: start;
+}
+.alc-mode__head {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+  padding-top: 4px;
+}
+.alc-mode__lede {
+  margin: 0;
+  font-size: 14.5px;
+  line-height: 1.6;
+  color: var(--alc-fg-2);
+}
+.alc-mode__lede code {
+  font-family: var(--alc-font-mono);
+  font-size: 0.92em;
+  color: var(--alc-accent-deep);
+  background: rgba(184, 138, 74, 0.1);
+  padding: 0 4px;
+  border-radius: 3px;
+}
+/* The escape-hatch mode keeps a 2-up code split inside the right column,
+   so on desktop we let it span the full row instead of competing with
+   the head column. Keeps reading order: title → details → 2 code blocks. */
+.alc-mode--escape {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 18px;
+}
+.alc-mode--escape .alc-mode__head {
+  text-align: center;
+  align-items: center;
+  max-width: 760px;
+  margin: 0 auto;
+}
+.alc-mode--escape .alc-mode__lede {
+  text-align: center;
+}
+@media (max-width: 880px) {
+  .alc-mode {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 16px;
+  }
+  .alc-modes {
+    gap: 44px;
+  }
+}
+
+/* ============================================================
+   Dev terminal stage (Hot reload section). Single, centered
+   terminal — narrower than full-width so it doesn't sprawl.
+   ============================================================ */
+.alc-dev-stage {
+  max-width: 880px;
+  margin: 0 auto;
+}
+
 /* Two-column code+illustration splits */
 .alc-split-2 {
   display: grid;

--- a/website/src/styles/marketing.css
+++ b/website/src/styles/marketing.css
@@ -282,6 +282,117 @@ body.alc-root,
 }
 
 /* ============================================================
+   Stack ↔ Deploy mobile toggle (home page section 1)
+   On narrow screens the side-by-side diagram is replaced by a single
+   tabbed card that auto-cycles between the source and the deploy
+   terminal. Saves vertical space and keeps both views accessible.
+   ============================================================ */
+
+.stack-mobile {
+  display: none; /* hidden on desktop — see media query below */
+  flex-direction: column;
+  gap: 8px;
+  max-width: 560px;
+  margin: 0 auto;
+}
+.stack-mobile__chrome {
+  background: var(--alc-bg-code);
+  border: 1px solid var(--alc-hairline);
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: var(--alc-shadow-sm);
+  display: flex;
+  flex-direction: column;
+}
+.stack-mobile__header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-bottom: 1px solid rgba(232, 220, 192, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+}
+.stack-mobile__tabs {
+  display: flex;
+  gap: 4px;
+  margin-left: 12px;
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.stack-mobile__tabs::-webkit-scrollbar {
+  display: none;
+}
+.stack-mobile__tab {
+  flex: 0 0 auto;
+  appearance: none;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--alc-code-comment);
+  font-family: var(--alc-font-mono);
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 5px;
+  cursor: pointer;
+  transition:
+    color 160ms ease,
+    background 160ms ease,
+    border-color 160ms ease;
+}
+.stack-mobile__tab:hover {
+  color: var(--alc-fg-invert);
+}
+.stack-mobile__tab[data-active="true"] {
+  color: var(--alc-fg-invert);
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(232, 220, 192, 0.12);
+}
+.stack-mobile__body {
+  position: relative;
+  min-height: 320px;
+  display: flex;
+  flex-direction: column;
+}
+.stack-mobile__panel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+.stack-mobile__panel[hidden] {
+  display: none;
+}
+.stack-mobile__pre {
+  margin: 0;
+  padding: 14px 16px;
+  font-family: var(--alc-font-mono);
+  font-size: 12px;
+  line-height: 1.65;
+  color: var(--alc-code-var);
+  overflow-x: auto;
+  flex: 1;
+  min-height: 296px;
+}
+.stack-mobile__hint {
+  font-family: var(--alc-font-mono);
+  font-size: 10.5px;
+  color: var(--alc-fg-3);
+  text-align: center;
+  letter-spacing: 0.04em;
+}
+
+/* Swap the side-by-side diagram for the tabbed toggle on narrow screens. */
+@media (max-width: 880px) {
+  .stack-deploy-diagram {
+    display: none;
+  }
+  .stack-mobile {
+    display: flex;
+  }
+}
+
+/* ============================================================
    Animated Output / resource-graph (/product/iac)
    Code on the left, progressive nodes/edges on the right with
    a step indicator + rotating annotation.


### PR DESCRIPTION
## Summary
- Reframes section 2 as **Type IAM policies and env vars. Never forget another permission.** with two sub-sections: **Effect-pilled mode** (recommended) and an **`export default { async fetch }`** escape hatch.
- Splits the previously merged dev+test block into two dedicated sections: **Hot reload your cloud resources as you develop** and **Run tests against live cloud resources**.
- Tweaks the hero subtitle and renames the PR-preview / productionize sections to match the new narrative arc.
- Adds `.alc-h3`, `.alc-modes` / `.alc-mode` and `.alc-dev-stage` styles in `marketing.css` to support the new sub-section layout (with mobile collapse).

## Test plan
- [ ] `cd website && bun run dev` and visually QA each section at desktop, tablet, and mobile widths.
- [ ] Confirm `BindingsToIAM`, `DevTerminal`, `TestTerminal`, and `PRLifecycle` islands all hydrate and animate as expected.
- [ ] Verify the Effect-pilled / async-fetch sub-sections stack cleanly on narrow viewports.


Made with [Cursor](https://cursor.com)