### PR TITLE
feat(Cloudflare): D1Database migrationsDir, importFiles, and clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean:shallow": "rm -rf alchemy/*.tgz && bun tsc -b --clean",
     "clean": "git clean -fqdx -e .env",
     "dev": "tsc -b -w & bun run --filter alchemy dev",
-    "deploy:website": "cd ./website && bun alchemy deploy",
+    "deploy:website": "cd ./website && bun run build && bun alchemy deploy",
     "deploy:website:prod": "bun deploy:website --stage prod --profile prod",
     "deploy:github": "doppler run -c dev --project alchemy-v2 -- bun alchemy deploy ./stacks/github.ts --profile admin",
     "logs:otel": "doppler run -c dev --project alchemy-v2 -- bun alchemy logs ./stacks/otel.ts",

--- a/packages/alchemy/src/Cloudflare/D1/D1Clone.ts
+++ b/packages/alchemy/src/Cloudflare/D1/D1Clone.ts
@@ -1,0 +1,42 @@
+import * as Effect from "effect/Effect";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import { exportD1Database } from "./D1Export.ts";
+import { importD1Database } from "./D1Import.ts";
+
+export interface CloneD1DatabaseOptions {
+  accountId: string;
+  sourceDatabaseId: string;
+  targetDatabaseId: string;
+}
+
+/**
+ * Clone a D1 database by exporting from the source and importing into the
+ * target. Fetches the SQL dump from the export's signed URL and streams the
+ * payload through the import flow.
+ */
+export const cloneD1Database = (options: CloneD1DatabaseOptions) =>
+  Effect.gen(function* () {
+    const exportResult = yield* exportD1Database({
+      accountId: options.accountId,
+      databaseId: options.sourceDatabaseId,
+    });
+
+    const client = yield* HttpClient.HttpClient;
+    const dumpRes = yield* client
+      .execute(HttpClientRequest.get(exportResult.signedUrl))
+      .pipe(Effect.orDie);
+    if (dumpRes.status < 200 || dumpRes.status >= 300) {
+      return yield* Effect.die(
+        `Failed to fetch D1 export dump (${dumpRes.status})`,
+      );
+    }
+    const sqlData = yield* dumpRes.text.pipe(Effect.orDie);
+
+    return yield* importD1Database({
+      accountId: options.accountId,
+      databaseId: options.targetDatabaseId,
+      sqlData,
+      filename: exportResult.filename,
+    });
+  });

--- a/packages/alchemy/src/Cloudflare/D1/D1Database.ts
+++ b/packages/alchemy/src/Cloudflare/D1/D1Database.ts
@@ -7,6 +7,10 @@ import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { Providers } from "../Providers.ts";
+import { cloneD1Database } from "./D1Clone.ts";
+import { importD1Database } from "./D1Import.ts";
+import { applyMigrations } from "./D1Migrations.ts";
+import { listSqlFiles, readSqlFile } from "./D1SqlFile.ts";
 
 export type Jurisdiction = "default" | "eu" | "fedramp";
 export type PrimaryLocationHint =
@@ -17,6 +21,13 @@ export type PrimaryLocationHint =
   | "apac"
   | "oc";
 
+const DEFAULT_MIGRATIONS_TABLE = "d1_migrations";
+
+export type CloneSource =
+  | D1Database
+  | { databaseId: string }
+  | { name: string };
+
 export type DatabaseProps = {
   /**
    * Name of the database. If omitted, a unique name will be generated.
@@ -24,20 +35,72 @@ export type DatabaseProps = {
    */
   name?: string;
   /**
-   * Optional primary location hint for the database.
+   * Region in which the primary copy of the data is stored. Cannot be
+   * changed after creation — updating this property triggers a replacement.
+   *
+   * - `wnam` — Western North America
+   * - `enam` — Eastern North America
+   * - `weur` — Western Europe
+   * - `eeur` — Eastern Europe
+   * - `apac` — Asia Pacific
+   * - `oc`   — Oceania
    */
   primaryLocationHint?: PrimaryLocationHint;
   /**
-   * Read replication configuration. Only mutable property during updates.
+   * Read replication configuration. The only mutable property after
+   * creation; toggling `mode` triggers an in-place update.
+   *
+   * @default { mode: "disabled" }
    */
   readReplication?: {
     mode: "auto" | "disabled";
   };
   /**
-   * Jurisdiction where data is guaranteed to be stored.
+   * Jurisdiction in which the database data is guaranteed to be stored.
+   * Cannot be changed after creation.
+   *
    * @default "default"
    */
   jurisdiction?: Jurisdiction;
+  /**
+   * Directory containing `.sql` migration files. Files are sorted by their
+   * numeric prefix (e.g. `0001_init.sql`, `0002_add_users.sql`) and applied
+   * in order. Pending migrations are detected on each deploy and applied as
+   * part of `update`. Equivalent to wrangler's `migrations_dir`.
+   */
+  migrationsDir?: string;
+  /**
+   * Name of the table used to track applied migrations. Useful for
+   * compatibility with frameworks that expect a specific name (e.g.
+   * `drizzle_migrations`).
+   *
+   * The table schema is the wrangler-compatible
+   * `(id TEXT PRIMARY KEY, name TEXT, applied_at TEXT)`. A pre-existing
+   * legacy 2-column table is migrated in place.
+   *
+   * @default "d1_migrations"
+   */
+  migrationsTable?: string;
+  /**
+   * Paths to additional `.sql` files to import after migrations are
+   * applied. Each file is uploaded via Cloudflare's D1 import API and
+   * hashed; only files whose contents change are re-imported on subsequent
+   * deploys.
+   *
+   * @see https://developers.cloudflare.com/d1/best-practices/import-export-data/
+   */
+  importFiles?: string[];
+  /**
+   * Clone data from an existing database during creation by exporting the
+   * source and importing it into the new database. Only applied during the
+   * `create` phase.
+   *
+   * Accepts:
+   * - another `D1Database` resource (uses its `databaseId`)
+   * - `{ databaseId }` — clone by explicit UUID
+   * - `{ name }` — look up the source by name and clone it
+   */
+  clone?: CloneSource;
 };
 
 export type D1Database = Resource<
@@ -49,6 +112,10 @@ export type D1Database = Resource<
     jurisdiction: Jurisdiction;
     readReplication: { mode: "auto" | "disabled" } | undefined;
     accountId: string;
+    migrationsDir: string | undefined;
+    migrationsTable: string | undefined;
+    migrationsHashes: Record<string, string>;
+    importHashes: Record<string, string>;
   },
   never,
   Providers
