### PR TITLE
feat(cli): add alchemy profile clear command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,27 +1,25 @@
 name: Deploy Website
 
 on:
-  workflow_dispatch:
-    # TODO(sam): re-enable
-    # push:
-    #   branches:
-    #     - main
-    #   paths:
-    #     - "website/**"
-    #     - "packages/alchemy/**"
-    #     - "bun.lock"
-    #     - ".github/workflows/deploy.yml"
-    # pull_request:
-    #   types:
-    #     - opened
-    #     - reopened
-    #     - synchronize
-    #     - closed
-    #   paths:
-    #     - "website/**"
-    #     - "packages/alchemy/**"
-    #     - "bun.lock"
-    #     - ".github/workflows/deploy.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "website/**"
+      - "packages/alchemy/**"
+      - "bun.lock"
+      - ".github/workflows/deploy.yml"
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+    paths:
+      - "website/**"
+      - "packages/alchemy/**"
+      - "bun.lock"
+      - ".github/workflows/deploy.yml"
 
 concurrency:
   group: deploy-website-${{ github.ref }}
@@ -52,8 +50,8 @@ jobs:
         working-directory: website
         run: bun alchemy deploy --stage ${{ env.STAGE }}
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ env.STAGE == 'prod' && secrets.PROD_CLOUDFLARE_API_TOKEN || secrets.TEST_CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ env.STAGE == 'prod' && secrets.PROD_CLOUDFLARE_ACCOUNT_ID || secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
           PULL_REQUEST: ${{ github.event.number }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -85,6 +83,6 @@ jobs:
         working-directory: website
         run: bun alchemy destroy --stage ${{ env.STAGE }}
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
           PULL_REQUEST: ${{ github.event.number }}

--- a/packages/alchemy/bin/cli.js
+++ b/packages/alchemy/bin/cli.js
@@ -21,24 +21,26 @@
 //
 // foreground-child forwards stdio + signals and exits with the child's code,
 // so the launcher is transparent to the invoking shell / npm script.
-import { existsSync } from "node:fs";
-import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 import path from "pathe";
 import { foregroundChild } from "foreground-child";
-
-const require = createRequire(import.meta.url);
 
 const execpath = (process.env.npm_execpath ?? "").toLowerCase();
 const userAgent = (process.env.npm_config_user_agent ?? "").toLowerCase();
 const invokedByBun = execpath.includes("bun") || userAgent.startsWith("bun/");
 
-const jsEntry = require.resolve("alchemy/bin/alchemy.js");
-const binDir = path.dirname(jsEntry);
+// Derive the bin dir from this launcher's own location rather than
+// require.resolve("alchemy/bin/alchemy.js"). The bundled alchemy.js is a
+// build artifact (tsdown output) and may not exist in a fresh checkout
+// (e.g. CI before `bun run build`); resolving it would throw
+// MODULE_NOT_FOUND before we get a chance to fall back to the .ts source.
+const binDir = path.dirname(fileURLToPath(import.meta.url));
+const jsEntry = path.join(binDir, "alchemy.js");
 const tsEntry = path.join(binDir, "alchemy.ts");
 
 // Treat any install-tree path as published; only a raw checkout uses .ts.
 const useTs = !(
-  jsEntry.includes("/node_modules/") || jsEntry.includes("\\node_modules\\")
+  binDir.includes("/node_modules/") || binDir.includes("\\node_modules\\")
 );
 
 // .ts only runs under bun. Force bun in dev even if node was the invoker.

--- a/packages/alchemy/bin/commands/profile.ts
+++ b/packages/alchemy/bin/commands/profile.ts
@@ -6,7 +6,9 @@ import * as Logger from "effect/Logger";
 import { Command } from "effect/unstable/cli";
 
 import { AuthProviders } from "../../src/Auth/AuthProvider.ts";
+import { deleteProfileCredentials } from "../../src/Auth/Credentials.ts";
 import {
+  deleteProfile,
   getProfile,
   readConfig,
   withProfileOverride,
@@ -81,6 +83,24 @@ const showCommand = Command.make(
   }),
 );
 
