### PR TITLE
docs(website): readable mobile sidebar & TOC (dark-on-dark)

### DIFF
--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -31,9 +31,16 @@ starlight-theme-select {
 
   /* Walnut neutral scale — light-mode convention: gray-1 = darkest text,
      gray-7 = lightest surface. Starlight's hero `.tagline`, body copy,
-     and muted prose all read off this scale. */
+     and muted prose all read off this scale.
+
+     IMPORTANT: Starlight uses `--sl-color-white` as the darkest text token
+     and `--sl-color-black` as the lightest surface token in light mode
+     (the names refer to their dark-mode roles; the values flip in light).
+     The mobile sidebar pane and mobile TOC dropdown both paint their
+     background with `--sl-color-black`, so it MUST resolve to a light
+     surface — otherwise we get dark walnut text on a dark walnut panel. */
   --sl-color-white: var(--alc-fg-1);
-  --sl-color-black: var(--alc-fg-1);
+  --sl-color-black: var(--alc-bg-nav);
   --sl-color-gray-1: var(--alc-walnut-900);
   --sl-color-gray-2: var(--alc-walnut-700);
   --sl-color-gray-3: var(--alc-walnut-600);


### PR DESCRIPTION
## Summary
- The website forces `data-theme=\"dark\"` and remaps Starlight's color tokens to the parchment palette. Both `--sl-color-white` and `--sl-color-black` were aliased to `--alc-fg-1` (dark walnut).
- Starlight uses `--sl-color-black` as the **background** of the mobile sidebar pane and mobile \"On this page\" TOC dropdown, so those panels rendered as dark walnut text on a dark walnut surface (unreadable on mobile, fine on desktop).
- Map `--sl-color-black` to `--alc-bg-nav` (lightest nav surface) and leave `--sl-color-white` as `--alc-fg-1` (darkest text). Added a comment explaining the trap so it doesn't regress.

## Test plan
- [x] `bun run dev:site` and load `/getting-started` at mobile width (≤640px)
- [x] Open hamburger sidebar → links readable on parchment, active item highlighted in moss
- [x] Tap \"On this page\" pill → TOC dropdown is light parchment with dark walnut links
- [x] Desktop layout unchanged (sidebar uses `--sl-color-bg-sidebar`, already mapped correctly)

Made with [Cursor](https://cursor.com)