@@ -67,9 +134,92 @@ export type D1Database = Resource<
  * ```
  *
  * @example Database with location hint
+ * The primary copy of the data is stored in the chosen region; reads can be
+ * served closer to users when read replication is enabled.
  * ```typescript
  * const db = yield* Cloudflare.D1Database("my-db", {
  *   primaryLocationHint: "wnam",
+ * });
+ * ```
+ *
+ * @example Database with read replication
+ * Read replication is the only mutable property after creation — toggling it
+ * triggers an update rather than a replacement.
+ * ```typescript
+ * const db = yield* Cloudflare.D1Database("my-db", {
+ *   readReplication: { mode: "auto" },
+ * });
+ * ```
+ *
+ * @example Database in a specific jurisdiction
+ * ```typescript
+ * const db = yield* Cloudflare.D1Database("my-db", {
+ *   jurisdiction: "eu",
+ * });
+ * ```
+ *
+ * @section Migrations
+ * Point `migrationsDir` at a folder of `.sql` files. Files are sorted by
+ * numeric prefix (e.g. `0001_`, `0002_`) and applied in order. Already-applied
+ * migrations are skipped on subsequent deploys; new files are detected
+ * automatically and applied as part of the next update.
+ *
+ * Migration tracking uses the wrangler-compatible
+ * `(id TEXT PRIMARY KEY, name TEXT, applied_at TEXT)` schema. The resource
+ * also detects and upgrades a legacy 2-column tracking table in place if one
+ * already exists.
+ *
+ * @example Apply migrations from a directory
+ * ```typescript
+ * const db = yield* Cloudflare.D1Database("my-db", {
+ *   migrationsDir: "./migrations",
+ * });
+ * ```
+ *
+ * @example Custom migrations table (e.g. for Drizzle)
+ * ```typescript
+ * const db = yield* Cloudflare.D1Database("my-db", {
+ *   migrationsDir: "./migrations",
+ *   migrationsTable: "drizzle_migrations",
+ * });
+ * ```
+ *
+ * @section Importing SQL
+ * Use `importFiles` to seed the database with raw `.sql` files via Cloudflare's
+ * D1 import API. Each file is hashed; only files whose contents change are
+ * re-imported on subsequent deploys.
+ *
+ * @example Seed a database with SQL files
+ * ```typescript
+ * const db = yield* Cloudflare.D1Database("my-db", {
+ *   importFiles: ["./seed/users.sql", "./seed/posts.sql"],
+ * });
+ * ```
+ *
+ * @section Cloning a Database
+ * `clone` performs a full export → import from a source database during
+ * creation. It accepts a `D1Database` resource, a `{ databaseId }`, or a
+ * `{ name }` to look up by name.
+ *
+ * @example Clone by passing the source resource directly
+ * ```typescript
+ * const source = yield* Cloudflare.D1Database("source-db");
+ * const cloned = yield* Cloudflare.D1Database("cloned-db", {
+ *   clone: source,
+ * });
+ * ```
+ *
+ * @example Clone by databaseId
+ * ```typescript
+ * const cloned = yield* Cloudflare.D1Database("cloned-db", {
+ *   clone: { databaseId: "abcdef12-3456-7890-abcd-ef1234567890" },
+ * });
+ * ```
+ *
+ * @example Clone by name
+ * ```typescript
+ * const cloned = yield* Cloudflare.D1Database("cloned-db", {
+ *   clone: { name: "source-db" },
  * });
  * ```
  *
@@ -88,6 +238,8 @@ export type D1Database = Resource<
  *   .bind(newId, name)
  *   .run();
  * ```
+ *
+ * @see https://developers.cloudflare.com/d1/
  */
 export const D1Database = Resource<D1Database>("Cloudflare.D1Database");
 
@@ -101,6 +253,8 @@ export const DatabaseProvider = () =>
       const patchDb = yield* d1.patchDatabase;
       const deleteDb = yield* d1.deleteDatabase;
       const listDbs = yield* d1.listDatabases;
+      // rootDir for resolving relative `importFiles` paths
+      const rootDir = process.cwd();
 
       const createDatabaseName = (id: string, name: string | undefined) =>
         Effect.gen(function* () {
@@ -136,6 +290,34 @@ export const DatabaseProvider = () =>
           if (oldReplicationMode !== newReplicationMode) {
             return { action: "update" } as const;
           }
+          // Detect migration/import file drift.
+          if (news.migrationsDir) {
+            const newHashes = yield* hashMigrations(news.migrationsDir);
+            const oldHashes = output?.migrationsHashes ?? {};
+            if (!recordsEqual(newHashes, oldHashes)) {
+              return { action: "update" } as const;
+            }
+            if (
+              (news.migrationsTable ?? DEFAULT_MIGRATIONS_TABLE) !==
+              (output?.migrationsTable ?? DEFAULT_MIGRATIONS_TABLE)
+            ) {
+              return { action: "update" } as const;
+            }
+          } else if (
+            output?.migrationsHashes &&
+            Object.keys(output.migrationsHashes).length > 0
+          ) {
+            // migrationsDir was removed but state still tracks migrations: nothing
+            // to do remotely (we never un-apply), but no diff needed either.
+          }
+          if (news.importFiles?.length) {
+            const newHashes = yield* hashImports(news.importFiles, rootDir);
+            const oldHashes = output?.importHashes ?? {};
+            if (!recordsEqual(newHashes, oldHashes)) {
+              return { action: "update" } as const;
+            }
+          }
+          return undefined;
         }),
         read: Effect.fn(function* ({ id, output, olds }) {
           if (output?.databaseId) {
@@ -149,6 +331,10 @@ export const DatabaseProvider = () =>
                 jurisdiction: output.jurisdiction,
                 readReplication: db.readReplication ?? undefined,
                 accountId: output.accountId,
+                migrationsDir: output.migrationsDir,
+                migrationsTable: output.migrationsTable,
+                migrationsHashes: output.migrationsHashes,
+                importHashes: output.importHashes,
               })),
               Effect.catchTag("DatabaseNotFound", () =>
                 Effect.succeed(undefined),
@@ -165,6 +351,10 @@ export const DatabaseProvider = () =>
               jurisdiction: (olds?.jurisdiction ?? "default") as Jurisdiction,
               readReplication: olds?.readReplication,
               accountId,
+              migrationsDir: olds?.migrationsDir,
+              migrationsTable: olds?.migrationsTable,
+              migrationsHashes: {},
+              importHashes: {},
             };
           }
           return undefined;
@@ -202,12 +392,49 @@ export const DatabaseProvider = () =>
             });
           }
 
+          if (news.clone) {
+            const sourceId = yield* resolveCloneSource(
+              news.clone,
+              accountId,
+              listDbs,
+            );
+            yield* cloneD1Database({
+              accountId,
+              sourceDatabaseId: sourceId,
+              targetDatabaseId: databaseId,
+            });
+          }
+
+          const migrationsTable =
+            news.migrationsTable ?? DEFAULT_MIGRATIONS_TABLE;
+          const migrationsHashes = news.migrationsDir
+            ? yield* runMigrations(
+                accountId,
+                databaseId,
+                news.migrationsDir,
+                migrationsTable,
+              )
+            : {};
+          const importHashes = news.importFiles?.length
+            ? yield* runImports(
+                accountId,
+                databaseId,
+                news.importFiles,
+                rootDir,
+                {},
+              )
+            : {};
+
           return {
             databaseId,
             databaseName: db.name ?? name,
             jurisdiction,
             readReplication: news.readReplication,
             accountId,
+            migrationsDir: news.migrationsDir,
+            migrationsTable: news.migrationsDir ? migrationsTable : undefined,
+            migrationsHashes,
+            importHashes,
           };
         }),
         update: Effect.fn(function* ({ news = {}, output }) {
@@ -217,12 +444,39 @@ export const DatabaseProvider = () =>
             databaseId: output.databaseId,
             readReplication: { mode: replicationMode },
           });
