### PR TITLE
fix(core): treat raw Resource refs as upstream dependencies

### DIFF
--- a/packages/alchemy/src/Output.ts
+++ b/packages/alchemy/src/Output.ts
@@ -499,7 +499,9 @@ export const upstreamAny = (
 ): {
   [ID in string]: Resource;
 } => {
-  if (isExpr(value)) {
+  if (isResource(value)) {
+    return { [value.FQN]: value as Resource };
+  } else if (isExpr(value)) {
     return upstream(value);
   } else if (Array.isArray(value)) {
     return Object.assign({}, ...value.map(resolveUpstream));
@@ -517,7 +519,11 @@ export const upstreamAny = (
 
 // TODO(sam): add a type
 export const upstream = <E extends Output<any, any>>(expr: E): any => {
-  if (isResourceExpr(expr)) {
+  if (isResource(expr)) {
+    return {
+      [(expr as unknown as Resource).FQN]: expr,
+    };
+  } else if (isResourceExpr(expr)) {
     return {
       [expr.src.FQN]: expr.src,
     };
@@ -541,6 +547,8 @@ export const upstream = <E extends Output<any, any>>(expr: E): any => {
 export const resolveUpstream = <const A>(value: A): any => {
   if (isPrimitive(value)) {
     return {} as any;
+  } else if (isResource(value)) {
+    return { [(value as unknown as Resource).FQN]: value } as any;
   } else if (isOutput(value)) {
     return upstream(value) as any;
   } else if (Array.isArray(value)) {

--- a/packages/alchemy/test/Output.test.ts
+++ b/packages/alchemy/test/Output.test.ts
@@ -536,6 +536,49 @@ describe("Output.upstream / hasOutputs / resolveUpstream", () => {
     expect(Output.upstream(Output.literal(1))).toEqual({});
   });
 
+  it("treats a raw Resource passed directly as an upstream dependency", () => {
+    const src = fakeResource("Test.A", "RawA");
+    expect(Object.keys(Output.upstream(src as any))).toEqual(["RawA"]);
+  });
+
+  it("upstreamAny detects a raw Resource passed directly as a prop value", () => {
+    const a = fakeResource("Test.A", "FQN-A");
+    const b = fakeResource("Test.B", "FQN-B");
+    const props = { image: a, network: b };
+    expect(Object.keys(Output.upstreamAny(props)).sort()).toEqual([
+      "FQN-A",
+      "FQN-B",
+    ]);
+  });
+
+  it("upstreamAny detects raw Resources nested in arrays/objects", () => {
+    const a = fakeResource("Test.A", "FQN-A");
+    const b = fakeResource("Test.B", "FQN-B");
+    const props = {
+      volumes: [{ source: a }],
+      env: { ref: b },
+    };
+    expect(Object.keys(Output.upstreamAny(props)).sort()).toEqual([
+      "FQN-A",
+      "FQN-B",
+    ]);
+  });
+
+  it("upstreamAny detects raw Resource at the top level", () => {
+    const a = fakeResource("Test.A", "Top");
+    expect(Object.keys(Output.upstreamAny(a))).toEqual(["Top"]);
+  });
+
+  it("resolveUpstream picks up raw Resources alongside Output expressions", () => {
+    const a = fakeResource("Test.A", "A1");
+    const b = fakeResource("Test.B", "B1");
+    const result = Output.resolveUpstream({
+      raw: a,
+      via: Output.of(b),
+    });
+    expect(Object.keys(result).sort()).toEqual(["A1", "B1"]);
+  });
+
   it("hasOutputs is true when an object contains an Output referencing a resource", () => {
     const src = fakeResource("Test.A", "X");
     expect(Output.hasOutputs({ k: Output.of(src) })).toBe(true);

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -1847,6 +1847,47 @@ describe("Outputs should resolve to old values", () => {
   );
 });
 
+describe("raw Resource refs in props are tracked as upstream dependencies", () => {
+  test(
+    "raw Resource passed directly as a prop value populates the upstream's downstream",
+    {
+      state: test.state(),
+    },
+    Effect.gen(function* () {
+      const plan = yield* Effect.gen(function* () {
+        const A = yield* TestResource("A", { string: "a-value" });
+        yield* TestResource("B", {
+          object: A as any,
+        });
+      }).pipe(makePlan);
+
+      expect(plan.resources.A!.downstream).toEqual(["B"]);
+      expect(plan.resources.B!.downstream).toEqual([]);
+    }),
+  );
+
+  test(
+    "raw Resources nested in arrays/objects are tracked as upstream dependencies",
+    {
+      state: test.state(),
+    },
+    Effect.gen(function* () {
+      const plan = yield* Effect.gen(function* () {
+        const A = yield* TestResource("A", { string: "a-value" });
+        const B = yield* TestResource("B", { string: "b-value" });
+        yield* TestResource("C", {
+          stringArray: [A] as any,
+          object: { ref: B } as any,
+        });
+      }).pipe(makePlan);
+
+      expect(plan.resources.A!.downstream).toEqual(["C"]);
+      expect(plan.resources.B!.downstream).toEqual(["C"]);
+      expect(plan.resources.C!.downstream).toEqual([]);
+    }),
+  );
+});
+
 describe("stable properties should not cause downstream changes", () => {
   const test = (
     description: string,

--- a/website/src/pages/og/[...slug].png.ts
+++ b/website/src/pages/og/[...slug].png.ts
@@ -196,7 +196,7 @@ function classifyDoc(slug: string): { kind: OgCardKind; eyebrow: string } {
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const docs = await getCollection("docs");
-  const docPaths = docs.map((entry) => {
+  const docPaths = docs.map((entry: any) => {
     const slug = (entry as { slug?: string; id?: string }).slug ?? entry.id;
     const meta = classifyDoc(slug);
     const data = entry.data as { title?: string; description?: string };


### PR DESCRIPTION
`upstreamAny`, `upstream` and `resolveUpstream` only walked Output expressions when collecting upstream resources, missing Resources passed directly as prop values (e.g. `prop: someResource`). Only Output-mediated refs (like `someResource.someAttribute` accessed inside `Output.interpolate`) were tracked.

The plan's per-resource `downstream` map is built from this traversal, and the destroy graph in `Apply.collectGarbage` uses `downstream` to order deletions in reverse. The gap meant a Resource and a downstream Resource that referenced it via a direct ref (rather than through an attribute access) could be deleted in parallel.

Detect raw Resource refs in all three traversers and key them under `{ [resource.FQN]: resource }`, matching the existing ResourceExpr path.