### PR TITLE
fix(cloudflare): infer worker service bindings

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
@@ -10,9 +10,15 @@ export type InferEnv<W> = W extends
   | Worker<infer Bindings>
   | Effect.Effect<Worker<infer Bindings>, any, any>
   ? {
-      [K in keyof Bindings]: GetBindingType<UnwrapEffect<Bindings[K]>>;
+      [K in keyof Bindings]: GetBindingType<UnwrapBinding<Bindings[K]>>;
     }
   : never;
+
+type UnwrapBinding<T> = T extends {
+  asEffect(): Effect.Effect<infer A, any, any>;
+}
+  ? A
+  : UnwrapEffect<T>;
 
 type GetBindingType<T> = T extends Cloudflare.Assets
   ? Service
@@ -24,6 +30,8 @@ type GetBindingType<T> = T extends Cloudflare.Assets
         ? KVNamespace
         : T extends Cloudflare.Queue
           ? Queue<unknown>
-          : T extends Cloudflare.DurableObjectNamespaceLike
-            ? DurableObjectNamespace<Exclude<T["Shape"], undefined>>
-            : never;
+          : T extends Cloudflare.Worker
+            ? Fetcher
+            : T extends Cloudflare.DurableObjectNamespaceLike
+              ? DurableObjectNamespace<Exclude<T["Shape"], undefined>>
+              : never;

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -183,29 +183,56 @@ export type WorkerBindingResource =
   | D1Database
   | KVNamespace
   | CloudflareQueue
-  | DurableObjectNamespaceLike<any>;
+  | DurableObjectNamespaceLike<any>
+  | Worker<any>;
+
+type WorkerBindingInput =
+  | WorkerBindingResource
+  | Effect.Effect<WorkerBindingResource, any, any>
+  | WorkerBindingEffectClass;
+
+type WorkerBindingEffectClass = {
+  asEffect(): Effect.Effect<WorkerBindingResource, any, any>;
+};
+
+const isWorkerBindingEffectClass = (
+  binding: WorkerBindingInput,
+): binding is WorkerBindingEffectClass =>
+  (typeof binding === "object" || typeof binding === "function") &&
+  binding !== null &&
+  "asEffect" in binding &&
+  typeof binding.asEffect === "function";
 
 export type WorkerBindings = {
   [bindingName in string]: WorkerBindingResource;
 };
 
 export type WorkerBindingProps = {
-  [bindingName in string]:
-    | WorkerBindingResource
-    | Effect.Effect<WorkerBindingResource, any, any>;
+  [bindingName in string]: WorkerBindingInput;
 };
+
+type UnwrapWorkerBindingInput<T> =
+  T extends Effect.Effect<
+    infer Resource extends WorkerBindingResource,
+    any,
+    any
+  >
+    ? Resource
+    : T extends {
+          asEffect(): Effect.Effect<
+            infer Resource extends WorkerBindingResource,
+            any,
+            any
+          >;
+        }
+      ? Resource
+      : Extract<T, WorkerBindingResource>;
 
 type NormalizedBindings<
   Bindings extends WorkerBindingProps = {},
   AssetsConfig extends WorkerAssetsConfig | undefined = undefined,
 > = {
-  [B in keyof Bindings]: Bindings[B] extends Effect.Effect<
-    infer T extends WorkerBindingResource,
-    any,
-    any
-  >
-    ? T
-    : Extract<Bindings[B], WorkerBindingResource>;
+  [B in keyof Bindings]: UnwrapWorkerBindingInput<Bindings[B]>;
 } & (undefined extends AssetsConfig ? {} : { ASSETS: Assets });
 
 export type WorkerAssetsConfig = string | AssetsProps | AssetsWithHash;