+
+          const migrationsTable =
+            news.migrationsTable ??
+            output.migrationsTable ??
+            DEFAULT_MIGRATIONS_TABLE;
+          const migrationsHashes = news.migrationsDir
+            ? yield* runMigrations(
+                output.accountId,
+                output.databaseId,
+                news.migrationsDir,
+                migrationsTable,
+              )
+            : output.migrationsHashes;
+          const importHashes = news.importFiles?.length
+            ? yield* runImports(
+                output.accountId,
+                output.databaseId,
+                news.importFiles,
+                rootDir,
+                output.importHashes ?? {},
+              )
+            : {};
+
           return {
             databaseId: updated.uuid ?? output.databaseId,
             databaseName: updated.name ?? output.databaseName,
             jurisdiction: output.jurisdiction,
             readReplication: news.readReplication,
             accountId: output.accountId,
+            migrationsDir: news.migrationsDir,
+            migrationsTable: news.migrationsDir ? migrationsTable : undefined,
+            migrationsHashes,
+            importHashes,
           };
         }),
         delete: Effect.fn(function* ({ output }) {
@@ -234,3 +488,132 @@ export const DatabaseProvider = () =>
       };
     }),
   );
+
+/**
+ * Resolve a clone source spec into a concrete database UUID. Looks up by
+ * name through `listDatabases` when only a name is provided.
+ */
+const resolveCloneSource = (
+  source: CloneSource,
+  accountId: string,
+  listDbs: (input: {
+    accountId: string;
+    name?: string;
+  }) => Effect.Effect<d1.ListDatabasesResponse, d1.ListDatabasesError, never>,
+) =>
+  Effect.gen(function* () {
+    if ("databaseId" in source && source.databaseId) {
+      // At lifecycle time, Output<string> attributes have resolved to strings.
+      return source.databaseId as unknown as string;
+    }
+    if ("name" in source && source.name) {
+      const name = source.name as unknown as string;
+      const dbs = yield* listDbs({ accountId, name });
+      const match = dbs.result.find((db) => db.name === name);
+      if (!match?.uuid) {
+        return yield* Effect.die(
+          `Source database "${name}" not found for cloning`,
+        );
+      }
+      return match.uuid;
+    }
+    return yield* Effect.die(
+      "Invalid clone source: must provide databaseId or name",
+    );
+  });
+
+/**
+ * Read all migration files from `migrationsDir`, run pending migrations,
+ * and return the per-file content hashes for state tracking.
+ */
+const runMigrations = (
+  accountId: string,
+  databaseId: string,
+  migrationsDir: string,
+  migrationsTable: string,
+) =>
+  Effect.gen(function* () {
+    const files = yield* listSqlFiles(migrationsDir);
+    if (files.length > 0) {
+      yield* applyMigrations({
+        accountId,
+        databaseId,
+        migrationsTable,
+        migrationsFiles: files,
+      });
+    }
+    const hashes: Record<string, string> = {};
+    for (const file of files) hashes[file.id] = file.hash;
+    return hashes;
+  });
+
+/**
+ * Read each `importFiles` entry and run it through the D1 import flow,
+ * skipping files whose hash matches the previously-imported hash.
+ */
+const runImports = (
+  accountId: string,
+  databaseId: string,
+  importFiles: ReadonlyArray<string>,
+  rootDir: string,
+  previous: Record<string, string>,
+) =>
+  Effect.gen(function* () {
+    const hashes: Record<string, string> = { ...previous };
+    for (const filePath of importFiles) {
+      const file = yield* readSqlFile(rootDir, filePath);
+      if (previous[filePath] === file.hash) {
+        hashes[filePath] = file.hash;
+        continue;
+      }
+      yield* importD1Database({
+        accountId,
+        databaseId,
+        sqlData: file.sql,
+        filename: file.id,
+      });
+      hashes[filePath] = file.hash;
+    }
+    // Drop entries for files no longer listed.
+    const tracked = new Set(importFiles);
+    for (const key of Object.keys(hashes)) {
+      if (!tracked.has(key)) delete hashes[key];
+    }
+    return hashes;
+  });
+
+/**
+ * Hash all `.sql` files in `migrationsDir` without applying them; used by
+ * `diff` to detect drift relative to previously-applied state.
+ */
+const hashMigrations = (migrationsDir: string) =>
+  listSqlFiles(migrationsDir).pipe(
+    Effect.map((files) => {
+      const hashes: Record<string, string> = {};
+      for (const file of files) hashes[file.id] = file.hash;
+      return hashes;
+    }),
+  );
+
+const hashImports = (importFiles: ReadonlyArray<string>, rootDir: string) =>
+  Effect.gen(function* () {
+    const hashes: Record<string, string> = {};
+    for (const filePath of importFiles) {
+      const file = yield* readSqlFile(rootDir, filePath);
+      hashes[filePath] = file.hash;
+    }
+    return hashes;
+  });
+
+const recordsEqual = (
+  a: Record<string, string>,
+  b: Record<string, string>,
+): boolean => {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const k of aKeys) {
+    if (a[k] !== b[k]) return false;
+  }
+  return true;
+};

--- a/packages/alchemy/src/Cloudflare/D1/D1Export.ts
+++ b/packages/alchemy/src/Cloudflare/D1/D1Export.ts
@@ -1,0 +1,70 @@
+import * as d1 from "@distilled.cloud/cloudflare/d1";
+import * as Effect from "effect/Effect";
+import type * as HttpClient from "effect/unstable/http/HttpClient";
+import type { Credentials } from "@distilled.cloud/cloudflare/Credentials";
+
+export interface ExportD1DatabaseOptions {
+  accountId: string;
+  databaseId: string;
+  dumpOptions?: {
+    tables?: string[];
+    noSchema?: boolean;
+    noData?: boolean;
+  };
+}
+
+export interface ExportD1DatabaseResult {
+  filename: string;
+  signedUrl: string;
+}
+
+/**
+ * Initiates an export of a Cloudflare D1 database and returns a signed
+ * download URL. Recursively polls with the bookmark until the export
+ * completes or fails.
+ */
+export const exportD1Database = (
+  options: ExportD1DatabaseOptions,
+): Effect.Effect<
+  ExportD1DatabaseResult,
+  d1.ExportDatabaseError,
+  Credentials | HttpClient.HttpClient
+> =>
+  Effect.gen(function* () {
+    const exportDb = yield* d1.exportDatabase;
+
+    const poll = (
+      currentBookmark?: string,
+    ): Effect.Effect<
+      ExportD1DatabaseResult,
+      d1.ExportDatabaseError,
+      never
+    > =>
+      Effect.gen(function* () {
+        const data = yield* exportDb({
+          accountId: options.accountId,
+          databaseId: options.databaseId,
+          outputFormat: "polling",
+          currentBookmark,
+          dumpOptions: options.dumpOptions,
+        });
+
+        if (data.status === "complete" && data.result) {
+          if (!data.result.filename || !data.result.signedUrl) {
+            return yield* Effect.die(
+              "D1 export completed but missing filename/signedUrl",
+            );
+          }
+          return {
+            filename: data.result.filename,
+            signedUrl: data.result.signedUrl,
+          };
+        }
+        if (data.status === "error") {
+          return yield* Effect.die(data.error ?? "Error during D1 export");
+        }
+        return yield* poll(data.atBookmark ?? undefined);
+      });
+
+    return yield* poll();
+  });

