### PR TITLE
fix(Cloudflare): set rolldown resolve.conditionNames for bun/node in container bundle

### DIFF
--- a/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
+++ b/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
@@ -496,6 +496,12 @@ export const ContainerProvider = () =>
                 ...external,
               ],
               platform: "node",
+              resolve: {
+                conditionNames:
+                  runtime === "bun"
+                    ? ["bun", "import", "module", "default"]
+                    : ["node", "import", "module", "default"],
+              },
               plugins,
               treeshake: true,
             },


### PR DESCRIPTION
## Problem

Rolldown's default resolve conditions are `["import", "module", "default"]`. Alchemy's `package.json` maps subpaths like `./Http`, `./Stack`, `./Cloudflare` under the `"bun"` condition.

When bundling a container with `runtime: "bun"`, subpath imports like `alchemy/Http` injected by the virtual entry plugin fail to resolve, get emitted as bare externals, and the container crashes at boot:

```
Error: Cannot find module 'alchemy/Http'
```

## Fix

Set `resolve.conditionNames` on the `Bundle.build` call based on the selected runtime:

- `bun`:  `["bun", "import", "module", "default"]`
- `node`: `["node", "import", "module", "default"]`

## Scope

One-line addition inside `ContainerProvider` in `ContainerApplication.ts`. Mirrors the pattern used for the `external` array (already branches on `runtime`).