+const clearCommand = Command.make(
+  "clear",
+  { profile },
+  Effect.fnUntraced(function* ({ profile }) {
+    const removed = yield* deleteProfile(profile);
+    yield* deleteProfileCredentials(profile);
+    if (removed) {
+      yield* Console.log(
+        `Cleared profile '${profile}' and all its credentials.`,
+      );
+    } else {
+      yield* Console.log(
+        `Profile '${profile}' not found in profiles.json; removed any stray credentials directory.`,
+      );
+    }
+  }),
+);
+
 export const profileCommand = Command.make("profile", {}).pipe(
-  Command.withSubcommands([showCommand]),
+  Command.withSubcommands([showCommand, clearCommand]),
 );

--- a/packages/alchemy/src/Auth/Credentials.ts
+++ b/packages/alchemy/src/Auth/Credentials.ts
@@ -6,8 +6,11 @@ import { rootDir } from "./Profile.ts";
 
 const credentialsDirPath = path.join(rootDir, "credentials");
 
+export const profileCredentialsDirPath = (profile: string) =>
+  path.join(credentialsDirPath, profile);
+
 export const credentialsFilePath = (profile: string, provider: string) =>
-  path.join(credentialsDirPath, profile, `${provider}.json`);
+  path.join(profileCredentialsDirPath(profile), `${provider}.json`);
 
 export const readCredentials = Effect.fnUntraced(function* <T>(
   profile: string,
@@ -43,6 +46,19 @@ export const deleteCredentials = Effect.fnUntraced(function* (
   const fs = yield* FileSystem.FileSystem;
   yield* fs
     .remove(credentialsFilePath(profile, provider))
+    .pipe(Effect.catch(() => Effect.void));
+});
+
+/**
+ * Recursively remove the `~/.alchemy/credentials/{profile}` directory
+ * containing all per-provider secrets for `profile`. No-op if it doesn't exist.
+ */
+export const deleteProfileCredentials = Effect.fnUntraced(function* (
+  profile: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs
+    .remove(profileCredentialsDirPath(profile), { recursive: true })
     .pipe(Effect.catch(() => Effect.void));
 });
 

--- a/packages/alchemy/src/Auth/Profile.ts
+++ b/packages/alchemy/src/Auth/Profile.ts
@@ -92,6 +92,21 @@ export const setProfile = (name: string, profile: AlchemyProfile) =>
   );
 
 /**
+ * Remove `name` and all its provider credentials from the on-disk config.
+ * Returns `true` if the profile existed and was removed, `false` otherwise.
+ */
+export const deleteProfile = (name: string) =>
+  readConfig.pipe(
+    Effect.flatMap((config) => {
+      if (!(name in config.profiles)) {
+        return Effect.succeed(false);
+      }
+      delete config.profiles[name];
+      return writeConfig(config).pipe(Effect.as(true));
+    }),
+  );
+
+/**
  * Returns a `ConfigProvider` that overrides `ALCHEMY_PROFILE` with the
  * given `profile` (when explicitly passed via the CLI `--profile` flag),
  * falling through to `base` for everything else.

--- a/packages/alchemy/test/Output.test.ts
+++ b/packages/alchemy/test/Output.test.ts
@@ -1,46 +1,570 @@
 import * as Output from "@/Output";
+import { ref as makeRef } from "@/Ref";
+import type { ResourceLike } from "@/Resource";
+import { Stack } from "@/Stack";
+import { Stage } from "@/Stage";
 import { inMemoryState } from "@/State/InMemoryState";
+import type { ResourceState } from "@/State/ResourceState";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
 
 const provideState = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   effect.pipe(Effect.provide(inMemoryState()));
 
+const fakeResource = <T extends string, A extends object>(
+  type: T,
+  fqn: string,
+  logicalId: string = fqn,
+): ResourceLike<T, any, A> =>
+  ({
+    Type: type,
+    FQN: fqn,
+    LogicalId: logicalId,
+    Namespace: undefined,
+  }) as any;
+
 describe("Output.evaluate", () => {
-  it.effect("preserves Redacted values at the top level", () =>
-    provideState(
+  describe("primitives and plain values", () => {
+    it.effect("returns primitive values as-is", () =>
+      provideState(
+        Effect.gen(function* () {
+          expect(yield* Output.evaluate(42, {})).toBe(42);
+          expect(yield* Output.evaluate("hello", {})).toBe("hello");
+          expect(yield* Output.evaluate(true, {})).toBe(true);
+          expect(yield* Output.evaluate(null, {})).toBe(null);
+          expect(yield* Output.evaluate(undefined, {})).toBe(undefined);
+        }),
+      ),
+    );
+
+    it.effect("recursively evaluates plain objects", () =>
+      provideState(
+        Effect.gen(function* () {
+          const result = yield* Output.evaluate({ a: 1, b: { c: "x" } }, {});
+          expect(result).toEqual({ a: 1, b: { c: "x" } });
+        }),
+      ),
+    );
+
+    it.effect("recursively evaluates arrays", () =>
+      provideState(
+        Effect.gen(function* () {
+          const result = yield* Output.evaluate([1, "two", { k: 3 }], {});
+          expect(result).toEqual([1, "two", { k: 3 }]);
+        }),
+      ),
+    );
+  });
+
+  describe("Redacted", () => {
+    it.effect("preserves Redacted values at the top level", () =>
+      provideState(
+        Effect.gen(function* () {
+          const secret = Redacted.make("hunter2");
+          const result = yield* Output.evaluate(secret, {});
+          expect(Redacted.isRedacted(result)).toBe(true);
+          expect(Redacted.value(result as Redacted.Redacted<string>)).toBe(
+            "hunter2",
+          );
+        }),
+      ),
+    );
+
+    it.effect("preserves Redacted values nested inside an object", () =>
+      provideState(
+        Effect.gen(function* () {
+          const secret = Redacted.make("hunter2");
+          const result = yield* Output.evaluate(
+            { value: secret, name: "x" },
+            {},
+          );
+          expect(result.name).toBe("x");
+          expect(Redacted.isRedacted(result.value)).toBe(true);
+          expect(Redacted.value(result.value)).toBe("hunter2");
+        }),
+      ),
+    );
+
+    it.effect("preserves Redacted values nested inside an array", () =>
+      provideState(
+        Effect.gen(function* () {
+          const secret = Redacted.make("hunter2");
+          const [result] = yield* Output.evaluate([secret], {});
+          expect(Redacted.isRedacted(result)).toBe(true);
+          expect(Redacted.value(result)).toBe("hunter2");
+        }),
+      ),
+    );
+  });
+
+  describe("LiteralExpr", () => {
+    it.effect("evaluates Output.literal(value)", () =>
+      provideState(
+        Effect.gen(function* () {
+          const expr = Output.literal("foo");
+          expect(yield* Output.evaluate(expr, {})).toBe("foo");
+        }),
+      ),
+    );
+
+    it.effect("evaluates a literal nested within an object", () =>
+      provideState(
+        Effect.gen(function* () {
+          const result = yield* Output.evaluate(
+            { greeting: Output.literal("hi") },
+            {},
+          );
+          expect(result).toEqual({ greeting: "hi" });
+        }),
+      ),
+    );
+  });
+
+  describe("ResourceExpr", () => {
+    it.effect("resolves to the upstream value keyed by FQN", () =>
+      provideState(
+        Effect.gen(function* () {
+          const src = fakeResource("Test.Bucket", "MyBucket");
+          const expr = Output.of(src);
+          const result = yield* Output.evaluate(expr, {
+            MyBucket: { name: "my-bucket" },
+          });
+          expect(result).toEqual({ name: "my-bucket" });
+        }),
+      ),
+    );
+
+    it.effect("fails with MissingSourceError when upstream is absent", () =>
+      provideState(
+        Effect.gen(function* () {
+          const src = fakeResource("Test.Bucket", "Missing");
+          const expr = Output.of(src);
+          const exit = yield* Effect.exit(Output.evaluate(expr, {}));
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (Exit.isFailure(exit)) {
+            const failure = exit.cause.toJSON() as any;
+            expect(JSON.stringify(failure)).toContain("MissingSourceError");
+          }
+        }),
+      ),
+    );
+
+    it.effect("evaluates a raw resource (isResource branch)", () =>
+      provideState(
+        Effect.gen(function* () {
+          const src = fakeResource("Test.Bucket", "RawBucket");
+          const result = yield* Output.evaluate(src as any, {
+            RawBucket: { ok: true },
+          });
+          expect(result).toEqual({ ok: true });
+        }),
+      ),
+    );
+
+    it.effect("raw resource with missing upstream fails", () =>
+      provideState(
+        Effect.gen(function* () {
+          const src = fakeResource("Test.Bucket", "Gone");
+          const exit = yield* Effect.exit(Output.evaluate(src as any, {}));
+          expect(Exit.isFailure(exit)).toBe(true);
+        }),
+      ),
+    );
+  });
+
+  describe("PropExpr", () => {
+    it.effect("accesses a property on a resource expression", () =>
+      provideState(
+        Effect.gen(function* () {
+          const src = fakeResource<"Test.Bucket", { name: string }>(
+            "Test.Bucket",
+            "B",
+          );
+          const expr = Output.of(src) as any;
+          const result = yield* Output.evaluate(expr.name, {
+            B: { name: "the-name" },
+          });
+          expect(result).toBe("the-name");
+        }),
+      ),
+    );
+
+    it.effect("returns undefined when accessing missing property", () =>
+      provideState(
+        Effect.gen(function* () {
+          const src = fakeResource("Test.Bucket", "B2");
+          const expr = Output.of(src) as any;
+          const result = yield* Output.evaluate(expr.missing, {
+            B2: { other: 1 },
+          });
+          expect(result).toBeUndefined();
+        }),
+      ),
+    );
+
+    it.effect("supports nested property access", () =>
+      provideState(
+        Effect.gen(function* () {
+          const src = fakeResource("Test.Bucket", "B3");
+          const expr = Output.of(src) as any;
+          const result = yield* Output.evaluate(expr.nested.deep, {
+            B3: { nested: { deep: "value" } },
+          });
+          expect(result).toBe("value");
+        }),
+      ),
+    );
+  });
+
+  describe("ApplyExpr (map)", () => {
+    it.effect("applies a synchronous function over a literal", () =>
+      provideState(
+        Effect.gen(function* () {
+          const expr = Output.map(Output.literal(2), (n) => n * 3);
+          expect(yield* Output.evaluate(expr, {})).toBe(6);
+        }),
+      ),
+    );
+
+    it.effect("composes multiple maps", () =>
+      provideState(
+        Effect.gen(function* () {
+          const expr = Output.literal(2).pipe(
+            Output.map((n: number) => n + 1),
+            Output.map((n: number) => n * 10),
+          );
+          expect(yield* Output.evaluate(expr, {})).toBe(30);
+        }),
+      ),
+    );
+
+    it.effect("maps over a resource attribute", () =>
+      provideState(
+        Effect.gen(function* () {
+          const src = fakeResource("Test.Bucket", "B4");
+          const expr = (Output.of(src) as any).name.pipe(
+            Output.map((s: string) => s.toUpperCase()),
+          );
+          const result = yield* Output.evaluate(expr, {
+            B4: { name: "abc" },
+          });
+          expect(result).toBe("ABC");
+        }),
+      ),
+    );
+  });
+
+  describe("EffectExpr (mapEffect)", () => {
+    it.effect("evaluates an effectful transformation", () =>
+      provideState(
+        Effect.gen(function* () {
+          const expr = Output.literal(5).pipe(
+            Output.mapEffect((n: number) => Effect.succeed(n * 2)),
+          );
+          expect(yield* Output.evaluate(expr, {})).toBe(10);
+        }),
+      ),
+    );
+
+    it.effect("chains multiple effectful transformations", () =>
+      provideState(
+        Effect.gen(function* () {
+          const expr = Output.literal("a").pipe(
+            Output.mapEffect((s: string) => Effect.succeed(s + "b")),
+            Output.mapEffect((s) => Effect.succeed(s + "c")),
+          );
+          expect(yield* Output.evaluate(expr, {})).toBe("abc");
+        }),
+      ),
+    );
+  });
+
+  describe("AllExpr", () => {
+    it.effect("evaluates all wrapped outputs in parallel", () =>
+      provideState(
+        Effect.gen(function* () {
+          const expr = Output.all(
+            Output.literal(1),
+            Output.literal("two"),
+            Output.literal(true),
+          );
+          const result = yield* Output.evaluate(expr, {});
+          expect(result).toEqual([1, "two", true]);
+        }),
+      ),
+    );
+
+    it.effect("evaluates all with resource expressions", () =>
+      provideState(
+        Effect.gen(function* () {
+          const a = fakeResource("Test.A", "A");
+          const b = fakeResource("Test.B", "B");
+          const expr = Output.all(Output.of(a), Output.of(b));
+          const result = yield* Output.evaluate(expr, {
+            A: { x: 1 },
+            B: { y: 2 },
+          });
+          expect(result).toEqual([{ x: 1 }, { y: 2 }]);
+        }),
+      ),
+    );
+  });
+
+  describe("RefExpr", () => {
+    const provideStackStage = <A, E, R>(
+      effect: Effect.Effect<A, E, R>,
+      stack = "myStack",
+      stage = "myStage",
+    ) =>
+      effect.pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(Stack, { name: stack } as any),
+            Layer.succeed(Stage, stage),
+          ),
+        ),
+      );
+
+    it.effect("resolves a Ref against in-memory state", () =>
       Effect.gen(function* () {
-        const secret = Redacted.make("hunter2");
-        const result = yield* Output.evaluate(secret, {});
-        expect(Redacted.isRedacted(result)).toBe(true);
-        expect(Redacted.value(result as Redacted.Redacted<string>)).toBe(
-          "hunter2",
+        const initial = {
+          myStack: {
+            myStage: {
+              myResource: {
+                fqn: "myResource",
+                attr: { hello: "world" },
+              } as unknown as ResourceState,
+            },
+          },
+        };
+        const r = makeRef<ResourceLike>({ id: "myResource" });
+        const expr = Output.of(r);
+        const result = yield* provideStackStage(
+          Output.evaluate(expr, {}).pipe(
+            Effect.provide(inMemoryState(initial)),
+          ),
         );
+        expect(result).toEqual({ hello: "world" });
+      }),
+    );
+
+    it.effect("uses explicit stack/stage when provided on the ref", () =>
+      Effect.gen(function* () {
+        const initial = {
+          otherStack: {
+            otherStage: {
+              someResource: {
+                fqn: "someResource",
+                attr: { v: 1 },
+              } as unknown as ResourceState,
+            },
+          },
+        };
+        const r = makeRef<ResourceLike>({
+          id: "someResource",
+          stack: "otherStack",
+          stage: "otherStage",
+        });
+        const expr = Output.of(r);
+        // No Stack/Stage layers needed since the ref carries them.
+        const result = yield* Output.evaluate(expr, {}).pipe(
+          Effect.provide(inMemoryState(initial)),
+        );
+        expect(result).toEqual({ v: 1 });
+      }),
+    );
+
+    it.effect(
+      "fails with InvalidReferenceError when ref target is missing",
+      () =>
+        Effect.gen(function* () {
+          const r = makeRef<ResourceLike>({
+            id: "ghost",
+            stack: "s",
+            stage: "t",
+          });
+          const expr = Output.of(r);
+          const exit = yield* Effect.exit(
+            Output.evaluate(expr, {}).pipe(Effect.provide(inMemoryState())),
+          );
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (Exit.isFailure(exit)) {
+            expect(JSON.stringify(exit.cause.toJSON())).toContain(
+              "InvalidReferenceError",
+            );
+          }
+        }),
+    );
+  });
+
+  describe("composition", () => {
+    it.effect("evaluates outputs nested inside arrays and objects", () =>
+      provideState(
+        Effect.gen(function* () {
+          const a = fakeResource("Test.A", "RA");
+          const b = fakeResource("Test.B", "RB");
+          const value = {
+            list: [Output.of(a), Output.literal("lit")],
+            nested: {
+              prop: (Output.of(b) as any).name.pipe(
+                Output.map((s: string) => `name=${s}`),
+              ),
+            },
+            scalar: 42,
+          };
+          const result = yield* Output.evaluate(value, {
+            RA: { foo: "f" },
+            RB: { name: "bee" },
+          });
+          expect(result).toEqual({
+            list: [{ foo: "f" }, "lit"],
+            nested: { prop: "name=bee" },
+            scalar: 42,
+          });
+        }),
+      ),
+    );
+  });
+});
+
+describe("Output.interpolate", () => {
+  it.effect("interpolates literal values into a template", () =>
+    provideState(
+      Effect.gen(function* () {
+        const expr = Output.interpolate`hello ${Output.literal("world")}!`;
+        expect(yield* Output.evaluate(expr, {})).toBe("hello world!");
       }),
     ),
   );
 
-  it.effect("preserves Redacted values nested inside an object", () =>
+  it.effect("interpolates resource attributes", () =>
     provideState(
       Effect.gen(function* () {
-        const secret = Redacted.make("hunter2");
-        const result = yield* Output.evaluate({ value: secret, name: "x" }, {});
-        expect(result.name).toBe("x");
-        expect(Redacted.isRedacted(result.value)).toBe(true);
-        expect(Redacted.value(result.value)).toBe("hunter2");
+        const src = fakeResource("Test.Bucket", "Buck");
+        // @ts-expect-error
+        const name = Output.of(src).name;
+        const expr = Output.interpolate`s3://${name}/key`;
+        const result = yield* Output.evaluate(expr, {
+          Buck: { name: "my-bucket" },
+        });
+        expect(result).toBe("s3://my-bucket/key");
       }),
     ),
   );
 
-  it.effect("preserves Redacted values nested inside an array", () =>
+  it.effect("renders nullish args as empty strings", () =>
     provideState(
       Effect.gen(function* () {
-        const secret = Redacted.make("hunter2");
-        const [result] = yield* Output.evaluate([secret], {});
-        expect(Redacted.isRedacted(result)).toBe(true);
-        expect(Redacted.value(result)).toBe("hunter2");
+        const expr = Output.interpolate`a${Output.literal(null)}b${Output.literal(
+          undefined,
+        )}c`;
+        expect(yield* Output.evaluate(expr, {})).toBe("abc");
       }),
     ),
   );
+});
+
+describe("Output.isOutput / isExpr", () => {
+  it("identifies Output expressions", () => {
+    expect(Output.isOutput(Output.literal(1))).toBe(true);
+    expect(Output.isOutput(Output.all(Output.literal(1)))).toBe(true);
+    expect(Output.isExpr(Output.literal(1))).toBe(true);
+  });
+
+  it("rejects non-Output values", () => {
+    expect(Output.isOutput(1)).toBeFalsy();
+    expect(Output.isOutput("x")).toBeFalsy();
+    expect(Output.isOutput(null)).toBeFalsy();
+    expect(Output.isOutput(undefined)).toBeFalsy();
+    expect(Output.isOutput({})).toBeFalsy();
+    expect(Output.isOutput([])).toBeFalsy();
+  });
+});
+
+describe("Output.asOutput", () => {
+  it.effect("wraps a plain value as a literal Output", () =>
+    provideState(
+      Effect.gen(function* () {
+        const o = Output.asOutput("foo");
+        expect(Output.isOutput(o)).toBe(true);
+        expect(yield* Output.evaluate(o, {})).toBe("foo");
+      }),
+    ),
+  );
+
+  it.effect("wraps an Effect as an EffectExpr", () =>
+    provideState(
+      Effect.gen(function* () {
+        const o = Output.asOutput(Effect.succeed(123));
+        expect(Output.isOutput(o)).toBe(true);
+        expect(yield* Output.evaluate(o, {})).toBe(123);
+      }),
+    ),
+  );
+
+  it("returns the same Output if already an Output", () => {
+    const o = Output.literal("x");
+    expect(Output.asOutput(o)).toBe(o);
+  });
+});
+
+describe("Output.upstream / hasOutputs / resolveUpstream", () => {
+  it("returns upstream resources from a ResourceExpr", () => {
+    const src = fakeResource("Test.A", "FQN-A");
+    const expr = Output.of(src);
+    const up = Output.upstream(expr);
+    expect(Object.keys(up)).toEqual(["FQN-A"]);
+  });
+
+  it("returns upstream resources from a PropExpr", () => {
+    const src = fakeResource("Test.A", "FQN-A");
+    const expr = (Output.of(src) as any).foo;
+    expect(Object.keys(Output.upstream(expr))).toEqual(["FQN-A"]);
+  });
+
+  it("merges upstream resources from AllExpr", () => {
+    const a = fakeResource("Test.A", "A");
+    const b = fakeResource("Test.B", "B");
+    const expr = Output.all(Output.of(a), Output.of(b));
+    expect(Object.keys(Output.upstream(expr)).sort()).toEqual(["A", "B"]);
+  });
+
+  it("returns empty upstream for literals", () => {
+    expect(Output.upstream(Output.literal(1))).toEqual({});
+  });
+
+  it("hasOutputs is true when an object contains an Output referencing a resource", () => {
+    const src = fakeResource("Test.A", "X");
+    expect(Output.hasOutputs({ k: Output.of(src) })).toBe(true);
+  });
+
+  it("hasOutputs is false for plain values", () => {
+    expect(Output.hasOutputs({ k: 1, b: "x" })).toBe(false);
+    expect(Output.hasOutputs([1, 2, 3])).toBe(false);
+  });
+
+  it("resolveUpstream walks arrays and objects to gather resources", () => {
+    const a = fakeResource("Test.A", "RA");
+    const b = fakeResource("Test.B", "RB");
+    const result = Output.resolveUpstream({
+      arr: [Output.of(a)],
+      nested: { prop: Output.of(b) },
+      scalar: 1,
+    });
+    expect(Object.keys(result).sort()).toEqual(["RA", "RB"]);
+  });
+});
+
+describe("Output.toEnvKey / toUpper", () => {
+  it("uppercases strings", () => {
+    expect(Output.toUpper("hello")).toBe("HELLO");
+  });
+
+  it("joins id + suffix and replaces dashes with underscores", () => {
+    expect(Output.toEnvKey("my-bucket", "name")).toBe("MY_BUCKET_NAME");
+    expect(Output.toEnvKey("svc", "api-key")).toBe("SVC_API_KEY");
+  });
 });


### PR DESCRIPTION
Adds an `alchemy profile clear` command that wipes a profile's entry from `~/.alchemy/profiles.json` and recursively removes its `~/.alchemy/credentials/{profile}` directory.

```sh
alchemy profile clear                    # clears 'default'
alchemy profile clear --profile staging  # clears 'staging'
```

Made with [Cursor](https://cursor.com)