--- a/packages/alchemy/src/Cloudflare/D1/D1Import.ts
+++ b/packages/alchemy/src/Cloudflare/D1/D1Import.ts
@@ -1,0 +1,156 @@
+import * as d1 from "@distilled.cloud/cloudflare/d1";
+import {
+  Credentials,
+  formatHeaders,
+} from "@distilled.cloud/cloudflare/Credentials";
+import crypto from "node:crypto";
+import * as Effect from "effect/Effect";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+
+export interface ImportD1DatabaseOptions {
+  accountId: string;
+  databaseId: string;
+  sqlData: string | Uint8Array;
+  filename?: string;
+}
+
+export interface ImportD1DatabaseResult {
+  filename: string;
+  numQueries: number;
+}
+
+interface ImportPollingResponse {
+  at_bookmark?: string | null;
+  error?: string | null;
+  filename?: string | null;
+  messages?: string[] | null;
+  result?: {
+    final_bookmark?: string | null;
+    num_queries?: number | null;
+  } | null;
+  status?: "complete" | "error" | null;
+  success?: boolean | null;
+  upload_url?: string | null;
+}
+
+const md5 = (data: string | Uint8Array): string =>
+  crypto.createHash("md5").update(data).digest("hex");
+
+const importEndpoint = (
+  apiBaseUrl: string,
+  accountId: string,
+  databaseId: string,
+) => `${apiBaseUrl}/accounts/${accountId}/d1/database/${databaseId}/import`;
+
+/**
+ * Import SQL into a D1 database via the multi-step Cloudflare flow:
+ *   1. POST `action: "init"` -> returns presigned `upload_url`
+ *   2. PUT raw SQL to `upload_url`
+ *   3. POST `action: "ingest"` -> returns `at_bookmark`
+ *   4. POST `action: "poll"` until `status === "complete"`
+ */
+export const importD1Database = (options: ImportD1DatabaseOptions) =>
+  Effect.gen(function* () {
+    const credentialsEff = yield* Credentials;
+    const credentials = yield* credentialsEff;
+    const authHeaders = formatHeaders(credentials);
+    const url = importEndpoint(
+      credentials.apiBaseUrl,
+      options.accountId,
+      options.databaseId,
+    );
+    const client = yield* HttpClient.HttpClient;
+
+    const postJson = (
+      body: unknown,
+    ): Effect.Effect<ImportPollingResponse, never, never> =>
+      Effect.gen(function* () {
+        const req = HttpClientRequest.post(url).pipe(
+          HttpClientRequest.setHeaders(authHeaders),
+          HttpClientRequest.bodyJsonUnsafe(body),
+        );
+        const res = yield* client.execute(req).pipe(Effect.orDie);
+        if (res.status < 200 || res.status >= 300) {
+          const text = yield* res.text.pipe(Effect.orElseSucceed(() => ""));
+          return yield* Effect.die(
+            `D1 import request failed (${res.status}): ${text}`,
+          );
+        }
+        const text = yield* res.text.pipe(Effect.orDie);
+        const json = JSON.parse(text) as { result: ImportPollingResponse };
+        return json.result;
+      });
+
+    const etag = md5(options.sqlData);
+
+    // Step 1: init via the typed d1 client
+    const initDb = yield* d1.importDatabase;
+    const init = yield* initDb({
+      accountId: options.accountId,
+      databaseId: options.databaseId,
+      action: "init",
+      etag,
+    });
+
+    if (!init.uploadUrl) {
+      return yield* Effect.die(
+        init.error ?? "Failed to get upload URL for D1 import",
+      );
+    }
+    const uploadFilename = options.filename ?? init.filename ?? "import.sql";
+
+    // Step 2: PUT to the presigned upload URL
+    const bytes =
+      typeof options.sqlData === "string"
+        ? new TextEncoder().encode(options.sqlData)
+        : options.sqlData;
+    const putReq = HttpClientRequest.put(init.uploadUrl).pipe(
+      HttpClientRequest.bodyUint8Array(bytes, "application/sql"),
+    );
+    const putRes = yield* client.execute(putReq).pipe(Effect.orDie);
+    if (putRes.status < 200 || putRes.status >= 300) {
+      const text = yield* putRes.text.pipe(Effect.orElseSucceed(() => ""));
+      return yield* Effect.die(
+        `Failed to upload SQL file to D1 (${putRes.status}): ${text}`,
+      );
+    }
+
+    // Step 3: ingest
+    const ingest = yield* postJson({
+      action: "ingest",
+      etag,
+      filename: init.filename,
+    });
+    if (!ingest.at_bookmark) {
+      return yield* Effect.die(
+        ingest.error ?? "Ingest response missing bookmark",
+      );
+    }
+
+    // Step 4: poll until complete
+    const poll = (
+      bookmark: string,
+    ): Effect.Effect<ImportD1DatabaseResult, never, never> =>
+      Effect.gen(function* () {
+        const data = yield* postJson({
+          action: "poll",
+          current_bookmark: bookmark,
+        });
+        if (data.status === "complete" && data.result) {
+          return {
+            filename: data.filename ?? uploadFilename,
+            numQueries: data.result.num_queries ?? 0,
+          };
+        }
+        if (data.status === "error") {
+          return yield* Effect.die(data.error ?? "Error during D1 import");
+        }
+        if (!data.at_bookmark) {
+          return yield* Effect.die("D1 import poll missing bookmark");
+        }
+        return yield* poll(data.at_bookmark);
+      });
+
+    return yield* poll(ingest.at_bookmark);
+  });

