### PR TITLE
fix: resolve bin/exec.ts via package name so devs' bundled CLI works

### DIFF
--- a/packages/alchemy/bin/commands/dev.ts
+++ b/packages/alchemy/bin/commands/dev.ts
@@ -6,6 +6,18 @@ import { fileURLToPath } from "node:url";
 import { envFile, force, main, profile, stage } from "./_shared.ts";
 import { ExecStackOptions } from "./deploy.ts";
 
+// Source iteration uses unbundled exec.ts so --watch sees source-file changes;
+// published installs use the bundled exec.js so react/ink/pathe stay
+// devDependencies (matching the CLI bundle's intent). Detect which world we're
+// in by whether dev.ts (or the alchemy.js bundle that contains it) lives
+// inside a node_modules tree — same heuristic as bin/cli.js.
+const selfPath = fileURLToPath(import.meta.url);
+const isInstalled =
+  selfPath.includes("/node_modules/") || selfPath.includes("\\node_modules\\");
+const execEntry = isInstalled
+  ? "alchemy/bin/exec.js"
+  : "alchemy/bin/exec.ts";
+
 export const devCommand = Command.make(
   "dev",
   {
@@ -28,7 +40,7 @@ export const devCommand = Command.make(
         "run",
         "--watch",
         "--no-clear-screen",
-        fileURLToPath(import.meta.resolve("alchemy/bin/exec.ts")),
+        fileURLToPath(import.meta.resolve(execEntry)),
       ],
       {
         stdin: "inherit",

--- a/packages/alchemy/bin/commands/dev.ts
+++ b/packages/alchemy/bin/commands/dev.ts
@@ -28,7 +28,7 @@ export const devCommand = Command.make(
         "run",
         "--watch",
         "--no-clear-screen",
-        fileURLToPath(import.meta.resolve("../exec.ts")),
+        fileURLToPath(import.meta.resolve("alchemy/bin/exec.ts")),
       ],
       {
         stdin: "inherit",

--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -226,7 +226,8 @@
       "worker": "./src/Util/Clank.ts",
       "import": "./lib/Util/Clank.js"
     },
-    "./bin/alchemy.js": "./bin/alchemy.js"
+    "./bin/alchemy.js": "./bin/alchemy.js",
+    "./bin/exec.ts": "./bin/exec.ts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -227,7 +227,8 @@
       "import": "./lib/Util/Clank.js"
     },
     "./bin/alchemy.js": "./bin/alchemy.js",
-    "./bin/exec.ts": "./bin/exec.ts"
+    "./bin/exec.ts": "./bin/exec.ts",
+    "./bin/exec.js": "./bin/exec.js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/alchemy/tsdown.config.ts
+++ b/packages/alchemy/tsdown.config.ts
@@ -16,6 +16,24 @@ export default [
     noExternal: ["execa", "open", "env-paths"],
     tsconfig: "tsconfig.bundle.json",
   }),
+  // bundle the dev-mode worker entrypoint. dev.ts spawns this in a child bun
+  // process; under a published install it loads from node_modules and would
+  // otherwise need react/ink/pathe at runtime to resolve InkCLI.tsx as source.
+  // Bundling inlines those so they stay devDependencies (same rationale as
+  // the cli bundle below).
+  defineConfig({
+    entry: ["bin/exec.ts"],
+    format: ["esm"],
+    clean: false,
+    shims: true,
+    outDir: "bin",
+    dts: false,
+    sourcemap: true,
+    outputOptions: {
+      inlineDynamicImports: true,
+    },
+    tsconfig: "tsconfig.bundle.json",
+  }),
   // bundlde the cli entrypoint so that react does not end up in our dependencies
   // problem‼️ this means react is bundled twice in our tar.gz. Should we have bin/alchemy.ts import the cli entrypoint instead?
   defineConfig({


### PR DESCRIPTION
## Summary

`alchemy dev` fails for any consumer of the published tarball with:

```
error: Module not found ".../node_modules/alchemy/exec.ts"
```

The dev command resolved its worker entrypoint with `import.meta.resolve("../exec.ts")`. In source that works because `dev.ts` lives at `bin/commands/dev.ts` and `../exec.ts` lands on `bin/exec.ts`. After tsdown bundles the CLI into `bin/alchemy.js`, the same expression resolves one directory higher — to `<pkg-root>/exec.ts`, which is not shipped — so every install hits this error regardless of linker mode.

This wasn't caught locally because [bin/cli.js](packages/alchemy/bin/cli.js) detects "running from a checkout" by looking for `node_modules` in the path and runs the unbundled `.ts` source in that case, bypassing the bundle.

## Fix

- Switch to `import.meta.resolve("alchemy/bin/exec.ts")` so resolution is package-name based and independent of where the bundler placed the calling module.
- Add `"./bin/exec.ts": "./bin/exec.ts"` to the `exports` map so the path is resolvable.

Self-resolution works in both source (workspace symlinks `alchemy` to `packages/alchemy`) and published installs.

## Test plan

- [ ] `bun alchemy dev` from a checkout still runs (source path)
- [ ] `bun alchemy dev` from a fresh consumer install (`bun add alchemy`, both default and isolated linkers) no longer errors on `exec.ts`
- [ ] `bun tsc -b` clean