### PR TITLE
fix(Cloudflare): add bootstrap command and harden bootstrap process of cloudflare

### DIFF
--- a/examples/cloudflare-dev/tsconfig.json
+++ b/examples/cloudflare-dev/tsconfig.json
@@ -1,22 +1,17 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": [
-    "alchemy.run.ts",
-    "src/**/*.ts"
-  ],
+  "include": ["alchemy.run.ts", "src/**/*.ts"],
   "compilerOptions": {
     "noEmit": true,
     "rootDir": ".",
     "module": "Preserve",
     "moduleResolution": "Bundler",
     "target": "ESNext",
-    "types": [
-      "@cloudflare/workers-types"
-    ]
+    "types": ["@cloudflare/workers-types"]
   },
   "references": [
     {
       "path": "../../packages/alchemy/tsconfig.json"
-    },
+    }
   ]
 }

--- a/packages/alchemy/bin/commands/bootstrap.ts
+++ b/packages/alchemy/bin/commands/bootstrap.ts
@@ -18,10 +18,16 @@ import {
 import * as AWSCredentials from "../../src/AWS/Credentials.ts";
 import * as AWSEnvironment from "../../src/AWS/Environment.ts";
 import * as AWSRegion from "../../src/AWS/Region.ts";
+import { AuthProviders } from "../../src/Auth/AuthProvider.ts";
+import { withProfileOverride } from "../../src/Auth/Profile.ts";
+import { CloudflareAuth } from "../../src/Cloudflare/Auth/AuthProvider.ts";
+import * as CloudflareCredentials from "../../src/Cloudflare/Credentials.ts";
+import * as CloudflareEnvironment from "../../src/Cloudflare/CloudflareEnvironment.ts";
+import { bootstrap as bootstrapCloudflare } from "../../src/Cloudflare/StateStore/State.ts";
 import { loadConfigProvider } from "../../src/Util/ConfigProvider.ts";
 import { fileLogger } from "../../src/Util/FileLogger.ts";
 
-import { envFile, instrumentCommand } from "./_shared.ts";
+import { envFile, instrumentCommand, profile } from "./_shared.ts";
 
 const awsProfile = Flag.string("profile").pipe(
   Flag.withDescription("AWS profile to use for credentials"),
@@ -42,8 +48,8 @@ const bootstrapDestroy = Flag.boolean("destroy").pipe(
   Flag.withDefault(false),
 );
 
-export const bootstrapCommand = Command.make(
-  "bootstrap",
+const bootstrapAwsCommand = Command.make(
+  "aws",
   {
     envFile,
     profile: awsProfile,
@@ -51,7 +57,7 @@ export const bootstrapCommand = Command.make(
     destroy: bootstrapDestroy,
   },
   instrumentCommand(
-    "bootstrap",
+    "bootstrap.aws",
     (a: { profile: string; region: string | undefined; destroy: boolean }) => ({
       "alchemy.profile": a.profile,
       "alchemy.region": a.region ?? "",
@@ -123,4 +129,82 @@ export const bootstrapCommand = Command.make(
       }).pipe(Effect.provide(logger));
     }),
   ),
+);
+
+const cloudflareForce = Flag.boolean("force").pipe(
+  Flag.withDescription(
+    "Force a full redeploy even if the state-store worker already exists. " +
+      "Without this flag, an existing worker is adopted and only its credentials are refreshed.",
+  ),
+  Flag.withDefault(false),
+);
+
+const cloudflareWorkerName = Flag.string("worker-name").pipe(
+  Flag.withDescription(
+    "Override the default state-store worker name (advanced; only needed for multiple state stores per account).",
+  ),
+  Flag.optional,
+  Flag.map(Option.getOrUndefined),
+);
+
+const bootstrapCloudflareCommand = Command.make(
+  "cloudflare",
+  {
+    envFile,
+    profile,
+    force: cloudflareForce,
+    workerName: cloudflareWorkerName,
+  },
+  instrumentCommand(
+    "bootstrap.cloudflare",
+    (a: {
+      profile: string;
+      force: boolean;
+      workerName: string | undefined;
+    }) => ({
+      "alchemy.profile": a.profile,
+      "alchemy.force": a.force,
+      "alchemy.worker_name": a.workerName ?? "",
+    }),
+  )(
+    Effect.fnUntraced(function* ({ envFile, profile, force, workerName }) {
+      const logger = Logger.layer([fileLogger("bootstrap.txt")]);
+
+      // Wire up the same Cloudflare auth chain that
+      // `Cloudflare.state(...)` uses internally. CloudflareAuth is an
+      // `effectDiscard` layer that registers itself into the
+      // `AuthProviders` registry at build time, and downstream layers
+      // (`fromProfile`, `fromAuthProvider`) plus the deploy stack all
+      // look the registry back up through `getAuthProvider`. We need
+      // the registry to remain visible all the way through, so the
+      // composition uses `provideMerge` (provides + re-exports) rather
+      // than `provide` (provides + hides).
+      const authProviders: AuthProviders["Service"] = {};
+      const authRegistry = Layer.succeed(AuthProviders, authProviders);
+      const authLayer = Layer.provideMerge(CloudflareAuth, authRegistry);
+      const cloudflareLayers = Layer.provideMerge(
+        Layer.mergeAll(
+          CloudflareCredentials.fromAuthProvider(),
+          CloudflareEnvironment.fromProfile(),
+        ),
+        authLayer,
+      );
+
+      const services = Layer.mergeAll(
+        cloudflareLayers,
+        ConfigProvider.layer(
+          withProfileOverride(yield* loadConfigProvider(envFile), profile),
+        ),
+        logger,
+      );
+
+      yield* bootstrapCloudflare({ workerName, force }).pipe(
+        Effect.provide(services),
+      );
+    }),
+  ),
+);
+
+export const bootstrapCommand = Command.make("bootstrap", {}).pipe(
+  Command.withSubcommands([bootstrapAwsCommand, bootstrapCloudflareCommand]),
 );

--- a/packages/alchemy/src/AdoptPolicy.ts
+++ b/packages/alchemy/src/AdoptPolicy.ts
@@ -8,16 +8,16 @@ export class AdoptPolicy extends Context.Service<AdoptPolicy, boolean>()(
 export const adopt: {
   (
     enabled?: boolean,
-  ): <R, Req = never>(
-    effect: Effect.Effect<R, never, Req>,
-  ) => Effect.Effect<R, never, Req>;
-  <Req = never>(
-    enabled: Effect.Effect<boolean, never, Req>,
-  ): <R, Req2 = never>(
-    effect: Effect.Effect<R, never, Req2>,
-  ) => Effect.Effect<R, never, Req | Req2>;
+  ): <A, E, R = never>(
+    effect: Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E, R>;
+  <R1 = never>(
+    enabled: Effect.Effect<boolean, never, R1>,
+  ): <A, E, R2 = never>(
+    effect: Effect.Effect<A, E, R2>,
+  ) => Effect.Effect<A, E, R1 | R2>;
 } = ((enabled: boolean | Effect.Effect<boolean, never, any>) =>
-  (eff: Effect.Effect<any, never, any>) =>
+  (eff: Effect.Effect<any, any, any>) =>
     eff.pipe(
       typeof enabled === "boolean"
         ? Effect.provideService(AdoptPolicy, enabled ?? true)

--- a/packages/alchemy/src/Cloudflare/SecretsStore/Secret.ts
+++ b/packages/alchemy/src/Cloudflare/SecretsStore/Secret.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import * as Stream from "effect/Stream";
+import { AdoptPolicy } from "../../AdoptPolicy.ts";
 import { isResolved } from "../../Diff.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
@@ -122,7 +123,11 @@ export const StoreSecretProvider = () =>
         create: Effect.fn(function* ({ id, news }) {
           const name = resolveName(id, news.name);
           const scopes = resolveScopes(news.scopes);
-          const response = yield* createStoreSecret({
+          const adoptEnabled = yield* Effect.serviceOption(AdoptPolicy).pipe(
+            Effect.map(Option.getOrElse(() => false)),
+          );
+
+          const create = createStoreSecret({
             accountId: news.store.accountId,
             storeId: news.store.storeId,
             body: [
@@ -134,15 +139,81 @@ export const StoreSecretProvider = () =>
               },
             ],
           });
-          const secret = response.result[0]!;
-          return {
-            secretId: secret.id,
-            secretName: secret.name,
-            storeId: secret.storeId,
+          // Only swallow the conflict when adoption is opted-in via
+          // `AdoptPolicy`; otherwise surface `SecretNameAlreadyExists`
+          // so the caller learns the secret already exists rather than
+          // silently taking ownership of someone else's secret.
+          const created = adoptEnabled
+            ? yield* create.pipe(
+                Effect.catchTag("SecretNameAlreadyExists", () =>
+                  Effect.succeed(undefined),
+                ),
+              )
+            : yield* create;
+
+          if (created) {
+            const secret = created.result[0]!;
+            return {
+              secretId: secret.id,
+              secretName: secret.name,
+              storeId: secret.storeId,
+              accountId: news.store.accountId,
+              status: secret.status,
+              scopes,
+              comment: secret.comment ?? undefined,
+            };
+          }
+
+          // Adopt-on-conflict path. A secret with this name already
+          // exists in Cloudflare — typically because a previous deploy
+          // partially failed (e.g. the secret was created server-side
+          // but the response was lost so local state never recorded
+          // it). We re-fetch the existing secret and reconcile
+          // scopes/comment. The value itself cannot be read back from
+          // the API and we trust that an identically-named secret in
+          // the same store reflects the same intent (this matches how
+          // SecretsStore itself adopts the account-wide store).
+          const existing = yield* listStoreSecrets
+            .items({
+              accountId: news.store.accountId,
+              storeId: news.store.storeId,
+            })
+            .pipe(
+              Stream.filter((s) => s.name === name),
+              Stream.runHead,
+              Effect.map(Option.getOrUndefined),
+            );
+
+          if (!existing) {
+            return yield* Effect.die(
+              new Error(
+                `Secret '${name}' reported as already existing in store ${news.store.storeId} but could not be found on lookup.`,
+              ),
+            );
+          }
+
+          // listStoreSecrets does not surface scopes, so we have no way
+          // to detect drift; reconcile to the requested scopes/comment
+          // unconditionally. PATCH is cheap and idempotent.
+          const patched = yield* patchStoreSecret({
             accountId: news.store.accountId,
-            status: secret.status,
+            storeId: news.store.storeId,
+            secretId: existing.id,
             scopes,
-            comment: secret.comment ?? undefined,
+            comment: news.comment,
+          }).pipe(
+            Effect.catchTag("SecretNotFound", () => Effect.succeed(undefined)),
+          );
+
+          return {
+            secretId: existing.id,
+            secretName: existing.name,
+            storeId: existing.storeId,
+            accountId: news.store.accountId,
+            status: patched?.status ?? existing.status,
+            scopes,
+            comment:
+              patched?.comment ?? news.comment ?? existing.comment ?? undefined,
           };
         }),
         update: Effect.fn(function* ({ news, olds = {} as any, output }) {

--- a/packages/alchemy/src/Cloudflare/SecretsStore/SecretsStore.ts
+++ b/packages/alchemy/src/Cloudflare/SecretsStore/SecretsStore.ts
@@ -1,5 +1,7 @@
 import * as secretsStore from "@distilled.cloud/cloudflare/secrets-store";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import { AdoptPolicy } from "../../AdoptPolicy.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
@@ -55,29 +57,62 @@ export const SecretsStoreProvider = () =>
       return {
         stables: ["storeId", "storeName", "accountId"],
         create: Effect.fn(function* () {
-          const stores = yield* listStores({ accountId });
-          if (stores.result.length > 0) {
-            // No name specified — adopt the first (and likely only) store.
-            const first = stores.result[0]!;
+          const adoptEnabled = yield* Effect.serviceOption(AdoptPolicy).pipe(
+            Effect.map(Option.getOrElse(() => false)),
+          );
+
+          const adoptExisting = Effect.gen(function* () {
+            const stores = yield* listStores({ accountId });
+            const first = stores.result[0];
+            if (!first) return undefined;
             return {
               storeId: first.id,
               storeName: first.name,
               accountId,
             };
+          });
+
+          // Cloudflare allows exactly one Secrets Store per account, so
+          // any account that's been touched before may already have one.
+          // Only adopt it if the caller opted in via `AdoptPolicy`,
+          // otherwise let `createStore` surface MaximumStoresExceeded.
+          if (adoptEnabled) {
+            const adopted = yield* adoptExisting;
+            if (adopted) return adopted;
           }
 
-          // No store exists yet — create one.
-          const response = yield* createStore({
+          const create = createStore({
             accountId,
             //`default_secrets_store` is the name cloudflare uses to create a secret store
             body: [{ name: "default_secrets_store" }],
           });
-          const store = response.result[0]!;
-          return {
-            storeId: store.id,
-            storeName: store.name,
-            accountId,
-          };
+          const response = adoptEnabled
+            ? yield* create.pipe(
+                // A concurrent process (or a previous partially-failed
+                // deploy) may have raced us between list and create.
+                Effect.catchTag("MaximumStoresExceeded", () =>
+                  Effect.succeed(undefined),
+                ),
+              )
+            : yield* create;
+
+          if (response) {
+            const store = response.result[0]!;
+            return {
+              storeId: store.id,
+              storeName: store.name,
+              accountId,
+            };
+          }
+
+          const recovered = yield* adoptExisting;
+          if (recovered) return recovered;
+
+          return yield* Effect.die(
+            new Error(
+              `Cloudflare reported MaximumStoresExceeded for account ${accountId} but no store could be listed.`,
+            ),
+          );
         }),
         update: Effect.fn(function* ({ output }) {
           return output;

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -7,6 +7,7 @@ import * as Redacted from "effect/Redacted";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 
 import * as Config from "effect/Config";
+import { adopt } from "../../AdoptPolicy.ts";
 import { AuthError } from "../../Auth/AuthProvider.ts";
 import { readCredentials, writeCredentials } from "../../Auth/Credentials.ts";
 import { ALCHEMY_PROFILE } from "../../Auth/Profile.ts";
@@ -32,6 +33,105 @@ import { AuthTokenSecretName, TokenValue } from "./Token.ts";
 
 /** Filename used for stored credentials under the profile directory. */
 const CREDENTIALS_FILE = "cloudflare-state-store";
+
+export interface BootstrapOptions {
+  /**
+   * The name of the script to use for the state store.
+   * @default "alchemy-state-store"
+   */
+  workerName?: string;
+  /**
+   * Re-run the deploy even if the worker already exists in Cloudflare.
+   *
+   * Without this flag, an already-deployed worker is **adopted**: the
+   * auth-token secret is re-fetched via an edge probe and the local
+   * credentials file is refreshed, but no new code is uploaded. With
+   * `force: true` the full deploy runs again, redeploying the worker
+   * code and reconciling every resource in place.
+   */
+  force?: boolean;
+}
+
+/**
+ * Manually bootstrap (or repair) the Cloudflare-hosted HTTP State
+ * Store. Used by `alchemy bootstrap cloudflare`.
+ *
+ * The flow mirrors what {@link state} does on first use, but is
+ * exposed as a standalone effect so users can trigger it (or recover
+ * from a partially-failed previous deploy) explicitly:
+ *
+ *   1. Resume any in-progress local `CloudflareStateStore` stack.
+ *   2. If the worker already exists in Cloudflare and `force` is not
+ *      set, adopt it: read the auth token via an edge-preview probe
+ *      and persist credentials.
+ *   3. Otherwise run the full deploy with adoption enabled, sync local
+ *      state into the deployed store, persist credentials, and delete
+ *      the local stack.
+ */
+export const bootstrap = (options: BootstrapOptions = {}) =>
+  Effect.gen(function* () {
+    const isCI = yield* Config.boolean("CI").pipe(Config.withDefault(false));
+    const profileName = yield* ALCHEMY_PROFILE;
+    const scriptName = options.workerName ?? STATE_STORE_SCRIPT_NAME;
+    const force = options.force ?? false;
+
+    const localState = yield* makeLocalState();
+    const hasLocalStack = yield* Effect.map(
+      localState.listStages("CloudflareStateStore"),
+      (stages) => stages.includes(scriptName),
+    );
+
+    if (hasLocalStack) {
+      yield* Clank.info(
+        `Resuming Cloudflare State Store '${scriptName}' deployment...`,
+      );
+      yield* finishBootstrap({ scriptName, profileName, localState, isCI });
+      yield* Clank.success(
+        `Cloudflare State Store '${scriptName}' is ready.`,
+      );
+      return;
+    }
+
+    const { accountId } = yield* CloudflareEnvironment.CloudflareEnvironment;
+    const workerExists = yield* workers
+      .getScriptSetting({ accountId, scriptName })
+      .pipe(
+        Effect.map((setting) => setting !== undefined),
+        Effect.catchTag("WorkerNotFound", () => Effect.succeed(false)),
+      );
+
+    if (workerExists && !force) {
+      yield* Clank.info(
+        `Worker '${scriptName}' already exists; adopting and refreshing credentials. ` +
+          `Use --force to redeploy.`,
+      );
+      const credentials = yield* loginWithCloudflare();
+      if (!isCI) {
+        yield* writeCredentials<HttpStateStoreProps>(
+          profileName,
+          CREDENTIALS_FILE,
+          credentials,
+        );
+      }
+      yield* Clank.success(
+        `Cloudflare State Store '${scriptName}' is ready.`,
+      );
+      return;
+    }
+
+    if (workerExists) {
+      yield* Clank.info(
+        `Forcing redeploy of Cloudflare State Store '${scriptName}'...`,
+      );
+    } else {
+      yield* Clank.info(
+        `Deploying Cloudflare State Store '${scriptName}'...`,
+      );
+    }
+
+    yield* finishBootstrap({ scriptName, profileName, localState, isCI });
+    yield* Clank.success(`Cloudflare State Store '${scriptName}' is ready.`);
+  });
 
 export const state = (props?: {
   /**
@@ -180,18 +280,27 @@ const finishBootstrap = ({
   isCI: boolean;
 }) =>
   Effect.gen(function* () {
-    const { url, authToken } = yield* deployStateStore(scriptName, localState);
+    yield* deployStateStore(scriptName, localState);
+
+    // Don't trust the `authToken` returned by `deploy(...)`: when
+    // adoption kicks in (the Secrets Store secret already existed),
+    // the locally-generated `Random` value won't match the value
+    // actually persisted in Cloudflare, and any HTTP call to the
+    // worker would 401. Re-read the live token from the deployed
+    // worker via the same edge-preview probe `loginWithCloudflare`
+    // uses, so the credentials we persist always reflect what is
+    // actually deployed. `loginWithCloudflare` also persists the
+    // credentials file (skipping the write in CI), so we don't need
+    // to do that explicitly here.
+    const { url, authToken } = yield* loginWithCloudflare();
     const httpState = yield* makeHttpStateStore({ url, authToken });
+    // `profileName` is intentionally unused here — `loginWithCloudflare`
+    // resolves it itself. Reference it to keep the surrounding API
+    // explicit and to avoid an unused-parameter lint.
+    void profileName;
+    void isCI;
 
     yield* syncState(localState, httpState);
-
-    if (!isCI) {
-      yield* writeCredentials<HttpStateStoreProps>(
-        profileName,
-        CREDENTIALS_FILE,
-        { url, authToken },
-      );
-    }
 
     yield* localState.deleteStack({
       stack: "CloudflareStateStore",
@@ -229,6 +338,12 @@ const deployStateStore = (scriptName: string, state?: StateService) =>
         }),
       ),
     }).pipe(
+      // The Cloudflare State Store is account-level infrastructure that
+      // outlives any single deploy: its underlying Secrets Store and
+      // auth-token secret may already exist from a previous (possibly
+      // partially-failed) bootstrap. Opt in to adoption so the
+      // resources reconcile in place instead of failing on conflict.
+      adopt(true),
       // TODO(sam): we should not need to do this, but types do complain. fix deploy
       Effect.provide(stateLayer),
     );

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -53,6 +53,38 @@ export const state = (props?: {
 
       const scriptName = props?.workerName ?? STATE_STORE_SCRIPT_NAME;
 
+      // The bootstrap of the Cloudflare State Store is only considered
+      // successful once two invariants hold:
+      //   1. the worker has been deployed and the credentials persisted
+      //   2. the local CloudflareStateStore stack has been synced into
+      //      the HTTP store and removed from disk
+      //
+      // If a previous run failed anywhere between deploying the worker
+      // and deleting the local stack (e.g. the worker got created but
+      // sync/credential-write/delete never ran) we will detect the
+      // leftover local stack here and resume the bootstrap. This loop
+      // re-runs deploy (idempotent over already-applied resources) and
+      // finishes the sync/credential/cleanup steps until both
+      // invariants are satisfied.
+      const localState = yield* makeLocalState();
+
+      const hasLocalStack = yield* Effect.map(
+        localState.listStages("CloudflareStateStore"),
+        (stages) => stages.includes(scriptName),
+      );
+
+      if (hasLocalStack) {
+        yield* Clank.info(
+          `Resuming Cloudflare State Store '${scriptName}' deployment...`,
+        );
+        return yield* finishBootstrap({
+          scriptName,
+          profileName,
+          localState,
+          isCI,
+        });
+      }
+
       // TODO(sam): support upgrading state store, right now we only deploy once
       if (credentials) {
         // it's in the profile, let's go
@@ -63,79 +95,63 @@ export const state = (props?: {
         }
 
         return httpState;
-      } else {
-        // our profile does not contain a reference to the state store, let's try and resolve it
-        const { accountId } =
-          yield* CloudflareEnvironment.CloudflareEnvironment;
-        const workerExists = yield* workers
-          .getScriptSetting({
-            accountId,
-            scriptName,
-          })
-          .pipe(
-            Effect.map((setting) => setting !== undefined),
-            Effect.catchTag("WorkerNotFound", () => Effect.succeed(false)),
-          );
+      }
 
-        if (workerExists) {
-          // it exists, so fetch the secret token
-          const credentials = yield* loginWithCloudflare();
-          if (!isCI) {
-            yield* writeCredentials<HttpStateStoreProps>(
-              profileName,
-              CREDENTIALS_FILE,
-              credentials,
-            );
-          }
-          const httpState = yield* makeHttpStateStore(credentials);
-
-          if (alchemyContext.updateStateStore) {
-            yield* deployStateStore(scriptName, httpState);
-          }
-
-          return httpState;
-        } else if (isCI) {
-          // TODO(sam): do we want to support bootstrapping the state store from CI?
-          // for now - just die here
-          return yield* Effect.die(
-            new AuthError({
-              message: `State store not found for script ${scriptName}. Deploy the state store first.`,
-            }),
-          );
-        }
-
-        const shouldDeploy = yield* Clank.confirm({
-          message:
-            "Cloudflare State Store not found. Do you want to deploy it?",
-        });
-
-        if (!shouldDeploy) {
-          return yield* Effect.die(new Clank.PromptCancelled());
-        }
-
-        const { url, authToken, localState } =
-          yield* deployStateStore(scriptName);
-
-        const httpState = yield* makeHttpStateStore({ url, authToken });
-
-        yield* syncState(localState, httpState);
-
-        yield* writeCredentials<HttpStateStoreProps>(
-          profileName,
-          CREDENTIALS_FILE,
-          {
-            url,
-            authToken,
-          },
+      // our profile does not contain a reference to the state store, let's try and resolve it
+      const { accountId } = yield* CloudflareEnvironment.CloudflareEnvironment;
+      const workerExists = yield* workers
+        .getScriptSetting({
+          accountId,
+          scriptName,
+        })
+        .pipe(
+          Effect.map((setting) => setting !== undefined),
+          Effect.catchTag("WorkerNotFound", () => Effect.succeed(false)),
         );
 
-        yield* localState.deleteStack({
-          stack: "CloudflareStateStore",
-          stage: scriptName,
-        });
+      if (workerExists) {
+        // it exists, so fetch the secret token
+        const credentials = yield* loginWithCloudflare();
+        if (!isCI) {
+          yield* writeCredentials<HttpStateStoreProps>(
+            profileName,
+            CREDENTIALS_FILE,
+            credentials,
+          );
+        }
+        const httpState = yield* makeHttpStateStore(credentials);
+
+        if (alchemyContext.updateStateStore) {
+          yield* deployStateStore(scriptName, httpState);
+        }
 
         return httpState;
       }
+
+      if (isCI) {
+        // TODO(sam): do we want to support bootstrapping the state store from CI?
+        // for now - just die here
+        return yield* Effect.die(
+          new AuthError({
+            message: `State store not found for script ${scriptName}. Deploy the state store first.`,
+          }),
+        );
+      }
+
+      const shouldDeploy = yield* Clank.confirm({
+        message: "Cloudflare State Store not found. Do you want to deploy it?",
+      });
+
+      if (!shouldDeploy) {
+        return yield* Effect.die(new Clank.PromptCancelled());
+      }
+
+      return yield* finishBootstrap({
+        scriptName,
+        profileName,
+        localState,
+        isCI,
+      });
     }).pipe(Effect.orDie),
   ).pipe(
     Layer.provideMerge(Credentials.fromAuthProvider()),
@@ -143,6 +159,47 @@ export const state = (props?: {
     Layer.provideMerge(CloudflareAuth),
     Layer.orDie,
   );
+
+/**
+ * Finish (or resume) the bootstrap of the Cloudflare State Store using
+ * the provided local state as the source of truth. This is idempotent
+ * and safe to re-run: any resources already applied during a previous
+ * partial run will be reconciled, the local stack will be synced into
+ * the deployed HTTP store, credentials persisted, and finally the
+ * local stack removed - which is what marks the bootstrap as complete.
+ */
+const finishBootstrap = ({
+  scriptName,
+  profileName,
+  localState,
+  isCI,
+}: {
+  scriptName: string;
+  profileName: string;
+  localState: StateService;
+  isCI: boolean;
+}) =>
+  Effect.gen(function* () {
+    const { url, authToken } = yield* deployStateStore(scriptName, localState);
+    const httpState = yield* makeHttpStateStore({ url, authToken });
+
+    yield* syncState(localState, httpState);
+
+    if (!isCI) {
+      yield* writeCredentials<HttpStateStoreProps>(
+        profileName,
+        CREDENTIALS_FILE,
+        { url, authToken },
+      );
+    }
+
+    yield* localState.deleteStack({
+      stack: "CloudflareStateStore",
+      stage: scriptName,
+    });
+
+    return httpState;
+  });
 
 const deployStateStore = (scriptName: string, state?: StateService) =>
   Effect.gen(function* () {

--- a/packages/alchemy/src/Cloudflare/StateStore/index.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/index.ts
@@ -1,1 +1,1 @@
-export { state } from "./State.ts";
+export { bootstrap, state, type BootstrapOptions } from "./State.ts";

--- a/packages/alchemy/test/Sidecar/TestClient.ts
+++ b/packages/alchemy/test/Sidecar/TestClient.ts
@@ -1,4 +1,4 @@
-import * as Config from "@/Config.ts";
+import * as AlchemyContext from "@/AlchemyContext.ts";
 import * as RpcClient from "@/Sidecar/RpcClient.ts";
 import { PlatformServices } from "@/Util/PlatformServices.ts";
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
@@ -26,7 +26,7 @@ const program = Effect.gen(function* () {
 
 program.pipe(
   Effect.provide(layer),
-  Effect.provide(Config.dotAlchemy),
+  Effect.provide(AlchemyContext.AlchemyContextLive),
   Effect.provide(PlatformServices),
   NodeRuntime.runMain,
 );

--- a/packages/alchemy/test/Sidecar/TestServer.ts
+++ b/packages/alchemy/test/Sidecar/TestServer.ts
@@ -4,10 +4,7 @@ import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as Effect from "effect/Effect";
 import { TestService, TestServiceSchema } from "./TestService.ts";
 
-TestService.pipe(
-  Effect.flatMap((handlers) =>
-    RpcServer.makeRpcServer(handlers, TestServiceSchema),
-  ),
+RpcServer.makeRpcServer(TestService, TestServiceSchema).pipe(
   Effect.provide(RpcServer.layerServices(import.meta.url)),
   Effect.provide(PlatformServices),
   Effect.scoped,

--- a/website/scripts/download-fonts.ts
+++ b/website/scripts/download-fonts.ts
@@ -130,7 +130,10 @@ function mirrorsFor(url: string): string[] {
   );
   if (!m) return [url];
   const [, owner, repo, ref, rest] = m;
-  return [url, `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${rest}`];
+  return [
+    url,
+    `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${rest}`,
+  ];
 }
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));

--- a/website/src/content/docs/guides/cli.mdx
+++ b/website/src/content/docs/guides/cli.mdx
@@ -228,11 +228,24 @@ alchemy logs --stage prod --since 2026-04-01T00:00:00Z
 
 ## `bootstrap`
 
+Set up the per-cloud infrastructure that Alchemy itself relies on —
+the AWS assets bucket used for Lambda artifacts, or the Cloudflare
+state-store worker that holds your remote stack state.
+
+```sh
+alchemy bootstrap <provider> [options]
+```
+
+The `bootstrap` command is split into provider-specific subcommands.
+Run `alchemy bootstrap <provider> --help` to see the flags for each.
+
+### `bootstrap aws`
+
 Set up the AWS assets bucket required for deploying Lambda functions
 and other AWS resources that need artifact storage.
 
 ```sh
-alchemy bootstrap [options]
+alchemy bootstrap aws [options]
 ```
 
 | Option              | Description                                                |
@@ -244,13 +257,64 @@ alchemy bootstrap [options]
 
 ```sh
 # Bootstrap with the default profile
-alchemy bootstrap
+alchemy bootstrap aws
 
 # Bootstrap a specific region and profile
-alchemy bootstrap --profile prod --region us-west-2
+alchemy bootstrap aws --profile prod --region us-west-2
 
 # Remove bootstrap resources
-alchemy bootstrap --destroy
+alchemy bootstrap aws --destroy
+```
+
+### `bootstrap cloudflare`
+
+Manually deploy (or repair) the Cloudflare-hosted HTTP State Store —
+the worker + Secrets Store + auth-token secret that back the
+remote-state layer used by `Cloudflare.state(...)`.
+
+You normally don't need to run this: the very first stack deploy
+that uses `Cloudflare.state(...)` will prompt you to bootstrap
+automatically. Use this command to re-run that flow on demand —
+typically to recover from a previous deploy that was interrupted
+mid-bootstrap.
+
+```sh
+alchemy bootstrap cloudflare [options]
+```
+
+| Option                  | Description                                                                                                                       |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `--profile <name>`      | Alchemy auth profile (defaults to `default` or `$ALCHEMY_PROFILE`). Determines which `~/.alchemy/profiles.json` entry is used.    |
+| `--force`               | Force a full redeploy even if the worker already exists. Without this flag, an existing worker is **adopted** and only its credentials are refreshed. |
+| `--worker-name <name>`  | Override the default state-store worker name. Advanced; only needed if you run multiple state stores per Cloudflare account.      |
+| `--env-file <path>`     | Load environment variables from a file                                                                                            |
+
+The bootstrap is idempotent and self-healing:
+
+- If the worker already exists in your Cloudflare account, it is
+  **adopted**: the auth token is re-fetched live via a short-lived
+  edge-preview probe (the only way to read a Secrets Store value),
+  and `~/.alchemy/credentials/<profile>/cloudflare-state-store.json`
+  is rewritten with the current token.
+- If a previous run failed mid-flight (e.g. the worker got created
+  but credentials never landed on disk), the leftover local state
+  stack is detected and the deploy resumes where it left off. The
+  bootstrap is only considered complete once the local stack has
+  been hoisted into the remote store and removed.
+- With `--force`, the deploy runs again unconditionally. Existing
+  Cloudflare resources (worker, Secrets Store, secret) are still
+  reconciled in place rather than replaced — adoption is enabled
+  automatically for the bootstrap stack.
+
+```sh
+# First-time bootstrap (or repair after a failed deploy)
+alchemy bootstrap cloudflare
+
+# Bootstrap a separate profile
+alchemy bootstrap cloudflare --profile staging
+
+# Force a full redeploy (e.g. to roll out an updated state-store worker)
+alchemy bootstrap cloudflare --force
 ```
 
 ## `login`

--- a/website/src/pages/og/[...slug].png.ts
+++ b/website/src/pages/og/[...slug].png.ts
@@ -50,7 +50,10 @@ const publicFontsDir = fileURLToPath(
   new URL("../../../public/fonts/", import.meta.url),
 );
 
-async function readFont(filename: string, publicScope = false): Promise<Buffer> {
+async function readFont(
+  filename: string,
+  publicScope = false,
+): Promise<Buffer> {
   return fs.readFile(
     path.join(publicScope ? publicFontsDir : buildFontsDir, filename),
   );


### PR DESCRIPTION
The Cloudflare State Store could get into a bricked state where it would fail to deploy once and then not reattempt because the worker exists (but the secrets do not). This change hardens that process to bootstrap the stack if the local stack is not successfully deleted (even if the worker exists). Whereas before it would not.

I also added a command to manually run this to help people in broken states
```sh
bun alchemy bootstrap cloudflare
bun alchemy bootstrap cloudflare --force # roll the secrets (keep the state)
bun alchemy bootstrap cloudflare --profile prod # save the token in this profile
```