--- a/packages/alchemy/src/Cloudflare/D1/D1Migrations.ts
+++ b/packages/alchemy/src/Cloudflare/D1/D1Migrations.ts
@@ -1,0 +1,229 @@
+import * as d1 from "@distilled.cloud/cloudflare/d1";
+import * as Effect from "effect/Effect";
+import type * as HttpClient from "effect/unstable/http/HttpClient";
+import type { Credentials } from "@distilled.cloud/cloudflare/Credentials";
+import type { D1SqlFile } from "./D1SqlFile.ts";
+
+export interface ApplyMigrationsOptions {
+  accountId: string;
+  databaseId: string;
+  migrationsTable: string;
+  migrationsFiles: ReadonlyArray<D1SqlFile>;
+}
+
+interface TableColumn {
+  name: string;
+  type: string;
+  pk: number;
+}
+
+interface SchemaInfo {
+  exists: boolean;
+  hasIdColumn: boolean;
+  hasNameColumn: boolean;
+  isLegacySchema: boolean;
+  columns: TableColumn[];
+}
+
+const executeSQL = (
+  accountId: string,
+  databaseId: string,
+  sql: string,
+): Effect.Effect<
+  d1.QueryDatabaseResponse,
+  d1.QueryDatabaseError,
+  Credentials | HttpClient.HttpClient
+> =>
+  Effect.gen(function* () {
+    const queryDb = yield* d1.queryDatabase;
+    return yield* queryDb({ accountId, databaseId, sql });
+  });
+
+const detectSchema = (
+  accountId: string,
+  databaseId: string,
+  migrationsTable: string,
+) =>
+  Effect.gen(function* () {
+    const result = yield* executeSQL(
+      accountId,
+      databaseId,
+      `PRAGMA table_info(${migrationsTable});`,
+    ).pipe(Effect.option);
+
+    const columns: TableColumn[] = [];
+    if (result._tag === "Some") {
+      const rows = (result.value.result[0]?.results ?? []) as Array<{
+        name: string;
+        type: string;
+        pk: number;
+      }>;
+      for (const row of rows) {
+        columns.push({ name: row.name, type: row.type, pk: row.pk });
+      }
+    }
+
+    if (columns.length === 0) {
+      return {
+        exists: false,
+        hasIdColumn: false,
+        hasNameColumn: false,
+        isLegacySchema: false,
+        columns,
+      } satisfies SchemaInfo;
+    }
+
+    const names = columns.map((c) => c.name);
+    const hasIdColumn = names.includes("id");
+    const hasNameColumn = names.includes("name");
+    const isLegacySchema =
+      columns.length === 2 && !(hasIdColumn && hasNameColumn);
+
+    return {
+      exists: true,
+      hasIdColumn,
+      hasNameColumn,
+      isLegacySchema,
+      columns,
+    } satisfies SchemaInfo;
+  });
+
+const migrateLegacySchema = (
+  accountId: string,
+  databaseId: string,
+  migrationsTable: string,
+  schema: SchemaInfo,
+) =>
+  Effect.gen(function* () {
+    const primaryColumn =
+      schema.columns.find((c) => c.pk === 1)?.name ?? schema.columns[0]?.name;
+    if (!primaryColumn) {
+      return yield* Effect.die(
+        "Cannot migrate legacy migration table: no columns found",
+      );
+    }
+    const tempTable = `${migrationsTable}_temp_migration`;
+    yield* executeSQL(
+      accountId,
+      databaseId,
+      `CREATE TABLE ${tempTable} (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        applied_at TEXT NOT NULL
+      );`,
+    );
+    yield* executeSQL(
+      accountId,
+      databaseId,
+      `INSERT INTO ${tempTable} (id, name, applied_at)
+       SELECT
+         printf('%05d', row_number() OVER (ORDER BY applied_at)) as id,
+         ${primaryColumn} as name,
+         applied_at
+       FROM ${migrationsTable}
+       ORDER BY applied_at;`,
+    );
+    yield* executeSQL(accountId, databaseId, `DROP TABLE ${migrationsTable};`);
+    yield* executeSQL(
+      accountId,
+      databaseId,
+      `ALTER TABLE ${tempTable} RENAME TO ${migrationsTable};`,
+    );
+  });
+
+const ensureMigrationsTable = (
+  accountId: string,
+  databaseId: string,
+  migrationsTable: string,
+) =>
+  Effect.gen(function* () {
+    const schema = yield* detectSchema(accountId, databaseId, migrationsTable);
+    if (!schema.exists) {
+      yield* executeSQL(
+        accountId,
+        databaseId,
+        `CREATE TABLE ${migrationsTable} (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          applied_at TEXT NOT NULL
+        );`,
+      );
+      return;
+    }
+    if (schema.isLegacySchema || !schema.hasIdColumn || !schema.hasNameColumn) {
+      yield* migrateLegacySchema(
+        accountId,
+        databaseId,
+        migrationsTable,
+        schema,
+      );
+    }
+  });
+
+const getAppliedMigrations = (
+  accountId: string,
+  databaseId: string,
+  migrationsTable: string,
+) =>
+  Effect.gen(function* () {
+    const result = yield* executeSQL(
+      accountId,
+      databaseId,
+      `SELECT name FROM ${migrationsTable};`,
+    );
+    const rows = (result.result[0]?.results ?? []) as Array<{ name: string }>;
+    return new Set(rows.map((r) => r.name));
+  });
+
+const getNextSeq = (
+  accountId: string,
+  databaseId: string,
+  migrationsTable: string,
+) =>
+  Effect.gen(function* () {
+    const result = yield* executeSQL(
+      accountId,
+      databaseId,
+      `SELECT id FROM ${migrationsTable} ORDER BY id;`,
+    );
+    const rows = (result.result[0]?.results ?? []) as Array<{ id: string }>;
+    let max = 0;
+    for (const { id } of rows) {
+      if (/^\d+$/.test(id)) {
+        max = Math.max(max, Number.parseInt(id, 10));
+      }
+    }
+    return max + 1;
+  });
+
+/**
+ * Apply pending D1 migrations in order. Uses the wrangler-compatible
+ * 3-column schema `(id TEXT PK, name TEXT, applied_at TEXT)`.
+ */
+export const applyMigrations = (options: ApplyMigrationsOptions) =>
+  Effect.gen(function* () {
+    const { accountId, databaseId, migrationsTable, migrationsFiles } = options;
+    yield* ensureMigrationsTable(accountId, databaseId, migrationsTable);
+    const applied = yield* getAppliedMigrations(
+      accountId,
+      databaseId,
+      migrationsTable,
+    );
+    let nextSeq = yield* getNextSeq(accountId, databaseId, migrationsTable);
+
+    for (const migration of migrationsFiles) {
+      if (applied.has(migration.id)) continue;
+      const migrationId = nextSeq.toString().padStart(5, "0");
+      nextSeq += 1;
+      // D1 over HTTP doesn't support transactions; run migration + record
+      // in a single batched query.
+      yield* executeSQL(
+        accountId,
+        databaseId,
+        [
+          migration.sql,
+          `INSERT INTO ${migrationsTable} (id, name, applied_at) VALUES ('${migrationId}', '${migration.id}', datetime('now'));`,
+        ].join("\n"),
+      );
+    }
+  });

