### PR TITLE
chore: repair build failures on main

### DIFF
--- a/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
+++ b/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
@@ -240,11 +240,6 @@ export interface ContainerApplicationProps extends PlatformProps {
    * Exports passed to the container runtime.
    */
   exports?: string[];
-  /**
-   * Module specifiers to exclude from the bundle and leave as external imports.
-   * Useful for native addons or packages that cannot be bundled (e.g. `sharp`, `impit`).
-   */
-  external?: string[];
 }
 
 export type ContainerServices =

--- a/packages/alchemy/src/Cloudflare/Queue/Queue.ts
+++ b/packages/alchemy/src/Cloudflare/Queue/Queue.ts
@@ -4,7 +4,7 @@ import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
-import { Account } from "../Account.ts";
+import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { Providers } from "../Providers.ts";
 import { QueueBinding } from "./QueueBinding.ts";
 
@@ -65,7 +65,7 @@ export const QueueProvider = () =>
   Provider.effect(
     Queue,
     Effect.gen(function* () {
-      const accountId = yield* Account;
+      const { accountId } = yield* CloudflareEnvironment;
       const createQueue = yield* queues.createQueue;
       const getQueue = yield* queues.getQueue;
       const updateQueue = yield* queues.updateQueue;

--- a/packages/alchemy/src/Cloudflare/Queue/QueueConsumer.ts
+++ b/packages/alchemy/src/Cloudflare/Queue/QueueConsumer.ts
@@ -3,7 +3,7 @@ import * as Effect from "effect/Effect";
 import { isResolved } from "../../Diff.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
-import { Account } from "../Account.ts";
+import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { Providers } from "../Providers.ts";
 
 export type QueueConsumerProps = {
@@ -101,7 +101,7 @@ export const QueueConsumerProvider = () =>
   Provider.effect(
     QueueConsumer,
     Effect.gen(function* () {
-      const accountId = yield* Account;
+      const { accountId } = yield* CloudflareEnvironment;
       const createConsumer = yield* queues.createConsumer;
       const getConsumer = yield* queues.getConsumer;
       const updateConsumer = yield* queues.updateConsumer;


### PR DESCRIPTION
## Summary

Fixes the broken `tsc -b` build on `main` ([failed run](https://github.com/alchemy-run/alchemy-effect/actions/runs/24765251707/job/72457982381)).

- Remove duplicate `external?: string[]` declaration in `ContainerApplicationProps` (TS2300). The earlier declaration carries the canonical JSDoc and is the one already wired up.
- Replace non-existent `../Account.ts` import in `Queue` and `QueueConsumer` with `CloudflareEnvironment`, matching the pattern used by `R2Bucket`, `KVNamespace`, `D1Database`, etc. This also resolves the cascading TS2345 errors where `Provider.effect` was inferring an `unknown` requirements channel because the missing import poisoned the inferred type.

## Test plan

- [x] `bun run build` passes locally in `packages/alchemy` (both `tsc -b` and `bun bundle`).
- [ ] CI green on this PR.


Made with [Cursor](https://cursor.com)