@@ -653,12 +680,12 @@ export const Worker: Platform<
     if (props.bindings) {
       for (const bindingName in props.bindings) {
         // @ts-expect-error
-        const bindingEff = props.bindings?.[bindingName] as
-          | WorkerBindingResource
-          | Effect.Effect<WorkerBindingResource>;
-        const binding = Effect.isEffect(bindingEff)
-          ? yield* bindingEff
-          : bindingEff;
+        const bindingEff = props.bindings?.[bindingName] as WorkerBindingInput;
+        const binding: WorkerBindingResource = Effect.isEffect(bindingEff)
+          ? yield* bindingEff as Effect.Effect<WorkerBindingResource>
+          : isWorkerBindingEffectClass(bindingEff)
+            ? yield* bindingEff.asEffect() as Effect.Effect<WorkerBindingResource>
+            : bindingEff;
 
         const bindingMeta: InputProps<WorkerBinding> | undefined = isAssets(
           binding,
@@ -673,37 +700,43 @@ export const Worker: Platform<
                 name: bindingName,
                 className: binding.className ?? binding.name,
               }
-            : binding.Type === "Cloudflare.D1Database"
+            : isWorker(binding)
               ? {
-                  type: "d1",
-                  id: binding.databaseId,
+                  type: "service",
                   name: bindingName,
+                  service: binding.workerName,
                 }
-              : binding.Type === "Cloudflare.R2Bucket"
+              : binding.Type === "Cloudflare.D1Database"
                 ? {
-                    type: "r2_bucket",
+                    type: "d1",
+                    id: binding.databaseId,
                     name: bindingName,
-                    bucketName: binding.bucketName,
-                    jurisdiction: binding.jurisdiction.pipe(
-                      Output.map((jurisdiction) =>
-                        jurisdiction === "default" ? undefined : jurisdiction,
-                      ),
-                    ),
                   }
-                : binding.Type === "Cloudflare.KVNamespace"
+                : binding.Type === "Cloudflare.R2Bucket"
                   ? {
-                      type: "kv_namespace",
+                      type: "r2_bucket",
                       name: bindingName,
-                      namespaceId: binding.namespaceId,
+                      bucketName: binding.bucketName,
+                      jurisdiction: binding.jurisdiction.pipe(
+                        Output.map((jurisdiction) =>
+                          jurisdiction === "default" ? undefined : jurisdiction,
+                        ),
+                      ),
                     }
-                  : binding.Type === "Cloudflare.Queue"
+                  : binding.Type === "Cloudflare.KVNamespace"
                     ? {
-                        type: "queue",
+                        type: "kv_namespace",
                         name: bindingName,
-                        queueName: binding.queueName,
+                        namespaceId: binding.namespaceId,
                       }
-                    : // TODO(sam): handle others
-                      undefined;
+                    : binding.Type === "Cloudflare.Queue"
+                      ? {
+                          type: "queue",
+                          name: bindingName,
+                          queueName: binding.queueName,
+                        }
+                      : // TODO(sam): handle others
+                        undefined;
 
         if (bindingMeta) {
           yield* resource.bind`${bindingName}`({

--- a/packages/alchemy/test/types/Api.ts
+++ b/packages/alchemy/test/types/Api.ts
@@ -1,3 +1,5 @@
+/// <reference types="@cloudflare/workers-types" />
+
 import * as Cloudflare from "@/Cloudflare";
 import * as Effect from "effect/Effect";
 import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
@@ -135,3 +137,32 @@ export const Api3Live = Api3.make(
     };
   }),
 );
+
+export class AuthWorker extends Cloudflare.Worker<AuthWorker>()("AuthWorker", {
+  main: import.meta.filename,
+}) {}
+
+export const ViteApp = Cloudflare.Vite<{ AUTH: typeof AuthWorker }>("ViteApp", {
+  rootDir: import.meta.dirname,
+  bindings: {
+    AUTH: AuthWorker,
+  },
+});
+
+type ViteAppEnv = Cloudflare.InferEnv<typeof ViteApp>;
+type Assert<T extends true> = T;
+type IsNever<T> = [T] extends [never] ? true : false;
+type _ViteWorkerBindingIsNotNever = Assert<
+  IsNever<ViteAppEnv["AUTH"]> extends false ? true : false
+>;
+type _ViteWorkerBindingIsFetcher = ViteAppEnv["AUTH"] extends Fetcher
+  ? true
+  : false;
+type _ViteWorkerBindingAcceptsFetcher = Assert<_ViteWorkerBindingIsFetcher>;
+type _InferEnvWorkerBindingIsFetcher = Cloudflare.InferEnv<
+  Cloudflare.Worker<{ AUTH: Cloudflare.Worker<{}> }>
+>["AUTH"] extends Fetcher
+  ? true
+  : false;
+type _InferEnvWorkerBindingAcceptsFetcher =
+  Assert<_InferEnvWorkerBindingIsFetcher>;


### PR DESCRIPTION
Fixes #95 

## Summary
- allow Cloudflare Worker resources as Vite/plain Worker service bindings
- infer Worker bindings as Cloudflare Fetcher in InferEnv
- add a type fixture covering the Vite + auth Worker setup