--- a/packages/alchemy/src/Cloudflare/D1/D1SqlFile.ts
+++ b/packages/alchemy/src/Cloudflare/D1/D1SqlFile.ts
@@ -1,0 +1,57 @@
+import crypto from "node:crypto";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+export interface D1SqlFile {
+  id: string;
+  sql: string;
+  hash: string;
+}
+
+/**
+ * Recursively list `.sql` files under `directory`, sorted by their numeric
+ * prefix (e.g. `0001_init.sql`) and then by name.
+ */
+export const listSqlFiles = (directory: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const entries = yield* fs.readDirectory(directory, { recursive: true });
+
+    const sqlFiles = entries
+      .filter((name) => name.endsWith(".sql"))
+      .sort((a, b) => {
+        const aNum = getPrefix(a);
+        const bNum = getPrefix(b);
+        if (aNum !== null && bNum !== null) return aNum - bNum;
+        if (aNum !== null) return -1;
+        if (bNum !== null) return 1;
+        return a.localeCompare(b);
+      });
+
+    return yield* Effect.all(
+      sqlFiles.map((id) => readSqlFile(directory, id)),
+    );
+  });
+
+/**
+ * Read a single `.sql` file relative to `directory` and compute its content
+ * hash. The `sql` field is marked non-enumerable so it isn't serialized into
+ * resource state.
+ */
+export const readSqlFile = (directory: string, name: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const sql = yield* fs.readFileString(path.resolve(directory, name));
+    const hash = crypto.createHash("sha256").update(sql).digest("hex");
+    const file: D1SqlFile = { id: name, sql, hash };
+    Object.defineProperty(file, "sql", { enumerable: false });
+    return file;
+  });
+
+const getPrefix = (name: string): number | null => {
+  const prefix = name.split("_")[0];
+  const num = Number.parseInt(prefix, 10);
+  return Number.isNaN(num) ? null : num;
+};

--- a/packages/alchemy/test/Cloudflare/D1/Database.test.ts
+++ b/packages/alchemy/test/Cloudflare/D1/Database.test.ts
@@ -4,7 +4,10 @@ import { destroy, test } from "@/Test/Vitest";
 import * as d1 from "@distilled.cloud/cloudflare/d1";
 import { expect } from "@effect/vitest";
 import * as Data from "effect/Data";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 
@@ -84,6 +87,472 @@ test(
   }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
 );
 
+test(
+  "applies migrations from migrationsDir",
+  Effect.gen(function* () {
+    const { accountId } = yield* CloudflareEnvironment;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const migrationsDir = yield* fs.makeTempDirectory({
+      prefix: "alchemy-d1-migrations-",
+    });
+
+    yield* fs.writeFileString(
+      path.join(migrationsDir, "0001_users.sql"),
+      "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);",
+    );
+    yield* fs.writeFileString(
+      path.join(migrationsDir, "0002_posts.sql"),
+      "CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT NOT NULL);",
+    );
+
+    yield* destroy();
+
+    const database = yield* test.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.D1Database("MigrationDatabase", {
+          migrationsDir,
+        });
+      }),
+    );
+
+    expect(database.migrationsDir).toEqual(migrationsDir);
+    expect(database.migrationsTable).toEqual("d1_migrations");
+    expect(Object.keys(database.migrationsHashes).sort()).toEqual([
+      "0001_users.sql",
+      "0002_posts.sql",
+    ]);
+
+    const tables = yield* listTables(accountId, database.databaseId);
+    expect(tables).toContain("users");
+    expect(tables).toContain("posts");
+    expect(tables).toContain("d1_migrations");
+
+    const applied = yield* queryAll<{ id: string; name: string }>(
+      accountId,
+      database.databaseId,
+      "SELECT id, name FROM d1_migrations ORDER BY id;",
+    );
+    expect(applied).toEqual([
+      { id: "00001", name: "0001_users.sql" },
+      { id: "00002", name: "0002_posts.sql" },
+    ]);
+    for (const row of applied) {
+      expect(row.id).toMatch(/^\d{5}$/);
+    }
+
+    // Adding a new migration on update should apply only the new one and the
+    // sequential id should continue from where it left off.
+    yield* fs.writeFileString(
+      path.join(migrationsDir, "0003_comments.sql"),
+      "CREATE TABLE comments (id INTEGER PRIMARY KEY, body TEXT NOT NULL);",
+    );
+
+    const updated = yield* test.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.D1Database("MigrationDatabase", {
+          migrationsDir,
+        });
+      }),
+    );
+    expect(updated.databaseId).toEqual(database.databaseId);
+
+    const tablesAfter = yield* listTables(accountId, database.databaseId);
+    expect(tablesAfter).toContain("comments");
+
+    const appliedAfter = yield* queryAll<{ id: string; name: string }>(
+      accountId,
+      database.databaseId,
+      "SELECT id, name FROM d1_migrations ORDER BY id;",
+    );
+    expect(appliedAfter).toEqual([
+      { id: "00001", name: "0001_users.sql" },
+      { id: "00002", name: "0002_posts.sql" },
+      { id: "00003", name: "0003_comments.sql" },
+    ]);
+
+    yield* destroy();
+    yield* waitForDatabaseToBeDeleted(database.databaseId, accountId);
+  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+);
+
+test(
+  "applies migrations using a custom migrationsTable",
+  Effect.gen(function* () {
+    const { accountId } = yield* CloudflareEnvironment;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const migrationsDir = yield* fs.makeTempDirectory({
+      prefix: "alchemy-d1-custom-migrations-",
+    });
+    yield* fs.writeFileString(
+      path.join(migrationsDir, "0001_create.sql"),
+      "CREATE TABLE test_migrations_table (id INTEGER PRIMARY KEY, name TEXT);",
+    );
+
+    yield* destroy();
+
+    const database = yield* test.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.D1Database("CustomMigrationsTableDb", {
+          migrationsDir,
+          migrationsTable: "custom_migration_tracking",
+        });
+      }),
+    );
+
+    expect(database.migrationsTable).toEqual("custom_migration_tracking");
+
+    const tables = yield* listTables(accountId, database.databaseId);
+    expect(tables).toContain("custom_migration_tracking");
+    expect(tables).toContain("test_migrations_table");
+    // The default table must NOT be created when a custom one is configured.
+    expect(tables).not.toContain("d1_migrations");
+
+    yield* destroy();
+    yield* waitForDatabaseToBeDeleted(database.databaseId, accountId);
+  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+);
+
+test(
+  "migrates legacy 2-column migration table to wrangler schema",
+  Effect.gen(function* () {
+    const { accountId } = yield* CloudflareEnvironment;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const migrationsDir = yield* fs.makeTempDirectory({
+      prefix: "alchemy-d1-legacy-",
+    });
+    yield* fs.writeFileString(
+      path.join(migrationsDir, "0002_create_users.sql"),
+      "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);",
+    );
+    yield* fs.writeFileString(
+      path.join(migrationsDir, "0003_create_posts.sql"),
+      "CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT NOT NULL);",
+    );
+
+    yield* destroy();
+
+    // Step 1: deploy the database without migrations so we can seed a legacy
+    // 2-column d1_migrations table on it before re-deploying with a
+    // migrationsDir.
+    const seeded = yield* test.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.D1Database("LegacyMigrationDb");
+      }),
+    );
+
+    yield* execSql(
+      accountId,
+      seeded.databaseId,
+      `CREATE TABLE d1_migrations (
+         id TEXT PRIMARY KEY,
+         applied_at TEXT NOT NULL
+       );`,
+    );
+    yield* execSql(
+      accountId,
+      seeded.databaseId,
+      `INSERT INTO d1_migrations (id, applied_at) VALUES
+         ('0000_initial_setup.sql', datetime('now', '-1 day')),
+         ('0001_add_indexes.sql', datetime('now', '-1 hour'));`,
+    );
+
+    // Step 2: deploy again with a migrationsDir; the resource should detect
+    // the legacy 2-column schema, migrate to (id, name, applied_at), and apply
+    // the new migrations on top.
+    const upgraded = yield* test.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.D1Database("LegacyMigrationDb", {
+          migrationsDir,
+        });
+      }),
+    );
+    expect(upgraded.databaseId).toEqual(seeded.databaseId);
+
+    const columns = yield* queryAll<{ name: string }>(
+      accountId,
+      seeded.databaseId,
+      "PRAGMA table_info(d1_migrations);",
+    );
+    const colNames = columns.map((c) => c.name).sort();
+    expect(colNames).toEqual(["applied_at", "id", "name"]);
+
+    const records = yield* queryAll<{ id: string; name: string }>(
+      accountId,
+      seeded.databaseId,
+      "SELECT id, name FROM d1_migrations ORDER BY id;",
+    );
+    const names = records.map((r) => r.name);
+    expect(names).toContain("0000_initial_setup.sql");
+    expect(names).toContain("0001_add_indexes.sql");
+    expect(names).toContain("0002_create_users.sql");
+    expect(names).toContain("0003_create_posts.sql");
+
+    // All ids should be 5-digit zero-padded sequential numbers.
+    for (const r of records) {
+      expect(r.id).toMatch(/^\d{5}$/);
+    }
+    expect(records[0].id).toBe("00001");
+    expect(records[records.length - 1].id).toBe(
+      records.length.toString().padStart(5, "0"),
+    );
+
+    yield* destroy();
+    yield* waitForDatabaseToBeDeleted(seeded.databaseId, accountId);
+  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+);
+
+test(
+  "imports SQL files via importFiles",
+  Effect.gen(function* () {
+    const { accountId } = yield* CloudflareEnvironment;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const dir = yield* fs.makeTempDirectory({
+      prefix: "alchemy-d1-imports-",
+    });
+    const importPath = path.join(dir, "seed.sql");
+
+    yield* fs.writeFileString(
+      importPath,
+      [
+        "CREATE TABLE widgets (id INTEGER PRIMARY KEY, label TEXT NOT NULL);",
+        "INSERT INTO widgets (id, label) VALUES (1, 'one');",
+        "INSERT INTO widgets (id, label) VALUES (2, 'two');",
+      ].join("\n"),
+    );
+
+    yield* destroy();
+
+    const database = yield* test.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.D1Database("ImportDatabase", {
+          importFiles: [importPath],
+        });
+      }),
+    );
+
+    expect(database.importHashes[importPath]).toBeDefined();
+
+    const widgets = yield* getResults<{ id: number; label: string }>(
+      accountId,
+      database.databaseId,
+      "SELECT id, label FROM widgets ORDER BY id;",
+    );
+    expect(widgets).toEqual([
+      { id: 1, label: "one" },
+      { id: 2, label: "two" },
+    ]);
+
+    yield* destroy();
+    yield* waitForDatabaseToBeDeleted(database.databaseId, accountId);
+  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+);
+
+test(
+  "clones a database by databaseId",
+  Effect.gen(function* () {
+    const { accountId } = yield* CloudflareEnvironment;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const dir = yield* fs.makeTempDirectory({
+      prefix: "alchemy-d1-clone-id-",
+    });
+    const seedPath = path.join(dir, "seed.sql");
+
+    yield* fs.writeFileString(
+      seedPath,
+      [
+        "CREATE TABLE colors (id INTEGER PRIMARY KEY, name TEXT NOT NULL);",
+        "INSERT INTO colors (id, name) VALUES (1, 'red'), (2, 'green'), (3, 'blue');",
+      ].join("\n"),
+    );
+
+    yield* destroy();
+
+    const { source, target } = yield* test.deploy(
+      Effect.gen(function* () {
+        const source = yield* Cloudflare.D1Database("CloneByIdSource", {
+          importFiles: [seedPath],
+        });
+        const target = yield* Cloudflare.D1Database("CloneByIdTarget", {
+          clone: { databaseId: source.databaseId },
+        });
+        return { source, target };
+      }),
+    );
+
+    expect(target.databaseId).not.toEqual(source.databaseId);
+
+    const targetColors = yield* getResults<{ id: number; name: string }>(
+      accountId,
+      target.databaseId,
+      "SELECT id, name FROM colors ORDER BY id;",
+    );
+    expect(targetColors).toEqual([
+      { id: 1, name: "red" },
+      { id: 2, name: "green" },
+      { id: 3, name: "blue" },
+    ]);
+
+    yield* destroy();
+    yield* waitForDatabaseToBeDeleted(source.databaseId, accountId);
+    yield* waitForDatabaseToBeDeleted(target.databaseId, accountId);
+  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+);
+
+test(
+  "clones a database by name lookup",
+  Effect.gen(function* () {
+    const { accountId } = yield* CloudflareEnvironment;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const dir = yield* fs.makeTempDirectory({
+      prefix: "alchemy-d1-clone-name-",
+    });
+    const seedPath = path.join(dir, "seed.sql");
+
+    yield* fs.writeFileString(
+      seedPath,
+      [
+        "CREATE TABLE animals (id INTEGER PRIMARY KEY, kind TEXT NOT NULL);",
+        "INSERT INTO animals (id, kind) VALUES (1, 'cat'), (2, 'dog');",
+      ].join("\n"),
+    );
+
+    yield* destroy();
+
+    const { source, target } = yield* test.deploy(
+      Effect.gen(function* () {
+        const source = yield* Cloudflare.D1Database("CloneByNameSource", {
+          importFiles: [seedPath],
+        });
+        const target = yield* Cloudflare.D1Database("CloneByNameTarget", {
+          clone: { name: source.databaseName },
+        });
+        return { source, target };
+      }),
+    );
+
+    expect(target.databaseId).not.toEqual(source.databaseId);
+
+    const animals = yield* getResults<{ id: number; kind: string }>(
+      accountId,
+      target.databaseId,
+      "SELECT id, kind FROM animals ORDER BY id;",
+    );
+    expect(animals).toEqual([
+      { id: 1, kind: "cat" },
+      { id: 2, kind: "dog" },
+    ]);
+
+    yield* destroy();
+    yield* waitForDatabaseToBeDeleted(source.databaseId, accountId);
+    yield* waitForDatabaseToBeDeleted(target.databaseId, accountId);
+  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+);
+
+test(
+  "clones a database by passing the source resource directly",
+  Effect.gen(function* () {
+    const { accountId } = yield* CloudflareEnvironment;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const dir = yield* fs.makeTempDirectory({
+      prefix: "alchemy-d1-clone-direct-",
+    });
+    const seedPath = path.join(dir, "seed.sql");
+
+    yield* fs.writeFileString(
+      seedPath,
+      [
+        "CREATE TABLE shapes (id INTEGER PRIMARY KEY, name TEXT NOT NULL);",
+        "INSERT INTO shapes (id, name) VALUES (1, 'square'), (2, 'circle');",
+      ].join("\n"),
+    );
+
+    yield* destroy();
+
+    const { source, target } = yield* test.deploy(
+      Effect.gen(function* () {
+        const source = yield* Cloudflare.D1Database("CloneDirectSource", {
+          importFiles: [seedPath],
+        });
+        const target = yield* Cloudflare.D1Database("CloneDirectTarget", {
+          clone: source,
+        });
+        return { source, target };
+      }),
+    );
+
+    expect(target.databaseId).not.toEqual(source.databaseId);
+
+    const shapes = yield* getResults<{ id: number; name: string }>(
+      accountId,
+      target.databaseId,
+      "SELECT id, name FROM shapes ORDER BY id;",
+    );
+    expect(shapes).toEqual([
+      { id: 1, name: "square" },
+      { id: 2, name: "circle" },
+    ]);
+
+    yield* destroy();
+    yield* waitForDatabaseToBeDeleted(source.databaseId, accountId);
+    yield* waitForDatabaseToBeDeleted(target.databaseId, accountId);
+  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+);
+
+const queryAll = Effect.fn(function* <T>(
+  accountId: string,
+  databaseId: string,
+  sql: string,
+) {
+  const queryDb = yield* d1.queryDatabase;
+  const result = yield* queryDb({ accountId, databaseId, sql });
+  return (result.result[0]?.results ?? []) as T[];
+});
+
+const execSql = (accountId: string, databaseId: string, sql: string) =>
+  queryAll<unknown>(accountId, databaseId, sql);
+
+const listTables = Effect.fn(function* (accountId: string, databaseId: string) {
+  const rows = yield* queryAll<{ name: string }>(
+    accountId,
+    databaseId,
+    "SELECT name FROM sqlite_master WHERE type='table';",
+  );
+  return rows.map((r) => r.name);
+});
+
+/**
+ * D1 query results are eventually consistent following an import/clone, so
+ * retry until we see at least one row (matches v1's `getResults` helper).
+ */
+const getResults = Effect.fn(function* <T>(
+  accountId: string,
+  databaseId: string,
+  sql: string,
+) {
+  return yield* queryAll<T>(accountId, databaseId, sql).pipe(
+    Effect.flatMap((rows) =>
+      rows.length > 0
+        ? Effect.succeed(rows)
+        : Effect.fail(new EmptyResults({ sql })),
+    ),
+    Effect.retry({
+      while: (e) => e instanceof EmptyResults,
+      schedule: Schedule.both(
+        Schedule.spaced(Duration.seconds(1)),
+        Schedule.recurs(10),
+      ),
+    }),
+    Effect.orDie,
+  );
+});
+
 const waitForDatabaseToBeDeleted = Effect.fn(function* (
   databaseId: string,
   accountId: string,
@@ -105,3 +574,6 @@ const waitForDatabaseToBeDeleted = Effect.fn(function* (
 });
 
 class DatabaseStillExists extends Data.TaggedError("DatabaseStillExists") {}
+class EmptyResults extends Data.TaggedError("EmptyResults")<{
+  sql: string;
+}> {}


### PR DESCRIPTION
## Summary

Adds the v1 D1 feature surface (migrations / SQL imports / clone) to the alchemy-effect `D1Database` resource, fully Effect-based.

## Usage

**Migrations** — `.sql` files in `migrationsDir` are sorted by numeric prefix and applied via Cloudflare's HTTP query API. Tracked in a wrangler-compatible `(id, name, applied_at)` table; legacy 2-column tables are upgraded in place.

```ts
const db = yield* Cloudflare.D1Database("my-db", {
  migrationsDir: "./migrations",
  // optional, e.g. for Drizzle:
  migrationsTable: "drizzle_migrations",
});
```

**Imports** — seed via Cloudflare's D1 import API (init → presigned PUT → ingest → poll). Each file is hashed; only changed files re-run on subsequent deploys.

```ts
const db = yield* Cloudflare.D1Database("my-db", {
  importFiles: ["./seed/users.sql", "./seed/posts.sql"],
});
```

**Clone** — full export → import from a source DB during creation. Accepts a resource, a `{ databaseId }`, or a `{ name }`.

```ts
const source = yield* Cloudflare.D1Database("source");
const cloned1 = yield* Cloudflare.D1Database("c1", { clone: source });
const cloned2 = yield* Cloudflare.D1Database("c2", { clone: { databaseId: source.databaseId } });
const cloned3 = yield* Cloudflare.D1Database("c3", { clone: { name: "source-db" } });
```

## Implementation

New internal helpers under `packages/alchemy/src/Cloudflare/D1/`:

- `D1SqlFile.ts` — Effect-based `listSqlFiles` / `readSqlFile` using `FileSystem.FileSystem` + `Path.Path` (no `node:fs/promises`).
- `D1Migrations.ts` — `applyMigrations` via `d1.queryDatabase`, with legacy schema detection + in-place upgrade.
- `D1Export.ts` — `exportD1Database` recursive bookmark polling.
- `D1Import.ts` — typed `init` via `d1.importDatabase`, raw `HttpClient` for the presigned `PUT` + `ingest` + `poll` actions (the generated client only types `action: "init"`).
- `D1Clone.ts` — orchestrates export → fetch dump → import.

`D1Database.ts` provider:

- Extended `DatabaseProps` with `migrationsDir`, `migrationsTable`, `importFiles`, `clone`; output attributes track `migrationsHashes` / `importHashes` for drift detection.
- `diff` hashes migration/import files and triggers `update` on drift.
- `create` runs clone → migrations → imports after DB creation; `update` re-applies pending migrations and any changed import files.

## Out of scope

- `adopt` flag and local/miniflare dev mode (need infra not yet in alchemy-effect).

## Test plan

`bun vitest run packages/alchemy/test/Cloudflare/D1/Database.test.ts` — 9/9 passing:

- create / delete (default props)
- create + update (read replication toggle)
- migrations from `migrationsDir` (incl. sequential `^\d{5}$` ids and incremental new-migration application)
- custom `migrationsTable` (verifies default `d1_migrations` is **not** created)
- legacy 2-column → 3-column schema migration with id sequencing preserved
- `importFiles` (rows queryable on the imported table)
- clone by `databaseId`, by `name`, and by passing the source resource directly

Verification queries use an eventual-consistency retry helper (10× spaced 1s) ported from v1's `getResults` pattern.

Made with [Cursor](https://cursor.com)