### PR TITLE
feat(test): align vitest and bun test helpers and integrate with profiles

### DIFF
--- a/examples/aws-lambda/test/integ.test.ts
+++ b/examples/aws-lambda/test/integ.test.ts
@@ -1,13 +1,14 @@
-import {
-  afterAll,
-  beforeAll,
-  deploy,
-  destroy,
-  expect,
-  test,
-} from "alchemy/Test/Bun";
+import * as AWS from "alchemy/AWS";
+import * as Alchemy from "alchemy";
+import * as Test from "alchemy/Test/Bun";
+import { expect } from "bun:test";
 import * as Effect from "effect/Effect";
 import Stack from "../alchemy.run.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: AWS.providers(),
+  state: Alchemy.localState(),
+});
 
 const stack = beforeAll(deploy(Stack));
 afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));

--- a/examples/cloudflare-tanstack/test/integ.test.ts
+++ b/examples/cloudflare-tanstack/test/integ.test.ts
@@ -1,11 +1,11 @@
-import {
-  afterAll,
-  beforeAll,
-  deploy,
-  destroy,
-  expect,
-  test,
-} from "alchemy/Test/Bun";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Test from "alchemy/Test/Bun";
+import { expect } from "bun:test";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+  state: Cloudflare.state(),
+});
 import * as Effect from "effect/Effect";
 import Stack from "../alchemy.run.ts";
 

--- a/examples/cloudflare-worker-async/test/integ.test.ts
+++ b/examples/cloudflare-worker-async/test/integ.test.ts
@@ -1,13 +1,13 @@
-import {
-  afterAll,
-  beforeAll,
-  deploy,
-  destroy,
-  expect,
-  test,
-} from "alchemy/Test/Bun";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Test from "alchemy/Test/Bun";
+import { expect } from "bun:test";
 import * as Effect from "effect/Effect";
 import Stack from "../alchemy.run.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+  state: Cloudflare.state(),
+});
 
 const stack = beforeAll(deploy(Stack));
 afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));

--- a/examples/cloudflare-worker/test/integ.test.ts
+++ b/examples/cloudflare-worker/test/integ.test.ts
@@ -1,13 +1,13 @@
-import {
-  afterAll,
-  beforeAll,
-  deploy,
-  destroy,
-  expect,
-  test,
-} from "alchemy/Test/Bun";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Test from "alchemy/Test/Bun";
+import { expect } from "bun:test";
 import * as Effect from "effect/Effect";
 import Stack from "../alchemy.run.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+  state: Cloudflare.state(),
+});
 
 const stack = beforeAll(deploy(Stack));
 

--- a/packages/alchemy/src/Test/Bun.ts
+++ b/packages/alchemy/src/Test/Bun.ts
@@ -1,164 +1,187 @@
 import bun from "bun:test";
-import { ConfigProvider } from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Logger from "effect/Logger";
-import * as Option from "effect/Option";
-import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import type { HookOptions } from "node:test";
-import { AlchemyContext, AlchemyContextLive } from "../AlchemyContext.ts";
-import { provideFreshArtifactStore } from "../Artifacts.ts";
-import { AuthProviders } from "../Auth/AuthProvider.ts";
-import { inkCLI } from "../Cli/InkCLI.tsx";
-import { deploy as _deploy } from "../Deploy.ts";
-import { destroy as _destroy } from "../Destroy.ts";
-import {
-  type CompiledStack,
-  type StackEffect,
-  type StackServices,
-} from "../Stack.ts";
-import * as State from "../State/index.ts";
-import { TelemetryLive } from "../Telemetry/Layer.ts";
-import { loadConfigProvider } from "../Util/ConfigProvider.ts";
-import { PlatformServices } from "../Util/PlatformServices.ts";
 
-export type ProvidedServices = StackServices;
+import type { AlchemyContext } from "../AlchemyContext.ts";
+import type { CompiledStack } from "../Stack.ts";
+import type { Stage } from "../Stage.ts";
+import * as Core from "./Core.ts";
 
-type TestEffect<A, Req = never> = StackEffect<A, any, Req>;
+export type MakeOptions<ROut = any> = Core.MakeOptions<ROut>;
+export type ScratchStack = Core.ScratchStack;
+export type TestEffect<A, R = never> = Core.TestEffect<A, R>;
 
-const platform = Layer.mergeAll(PlatformServices, FetchHttpClient.layer);
+export interface TestApi {
+  test: TestFn;
+  beforeAll: BeforeAllFn;
+  beforeEach: BeforeEachFn;
+  afterAll: AfterAllFn;
+  afterEach: AfterEachFn;
+  deploy: <A>(
+    stack: TestEffect<CompiledStack<A>, Stage | AlchemyContext>,
+    options?: { stage?: string },
+  ) => ReturnType<typeof Core.deploy<A>>;
+  destroy: (
+    stack: TestEffect<CompiledStack, Stage | AlchemyContext>,
+    options?: { stage?: string },
+  ) => ReturnType<typeof Core.destroy>;
+}
 
-// override alchemy state store, CLI/reporting, state, and dotAlchemy
-const alchemy = Layer.mergeAll(
-  inkCLI(),
-  Logger.layer([Logger.consolePretty()], { mergeWithExisting: true }),
-  AlchemyContextLive,
-);
+interface TestFn {
+  (name: string, eff: TestEffect<void>, options?: bun.TestOptions): void;
+  skip: (
+    name: string,
+    eff: TestEffect<void>,
+    options?: bun.TestOptions,
+  ) => void;
+  skipIf: (
+    condition: boolean,
+  ) => (name: string, eff: TestEffect<void>, options?: bun.TestOptions) => void;
+  only: (
+    name: string,
+    eff: TestEffect<void>,
+    options?: bun.TestOptions,
+  ) => void;
+  todo: (
+    name: string,
+    eff: TestEffect<void>,
+    options?: bun.TestOptions,
+  ) => void;
+  provider: ProviderFn;
+}
 
-const run = <A>(effect: TestEffect<A>) =>
-  Effect.gen(function* () {
-    const configProvider = yield* loadConfigProvider(Option.none());
+interface ProviderFn {
+  (
+    name: string,
+    fn: (stack: ScratchStack) => Effect.Effect<void, any, any>,
+    options?: bun.TestOptions,
+  ): void;
+  skip: (
+    name: string,
+    fn: (stack: ScratchStack) => Effect.Effect<void, any, any>,
+    options?: bun.TestOptions,
+  ) => void;
+  skipIf: (
+    condition: boolean,
+  ) => (
+    name: string,
+    fn: (stack: ScratchStack) => Effect.Effect<void, any, any>,
+    options?: bun.TestOptions,
+  ) => void;
+}
 
-    return yield* effect.pipe(
-      provideFreshArtifactStore,
-      Effect.provide(Layer.succeed(ConfigProvider, configProvider)),
+interface BeforeAllFn {
+  <A>(eff: TestEffect<A>, options?: HookOptions): Effect.Effect<A>;
+}
+
+interface BeforeEachFn {
+  (eff: TestEffect<void>, options?: HookOptions): void;
+}
+
+interface AfterAllFn {
+  (eff: TestEffect<any>, options?: HookOptions): void;
+  skipIf: (
+    predicate: boolean,
+  ) => (eff: TestEffect<any>, options?: HookOptions) => void;
+}
+
+interface AfterEachFn {
+  (eff: TestEffect<void>, options?: HookOptions): void;
+}
+
+const DEFAULT_HOOK_TIMEOUT: HookOptions = { timeout: 120_000 };
+
+/**
+ * Build the per-file test API. Configure providers / state once at the top of
+ * the test file:
+ *
+ * ```ts
+ * import * as Test from "alchemy/Test/Bun";
+ * import * as Cloudflare from "alchemy/Cloudflare";
+ *
+ * const { test, deploy, destroy, beforeAll, afterAll } = Test.make({
+ *   providers: Cloudflare.providers(),
+ *   state: Cloudflare.state(),
+ * });
+ * ```
+ */
+export const make = <ROut = any>(options: MakeOptions<ROut>): TestApi => {
+  const runEff = <A>(eff: TestEffect<A>) => Core.run(eff, options);
+
+  const test = ((name, eff, opts) => {
+    bun.test(name, () => runEff(eff), opts);
+  }) as TestFn;
+
+  test.skip = (name, eff, opts) => {
+    bun.test.skip(name, () => runEff(eff), opts);
+  };
+  test.skipIf = (condition) => (name, eff, opts) => {
+    bun.test.skipIf(condition)(name, () => runEff(eff), opts);
+  };
+  test.only = (name, eff, opts) => {
+    bun.test.only(name, () => runEff(eff), opts);
+  };
+  test.todo = (name, eff, opts) => {
+    bun.test.todo(name, () => runEff(eff), opts);
+  };
+
+  const runProvider = (
+    name: string,
+    fn: (stack: ScratchStack) => Effect.Effect<void, any, any>,
+  ) => {
+    const scratch = Core.scratchStack(options, name);
+    return Core.run(Core.withProviders(fn(scratch), options, scratch.name), {
+      ...options,
+      state: scratch.state,
+    });
+  };
+
+  const provider = ((name, fn, opts) => {
+    bun.test(name, () => runProvider(name, fn), opts);
+  }) as ProviderFn;
+  provider.skip = (name, fn, opts) => {
+    bun.test.skip(name, () => runProvider(name, fn), opts);
+  };
+  provider.skipIf = (condition) => (name, fn, opts) => {
+    bun.test.skipIf(condition)(name, () => runProvider(name, fn), opts);
+  };
+  test.provider = provider;
+
+  const beforeAll: BeforeAllFn = <A>(
+    eff: TestEffect<A>,
+    hookOptions?: HookOptions,
+  ) => {
+    let result: A;
+    bun.beforeAll(
+      () => runEff(eff).then((v) => (result = v)),
+      hookOptions ?? DEFAULT_HOOK_TIMEOUT,
     );
-  }).pipe(
-    Effect.provideService(AuthProviders, {}),
-    Effect.provide(State.localState()),
-    Effect.provide(Layer.provideMerge(alchemy, platform)),
-    Effect.scoped,
-    Effect.runPromise,
-  );
+    return Effect.sync(() => result);
+  };
 
-export const it = test;
+  const beforeEach: BeforeEachFn = (eff, hookOptions) => {
+    bun.beforeEach(() => runEff(eff), hookOptions);
+  };
 
-export const expect = bun.expect;
+  const afterAll = ((eff, hookOptions) => {
+    bun.afterAll(() => runEff(eff), hookOptions ?? DEFAULT_HOOK_TIMEOUT);
+  }) as AfterAllFn;
+  afterAll.skipIf = (predicate) => (eff, hookOptions) => {
+    if (predicate) return;
+    bun.afterAll(() => runEff(eff), hookOptions ?? DEFAULT_HOOK_TIMEOUT);
+  };
 
-export function test(
-  name: string,
-  test: TestEffect<void>,
-  options?: bun.TestOptions,
-) {
-  bun.test(name, () => run(test), options);
-}
+  const afterEach: AfterEachFn = (eff, hookOptions) => {
+    bun.afterEach(() => runEff(eff), hookOptions);
+  };
 
-export namespace test {
-  export function skipIf(condition: boolean) {
-    return (
-      name: string,
-      test: TestEffect<void>,
-      options?: bun.TestOptions,
-    ) => {
-      bun.test.skipIf(condition)(name, () => run(test), options);
-    };
-  }
-
-  export function skip(
-    name: string,
-    test: TestEffect<void>,
-    options?: bun.TestOptions,
-  ) {
-    bun.test.skip(name, () => run(test), options);
-  }
-
-  export function only(
-    name: string,
-    test: TestEffect<void>,
-    options?: bun.TestOptions,
-  ) {
-    bun.test.only(name, () => run(test), options);
-  }
-
-  export function todo(
-    name: string,
-    test: TestEffect<void>,
-    options?: bun.TestOptions,
-  ) {
-    bun.test.todo(name, () => run(test), options);
-  }
-}
-
-export const describe = bun.describe;
-
-export function beforeAll<A>(eff: TestEffect<A>, options?: HookOptions) {
-  let a: A;
-  bun.beforeAll(
-    () => run(eff).then((v) => (a = v)),
-    options ?? {
-      timeout: 120_000,
-    },
-  );
-  return Effect.sync(() => a);
-}
-
-export function beforeEach(eff: TestEffect<void>, options?: HookOptions) {
-  bun.beforeEach(() => run(eff), options);
-}
-
-export function afterAll(eff: TestEffect<any>, options?: HookOptions) {
-  bun.afterAll(() => run(eff), options);
-}
-
-export namespace afterAll {
-  export const skipIf =
-    (predicate: boolean) => (test: TestEffect<void>, options?: HookOptions) => {
-      if (predicate) {
-      } else {
-        bun.afterAll(
-          () => run(test),
-          options ?? {
-            timeout: 120_000,
-          },
-        );
-      }
-    };
-}
-
-export function afterEach(eff: TestEffect<void>, options?: HookOptions) {
-  bun.afterEach(() => run(eff), options);
-}
-
-export const deploy = <A>(
-  stack: TestEffect<CompiledStack<A>, AlchemyContext>,
-  options?: {
-    /** @default test */
-    stage?: string;
-  },
-) =>
-  _deploy({
-    stack: stack,
-    stage: options?.stage ?? "test",
-  }).pipe(Effect.provide(TelemetryLive));
-
-export const destroy = (
-  stack: TestEffect<CompiledStack, AlchemyContext>,
-  options?: {
-    /** @default test */
-    stage?: string;
-  },
-) =>
-  _destroy({
-    stack,
-    stage: options?.stage ?? "test",
-  }).pipe(Effect.provide(TelemetryLive));
+  return {
+    test,
+    beforeAll,
+    beforeEach,
+    afterAll,
+    afterEach,
+    deploy: (stack, callOpts) => Core.deploy(options, stack, callOpts),
+    destroy: (stack, callOpts) => Core.destroy(options, stack, callOpts),
+  };
+};

--- a/packages/alchemy/src/Test/Core.ts
+++ b/packages/alchemy/src/Test/Core.ts
@@ -1,0 +1,225 @@
+import { ConfigProvider } from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
+import * as Option from "effect/Option";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+
+import type { AlchemyContext } from "../AlchemyContext.ts";
+import { AlchemyContextLive } from "../AlchemyContext.ts";
+import { apply } from "../Apply.ts";
+import { provideFreshArtifactStore } from "../Artifacts.ts";
+import { AuthProviders } from "../Auth/AuthProvider.ts";
+import { withProfileOverride } from "../Auth/Profile.ts";
+import { LoggingCli } from "../Cli/LoggingCli.ts";
+import { deploy as _deploy } from "../Deploy.ts";
+import { destroy as _destroy } from "../Destroy.ts";
+import type { Input } from "../Input.ts";
+import * as Plan from "../Plan.ts";
+import {
+  type CompiledStack,
+  make as makeStack,
+  Stack,
+  type StackEffect,
+  type StackServices,
+} from "../Stack.ts";
+import { Stage } from "../Stage.ts";
+import * as State from "../State/index.ts";
+import { TelemetryLive } from "../Telemetry/Layer.ts";
+import { loadConfigProvider } from "../Util/ConfigProvider.ts";
+import { PlatformServices } from "../Util/PlatformServices.ts";
+
+/**
+ * Configuration shared by every test in a file. Pass to `Test.make(...)`.
+ */
+export interface MakeOptions<ROut = any> {
+  /** Provider layer for the stack — e.g. `AWS.providers()`, `Cloudflare.providers()`. */
+  providers: Layer.Layer<ROut, never, StackServices>;
+  /** State store for top-level `deploy(Stack)` / `destroy(Stack)`; defaults to {@link State.localState}. */
+  state?: Layer.Layer<State.State, never, StackServices>;
+  /** Override `ALCHEMY_PROFILE`; otherwise resolved from env / .env. */
+  profile?: string;
+  /** Default stage for deploy/destroy (default `"test"`). */
+  stage?: string;
+}
+
+export type TestEffect<A, Req = never> = StackEffect<A, any, Req>;
+
+const platformLayer = Layer.mergeAll(PlatformServices, FetchHttpClient.layer);
+
+const alchemyLayer = Layer.mergeAll(
+  LoggingCli,
+  Logger.layer([Logger.consolePretty()], { mergeWithExisting: true }),
+  AlchemyContextLive,
+);
+
+/**
+ * Build the per-test runtime and return a self-contained Effect.
+ *
+ * Mirrors {@link "../bin/alchemy.ts"} composition: ConfigProvider via
+ * `loadConfigProvider` + `withProfileOverride`, an empty `AuthProviders`
+ * registry that the user's `providers` layer populates, the platform layers,
+ * and the configured state store. Adapters wrap this into runner-specific
+ * thunks (`bun.test` -> `runPromise`, `it.live` -> as-is).
+ */
+export const toEffect = <A>(
+  effect: TestEffect<A>,
+  options: MakeOptions,
+): Effect.Effect<A, any, never> =>
+  Effect.gen(function* () {
+    const base = yield* loadConfigProvider(Option.none());
+    const configProvider = withProfileOverride(base, options.profile);
+    return yield* effect.pipe(
+      provideFreshArtifactStore,
+      Effect.provide(Layer.succeed(ConfigProvider, configProvider)),
+    );
+  }).pipe(
+    Effect.provideService(AuthProviders, {}),
+    Effect.provide(options.state ?? State.localState()),
+    Effect.provide(Layer.provideMerge(alchemyLayer, platformLayer)),
+    Effect.scoped,
+  ) as Effect.Effect<A, any, never>;
+
+/** Promise wrapper around {@link toEffect} for `bun.test`-style runners. */
+export const run = <A>(
+  effect: TestEffect<A>,
+  options: MakeOptions,
+): Promise<A> => Effect.runPromise(toEffect(effect, options));
+
+/**
+ * Wrap an effect so it runs with `options.providers` + a placeholder Stack +
+ * Stage in scope. Used by `test.provider` so user code can call provider SDK
+ * APIs (e.g. `DynamoDB.describeTable`) directly inside the test body.
+ */
+export const withProviders = <A, E, R, ROut>(
+  effect: Effect.Effect<A, E, R>,
+  options: MakeOptions<ROut>,
+  stackName: string,
+): Effect.Effect<A, E, Exclude<R, ROut | Stack | Stage>> =>
+  effect.pipe(
+    Effect.provide(options.providers as Layer.Layer<any, never, any>),
+    Effect.provide(
+      Layer.succeed(Stack, {
+        name: stackName,
+        stage: options.stage ?? "test",
+        resources: {},
+        bindings: {},
+      }),
+    ),
+    Effect.provide(Layer.succeed(Stage, options.stage ?? "test")),
+  ) as Effect.Effect<A, E, Exclude<R, ROut | Stack | Stage>>;
+
+/**
+ * Curried `deploy` for the test factory: bakes in the configured stage and
+ * adds the telemetry layer the CLI uses, so `beforeAll(deploy(Stack))` works
+ * the same way as `alchemy deploy`.
+ */
+export const deploy = <A>(
+  options: MakeOptions,
+  stack: TestEffect<CompiledStack<A>, Stage | AlchemyContext>,
+  callOptions?: { stage?: string },
+) =>
+  _deploy({
+    stack: stack as Effect.Effect<CompiledStack<A>, never, any>,
+    stage: callOptions?.stage ?? options.stage ?? "test",
+  }).pipe(Effect.provide(TelemetryLive));
+
+export const destroy = (
+  options: MakeOptions,
+  stack: TestEffect<CompiledStack, Stage | AlchemyContext>,
+  callOptions?: { stage?: string },
+) =>
+  _destroy({
+    stack: stack as Effect.Effect<CompiledStack, never, any>,
+    stage: callOptions?.stage ?? options.stage ?? "test",
+  }).pipe(Effect.provide(TelemetryLive));
+
+/**
+ * In-test scratch stack handed to `test.provider(name, (stack) => ...)`.
+ *
+ * Each scratch stack owns a private in-memory state store that is shared
+ * between successive `deploy`/`destroy` calls AND visible to the user's test
+ * body (so `yield* State` / `state.get(...)` see the same store the deploys
+ * mutated). This makes create / update / replace / delete paths exercisable
+ * without polluting `.alchemy/` or other tests in the same file.
+ */
+export interface ScratchStack<ROut = any> {
+  readonly name: string;
+  /** The shared in-memory state Layer for this scratch. @internal */
+  readonly state: Layer.Layer<State.State, never, never>;
+  deploy<A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<Input.Resolve<A>, any, Exclude<R, ROut | StackServices>>;
+  destroy(): Effect.Effect<void, any, never>;
+}
+
+const sanitizeStackName = (name: string) =>
+  name.replaceAll(/[^a-zA-Z0-9_]/g, "-").replace(/-+/g, "-");
+
+/**
+ * Build a fresh `ScratchStack` for `test.provider`. Allocates a private
+ * in-memory state store so the test is isolated from `.alchemy/` and from
+ * other tests in the same file.
+ */
+export const scratchStack = <ROut>(
+  options: MakeOptions<ROut>,
+  name: string,
+): ScratchStack<ROut> => {
+  const stage = options.stage ?? "test";
+  const stackName = sanitizeStackName(name);
+  const inMemory: Record<
+    string,
+    Record<string, Record<string, State.ResourceState>>
+  > = {};
+  const stateLayer = Layer.succeed(
+    State.State,
+    State.InMemoryService(inMemory),
+  );
+
+  const buildAndApply = (effect: Effect.Effect<any, any, any>) =>
+    (effect as Effect.Effect<any, any, never>).pipe(
+      makeStack({
+        name: stackName,
+        providers: options.providers,
+        state: stateLayer,
+      } as any) as any,
+      Effect.flatMap((compiled: any) =>
+        Plan.make(compiled).pipe(
+          Effect.flatMap(apply),
+          Effect.provide(compiled.services),
+        ),
+      ),
+      Effect.provide(Layer.succeed(Stage, stage)),
+      provideFreshArtifactStore,
+    );
+
+  return {
+    name: stackName,
+    state: stateLayer,
+    deploy: ((effect: Effect.Effect<any, any, any>) =>
+      buildAndApply(effect)) as ScratchStack<ROut>["deploy"],
+    destroy: () =>
+      Plan.make({
+        name: stackName,
+        stage,
+        resources: {},
+        bindings: {},
+        output: {},
+      }).pipe(
+        Effect.flatMap(apply),
+        Effect.asVoid,
+        Effect.provide(stateLayer),
+        Effect.provide(options.providers as Layer.Layer<any, never, any>),
+        Effect.provide(
+          Layer.succeed(Stack, {
+            name: stackName,
+            stage,
+            resources: {},
+            bindings: {},
+          }),
+        ),
+        Effect.provide(Layer.succeed(Stage, stage)),
+        provideFreshArtifactStore,
+      ) as Effect.Effect<void, any, never>,
+  };
+};

--- a/packages/alchemy/src/Test/Vitest.ts
+++ b/packages/alchemy/src/Test/Vitest.ts
@@ -1,543 +1,191 @@
-import type * as aws from "@distilled.cloud/aws";
-import * as cf from "@distilled.cloud/cloudflare";
-// import { NodeServices } from "@effect/platform-node";
-import { expect, it } from "@effect/vitest";
-import { Logger } from "effect";
-import * as Config from "effect/Config";
-import * as ConfigProvider from "effect/ConfigProvider";
+import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
-import * as FileSystem from "effect/FileSystem";
-import * as Layer from "effect/Layer";
-import * as Path from "effect/Path";
-import { MinimumLogLevel } from "effect/References";
-import * as Scope from "effect/Scope";
-import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
-import * as HttpClient from "effect/unstable/http/HttpClient";
-import * as NodePath from "node:path";
 import {
   afterAll as vitestAfterAll,
+  afterEach as vitestAfterEach,
   beforeAll as vitestBeforeAll,
+  beforeEach as vitestBeforeEach,
 } from "vitest";
-import * as AWS from "../AWS/index.ts";
-import * as Cloudflare from "../Cloudflare/index.ts";
 
-import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
-import { AlchemyContext, AlchemyContextLive } from "../AlchemyContext.ts";
-import { apply } from "../Apply.ts";
-import { Artifacts, provideFreshArtifactStore } from "../Artifacts.ts";
-import { AuthProviders } from "../Auth/AuthProvider.ts";
-import * as AWSCredentials from "../AWS/Credentials.ts";
-import * as AWSEnvironment from "../AWS/Environment.ts";
-import * as AWSRegion from "../AWS/Region.ts";
-import type { Command } from "../Build/Command.ts";
-import type { Cli } from "../Cli/index.ts";
-import { LoggingCli } from "../Cli/LoggingCli.ts";
-import {
-  buildNamespaceTree,
-  flattenTree,
-  type DerivedAction,
-} from "../Cli/NamespaceTree.ts";
-import { ExecutionContext } from "../ExecutionContext.ts";
-import type { Input } from "../Input.ts";
-import type { Output } from "../Output.ts";
-import * as Plan from "../Plan.ts";
-import type { Provider } from "../Provider.ts";
-import * as Server from "../Server/index.ts";
-import * as Serverless from "../Serverless/index.ts";
-import * as Stack from "../Stack.ts";
-import * as Stage from "../Stage.ts";
-import * as State from "../State/index.ts";
-import { PlatformServices } from "../Util/PlatformServices.ts";
+import type { AlchemyContext } from "../AlchemyContext.ts";
+import type { CompiledStack } from "../Stack.ts";
+import type { Stage } from "../Stage.ts";
+import * as Core from "./Core.ts";
 
-export const expectEmptyObject = () =>
-  expect.toSatisfy(
-    (deletions) => Object.keys(deletions).length === 0,
-    "empty object",
-  );
+export type MakeOptions<ROut = any> = Core.MakeOptions<ROut>;
+export type ScratchStack = Core.ScratchStack;
+export type TestEffect<A, R = never> = Core.TestEffect<A, R>;
 
-export const expectPropExpr = (identifier: string, src: any) =>
-  expect.objectContaining({
-    kind: "PropExpr",
-    identifier,
-    expr: expect.objectContaining({
-      kind: "ResourceExpr",
-      src,
-    }),
-  });
+type TestOptions = number | { timeout?: number };
 
-type Provided =
-  | Scope.Scope
-  | Stack.Stack
-  | State.State
-  | Stage.Stage
-  | AlchemyContext
-  | HttpClient.HttpClient
-  | FileSystem.FileSystem
-  | Path.Path
-  | aws.Credentials.Credentials
-  | aws.Region.Region
-  | Cli
-  | ExecutionContext
-  | Server.ProcessContext
-  | Server.ServerHost
-  | Serverless.FunctionContext
-  | AWSEnvironment.AWSEnvironment
-  | Artifacts
-  | Provider<Command>
-  | AWS.Providers
-  | Cloudflare.Providers
-  | ChildProcessSpawner
-  | AuthProviders;
+const timeoutOf = (opts: TestOptions | undefined): number | undefined =>
+  typeof opts === "number" ? opts : opts?.timeout;
 
-const quietLogger = Logger.make(() => {
-  // console.log(options.message);
-});
+interface TestFn {
+  (name: string, eff: TestEffect<void>, options?: TestOptions): void;
+  skip: (name: string, eff: TestEffect<void>, options?: TestOptions) => void;
+  skipIf: (
+    condition: boolean,
+  ) => (name: string, eff: TestEffect<void>, options?: TestOptions) => void;
+  only: (name: string, eff: TestEffect<void>, options?: TestOptions) => void;
+  todo: (name: string, eff: TestEffect<void>, options?: TestOptions) => void;
+  provider: ProviderFn;
+}
 
-const platform = Layer.mergeAll(
-  PlatformServices,
-  FetchHttpClient.layer,
-  Logger.layer([process.env.VERBOSE ? Logger.consolePretty() : quietLogger]),
-);
+interface ProviderFn {
+  (
+    name: string,
+    fn: (stack: ScratchStack) => Effect.Effect<void, any, any>,
+    options?: TestOptions,
+  ): void;
+  skip: (
+    name: string,
+    fn: (stack: ScratchStack) => Effect.Effect<void, any, any>,
+    options?: TestOptions,
+  ) => void;
+  skipIf: (
+    condition: boolean,
+  ) => (
+    name: string,
+    fn: (stack: ScratchStack) => Effect.Effect<void, any, any>,
+    options?: TestOptions,
+  ) => void;
+}
 
-const awsEnvironment = Layer.unwrap(
-  Effect.gen(function* () {
-    const _profileName = yield* Config.string("AWS_PROFILE").pipe(
-      Config.withDefault("default"),
-    );
-    const LOCAL = yield* Config.boolean("LOCAL").pipe(
-      Config.withDefault(false),
-    );
-    const LOCALSTACK_ENDPOINT = yield* Config.string(
-      "LOCALSTACK_ENDPOINT",
-    ).pipe(Config.withDefault("http://localhost.localstack.cloud:4566"));
+interface BeforeAllFn {
+  <A>(eff: TestEffect<A>, options?: TestOptions): Effect.Effect<A>;
+}
 
-    if (LOCAL) {
-      return AWSEnvironment.makeEnvironment({
-        accountId: "000000000000",
-        region: "us-east-1",
-        credentials: {
-          accessKeyId: "test",
-          secretAccessKey: "test",
-          sessionToken: "test",
-        },
-        endpoint: LOCALSTACK_ENDPOINT,
-      });
-    }
-    return Layer.effect(
-      AWSEnvironment.AWSEnvironment,
-      AWSEnvironment.loadDefault(),
-    ).pipe(Layer.orDie);
-  }),
-);
+interface BeforeEachFn {
+  (eff: TestEffect<void>, options?: TestOptions): void;
+}
 
-const awsProviders = Layer.provideMerge(
-  AWS.providers(),
-  Layer.provideMerge(
-    Layer.mergeAll(AWSRegion.fromEnvironment, AWSCredentials.fromEnvironment),
-    awsEnvironment,
-  ),
-);
+interface AfterAllFn {
+  (eff: TestEffect<any>, options?: TestOptions): void;
+  skipIf: (
+    predicate: boolean,
+  ) => (eff: TestEffect<any>, options?: TestOptions) => void;
+}
 
-const cfProviders = Layer.provideMerge(
-  Cloudflare.providers(),
-  Layer.mergeAll(cf.CredentialsFromEnv, FetchHttpClient.layer),
-);
+interface AfterEachFn {
+  (eff: TestEffect<void>, options?: TestOptions): void;
+}
 
-const deriveStackName = (testPath: string, suffix: string) => {
-  const testDir = testPath.includes("/test/")
-    ? (testPath.split("/test/").pop() ?? "")
-    : NodePath.basename(testPath);
-  const testPathWithoutExt = testDir.replace(/\.[^.]+$/, "");
-  return `${testPathWithoutExt}-${suffix}`
-    .replaceAll(/[^a-zA-Z0-9_]/g, "-")
-    .replace(/-+/g, "-");
-};
+export interface TestApi {
+  test: TestFn;
+  beforeAll: BeforeAllFn;
+  beforeEach: BeforeEachFn;
+  afterAll: AfterAllFn;
+  afterEach: AfterEachFn;
+  deploy: <A>(
+    stack: TestEffect<CompiledStack<A>, Stage | AlchemyContext>,
+    options?: { stage?: string },
+  ) => ReturnType<typeof Core.deploy<A>>;
+  destroy: (
+    stack: TestEffect<CompiledStack, Stage | AlchemyContext>,
+    options?: { stage?: string },
+  ) => ReturnType<typeof Core.destroy>;
+}
 
-const runWithContext = <A, Err>(
-  stackName: string,
-  effect: Effect.Effect<A, Err, Provided>,
-  options: {
-    state?: Layer.Layer<State.State, never, Stack.Stack>;
-    providers?: boolean;
-  } = {},
-): Effect.Effect<
-  A,
-  aws.Credentials.CredentialsError | Config.ConfigError | Err,
-  never
-> => {
-  const stack = Layer.effect(
-    Stack.Stack,
-    Effect.succeed({
-      name: stackName,
-      stage: "test",
-      resources: {},
-      bindings: {},
-    }),
-  );
+const DEFAULT_TIMEOUT = 120_000;
 
-  const alchemy = Layer.provideMerge(
-    Layer.mergeAll(options.state ?? State.localState(), LoggingCli),
-    Layer.mergeAll(stack, AlchemyContextLive),
-  );
+/**
+ * Build the per-file test API. See {@link "./Bun.ts"} for the same shape
+ * over `bun:test`. Vitest variant uses `@effect/vitest`'s `it.live` so
+ * Effect-aware tests stay first-class.
+ */
+export const make = <ROut = any>(options: MakeOptions<ROut>): TestApi => {
+  const wrap = <A>(eff: TestEffect<A>) => Core.toEffect(eff, options);
+  const runEff = <A>(eff: TestEffect<A>) => Core.run(eff, options);
 
-  const context = {
-    Type: "Test",
-    id: "Test",
-    env: {},
-    exports: {},
-    listen: () => Effect.void,
-    serve: () => Effect.void,
-    get: <T>(_key: string) => Effect.succeed<T>(undefined as T),
-    set: (_id: string, _output: Output) =>
-      Effect.sync(() => _id.replaceAll(/[^a-zA-Z0-9]/g, "_")),
+  const test = ((name, eff, opts) => {
+    it.live(name, () => wrap(eff), timeoutOf(opts));
+  }) as TestFn;
+
+  test.skip = (name, _eff, opts) => {
+    it.skip(name, () => {}, timeoutOf(opts));
   };
-
-  // Test harness does not fully close `Req`; runtime provides enough for tests.
-  // @ts-expect-error Residual requirement channel on `effect` after ConfigProvider.
-  return Effect.gen(function* () {
-    const configProvider = ConfigProvider.orElse(
-      yield* ConfigProvider.fromDotEnv({ path: ".env" }),
-      ConfigProvider.fromEnv(),
-    );
-    return yield* effect.pipe(
-      Effect.provideService(ConfigProvider.ConfigProvider, configProvider),
-    );
-  }).pipe(
-    Effect.provide(
-      Layer.provideMerge(
-        options.providers === false
-          ? Layer.empty
-          : Layer.mergeAll(awsProviders, cfProviders),
-        Layer.provideMerge(alchemy, platform),
-      ),
-    ),
-    Effect.provideService(Stage.Stage, "test"),
-    Effect.provideService(AuthProviders, {}),
-    Effect.provideService(ExecutionContext, context as any),
-    Effect.provideService(Server.ServerHost, {
-      run: (_effect) => Effect.void,
-    }),
-    Effect.provideService(
-      MinimumLogLevel,
-      process.env.DEBUG ? "Debug" : "Info",
-    ),
-    Effect.provide(PlatformServices),
-  );
-};
-
-export function test(
-  name: string,
-  options: {
-    timeout?: number;
-    state?: Layer.Layer<State.State, never, Stack.Stack>;
-    providers?: boolean;
-  },
-  testCase: Effect.Effect<void, any, Provided>,
-): void;
-
-export function test(
-  name: string,
-  testCase: Effect.Effect<void, any, Provided>,
-): void;
-
-export function test(
-  name: string,
-  ...args:
-    | [
-        {
-          timeout?: number;
-          state?: Layer.Layer<State.State, never, Stack.Stack>;
-          providers?: boolean;
-        },
-        Effect.Effect<void, any, Provided>,
-      ]
-    | [Effect.Effect<void, any, Provided>]
-) {
-  const [options = {}, testCase] =
-    args.length === 1 ? [undefined, args[0]] : args;
-
-  const testPath = expect.getState().testPath ?? "";
-  const stackName = deriveStackName(testPath, name);
-  const effect = runWithContext(stackName, testCase, options);
-
-  return it.live(name, () => effect, options.timeout);
-}
-
-export namespace test {
-  export function skip(
-    name: string,
-    options: {
-      timeout?: number;
-      state?: Layer.Layer<State.State, never, Stack.Stack>;
-      providers?: boolean;
-    },
-    testCase: Effect.Effect<void, any, Provided>,
-  ): void;
-
-  export function skip(
-    name: string,
-    testCase: Effect.Effect<void, any, Provided>,
-  ): void;
-
-  export function skip(
-    name: string,
-    ...args:
-      | [
-          {
-            timeout?: number;
-            state?: Layer.Layer<State.State, never, Stack.Stack>;
-            providers?: boolean;
-          },
-          Effect.Effect<void, any, Provided>,
-        ]
-      | [Effect.Effect<void, any, Provided>]
-  ) {
-    const [options = {}, _testCase] =
-      args.length === 1 ? [undefined, args[0]] : args;
-    it.skip(name, () => {}, options.timeout);
-  }
-
-  export function skipIf(condition: boolean) {
-    return function (
-      name: string,
-      ...args:
-        | [
-            {
-              timeout?: number;
-              state?: Layer.Layer<State.State, never, Stack.Stack>;
-              providers?: boolean;
-            },
-            Effect.Effect<void, any, Provided>,
-          ]
-        | [Effect.Effect<void, any, Provided>]
-    ) {
-      if (condition) {
-        const [options = {}, _testCase] =
-          args.length === 1 ? [undefined, args[0]] : args;
-        it.skip(name, () => {}, options.timeout);
-      } else {
-        test(name, ...(args as [Effect.Effect<void, any, Provided>]));
-      }
-    };
-  }
-
-  export const state = (resources: Record<string, State.ResourceState> = {}) =>
-    Layer.effect(
-      State.State,
-      Effect.gen(function* () {
-        const stack = yield* Stack.Stack;
-        return State.InMemoryService({
-          [stack.name]: {
-            [stack.stage]: resources,
-          },
-        });
-      }),
-    );
-
-  export const defaultState = (
-    resources: Record<string, State.ResourceState> = {},
-    other?: {
-      [stack: string]: {
-        [stage: string]: {
-          [resourceId: string]: State.ResourceState;
-        };
-      };
-    },
-  ) =>
-    Layer.succeed(
-      State.State,
-      State.InMemoryService({
-        ["test-app"]: {
-          ["test-stage"]: resources,
-        },
-        ...other,
-      }),
-    );
-
-  export const deploy = <A, Err = never, Req = any>(
-    effect: Effect.Effect<A, Err, Req>,
-  ): Effect.Effect<Input.Resolve<A>, Err, Req | Stack.Stack> =>
-    Stack.Stack.use((stack) =>
-      effect.pipe(
-        // @ts-expect-error - test harness reuses ambient runtime context
-        Stack.make({
-          name: stack.name,
-          providers: Layer.effectContext(Effect.context<never>()),
-          state: State.localState(),
-          stack: {
-            ...stack,
-            resources: {},
-            bindings: {},
-            output: {},
-          },
-        }),
-        Effect.flatMap(Plan.make),
-        Effect.tap((plan) => Effect.logInfo(formatPlan(plan))),
-        Effect.flatMap(apply),
-        provideFreshArtifactStore,
-      ),
-    );
-}
-
-type AnyAction = Plan.CRUD["action"] | Plan.BindingAction | DerivedAction;
-
-const formatPlan = (plan: Plan.Plan) => {
-  const items = [
-    ...Object.values(plan.resources),
-    ...Object.values(plan.deletions),
-  ] as Plan.CRUD[];
-
-  if (items.length === 0) {
-    return "Plan: no changes planned";
-  }
-
-  const counts = items.reduce(
-    (acc, item) => {
-      acc[item.action] += 1;
-      return acc;
-    },
-    {
-      create: 0,
-      update: 0,
-      delete: 0,
-      noop: 0,
-      replace: 0,
-    },
-  );
-
-  const summary = (["create", "update", "delete", "replace"] as const)
-    .filter((action) => counts[action] > 0)
-    .map((action) => `${counts[action]} to ${action}`)
-    .join(" | ");
-
-  const flatItems = flattenTree(buildNamespaceTree(items));
-  const lines = [`Plan: ${summary}`];
-
-  for (const item of flatItems) {
-    const indent = "  ".repeat(item.depth);
-    const icon = getActionIcon(item.action);
-
-    if (item.type === "namespace") {
-      lines.push(`${indent}${icon} ${item.id}`);
-      continue;
-    }
-
-    if (item.type === "binding") {
-      lines.push(`${indent}${icon} ${item.bindingSid}`);
-      continue;
-    }
-
-    const bindingSuffix =
-      item.bindingCount && item.bindingCount > 0
-        ? ` (${item.bindingCount} bindings)`
-        : "";
-    lines.push(
-      `${indent}${icon} ${item.id} (${item.resourceType})${bindingSuffix}`,
-    );
-  }
-
-  return lines.join("\n");
-};
-
-const getActionIcon = (action: AnyAction): string =>
-  ({
-    create: "+",
-    update: "~",
-    delete: "-",
-    noop: "•",
-    replace: "!",
-    mixed: "*",
-  })[action] ?? "?";
-
-export function skip(
-  name: string,
-  options: {
-    timeout?: number;
-    state?: Layer.Layer<State.State, never, Stack.Stack>;
-    providers?: boolean;
-  },
-  testCase: Effect.Effect<void, any, Provided>,
-): void;
-
-export function skip(
-  name: string,
-  testCase: Effect.Effect<void, any, Provided>,
-): void;
-
-export function skip(
-  name: string,
-  ...args:
-    | [
-        {
-          timeout?: number;
-          state?: Layer.Layer<State.State, never, Stack.Stack>;
-          providers?: boolean;
-        },
-        Effect.Effect<void, any, Provided>,
-      ]
-    | [Effect.Effect<void, any, Provided>]
-) {
-  const [options = {}, _testCase] =
-    args.length === 1 ? [undefined, args[0]] : args;
-  it.skip(name, () => {}, options.timeout);
-}
-
-export function skipIf(condition: boolean) {
-  return function (
-    name: string,
-    ...args:
-      | [
-          {
-            timeout?: number;
-            state?: Layer.Layer<State.State, never, Stack.Stack>;
-            providers?: boolean;
-          },
-          Effect.Effect<void, any, Provided>,
-        ]
-      | [Effect.Effect<void, any, Provided>]
-  ) {
+  test.skipIf = (condition) => (name, eff, opts) => {
     if (condition) {
-      const [options = {}, _testCase] =
-        args.length === 1 ? [undefined, args[0]] : args;
-      it.skip(name, () => {}, options.timeout);
+      it.skip(name, () => {}, timeoutOf(opts));
     } else {
-      test(name, ...(args as [Effect.Effect<void, any, Provided>]));
+      it.live(name, () => wrap(eff), timeoutOf(opts));
     }
   };
-}
+  test.only = (name, eff, opts) => {
+    it.only(name, () => wrap(eff) as Effect.Effect<any>, timeoutOf(opts));
+  };
+  test.todo = (name, _eff, _opts) => {
+    it.todo(name);
+  };
 
-export function beforeAll<A, E = never, R extends Provided = never>(
-  effect: Effect.Effect<A, E, R>,
-  options?: { timeout?: number; stackName?: string },
-): void {
-  const testPath = expect.getState().testPath ?? "";
-  const stackName = options?.stackName ?? deriveStackName(testPath, "suite");
+  const wrapProvider = (
+    name: string,
+    fn: (stack: ScratchStack) => Effect.Effect<void, any, any>,
+  ) => {
+    const scratch = Core.scratchStack(options, name);
+    return Core.toEffect(
+      Core.withProviders(fn(scratch), options, scratch.name),
+      { ...options, state: scratch.state },
+    );
+  };
 
-  vitestBeforeAll(
-    () => Effect.runPromise(Effect.scoped(runWithContext(stackName, effect))),
-    options?.timeout,
-  );
-}
+  const provider = ((name, fn, opts) => {
+    it.live(name, () => wrapProvider(name, fn), timeoutOf(opts));
+  }) as ProviderFn;
+  provider.skip = (name, _fn, opts) => {
+    it.skip(name, () => {}, timeoutOf(opts));
+  };
+  provider.skipIf = (condition) => (name, fn, opts) => {
+    if (condition) {
+      it.skip(name, () => {}, timeoutOf(opts));
+    } else {
+      it.live(name, () => wrapProvider(name, fn), timeoutOf(opts));
+    }
+  };
+  test.provider = provider;
 
-export function afterAll<A, E, R extends Provided = never>(
-  effect: Effect.Effect<A, E, R>,
-  options?: { timeout?: number; stackName?: string },
-): void {
-  const testPath = expect.getState().testPath ?? "";
-  const stackName = options?.stackName ?? deriveStackName(testPath, "suite");
+  const beforeAll: BeforeAllFn = <A>(
+    eff: TestEffect<A>,
+    hookOptions?: TestOptions,
+  ) => {
+    let result: A;
+    vitestBeforeAll(
+      () => runEff(eff).then((v) => (result = v)),
+      timeoutOf(hookOptions) ?? DEFAULT_TIMEOUT,
+    );
+    return Effect.sync(() => result);
+  };
 
-  vitestAfterAll(
-    () => Effect.runPromise(Effect.scoped(runWithContext(stackName, effect))),
-    options?.timeout,
-  );
-}
-export const destroy = () =>
-  Stack.Stack.use((stack) =>
-    Plan.make({
-      name: stack.name,
-      stage: stack.stage,
-      resources: {},
-      bindings: {},
-      output: {},
-    }).pipe(Effect.flatMap(apply), provideFreshArtifactStore),
-  );
+  const beforeEach: BeforeEachFn = (eff, hookOptions) => {
+    vitestBeforeEach(() => runEff(eff), timeoutOf(hookOptions));
+  };
+
+  const afterAll = ((eff, hookOptions) => {
+    vitestAfterAll(
+      () => runEff(eff),
+      timeoutOf(hookOptions) ?? DEFAULT_TIMEOUT,
+    );
+  }) as AfterAllFn;
+  afterAll.skipIf = (predicate) => (eff, hookOptions) => {
+    if (predicate) return;
+    vitestAfterAll(
+      () => runEff(eff),
+      timeoutOf(hookOptions) ?? DEFAULT_TIMEOUT,
+    );
+  };
+
+  const afterEach: AfterEachFn = (eff, hookOptions) => {
+    vitestAfterEach(() => runEff(eff), timeoutOf(hookOptions));
+  };
+
+  return {
+    test,
+    beforeAll,
+    beforeEach,
+    afterAll,
+    afterEach,
+    deploy: (stack, callOpts) => Core.deploy(options, stack, callOpts),
+    destroy: (stack, callOpts) => Core.destroy(options, stack, callOpts),
+  };
+};

--- a/packages/alchemy/src/Test/index.ts
+++ b/packages/alchemy/src/Test/index.ts
@@ -1,2 +1,1 @@
 export * from "./TestState.ts";
-export * from "./Vitest.ts";

--- a/packages/alchemy/test/AWS/CloudFront/CachePolicy.test.ts
+++ b/packages/alchemy/test/AWS/CloudFront/CachePolicy.test.ts
@@ -1,80 +1,85 @@
 import * as AWS from "@/AWS";
 import { CachePolicy } from "@/AWS/CloudFront";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as cloudfront from "@distilled.cloud/aws/cloudfront";
 import { describe, expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 
+const { test } = Test.make({ providers: AWS.providers() });
+
 const runLive = process.env.ALCHEMY_RUN_LIVE_AWS_WEBSITE_TESTS === "true";
 
 describe("AWS.CloudFront.CachePolicy", () => {
-  test.skipIf(!runLive)(
+  test.provider.skipIf(!runLive)(
     "create, update, and delete a cache policy",
-    { timeout: 300_000 },
-    Effect.gen(function* () {
-      yield* destroy();
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-      const created = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* CachePolicy("ApiCachePolicy", {
-            comment: "initial",
-            minTTL: 0,
-            defaultTTL: 60,
-            maxTTL: 3600,
-            parametersInCacheKeyAndForwardedToOrigin: {
-              EnableAcceptEncodingGzip: true,
-              EnableAcceptEncodingBrotli: true,
-              HeadersConfig: {
-                HeaderBehavior: "whitelist",
-                Headers: { Quantity: 1, Items: ["Authorization"] },
+        const created = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* CachePolicy("ApiCachePolicy", {
+              comment: "initial",
+              minTTL: 0,
+              defaultTTL: 60,
+              maxTTL: 3600,
+              parametersInCacheKeyAndForwardedToOrigin: {
+                EnableAcceptEncodingGzip: true,
+                EnableAcceptEncodingBrotli: true,
+                HeadersConfig: {
+                  HeaderBehavior: "whitelist",
+                  Headers: { Quantity: 1, Items: ["Authorization"] },
+                },
+                CookiesConfig: { CookieBehavior: "none" },
+                QueryStringsConfig: { QueryStringBehavior: "all" },
               },
-              CookiesConfig: { CookieBehavior: "none" },
-              QueryStringsConfig: { QueryStringBehavior: "all" },
-            },
-          });
-        }),
-      );
+            });
+          }),
+        );
 
-      const initial = yield* cloudfront.getCachePolicy({
-        Id: created.cachePolicyId,
-      });
-      expect(initial.CachePolicy?.Id).toEqual(created.cachePolicyId);
-      expect(initial.CachePolicy?.CachePolicyConfig?.Comment).toEqual(
-        "initial",
-      );
-      expect(initial.CachePolicy?.CachePolicyConfig?.DefaultTTL).toEqual(60);
+        const initial = yield* cloudfront.getCachePolicy({
+          Id: created.cachePolicyId,
+        });
+        expect(initial.CachePolicy?.Id).toEqual(created.cachePolicyId);
+        expect(initial.CachePolicy?.CachePolicyConfig?.Comment).toEqual(
+          "initial",
+        );
+        expect(initial.CachePolicy?.CachePolicyConfig?.DefaultTTL).toEqual(60);
 
-      const updated = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* CachePolicy("ApiCachePolicy", {
-            comment: "updated",
-            minTTL: 0,
-            defaultTTL: 120,
-            maxTTL: 86400,
-            parametersInCacheKeyAndForwardedToOrigin: {
-              EnableAcceptEncodingGzip: true,
-              EnableAcceptEncodingBrotli: true,
-              HeadersConfig: { HeaderBehavior: "none" },
-              CookiesConfig: { CookieBehavior: "none" },
-              QueryStringsConfig: { QueryStringBehavior: "none" },
-            },
-          });
-        }),
-      );
+        const updated = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* CachePolicy("ApiCachePolicy", {
+              comment: "updated",
+              minTTL: 0,
+              defaultTTL: 120,
+              maxTTL: 86400,
+              parametersInCacheKeyAndForwardedToOrigin: {
+                EnableAcceptEncodingGzip: true,
+                EnableAcceptEncodingBrotli: true,
+                HeadersConfig: { HeaderBehavior: "none" },
+                CookiesConfig: { CookieBehavior: "none" },
+                QueryStringsConfig: { QueryStringBehavior: "none" },
+              },
+            });
+          }),
+        );
 
-      expect(updated.cachePolicyId).toEqual(created.cachePolicyId);
+        expect(updated.cachePolicyId).toEqual(created.cachePolicyId);
 
-      const after = yield* cloudfront.getCachePolicy({
-        Id: updated.cachePolicyId,
-      });
-      expect(after.CachePolicy?.CachePolicyConfig?.Comment).toEqual("updated");
-      expect(after.CachePolicy?.CachePolicyConfig?.DefaultTTL).toEqual(120);
-      expect(after.CachePolicy?.CachePolicyConfig?.MaxTTL).toEqual(86400);
+        const after = yield* cloudfront.getCachePolicy({
+          Id: updated.cachePolicyId,
+        });
+        expect(after.CachePolicy?.CachePolicyConfig?.Comment).toEqual(
+          "updated",
+        );
+        expect(after.CachePolicy?.CachePolicyConfig?.DefaultTTL).toEqual(120);
+        expect(after.CachePolicy?.CachePolicyConfig?.MaxTTL).toEqual(86400);
 
-      yield* destroy();
-      yield* assertCachePolicyDeleted(updated.cachePolicyId);
-    }).pipe(Effect.provide(AWS.providers())),
+        yield* stack.destroy();
+        yield* assertCachePolicyDeleted(updated.cachePolicyId);
+      }),
+    { timeout: 300_000 },
   );
 });
 

--- a/packages/alchemy/test/AWS/CloudFront/Distribution.smoke.test.ts
+++ b/packages/alchemy/test/AWS/CloudFront/Distribution.smoke.test.ts
@@ -11,11 +11,13 @@ import {
 import type { PolicyStatement } from "@/AWS/IAM/Policy";
 import { Bucket } from "@/AWS/S3";
 import * as Output from "@/Output";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as cloudfront from "@distilled.cloud/aws/cloudfront";
 import { describe, expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
 
 const runLive = process.env.ALCHEMY_RUN_LIVE_AWS_WEBSITE_TESTS === "true";
 
@@ -31,179 +33,182 @@ HQIDAQAB
 `;
 
 describe("AWS.CloudFront smoke", () => {
-  test.skipIf(!runLive)(
+  test.provider.skipIf(!runLive)(
     "deploy distribution wired to cache, origin request, and response headers policies alongside a key group",
-    { timeout: 900_000 },
-    Effect.gen(function* () {
-      yield* destroy();
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-      const deployed = yield* test.deploy(
-        Effect.gen(function* () {
-          const bucket = yield* Bucket("SmokeBucket", { forceDestroy: true });
-          const oac = yield* OriginAccessControl("SmokeOac", {
-            originType: "s3",
-          });
+        const deployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            const bucket = yield* Bucket("SmokeBucket", { forceDestroy: true });
+            const oac = yield* OriginAccessControl("SmokeOac", {
+              originType: "s3",
+            });
 
-          const cachePolicy = yield* CachePolicy("SmokeCachePolicy", {
-            comment: "smoke",
-            minTTL: 0,
-            defaultTTL: 60,
-            maxTTL: 86400,
-            parametersInCacheKeyAndForwardedToOrigin: {
-              EnableAcceptEncodingGzip: true,
-              EnableAcceptEncodingBrotli: true,
-              HeadersConfig: { HeaderBehavior: "none" },
-              CookiesConfig: { CookieBehavior: "none" },
-              QueryStringsConfig: { QueryStringBehavior: "none" },
-            },
-          });
-
-          const originRequestPolicy = yield* OriginRequestPolicy(
-            "SmokeOriginRequestPolicy",
-            {
+            const cachePolicy = yield* CachePolicy("SmokeCachePolicy", {
               comment: "smoke",
-              headersConfig: { HeaderBehavior: "none" },
-              cookiesConfig: { CookieBehavior: "none" },
-              queryStringsConfig: { QueryStringBehavior: "all" },
-            },
-          );
-
-          const responseHeadersPolicy = yield* ResponseHeadersPolicy(
-            "SmokeResponseHeadersPolicy",
-            {
-              comment: "smoke",
-              securityHeadersConfig: {
-                StrictTransportSecurity: {
-                  AccessControlMaxAgeSec: 31536000,
-                  IncludeSubdomains: true,
-                  Preload: true,
-                  Override: true,
-                },
-                ContentTypeOptions: { Override: true },
-                FrameOptions: { FrameOption: "DENY", Override: true },
+              minTTL: 0,
+              defaultTTL: 60,
+              maxTTL: 86400,
+              parametersInCacheKeyAndForwardedToOrigin: {
+                EnableAcceptEncodingGzip: true,
+                EnableAcceptEncodingBrotli: true,
+                HeadersConfig: { HeaderBehavior: "none" },
+                CookiesConfig: { CookieBehavior: "none" },
+                QueryStringsConfig: { QueryStringBehavior: "none" },
               },
-            },
-          );
+            });
 
-          const publicKey = yield* PublicKey("SmokeSigningKey", {
-            encodedKey: SIGNING_PUBLIC_KEY,
-            comment: "smoke signed-url key",
-          });
-
-          const keyGroup = yield* KeyGroup("SmokeSigningKeys", {
-            comment: "smoke signed-url group",
-            items: [publicKey.publicKeyId],
-          });
-
-          const distribution = yield* Distribution("SmokeDistribution", {
-            origins: [
+            const originRequestPolicy = yield* OriginRequestPolicy(
+              "SmokeOriginRequestPolicy",
               {
-                id: "site",
-                domainName: bucket.bucketRegionalDomainName,
-                s3Origin: true,
-                originAccessControlId: oac.originAccessControlId,
+                comment: "smoke",
+                headersConfig: { HeaderBehavior: "none" },
+                cookiesConfig: { CookieBehavior: "none" },
+                queryStringsConfig: { QueryStringBehavior: "all" },
               },
-            ],
-            defaultRootObject: "index.html",
-            defaultCacheBehavior: {
-              targetOriginId: "site",
-              viewerProtocolPolicy: "redirect-to-https",
-              compress: true,
-              allowedMethods: ["GET", "HEAD"],
-              cachedMethods: ["GET", "HEAD"],
-              cachePolicyId: cachePolicy.cachePolicyId,
-              originRequestPolicyId: originRequestPolicy.originRequestPolicyId,
-              responseHeadersPolicyId:
-                responseHeadersPolicy.responseHeadersPolicyId,
-            },
+            );
+
+            const responseHeadersPolicy = yield* ResponseHeadersPolicy(
+              "SmokeResponseHeadersPolicy",
+              {
+                comment: "smoke",
+                securityHeadersConfig: {
+                  StrictTransportSecurity: {
+                    AccessControlMaxAgeSec: 31536000,
+                    IncludeSubdomains: true,
+                    Preload: true,
+                    Override: true,
+                  },
+                  ContentTypeOptions: { Override: true },
+                  FrameOptions: { FrameOption: "DENY", Override: true },
+                },
+              },
+            );
+
+            const publicKey = yield* PublicKey("SmokeSigningKey", {
+              encodedKey: SIGNING_PUBLIC_KEY,
+              comment: "smoke signed-url key",
+            });
+
+            const keyGroup = yield* KeyGroup("SmokeSigningKeys", {
+              comment: "smoke signed-url group",
+              items: [publicKey.publicKeyId],
+            });
+
+            const distribution = yield* Distribution("SmokeDistribution", {
+              origins: [
+                {
+                  id: "site",
+                  domainName: bucket.bucketRegionalDomainName,
+                  s3Origin: true,
+                  originAccessControlId: oac.originAccessControlId,
+                },
+              ],
+              defaultRootObject: "index.html",
+              defaultCacheBehavior: {
+                targetOriginId: "site",
+                viewerProtocolPolicy: "redirect-to-https",
+                compress: true,
+                allowedMethods: ["GET", "HEAD"],
+                cachedMethods: ["GET", "HEAD"],
+                cachePolicyId: cachePolicy.cachePolicyId,
+                originRequestPolicyId:
+                  originRequestPolicy.originRequestPolicyId,
+                responseHeadersPolicyId:
+                  responseHeadersPolicy.responseHeadersPolicyId,
+              },
+            });
+
+            const statement: PolicyStatement = {
+              Effect: "Allow",
+              Principal: { Service: "cloudfront.amazonaws.com" },
+              Action: ["s3:GetObject"],
+              Resource: [Output.interpolate`${bucket.bucketArn}/*` as any],
+              Condition: {
+                StringEquals: {
+                  "AWS:SourceArn": distribution.distributionArn as any,
+                },
+              },
+            };
+
+            yield* bucket.bind`Allow(${distribution}, CloudFront.Read(${bucket}))`(
+              { policyStatements: [statement] },
+            );
+
+            return {
+              bucket,
+              oac,
+              cachePolicy,
+              originRequestPolicy,
+              responseHeadersPolicy,
+              publicKey,
+              keyGroup,
+              distribution,
+            };
+          }),
+        );
+
+        const dist = yield* cloudfront.getDistribution({
+          Id: deployed.distribution.distributionId,
+        });
+        expect(dist.Distribution?.Status).toEqual("Deployed");
+
+        const defaultBehavior =
+          dist.Distribution?.DistributionConfig?.DefaultCacheBehavior;
+        expect(defaultBehavior?.CachePolicyId).toEqual(
+          deployed.cachePolicy.cachePolicyId,
+        );
+        expect(defaultBehavior?.OriginRequestPolicyId).toEqual(
+          deployed.originRequestPolicy.originRequestPolicyId,
+        );
+        expect(defaultBehavior?.ResponseHeadersPolicyId).toEqual(
+          deployed.responseHeadersPolicy.responseHeadersPolicyId,
+        );
+
+        const cachePolicy = yield* cloudfront.getCachePolicy({
+          Id: deployed.cachePolicy.cachePolicyId,
+        });
+        expect(cachePolicy.CachePolicy?.Id).toEqual(
+          deployed.cachePolicy.cachePolicyId,
+        );
+
+        const originRequestPolicy = yield* cloudfront.getOriginRequestPolicy({
+          Id: deployed.originRequestPolicy.originRequestPolicyId,
+        });
+        expect(originRequestPolicy.OriginRequestPolicy?.Id).toEqual(
+          deployed.originRequestPolicy.originRequestPolicyId,
+        );
+
+        const responseHeadersPolicy =
+          yield* cloudfront.getResponseHeadersPolicy({
+            Id: deployed.responseHeadersPolicy.responseHeadersPolicyId,
           });
+        expect(responseHeadersPolicy.ResponseHeadersPolicy?.Id).toEqual(
+          deployed.responseHeadersPolicy.responseHeadersPolicyId,
+        );
 
-          const statement: PolicyStatement = {
-            Effect: "Allow",
-            Principal: { Service: "cloudfront.amazonaws.com" },
-            Action: ["s3:GetObject"],
-            Resource: [Output.interpolate`${bucket.bucketArn}/*` as any],
-            Condition: {
-              StringEquals: {
-                "AWS:SourceArn": distribution.distributionArn as any,
-              },
-            },
-          };
+        const keyGroup = yield* cloudfront.getKeyGroup({
+          Id: deployed.keyGroup.keyGroupId,
+        });
+        expect(keyGroup.KeyGroup?.KeyGroupConfig?.Items).toEqual([
+          deployed.publicKey.publicKeyId,
+        ]);
 
-          yield* bucket.bind`Allow(${distribution}, CloudFront.Read(${bucket}))`(
-            { policyStatements: [statement] },
-          );
-
-          return {
-            bucket,
-            oac,
-            cachePolicy,
-            originRequestPolicy,
-            responseHeadersPolicy,
-            publicKey,
-            keyGroup,
-            distribution,
-          };
-        }),
-      );
-
-      const dist = yield* cloudfront.getDistribution({
-        Id: deployed.distribution.distributionId,
-      });
-      expect(dist.Distribution?.Status).toEqual("Deployed");
-
-      const defaultBehavior =
-        dist.Distribution?.DistributionConfig?.DefaultCacheBehavior;
-      expect(defaultBehavior?.CachePolicyId).toEqual(
-        deployed.cachePolicy.cachePolicyId,
-      );
-      expect(defaultBehavior?.OriginRequestPolicyId).toEqual(
-        deployed.originRequestPolicy.originRequestPolicyId,
-      );
-      expect(defaultBehavior?.ResponseHeadersPolicyId).toEqual(
-        deployed.responseHeadersPolicy.responseHeadersPolicyId,
-      );
-
-      const cachePolicy = yield* cloudfront.getCachePolicy({
-        Id: deployed.cachePolicy.cachePolicyId,
-      });
-      expect(cachePolicy.CachePolicy?.Id).toEqual(
-        deployed.cachePolicy.cachePolicyId,
-      );
-
-      const originRequestPolicy = yield* cloudfront.getOriginRequestPolicy({
-        Id: deployed.originRequestPolicy.originRequestPolicyId,
-      });
-      expect(originRequestPolicy.OriginRequestPolicy?.Id).toEqual(
-        deployed.originRequestPolicy.originRequestPolicyId,
-      );
-
-      const responseHeadersPolicy = yield* cloudfront.getResponseHeadersPolicy({
-        Id: deployed.responseHeadersPolicy.responseHeadersPolicyId,
-      });
-      expect(responseHeadersPolicy.ResponseHeadersPolicy?.Id).toEqual(
-        deployed.responseHeadersPolicy.responseHeadersPolicyId,
-      );
-
-      const keyGroup = yield* cloudfront.getKeyGroup({
-        Id: deployed.keyGroup.keyGroupId,
-      });
-      expect(keyGroup.KeyGroup?.KeyGroupConfig?.Items).toEqual([
-        deployed.publicKey.publicKeyId,
-      ]);
-
-      yield* destroy();
-      yield* assertDistributionDeleted(deployed.distribution.distributionId);
-      yield* assertCachePolicyDeleted(deployed.cachePolicy.cachePolicyId);
-      yield* assertOriginRequestPolicyDeleted(
-        deployed.originRequestPolicy.originRequestPolicyId,
-      );
-      yield* assertResponseHeadersPolicyDeleted(
-        deployed.responseHeadersPolicy.responseHeadersPolicyId,
-      );
-      yield* assertKeyGroupDeleted(deployed.keyGroup.keyGroupId);
-      yield* assertPublicKeyDeleted(deployed.publicKey.publicKeyId);
-    }).pipe(Effect.provide(AWS.providers())),
+        yield* stack.destroy();
+        yield* assertDistributionDeleted(deployed.distribution.distributionId);
+        yield* assertCachePolicyDeleted(deployed.cachePolicy.cachePolicyId);
+        yield* assertOriginRequestPolicyDeleted(
+          deployed.originRequestPolicy.originRequestPolicyId,
+        );
+        yield* assertResponseHeadersPolicyDeleted(
+          deployed.responseHeadersPolicy.responseHeadersPolicyId,
+        );
+        yield* assertKeyGroupDeleted(deployed.keyGroup.keyGroupId);
+        yield* assertPublicKeyDeleted(deployed.publicKey.publicKeyId);
+      }),
+    900_000,
   );
 });
 

--- a/packages/alchemy/test/AWS/CloudFront/Distribution.test.ts
+++ b/packages/alchemy/test/AWS/CloudFront/Distribution.test.ts
@@ -3,108 +3,111 @@ import { Distribution, OriginAccessControl } from "@/AWS/CloudFront";
 import type { PolicyStatement } from "@/AWS/IAM/Policy";
 import { Bucket } from "@/AWS/S3";
 import * as Output from "@/Output";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as cloudfront from "@distilled.cloud/aws/cloudfront";
 import * as S3 from "@distilled.cloud/aws/s3";
 import { describe, expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 
+const { test } = Test.make({ providers: AWS.providers() });
+
 const runLive = process.env.ALCHEMY_RUN_LIVE_AWS_WEBSITE_TESTS === "true";
 
 describe("AWS.CloudFront.Distribution", () => {
-  test.skipIf(!runLive)(
+  test.provider.skipIf(!runLive)(
     "create and delete distribution for a private S3 origin",
-    { timeout: 600_000 },
-    Effect.gen(function* () {
-      yield* destroy();
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-      const deployed = yield* test.deploy(
-        Effect.gen(function* () {
-          const bucket = yield* Bucket("WebsiteBucket", {
-            forceDestroy: true,
-          });
-          const oac = yield* OriginAccessControl("WebsiteOac", {
-            originType: "s3",
-          });
-          const distribution = yield* Distribution("WebsiteDistribution", {
-            origins: [
-              {
-                id: "site",
-                domainName: bucket.bucketRegionalDomainName,
-                s3Origin: true,
-                originAccessControlId: oac.originAccessControlId,
-              },
-            ],
-            defaultRootObject: "index.html",
-            defaultCacheBehavior: {
-              targetOriginId: "site",
-              viewerProtocolPolicy: "redirect-to-https",
-              compress: true,
-              allowedMethods: ["GET", "HEAD"],
-              cachedMethods: ["GET", "HEAD"],
-              forwardedValues: {
-                QueryString: false,
-                Cookies: {
-                  Forward: "none",
+        const deployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            const bucket = yield* Bucket("WebsiteBucket", {
+              forceDestroy: true,
+            });
+            const oac = yield* OriginAccessControl("WebsiteOac", {
+              originType: "s3",
+            });
+            const distribution = yield* Distribution("WebsiteDistribution", {
+              origins: [
+                {
+                  id: "site",
+                  domainName: bucket.bucketRegionalDomainName,
+                  s3Origin: true,
+                  originAccessControlId: oac.originAccessControlId,
+                },
+              ],
+              defaultRootObject: "index.html",
+              defaultCacheBehavior: {
+                targetOriginId: "site",
+                viewerProtocolPolicy: "redirect-to-https",
+                compress: true,
+                allowedMethods: ["GET", "HEAD"],
+                cachedMethods: ["GET", "HEAD"],
+                forwardedValues: {
+                  QueryString: false,
+                  Cookies: {
+                    Forward: "none",
+                  },
                 },
               },
-            },
-          });
+            });
 
-          const statement: PolicyStatement = {
-            Effect: "Allow",
-            Principal: {
-              Service: "cloudfront.amazonaws.com",
-            },
-            Action: ["s3:GetObject"],
-            Resource: [Output.interpolate`${bucket.bucketArn}/*` as any],
-            Condition: {
-              StringEquals: {
-                "AWS:SourceArn": distribution.distributionArn as any,
+            const statement: PolicyStatement = {
+              Effect: "Allow",
+              Principal: {
+                Service: "cloudfront.amazonaws.com",
               },
-            },
-          };
+              Action: ["s3:GetObject"],
+              Resource: [Output.interpolate`${bucket.bucketArn}/*` as any],
+              Condition: {
+                StringEquals: {
+                  "AWS:SourceArn": distribution.distributionArn as any,
+                },
+              },
+            };
 
-          yield* bucket.bind`Allow(${distribution}, CloudFront.Read(${bucket}))`(
-            {
-              policyStatements: [statement],
-            },
-          );
+            yield* bucket.bind`Allow(${distribution}, CloudFront.Read(${bucket}))`(
+              {
+                policyStatements: [statement],
+              },
+            );
 
-          return {
-            bucket,
-            oac,
-            distribution,
-          };
-        }),
-      );
+            return {
+              bucket,
+              oac,
+              distribution,
+            };
+          }),
+        );
 
-      const current = yield* cloudfront.getDistribution({
-        Id: deployed.distribution.distributionId,
-      });
-      expect(current.Distribution?.Status).toEqual("Deployed");
-      expect(current.Distribution?.DomainName).toEqual(
-        deployed.distribution.domainName,
-      );
+        const current = yield* cloudfront.getDistribution({
+          Id: deployed.distribution.distributionId,
+        });
+        expect(current.Distribution?.Status).toEqual("Deployed");
+        expect(current.Distribution?.DomainName).toEqual(
+          deployed.distribution.domainName,
+        );
 
-      const control = yield* cloudfront.getOriginAccessControl({
-        Id: deployed.oac.originAccessControlId,
-      });
-      expect(control.OriginAccessControl?.Id).toEqual(
-        deployed.oac.originAccessControlId,
-      );
+        const control = yield* cloudfront.getOriginAccessControl({
+          Id: deployed.oac.originAccessControlId,
+        });
+        expect(control.OriginAccessControl?.Id).toEqual(
+          deployed.oac.originAccessControlId,
+        );
 
-      yield* S3.putObject({
-        Bucket: deployed.bucket.bucketName,
-        Key: "index.html",
-        Body: "<html>ok</html>",
-        ContentType: "text/html; charset=utf-8",
-      });
+        yield* S3.putObject({
+          Bucket: deployed.bucket.bucketName,
+          Key: "index.html",
+          Body: "<html>ok</html>",
+          ContentType: "text/html; charset=utf-8",
+        });
 
-      yield* destroy();
-      yield* assertDistributionDeleted(deployed.distribution.distributionId);
-    }).pipe(Effect.provide(AWS.providers())),
+        yield* stack.destroy();
+        yield* assertDistributionDeleted(deployed.distribution.distributionId);
+      }),
+    { timeout: 600_000 },
   );
 });
 

--- a/packages/alchemy/test/AWS/CloudFront/Function.test.ts
+++ b/packages/alchemy/test/AWS/CloudFront/Function.test.ts
@@ -1,45 +1,48 @@
 import * as AWS from "@/AWS";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as cloudfront from "@distilled.cloud/aws/cloudfront";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 
-test.skipIf(process.env.ALCHEMY_RUN_LIVE_AWS_WEBSITE_TESTS !== "true")(
-  "create and delete a CloudFront Function with key value store associations",
-  { timeout: 300_000 },
-  Effect.gen(function* () {
-    yield* destroy();
+const { test } = Test.make({ providers: AWS.providers() });
 
-    const deployed = yield* test.deploy(
-      Effect.gen(function* () {
-        const store = yield* AWS.CloudFront.KeyValueStore("RequestStore", {
-          comment: "request metadata",
-        });
-        const fn = yield* AWS.CloudFront.Function("RequestFn", {
-          comment: "request handler",
-          keyValueStoreArns: [store.keyValueStoreArn],
-          code: `async function handler(event) {
+test.provider.skipIf(process.env.ALCHEMY_RUN_LIVE_AWS_WEBSITE_TESTS !== "true")(
+  "create and delete a CloudFront Function with key value store associations",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const store = yield* AWS.CloudFront.KeyValueStore("RequestStore", {
+            comment: "request metadata",
+          });
+          const fn = yield* AWS.CloudFront.Function("RequestFn", {
+            comment: "request handler",
+            keyValueStoreArns: [store.keyValueStoreArn],
+            code: `async function handler(event) {
   return event.request;
 }`,
-        });
-        return { store, fn };
-      }),
-    );
+          });
+          return { store, fn };
+        }),
+      );
 
-    const current = yield* cloudfront.describeFunction({
-      Name: deployed.fn.functionName,
-      Stage: "LIVE",
-    });
-    expect(current.FunctionSummary?.Name).toEqual(deployed.fn.functionName);
-    expect(
-      current.FunctionSummary?.FunctionConfig.KeyValueStoreAssociations
-        ?.Items?.[0]?.KeyValueStoreARN,
-    ).toEqual(deployed.store.keyValueStoreArn);
+      const current = yield* cloudfront.describeFunction({
+        Name: deployed.fn.functionName,
+        Stage: "LIVE",
+      });
+      expect(current.FunctionSummary?.Name).toEqual(deployed.fn.functionName);
+      expect(
+        current.FunctionSummary?.FunctionConfig.KeyValueStoreAssociations
+          ?.Items?.[0]?.KeyValueStoreARN,
+      ).toEqual(deployed.store.keyValueStoreArn);
 
-    yield* destroy();
-    yield* assertFunctionDeleted(deployed.fn.functionName);
-  }).pipe(Effect.provide(AWS.providers())),
+      yield* stack.destroy();
+      yield* assertFunctionDeleted(deployed.fn.functionName);
+    }),
+  { timeout: 300_000 },
 );
 
 const assertFunctionDeleted = (name: string) =>

--- a/packages/alchemy/test/AWS/CloudFront/Invalidation.test.ts
+++ b/packages/alchemy/test/AWS/CloudFront/Invalidation.test.ts
@@ -3,108 +3,113 @@ import { Distribution, OriginAccessControl } from "@/AWS/CloudFront";
 import type { PolicyStatement } from "@/AWS/IAM/Policy";
 import { Bucket } from "@/AWS/S3";
 import * as Output from "@/Output";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as cloudfront from "@distilled.cloud/aws/cloudfront";
 import * as S3 from "@distilled.cloud/aws/s3";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 
-test.skipIf(process.env.ALCHEMY_RUN_LIVE_AWS_WEBSITE_TESTS !== "true")(
-  "create invalidation with explicit paths and wait for completion",
-  { timeout: 600_000 },
-  Effect.gen(function* () {
-    yield* destroy();
+const { test } = Test.make({ providers: AWS.providers() });
 
-    const deployed = yield* test.deploy(
-      Effect.gen(function* () {
-        const bucket = yield* Bucket("WebsiteBucket", {
-          forceDestroy: true,
-        });
-        const oac = yield* OriginAccessControl("WebsiteOac", {
-          originType: "s3",
-        });
-        const distribution = yield* Distribution("WebsiteDistribution", {
-          origins: [
-            {
-              id: "site",
-              domainName: bucket.bucketRegionalDomainName,
-              s3Origin: true,
-              originAccessControlId: oac.originAccessControlId,
-            },
-          ],
-          defaultRootObject: "index.html",
-          defaultCacheBehavior: {
-            targetOriginId: "site",
-            viewerProtocolPolicy: "redirect-to-https",
-            compress: true,
-            allowedMethods: ["GET", "HEAD"],
-            cachedMethods: ["GET", "HEAD"],
-            forwardedValues: {
-              QueryString: false,
-              Cookies: {
-                Forward: "none",
+test.provider.skipIf(process.env.ALCHEMY_RUN_LIVE_AWS_WEBSITE_TESTS !== "true")(
+  "create invalidation with explicit paths and wait for completion",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const bucket = yield* Bucket("WebsiteBucket", {
+            forceDestroy: true,
+          });
+          const oac = yield* OriginAccessControl("WebsiteOac", {
+            originType: "s3",
+          });
+          const distribution = yield* Distribution("WebsiteDistribution", {
+            origins: [
+              {
+                id: "site",
+                domainName: bucket.bucketRegionalDomainName,
+                s3Origin: true,
+                originAccessControlId: oac.originAccessControlId,
+              },
+            ],
+            defaultRootObject: "index.html",
+            defaultCacheBehavior: {
+              targetOriginId: "site",
+              viewerProtocolPolicy: "redirect-to-https",
+              compress: true,
+              allowedMethods: ["GET", "HEAD"],
+              cachedMethods: ["GET", "HEAD"],
+              forwardedValues: {
+                QueryString: false,
+                Cookies: {
+                  Forward: "none",
+                },
               },
             },
-          },
-        });
+          });
 
-        const statement: PolicyStatement = {
-          Effect: "Allow",
-          Principal: {
-            Service: "cloudfront.amazonaws.com",
-          },
-          Action: ["s3:GetObject"],
-          Resource: [Output.interpolate`${bucket.bucketArn}/*` as any],
-          Condition: {
-            StringEquals: {
-              "AWS:SourceArn": distribution.distributionArn as any,
+          const statement: PolicyStatement = {
+            Effect: "Allow",
+            Principal: {
+              Service: "cloudfront.amazonaws.com",
             },
-          },
-        };
+            Action: ["s3:GetObject"],
+            Resource: [Output.interpolate`${bucket.bucketArn}/*` as any],
+            Condition: {
+              StringEquals: {
+                "AWS:SourceArn": distribution.distributionArn as any,
+              },
+            },
+          };
 
-        yield* bucket.bind`Allow(${distribution}, CloudFront.Read(${bucket}))`({
-          policyStatements: [statement],
-        });
+          yield* bucket.bind`Allow(${distribution}, CloudFront.Read(${bucket}))`(
+            {
+              policyStatements: [statement],
+            },
+          );
 
-        const invalidation = yield* AWS.CloudFront.Invalidation(
-          "InvalidateDocs",
-          {
-            distributionId: distribution.distributionId,
-            version: "v2",
-            wait: true,
-            paths: ["/index.html", "/docs/*"],
-          },
-        );
+          const invalidation = yield* AWS.CloudFront.Invalidation(
+            "InvalidateDocs",
+            {
+              distributionId: distribution.distributionId,
+              version: "v2",
+              wait: true,
+              paths: ["/index.html", "/docs/*"],
+            },
+          );
 
-        return {
-          bucket,
-          distribution,
-          invalidation,
-        };
-      }),
-    );
+          return {
+            bucket,
+            distribution,
+            invalidation,
+          };
+        }),
+      );
 
-    yield* S3.putObject({
-      Bucket: deployed.bucket.bucketName,
-      Key: "index.html",
-      Body: "<html>ok</html>",
-      ContentType: "text/html; charset=utf-8",
-    });
+      yield* S3.putObject({
+        Bucket: deployed.bucket.bucketName,
+        Key: "index.html",
+        Body: "<html>ok</html>",
+        ContentType: "text/html; charset=utf-8",
+      });
 
-    const current = yield* cloudfront.getInvalidation({
-      DistributionId: deployed.distribution.distributionId,
-      Id: deployed.invalidation.invalidationId,
-    });
-    expect(current.Invalidation?.Status).toEqual("Completed");
-    expect(current.Invalidation?.InvalidationBatch?.Paths?.Items).toEqual([
-      "/index.html",
-      "/docs/*",
-    ]);
+      const current = yield* cloudfront.getInvalidation({
+        DistributionId: deployed.distribution.distributionId,
+        Id: deployed.invalidation.invalidationId,
+      });
+      expect(current.Invalidation?.Status).toEqual("Completed");
+      expect(current.Invalidation?.InvalidationBatch?.Paths?.Items).toEqual([
+        "/index.html",
+        "/docs/*",
+      ]);
 
-    yield* destroy();
-    yield* assertDistributionDeleted(deployed.distribution.distributionId);
-  }).pipe(Effect.provide(AWS.providers())),
+      yield* stack.destroy();
+      yield* assertDistributionDeleted(deployed.distribution.distributionId);
+    }),
+  { timeout: 600_000 },
 );
 
 const assertDistributionDeleted = (distributionId: string) =>

--- a/packages/alchemy/test/AWS/CloudFront/KeyGroup.test.ts
+++ b/packages/alchemy/test/AWS/CloudFront/KeyGroup.test.ts
@@ -1,10 +1,12 @@
 import * as AWS from "@/AWS";
 import { KeyGroup, PublicKey } from "@/AWS/CloudFront";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as cloudfront from "@distilled.cloud/aws/cloudfront";
 import { describe, expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
 
 const runLive = process.env.ALCHEMY_RUN_LIVE_AWS_WEBSITE_TESTS === "true";
 
@@ -31,71 +33,72 @@ JQIDAQAB
 `;
 
 describe("AWS.CloudFront.KeyGroup", () => {
-  test.skipIf(!runLive)(
+  test.provider.skipIf(!runLive)(
     "create, update items, and delete a key group",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const created = yield* stack.deploy(
+          Effect.gen(function* () {
+            const primary = yield* PublicKey("PrimarySigningKey", {
+              encodedKey: PRIMARY_PUBLIC_KEY,
+              comment: "primary",
+            });
+            const secondary = yield* PublicKey("SecondarySigningKey", {
+              encodedKey: SECONDARY_PUBLIC_KEY,
+              comment: "secondary",
+            });
+            const group = yield* KeyGroup("SignedUrlKeys", {
+              comment: "initial",
+              items: [primary.publicKeyId],
+            });
+            return { primary, secondary, group };
+          }),
+        );
+
+        const initial = yield* cloudfront.getKeyGroup({
+          Id: created.group.keyGroupId,
+        });
+        expect(initial.KeyGroup?.Id).toEqual(created.group.keyGroupId);
+        expect(initial.KeyGroup?.KeyGroupConfig?.Comment).toEqual("initial");
+        expect(initial.KeyGroup?.KeyGroupConfig?.Items).toEqual([
+          created.primary.publicKeyId,
+        ]);
+
+        const updated = yield* stack.deploy(
+          Effect.gen(function* () {
+            const primary = yield* PublicKey("PrimarySigningKey", {
+              encodedKey: PRIMARY_PUBLIC_KEY,
+              comment: "primary",
+            });
+            const secondary = yield* PublicKey("SecondarySigningKey", {
+              encodedKey: SECONDARY_PUBLIC_KEY,
+              comment: "secondary",
+            });
+            const group = yield* KeyGroup("SignedUrlKeys", {
+              comment: "updated",
+              items: [primary.publicKeyId, secondary.publicKeyId],
+            });
+            return { primary, secondary, group };
+          }),
+        );
+
+        expect(updated.group.keyGroupId).toEqual(created.group.keyGroupId);
+
+        const after = yield* cloudfront.getKeyGroup({
+          Id: updated.group.keyGroupId,
+        });
+        expect(after.KeyGroup?.KeyGroupConfig?.Comment).toEqual("updated");
+        expect(after.KeyGroup?.KeyGroupConfig?.Items).toEqual([
+          updated.primary.publicKeyId,
+          updated.secondary.publicKeyId,
+        ]);
+
+        yield* stack.destroy();
+        yield* assertKeyGroupDeleted(updated.group.keyGroupId);
+      }),
     { timeout: 300_000 },
-    Effect.gen(function* () {
-      yield* destroy();
-
-      const created = yield* test.deploy(
-        Effect.gen(function* () {
-          const primary = yield* PublicKey("PrimarySigningKey", {
-            encodedKey: PRIMARY_PUBLIC_KEY,
-            comment: "primary",
-          });
-          const secondary = yield* PublicKey("SecondarySigningKey", {
-            encodedKey: SECONDARY_PUBLIC_KEY,
-            comment: "secondary",
-          });
-          const group = yield* KeyGroup("SignedUrlKeys", {
-            comment: "initial",
-            items: [primary.publicKeyId],
-          });
-          return { primary, secondary, group };
-        }),
-      );
-
-      const initial = yield* cloudfront.getKeyGroup({
-        Id: created.group.keyGroupId,
-      });
-      expect(initial.KeyGroup?.Id).toEqual(created.group.keyGroupId);
-      expect(initial.KeyGroup?.KeyGroupConfig?.Comment).toEqual("initial");
-      expect(initial.KeyGroup?.KeyGroupConfig?.Items).toEqual([
-        created.primary.publicKeyId,
-      ]);
-
-      const updated = yield* test.deploy(
-        Effect.gen(function* () {
-          const primary = yield* PublicKey("PrimarySigningKey", {
-            encodedKey: PRIMARY_PUBLIC_KEY,
-            comment: "primary",
-          });
-          const secondary = yield* PublicKey("SecondarySigningKey", {
-            encodedKey: SECONDARY_PUBLIC_KEY,
-            comment: "secondary",
-          });
-          const group = yield* KeyGroup("SignedUrlKeys", {
-            comment: "updated",
-            items: [primary.publicKeyId, secondary.publicKeyId],
-          });
-          return { primary, secondary, group };
-        }),
-      );
-
-      expect(updated.group.keyGroupId).toEqual(created.group.keyGroupId);
-
-      const after = yield* cloudfront.getKeyGroup({
-        Id: updated.group.keyGroupId,
-      });
-      expect(after.KeyGroup?.KeyGroupConfig?.Comment).toEqual("updated");
-      expect(after.KeyGroup?.KeyGroupConfig?.Items).toEqual([
-        updated.primary.publicKeyId,
-        updated.secondary.publicKeyId,
-      ]);
-
-      yield* destroy();
-      yield* assertKeyGroupDeleted(updated.group.keyGroupId);
-    }).pipe(Effect.provide(AWS.providers())),
   );
 });
 

--- a/packages/alchemy/test/AWS/CloudFront/OriginRequestPolicy.test.ts
+++ b/packages/alchemy/test/AWS/CloudFront/OriginRequestPolicy.test.ts
@@ -1,87 +1,90 @@
 import * as AWS from "@/AWS";
 import { OriginRequestPolicy } from "@/AWS/CloudFront";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as cloudfront from "@distilled.cloud/aws/cloudfront";
 import { describe, expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 
+const { test } = Test.make({ providers: AWS.providers() });
+
 const runLive = process.env.ALCHEMY_RUN_LIVE_AWS_WEBSITE_TESTS === "true";
 
 describe("AWS.CloudFront.OriginRequestPolicy", () => {
-  test.skipIf(!runLive)(
+  test.provider.skipIf(!runLive)(
     "create, update, and delete an origin request policy",
-    { timeout: 300_000 },
-    Effect.gen(function* () {
-      yield* destroy();
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-      const created = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* OriginRequestPolicy("AppOriginRequest", {
-            comment: "initial",
-            headersConfig: {
-              HeaderBehavior: "whitelist",
-              Headers: { Quantity: 1, Items: ["Authorization"] },
-            },
-            cookiesConfig: { CookieBehavior: "none" },
-            queryStringsConfig: { QueryStringBehavior: "all" },
-          });
-        }),
-      );
-
-      const initial = yield* cloudfront.getOriginRequestPolicy({
-        Id: created.originRequestPolicyId,
-      });
-      expect(initial.OriginRequestPolicy?.Id).toEqual(
-        created.originRequestPolicyId,
-      );
-      expect(
-        initial.OriginRequestPolicy?.OriginRequestPolicyConfig?.Comment,
-      ).toEqual("initial");
-      expect(
-        initial.OriginRequestPolicy?.OriginRequestPolicyConfig?.HeadersConfig
-          ?.Headers?.Items,
-      ).toEqual(["Authorization"]);
-
-      const updated = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* OriginRequestPolicy("AppOriginRequest", {
-            comment: "updated",
-            headersConfig: {
-              HeaderBehavior: "whitelist",
-              Headers: {
-                Quantity: 2,
-                Items: ["Authorization", "Accept-Language"],
+        const created = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* OriginRequestPolicy("AppOriginRequest", {
+              comment: "initial",
+              headersConfig: {
+                HeaderBehavior: "whitelist",
+                Headers: { Quantity: 1, Items: ["Authorization"] },
               },
-            },
-            cookiesConfig: { CookieBehavior: "all" },
-            queryStringsConfig: { QueryStringBehavior: "all" },
-          });
-        }),
-      );
+              cookiesConfig: { CookieBehavior: "none" },
+              queryStringsConfig: { QueryStringBehavior: "all" },
+            });
+          }),
+        );
 
-      expect(updated.originRequestPolicyId).toEqual(
-        created.originRequestPolicyId,
-      );
+        const initial = yield* cloudfront.getOriginRequestPolicy({
+          Id: created.originRequestPolicyId,
+        });
+        expect(initial.OriginRequestPolicy?.Id).toEqual(
+          created.originRequestPolicyId,
+        );
+        expect(
+          initial.OriginRequestPolicy?.OriginRequestPolicyConfig?.Comment,
+        ).toEqual("initial");
+        expect(
+          initial.OriginRequestPolicy?.OriginRequestPolicyConfig?.HeadersConfig
+            ?.Headers?.Items,
+        ).toEqual(["Authorization"]);
 
-      const after = yield* cloudfront.getOriginRequestPolicy({
-        Id: updated.originRequestPolicyId,
-      });
-      expect(
-        after.OriginRequestPolicy?.OriginRequestPolicyConfig?.Comment,
-      ).toEqual("updated");
-      expect(
-        after.OriginRequestPolicy?.OriginRequestPolicyConfig?.HeadersConfig
-          ?.Headers?.Items,
-      ).toEqual(["Authorization", "Accept-Language"]);
-      expect(
-        after.OriginRequestPolicy?.OriginRequestPolicyConfig?.CookiesConfig
-          ?.CookieBehavior,
-      ).toEqual("all");
+        const updated = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* OriginRequestPolicy("AppOriginRequest", {
+              comment: "updated",
+              headersConfig: {
+                HeaderBehavior: "whitelist",
+                Headers: {
+                  Quantity: 2,
+                  Items: ["Authorization", "Accept-Language"],
+                },
+              },
+              cookiesConfig: { CookieBehavior: "all" },
+              queryStringsConfig: { QueryStringBehavior: "all" },
+            });
+          }),
+        );
 
-      yield* destroy();
-      yield* assertOriginRequestPolicyDeleted(updated.originRequestPolicyId);
-    }).pipe(Effect.provide(AWS.providers())),
+        expect(updated.originRequestPolicyId).toEqual(
+          created.originRequestPolicyId,
+        );
+
+        const after = yield* cloudfront.getOriginRequestPolicy({
+          Id: updated.originRequestPolicyId,
+        });
+        expect(
+          after.OriginRequestPolicy?.OriginRequestPolicyConfig?.Comment,
+        ).toEqual("updated");
+        expect(
+          after.OriginRequestPolicy?.OriginRequestPolicyConfig?.HeadersConfig
+            ?.Headers?.Items,
+        ).toEqual(["Authorization", "Accept-Language"]);
+        expect(
+          after.OriginRequestPolicy?.OriginRequestPolicyConfig?.CookiesConfig
+            ?.CookieBehavior,
+        ).toEqual("all");
+
+        yield* stack.destroy();
+        yield* assertOriginRequestPolicyDeleted(updated.originRequestPolicyId);
+      }),
+    300_000,
   );
 });
 

--- a/packages/alchemy/test/AWS/CloudFront/PublicKey.test.ts
+++ b/packages/alchemy/test/AWS/CloudFront/PublicKey.test.ts
@@ -1,10 +1,12 @@
 import * as AWS from "@/AWS";
 import { PublicKey } from "@/AWS/CloudFront";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as cloudfront from "@distilled.cloud/aws/cloudfront";
 import { describe, expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
 
 const runLive = process.env.ALCHEMY_RUN_LIVE_AWS_WEBSITE_TESTS === "true";
 
@@ -20,50 +22,51 @@ HQIDAQAB
 `;
 
 describe("AWS.CloudFront.PublicKey", () => {
-  test.skipIf(!runLive)(
+  test.provider.skipIf(!runLive)(
     "create, update comment, and delete a public key",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const created = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* PublicKey("SignedUrlKey", {
+              encodedKey: TEST_PUBLIC_KEY,
+              comment: "initial",
+            });
+          }),
+        );
+
+        const initial = yield* cloudfront.getPublicKey({
+          Id: created.publicKeyId,
+        });
+        expect(initial.PublicKey?.Id).toEqual(created.publicKeyId);
+        expect(initial.PublicKey?.PublicKeyConfig?.Comment).toEqual("initial");
+        expect(initial.PublicKey?.PublicKeyConfig?.EncodedKey).toEqual(
+          TEST_PUBLIC_KEY,
+        );
+
+        const updated = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* PublicKey("SignedUrlKey", {
+              encodedKey: TEST_PUBLIC_KEY,
+              comment: "updated",
+            });
+          }),
+        );
+
+        expect(updated.publicKeyId).toEqual(created.publicKeyId);
+        expect(updated.callerReference).toEqual(created.callerReference);
+
+        const after = yield* cloudfront.getPublicKey({
+          Id: updated.publicKeyId,
+        });
+        expect(after.PublicKey?.PublicKeyConfig?.Comment).toEqual("updated");
+
+        yield* stack.destroy();
+        yield* assertPublicKeyDeleted(updated.publicKeyId);
+      }),
     { timeout: 300_000 },
-    Effect.gen(function* () {
-      yield* destroy();
-
-      const created = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* PublicKey("SignedUrlKey", {
-            encodedKey: TEST_PUBLIC_KEY,
-            comment: "initial",
-          });
-        }),
-      );
-
-      const initial = yield* cloudfront.getPublicKey({
-        Id: created.publicKeyId,
-      });
-      expect(initial.PublicKey?.Id).toEqual(created.publicKeyId);
-      expect(initial.PublicKey?.PublicKeyConfig?.Comment).toEqual("initial");
-      expect(initial.PublicKey?.PublicKeyConfig?.EncodedKey).toEqual(
-        TEST_PUBLIC_KEY,
-      );
-
-      const updated = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* PublicKey("SignedUrlKey", {
-            encodedKey: TEST_PUBLIC_KEY,
-            comment: "updated",
-          });
-        }),
-      );
-
-      expect(updated.publicKeyId).toEqual(created.publicKeyId);
-      expect(updated.callerReference).toEqual(created.callerReference);
-
-      const after = yield* cloudfront.getPublicKey({
-        Id: updated.publicKeyId,
-      });
-      expect(after.PublicKey?.PublicKeyConfig?.Comment).toEqual("updated");
-
-      yield* destroy();
-      yield* assertPublicKeyDeleted(updated.publicKeyId);
-    }).pipe(Effect.provide(AWS.providers())),
   );
 });
 

--- a/packages/alchemy/test/AWS/CloudFront/ResponseHeadersPolicy.test.ts
+++ b/packages/alchemy/test/AWS/CloudFront/ResponseHeadersPolicy.test.ts
@@ -1,107 +1,110 @@
 import * as AWS from "@/AWS";
 import { ResponseHeadersPolicy } from "@/AWS/CloudFront";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as cloudfront from "@distilled.cloud/aws/cloudfront";
 import { describe, expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 
+const { test } = Test.make({ providers: AWS.providers() });
+
 const runLive = process.env.ALCHEMY_RUN_LIVE_AWS_WEBSITE_TESTS === "true";
 
 describe("AWS.CloudFront.ResponseHeadersPolicy", () => {
-  test.skipIf(!runLive)(
+  test.provider.skipIf(!runLive)(
     "create, update, and delete a response headers policy",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const created = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* ResponseHeadersPolicy("AppResponseHeaders", {
+              comment: "initial",
+              securityHeadersConfig: {
+                StrictTransportSecurity: {
+                  AccessControlMaxAgeSec: 31536000,
+                  IncludeSubdomains: true,
+                  Preload: true,
+                  Override: true,
+                },
+                ContentTypeOptions: { Override: true },
+                FrameOptions: { FrameOption: "DENY", Override: true },
+                ReferrerPolicy: {
+                  ReferrerPolicy: "no-referrer",
+                  Override: true,
+                },
+              },
+            });
+          }),
+        );
+
+        const initial = yield* cloudfront.getResponseHeadersPolicy({
+          Id: created.responseHeadersPolicyId,
+        });
+        expect(initial.ResponseHeadersPolicy?.Id).toEqual(
+          created.responseHeadersPolicyId,
+        );
+        expect(
+          initial.ResponseHeadersPolicy?.ResponseHeadersPolicyConfig?.Comment,
+        ).toEqual("initial");
+        expect(
+          initial.ResponseHeadersPolicy?.ResponseHeadersPolicyConfig
+            ?.SecurityHeadersConfig?.FrameOptions?.FrameOption,
+        ).toEqual("DENY");
+
+        const updated = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* ResponseHeadersPolicy("AppResponseHeaders", {
+              comment: "updated",
+              corsConfig: {
+                AccessControlAllowOrigins: {
+                  Quantity: 1,
+                  Items: ["https://app.example.com"],
+                },
+                AccessControlAllowMethods: {
+                  Quantity: 2,
+                  Items: ["GET", "OPTIONS"],
+                },
+                AccessControlAllowHeaders: {
+                  Quantity: 1,
+                  Items: ["Authorization"],
+                },
+                AccessControlAllowCredentials: false,
+                OriginOverride: true,
+              },
+              securityHeadersConfig: {
+                FrameOptions: { FrameOption: "SAMEORIGIN", Override: true },
+              },
+            });
+          }),
+        );
+
+        expect(updated.responseHeadersPolicyId).toEqual(
+          created.responseHeadersPolicyId,
+        );
+
+        const after = yield* cloudfront.getResponseHeadersPolicy({
+          Id: updated.responseHeadersPolicyId,
+        });
+        expect(
+          after.ResponseHeadersPolicy?.ResponseHeadersPolicyConfig?.Comment,
+        ).toEqual("updated");
+        expect(
+          after.ResponseHeadersPolicy?.ResponseHeadersPolicyConfig
+            ?.SecurityHeadersConfig?.FrameOptions?.FrameOption,
+        ).toEqual("SAMEORIGIN");
+        expect(
+          after.ResponseHeadersPolicy?.ResponseHeadersPolicyConfig?.CorsConfig
+            ?.AccessControlAllowOrigins?.Items,
+        ).toEqual(["https://app.example.com"]);
+
+        yield* stack.destroy();
+        yield* assertResponseHeadersPolicyDeleted(
+          updated.responseHeadersPolicyId,
+        );
+      }),
     { timeout: 300_000 },
-    Effect.gen(function* () {
-      yield* destroy();
-
-      const created = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* ResponseHeadersPolicy("AppResponseHeaders", {
-            comment: "initial",
-            securityHeadersConfig: {
-              StrictTransportSecurity: {
-                AccessControlMaxAgeSec: 31536000,
-                IncludeSubdomains: true,
-                Preload: true,
-                Override: true,
-              },
-              ContentTypeOptions: { Override: true },
-              FrameOptions: { FrameOption: "DENY", Override: true },
-              ReferrerPolicy: {
-                ReferrerPolicy: "no-referrer",
-                Override: true,
-              },
-            },
-          });
-        }),
-      );
-
-      const initial = yield* cloudfront.getResponseHeadersPolicy({
-        Id: created.responseHeadersPolicyId,
-      });
-      expect(initial.ResponseHeadersPolicy?.Id).toEqual(
-        created.responseHeadersPolicyId,
-      );
-      expect(
-        initial.ResponseHeadersPolicy?.ResponseHeadersPolicyConfig?.Comment,
-      ).toEqual("initial");
-      expect(
-        initial.ResponseHeadersPolicy?.ResponseHeadersPolicyConfig
-          ?.SecurityHeadersConfig?.FrameOptions?.FrameOption,
-      ).toEqual("DENY");
-
-      const updated = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* ResponseHeadersPolicy("AppResponseHeaders", {
-            comment: "updated",
-            corsConfig: {
-              AccessControlAllowOrigins: {
-                Quantity: 1,
-                Items: ["https://app.example.com"],
-              },
-              AccessControlAllowMethods: {
-                Quantity: 2,
-                Items: ["GET", "OPTIONS"],
-              },
-              AccessControlAllowHeaders: {
-                Quantity: 1,
-                Items: ["Authorization"],
-              },
-              AccessControlAllowCredentials: false,
-              OriginOverride: true,
-            },
-            securityHeadersConfig: {
-              FrameOptions: { FrameOption: "SAMEORIGIN", Override: true },
-            },
-          });
-        }),
-      );
-
-      expect(updated.responseHeadersPolicyId).toEqual(
-        created.responseHeadersPolicyId,
-      );
-
-      const after = yield* cloudfront.getResponseHeadersPolicy({
-        Id: updated.responseHeadersPolicyId,
-      });
-      expect(
-        after.ResponseHeadersPolicy?.ResponseHeadersPolicyConfig?.Comment,
-      ).toEqual("updated");
-      expect(
-        after.ResponseHeadersPolicy?.ResponseHeadersPolicyConfig
-          ?.SecurityHeadersConfig?.FrameOptions?.FrameOption,
-      ).toEqual("SAMEORIGIN");
-      expect(
-        after.ResponseHeadersPolicy?.ResponseHeadersPolicyConfig?.CorsConfig
-          ?.AccessControlAllowOrigins?.Items,
-      ).toEqual(["https://app.example.com"]);
-
-      yield* destroy();
-      yield* assertResponseHeadersPolicyDeleted(
-        updated.responseHeadersPolicyId,
-      );
-    }).pipe(Effect.provide(AWS.providers())),
   );
 });
 

--- a/packages/alchemy/test/AWS/DynamoDB/Bindings.test.ts
+++ b/packages/alchemy/test/AWS/DynamoDB/Bindings.test.ts
@@ -1,4 +1,6 @@
-import { afterAll, beforeAll, destroy, test } from "@/Test/Vitest";
+import * as AWS from "@/AWS";
+import * as Core from "@/Test/Core";
+import * as Test from "@/Test/Vitest";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
@@ -7,6 +9,10 @@ import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import { describe } from "vitest";
 
 import DynamoDBTestFunctionLive, { DynamoDBTestFunction } from "./handler";
+
+const testOptions = { providers: AWS.providers() };
+const { test, beforeAll, afterAll } = Test.make(testOptions);
+const sharedStack = Core.scratchStack(testOptions, "DynamoDBBindings");
 
 const readinessPolicy = Schedule.fixed("2 seconds").pipe(
   Schedule.both(Schedule.recurs(9)),
@@ -21,10 +27,10 @@ describe("DynamoDB Bindings", () => {
       yield* Effect.logInfo(
         "DynamoDB test setup: destroying previous resources",
       );
-      yield* destroy();
+      yield* sharedStack.destroy();
 
       yield* Effect.logInfo("DynamoDB test setup: deploying fixture");
-      const { functionUrl } = yield* test.deploy(
+      const { functionUrl } = yield* sharedStack.deploy(
         Effect.gen(function* () {
           return yield* DynamoDBTestFunction;
         }).pipe(Effect.provide(DynamoDBTestFunctionLive)),
@@ -41,7 +47,6 @@ describe("DynamoDB Bindings", () => {
         `DynamoDB test setup: probing readiness at ${readinessUrl} (20s budget)`,
       );
 
-      // Wait for the function to be ready
       yield* HttpClient.get(readinessUrl).pipe(
         Effect.flatMap((response) =>
           response.status === 200
@@ -62,11 +67,10 @@ describe("DynamoDB Bindings", () => {
     { timeout: 120_000 },
   );
 
-  afterAll(destroy(), { timeout: 60_000 });
+  afterAll(sharedStack.destroy(), { timeout: 60_000 });
 
   describe("PutItem", () => {
-    test(
-      "puts an item into the table",
+    test.provider("puts an item into the table", (_stack) =>
       Effect.gen(function* () {
         const response = yield* HttpClient.execute(
           HttpClientRequest.bodyJsonUnsafe(
@@ -81,10 +85,8 @@ describe("DynamoDB Bindings", () => {
   });
 
   describe("GetItem", () => {
-    test(
-      "gets an existing item from the table",
+    test.provider("gets an existing item from the table", (_stack) =>
       Effect.gen(function* () {
-        // First put an item
         yield* HttpClient.execute(
           HttpClientRequest.bodyJsonUnsafe(
             HttpClientRequest.post(`${baseUrl}/put`),
@@ -92,7 +94,6 @@ describe("DynamoDB Bindings", () => {
           ),
         );
 
-        // Then get it
         const response = yield* HttpClient.get(
           `${baseUrl}/get?pk=${encodeURIComponent("get-test#1")}&sk=item`,
         ).pipe(Effect.flatMap((r) => r.json));
@@ -104,8 +105,7 @@ describe("DynamoDB Bindings", () => {
       }),
     );
 
-    test(
-      "returns undefined for non-existent item",
+    test.provider("returns undefined for non-existent item", (_stack) =>
       Effect.gen(function* () {
         const response = yield* HttpClient.get(
           `${baseUrl}/get?pk=${encodeURIComponent("non-existent")}&sk=item`,
@@ -117,8 +117,7 @@ describe("DynamoDB Bindings", () => {
   });
 
   describe("DescribeTable", () => {
-    test(
-      "describes the bound table",
+    test.provider("describes the bound table", (_stack) =>
       Effect.gen(function* () {
         const response = yield* HttpClient.get(
           `${baseUrl}/describe-table`,
@@ -134,8 +133,7 @@ describe("DynamoDB Bindings", () => {
   });
 
   describe("DescribeTimeToLive", () => {
-    test(
-      "describes table ttl configuration",
+    test.provider("describes table ttl configuration", (_stack) =>
       Effect.gen(function* () {
         const response = yield* HttpClient.get(`${baseUrl}/describe-ttl`).pipe(
           Effect.flatMap((r) => r.json),
@@ -147,8 +145,7 @@ describe("DynamoDB Bindings", () => {
   });
 
   describe("BatchWriteItem", () => {
-    test(
-      "writes multiple items through the bound table",
+    test.provider("writes multiple items through the bound table", (_stack) =>
       Effect.gen(function* () {
         const response = yield* HttpClient.execute(
           HttpClientRequest.bodyJsonUnsafe(
@@ -186,8 +183,7 @@ describe("DynamoDB Bindings", () => {
   });
 
   describe("BatchGetItem", () => {
-    test(
-      "reads multiple items through the bound table",
+    test.provider("reads multiple items through the bound table", (_stack) =>
       Effect.gen(function* () {
         yield* HttpClient.execute(
           HttpClientRequest.bodyJsonUnsafe(
@@ -242,8 +238,7 @@ describe("DynamoDB Bindings", () => {
   });
 
   describe("UpdateTimeToLive", () => {
-    test(
-      "updates table ttl configuration",
+    test.provider("updates table ttl configuration", (_stack) =>
       Effect.gen(function* () {
         const response = yield* HttpClient.execute(
           HttpClientRequest.bodyJsonUnsafe(
@@ -261,52 +256,132 @@ describe("DynamoDB Bindings", () => {
   });
 
   describe("ExecuteStatement", () => {
-    test(
+    test.provider(
       "executes a PartiQL statement against the bound table",
-      Effect.gen(function* () {
-        yield* HttpClient.execute(
-          HttpClientRequest.bodyJsonUnsafe(
-            HttpClientRequest.post(`${baseUrl}/put`),
-            { pk: "statement#1", sk: "item", data: "statement data" },
-          ),
-        );
+      (_stack) =>
+        Effect.gen(function* () {
+          yield* HttpClient.execute(
+            HttpClientRequest.bodyJsonUnsafe(
+              HttpClientRequest.post(`${baseUrl}/put`),
+              { pk: "statement#1", sk: "item", data: "statement data" },
+            ),
+          );
 
-        const response = yield* HttpClient.execute(
-          HttpClientRequest.bodyJsonUnsafe(
-            HttpClientRequest.post(`${baseUrl}/execute-statement`),
-            { pk: "statement#1", sk: "item" },
-          ),
-        ).pipe(Effect.flatMap((r) => r.json));
+          const response = yield* HttpClient.execute(
+            HttpClientRequest.bodyJsonUnsafe(
+              HttpClientRequest.post(`${baseUrl}/execute-statement`),
+              { pk: "statement#1", sk: "item" },
+            ),
+          ).pipe(Effect.flatMap((r) => r.json));
 
-        expect((response as any).items).toHaveLength(1);
-        expect((response as any).items[0].data.S).toBe("statement data");
-      }),
+          expect((response as any).items).toHaveLength(1);
+          expect((response as any).items[0].data.S).toBe("statement data");
+        }),
     );
   });
 
   describe("BatchExecuteStatement", () => {
-    test(
+    test.provider(
       "executes PartiQL statements against the bound table",
-      Effect.gen(function* () {
-        yield* HttpClient.execute(
-          HttpClientRequest.bodyJsonUnsafe(
-            HttpClientRequest.post(`${baseUrl}/batch-write`),
-            {
-              RequestItems: {
-                [sourceTableId]: [
+      (_stack) =>
+        Effect.gen(function* () {
+          yield* HttpClient.execute(
+            HttpClientRequest.bodyJsonUnsafe(
+              HttpClientRequest.post(`${baseUrl}/batch-write`),
+              {
+                RequestItems: {
+                  [sourceTableId]: [
+                    {
+                      PutRequest: {
+                        Item: {
+                          pk: { S: "batch-statement#1" },
+                          sk: { S: "item" },
+                          data: { S: "first item" },
+                        },
+                      },
+                    },
+                    {
+                      PutRequest: {
+                        Item: {
+                          pk: { S: "batch-statement#2" },
+                          sk: { S: "item" },
+                          data: { S: "second item" },
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            ),
+          );
+
+          const response = yield* HttpClient.execute(
+            HttpClientRequest.bodyJsonUnsafe(
+              HttpClientRequest.post(`${baseUrl}/batch-execute-statement`),
+              {
+                first: { pk: "batch-statement#1", sk: "item" },
+                second: { pk: "batch-statement#2", sk: "item" },
+              },
+            ),
+          ).pipe(Effect.flatMap((r) => r.json));
+
+          expect((response as any).responses).toHaveLength(2);
+        }),
+    );
+  });
+
+  describe("ExecuteTransaction", () => {
+    test.provider(
+      "executes a PartiQL transaction against the table",
+      (_stack) =>
+        Effect.gen(function* () {
+          yield* HttpClient.execute(
+            HttpClientRequest.bodyJsonUnsafe(
+              HttpClientRequest.post(`${baseUrl}/put`),
+              { pk: "tx#1", sk: "item1", data: "first" },
+            ),
+          );
+          yield* HttpClient.execute(
+            HttpClientRequest.bodyJsonUnsafe(
+              HttpClientRequest.post(`${baseUrl}/put`),
+              { pk: "tx#1", sk: "item2", data: "second" },
+            ),
+          );
+
+          const response = yield* HttpClient.execute(
+            HttpClientRequest.post(`${baseUrl}/execute-transaction`),
+          ).pipe(Effect.flatMap((r) => r.json));
+
+          expect((response as any).responses).toHaveLength(2);
+        }),
+    );
+  });
+
+  describe("TransactWriteItems", () => {
+    test.provider(
+      "writes items transactionally through the bound table",
+      (_stack) =>
+        Effect.gen(function* () {
+          const response = yield* HttpClient.execute(
+            HttpClientRequest.bodyJsonUnsafe(
+              HttpClientRequest.post(`${baseUrl}/transact-write`),
+              {
+                TransactItems: [
                   {
-                    PutRequest: {
+                    Put: {
+                      Table: sourceTableId,
                       Item: {
-                        pk: { S: "batch-statement#1" },
+                        pk: { S: "transact-write#1" },
                         sk: { S: "item" },
                         data: { S: "first item" },
                       },
                     },
                   },
                   {
-                    PutRequest: {
+                    Put: {
+                      Table: sourceTableId,
                       Item: {
-                        pk: { S: "batch-statement#2" },
+                        pk: { S: "transact-write#2" },
                         sk: { S: "item" },
                         data: { S: "second item" },
                       },
@@ -314,162 +389,85 @@ describe("DynamoDB Bindings", () => {
                   },
                 ],
               },
-            },
-          ),
-        );
+            ),
+          ).pipe(Effect.flatMap((r) => r.json));
 
-        const response = yield* HttpClient.execute(
-          HttpClientRequest.bodyJsonUnsafe(
-            HttpClientRequest.post(`${baseUrl}/batch-execute-statement`),
-            {
-              first: { pk: "batch-statement#1", sk: "item" },
-              second: { pk: "batch-statement#2", sk: "item" },
-            },
-          ),
-        ).pipe(Effect.flatMap((r) => r.json));
-
-        expect((response as any).responses).toHaveLength(2);
-      }),
-    );
-  });
-
-  describe("ExecuteTransaction", () => {
-    test(
-      "executes a PartiQL transaction against the table",
-      Effect.gen(function* () {
-        yield* HttpClient.execute(
-          HttpClientRequest.bodyJsonUnsafe(
-            HttpClientRequest.post(`${baseUrl}/put`),
-            { pk: "tx#1", sk: "item1", data: "first" },
-          ),
-        );
-        yield* HttpClient.execute(
-          HttpClientRequest.bodyJsonUnsafe(
-            HttpClientRequest.post(`${baseUrl}/put`),
-            { pk: "tx#1", sk: "item2", data: "second" },
-          ),
-        );
-
-        const response = yield* HttpClient.execute(
-          HttpClientRequest.post(`${baseUrl}/execute-transaction`),
-        ).pipe(Effect.flatMap((r) => r.json));
-
-        expect((response as any).responses).toHaveLength(2);
-      }),
-    );
-  });
-
-  describe("TransactWriteItems", () => {
-    test(
-      "writes items transactionally through the bound table",
-      Effect.gen(function* () {
-        const response = yield* HttpClient.execute(
-          HttpClientRequest.bodyJsonUnsafe(
-            HttpClientRequest.post(`${baseUrl}/transact-write`),
-            {
-              TransactItems: [
-                {
-                  Put: {
-                    Table: sourceTableId,
-                    Item: {
-                      pk: { S: "transact-write#1" },
-                      sk: { S: "item" },
-                      data: { S: "first item" },
-                    },
-                  },
-                },
-                {
-                  Put: {
-                    Table: sourceTableId,
-                    Item: {
-                      pk: { S: "transact-write#2" },
-                      sk: { S: "item" },
-                      data: { S: "second item" },
-                    },
-                  },
-                },
-              ],
-            },
-          ),
-        ).pipe(Effect.flatMap((r) => r.json));
-
-        expect((response as any).success).toBe(true);
-      }),
+          expect((response as any).success).toBe(true);
+        }),
     );
   });
 
   describe("TransactGetItems", () => {
-    test(
+    test.provider(
       "reads items transactionally through the bound table",
-      Effect.gen(function* () {
-        yield* HttpClient.execute(
-          HttpClientRequest.bodyJsonUnsafe(
-            HttpClientRequest.post(`${baseUrl}/transact-write`),
-            {
-              TransactItems: [
-                {
-                  Put: {
-                    Table: sourceTableId,
-                    Item: {
-                      pk: { S: "transact-get#1" },
-                      sk: { S: "item" },
-                      data: { S: "first item" },
+      (_stack) =>
+        Effect.gen(function* () {
+          yield* HttpClient.execute(
+            HttpClientRequest.bodyJsonUnsafe(
+              HttpClientRequest.post(`${baseUrl}/transact-write`),
+              {
+                TransactItems: [
+                  {
+                    Put: {
+                      Table: sourceTableId,
+                      Item: {
+                        pk: { S: "transact-get#1" },
+                        sk: { S: "item" },
+                        data: { S: "first item" },
+                      },
                     },
                   },
-                },
-                {
-                  Put: {
-                    Table: sourceTableId,
-                    Item: {
-                      pk: { S: "transact-get#2" },
-                      sk: { S: "item" },
-                      data: { S: "second item" },
+                  {
+                    Put: {
+                      Table: sourceTableId,
+                      Item: {
+                        pk: { S: "transact-get#2" },
+                        sk: { S: "item" },
+                        data: { S: "second item" },
+                      },
                     },
                   },
-                },
-              ],
-            },
-          ),
-        );
+                ],
+              },
+            ),
+          );
 
-        const response = yield* HttpClient.execute(
-          HttpClientRequest.bodyJsonUnsafe(
-            HttpClientRequest.post(`${baseUrl}/transact-get`),
-            {
-              TransactItems: [
-                {
-                  Get: {
-                    Table: sourceTableId,
-                    Key: {
-                      pk: { S: "transact-get#1" },
-                      sk: { S: "item" },
+          const response = yield* HttpClient.execute(
+            HttpClientRequest.bodyJsonUnsafe(
+              HttpClientRequest.post(`${baseUrl}/transact-get`),
+              {
+                TransactItems: [
+                  {
+                    Get: {
+                      Table: sourceTableId,
+                      Key: {
+                        pk: { S: "transact-get#1" },
+                        sk: { S: "item" },
+                      },
                     },
                   },
-                },
-                {
-                  Get: {
-                    Table: sourceTableId,
-                    Key: {
-                      pk: { S: "transact-get#2" },
-                      sk: { S: "item" },
+                  {
+                    Get: {
+                      Table: sourceTableId,
+                      Key: {
+                        pk: { S: "transact-get#2" },
+                        sk: { S: "item" },
+                      },
                     },
                   },
-                },
-              ],
-            },
-          ),
-        ).pipe(Effect.flatMap((r) => r.json));
+                ],
+              },
+            ),
+          ).pipe(Effect.flatMap((r) => r.json));
 
-        expect((response as any).responses).toHaveLength(2);
-      }),
+          expect((response as any).responses).toHaveLength(2);
+        }),
     );
   });
 
   describe("UpdateItem", () => {
-    test(
-      "updates an existing item",
+    test.provider("updates an existing item", (_stack) =>
       Effect.gen(function* () {
-        // First put an item
         yield* HttpClient.execute(
           HttpClientRequest.bodyJsonUnsafe(
             HttpClientRequest.post(`${baseUrl}/put`),
@@ -477,7 +475,6 @@ describe("DynamoDB Bindings", () => {
           ),
         );
 
-        // Update it
         const response = yield* HttpClient.execute(
           HttpClientRequest.bodyJsonUnsafe(
             HttpClientRequest.post(`${baseUrl}/update`),
@@ -488,7 +485,6 @@ describe("DynamoDB Bindings", () => {
         expect(response).toHaveProperty("success", true);
         expect((response as any).attributes.data.S).toBe("updated");
 
-        // Verify the update
         const getResponse = yield* HttpClient.get(
           `${baseUrl}/get?pk=${encodeURIComponent("update-test#1")}&sk=item`,
         ).pipe(Effect.flatMap((r) => r.json));
@@ -499,10 +495,8 @@ describe("DynamoDB Bindings", () => {
   });
 
   describe("DeleteItem", () => {
-    test(
-      "deletes an existing item",
+    test.provider("deletes an existing item", (_stack) =>
       Effect.gen(function* () {
-        // First put an item
         yield* HttpClient.execute(
           HttpClientRequest.bodyJsonUnsafe(
             HttpClientRequest.post(`${baseUrl}/put`),
@@ -510,7 +504,6 @@ describe("DynamoDB Bindings", () => {
           ),
         );
 
-        // Delete it
         const response = yield* HttpClient.execute(
           HttpClientRequest.bodyJsonUnsafe(
             HttpClientRequest.delete(`${baseUrl}/delete`),
@@ -520,7 +513,6 @@ describe("DynamoDB Bindings", () => {
 
         expect(response).toHaveProperty("success", true);
 
-        // Verify deletion
         const getResponse = yield* HttpClient.get(
           `${baseUrl}/get?pk=${encodeURIComponent("delete-test#1")}&sk=item`,
         ).pipe(Effect.flatMap((r) => r.json));
@@ -531,10 +523,8 @@ describe("DynamoDB Bindings", () => {
   });
 
   describe("Query", () => {
-    test(
-      "queries items by partition key",
+    test.provider("queries items by partition key", (_stack) =>
       Effect.gen(function* () {
-        // Put multiple items with same pk
         yield* HttpClient.execute(
           HttpClientRequest.bodyJsonUnsafe(
             HttpClientRequest.post(`${baseUrl}/put`),
@@ -559,8 +549,7 @@ describe("DynamoDB Bindings", () => {
   });
 
   describe("ListTables", () => {
-    test(
-      "lists the deployed table",
+    test.provider("lists the deployed table", (_stack) =>
       Effect.gen(function* () {
         const described = yield* HttpClient.get(
           `${baseUrl}/describe-table`,
@@ -578,8 +567,7 @@ describe("DynamoDB Bindings", () => {
   });
 
   describe("ListTagsOfResource", () => {
-    test(
-      "lists alchemy ownership tags for the table",
+    test.provider("lists alchemy ownership tags for the table", (_stack) =>
       Effect.gen(function* () {
         const response = yield* HttpClient.get(`${baseUrl}/list-tags`).pipe(
           Effect.flatMap((r) => r.json),
@@ -594,30 +582,29 @@ describe("DynamoDB Bindings", () => {
   });
 
   describe("RestoreTableToPointInTime", () => {
-    test(
+    test.provider(
       "returns a structured error when point-in-time recovery is unavailable",
-      Effect.gen(function* () {
-        const response = yield* HttpClient.execute(
-          HttpClientRequest.bodyJsonUnsafe(
-            HttpClientRequest.post(`${baseUrl}/restore-table`),
-            {},
-          ),
-        ).pipe(Effect.flatMap((r) => r.json));
+      (_stack) =>
+        Effect.gen(function* () {
+          const response = yield* HttpClient.execute(
+            HttpClientRequest.bodyJsonUnsafe(
+              HttpClientRequest.post(`${baseUrl}/restore-table`),
+              {},
+            ),
+          ).pipe(Effect.flatMap((r) => r.json));
 
-        expect((response as any).ok).toBe(false);
-        expect([
-          "PointInTimeRecoveryUnavailableException",
-          "TableAlreadyExistsException",
-        ]).toContain((response as any).error);
-      }),
+          expect((response as any).ok).toBe(false);
+          expect([
+            "PointInTimeRecoveryUnavailableException",
+            "TableAlreadyExistsException",
+          ]).toContain((response as any).error);
+        }),
     );
   });
 
   describe("Scan", () => {
-    test(
-      "scans all items in the table",
+    test.provider("scans all items in the table", (_stack) =>
       Effect.gen(function* () {
-        // Put an item to ensure table isn't empty
         yield* HttpClient.execute(
           HttpClientRequest.bodyJsonUnsafe(
             HttpClientRequest.post(`${baseUrl}/put`),

--- a/packages/alchemy/test/AWS/DynamoDB/Stream.test.ts
+++ b/packages/alchemy/test/AWS/DynamoDB/Stream.test.ts
@@ -1,5 +1,5 @@
 import * as AWS from "@/AWS";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as DynamoDB from "@distilled.cloud/aws/dynamodb";
 import * as Lambda from "@distilled.cloud/aws/lambda";
 import * as SQS from "@distilled.cloud/aws/sqs";
@@ -12,71 +12,74 @@ import DynamoDBStreamFunctionLive, {
   TableAndQueue,
 } from "./stream-handler.ts";
 
+const { test } = Test.make({ providers: AWS.providers() });
+
 describe.sequential("AWS.DynamoDB.Stream", () => {
-  test(
+  test.provider(
     "processes real DynamoDB stream records through Lambda",
-    { timeout: 240_000 },
-    Effect.gen(function* () {
-      yield* Effect.logInfo(
-        "DynamoDB Stream test: destroying previous resources",
-      );
-      yield* destroy();
+    (stack) =>
+      Effect.gen(function* () {
+        yield* Effect.logInfo(
+          "DynamoDB Stream test: destroying previous resources",
+        );
+        yield* stack.destroy();
 
-      yield* Effect.logInfo("DynamoDB Stream test: deploying stream fixture");
-      const { table, queue, streamFunction } = yield* test
-        .deploy(
-          Effect.gen(function* () {
-            const { table, queue } = yield* TableAndQueue;
+        yield* Effect.logInfo("DynamoDB Stream test: deploying stream fixture");
+        const { table, queue, streamFunction } = yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              const { table, queue } = yield* TableAndQueue;
 
-            const func = yield* DynamoDBStreamFunction;
+              const func = yield* DynamoDBStreamFunction;
 
-            return { table, queue, streamFunction: func };
-          }),
-        )
-        .pipe(Effect.provide(DynamoDBStreamFunctionLive));
+              return { table, queue, streamFunction: func };
+            }),
+          )
+          .pipe(Effect.provide(DynamoDBStreamFunctionLive));
 
-      const streamState = yield* waitForTableStreamSpecification(
-        table.tableName,
-        {
+        const streamState = yield* waitForTableStreamSpecification(
+          table.tableName,
+          {
+            StreamEnabled: true,
+            StreamViewType: "NEW_AND_OLD_IMAGES",
+          },
+        );
+        expect(streamState.Table?.StreamSpecification).toEqual({
           StreamEnabled: true,
           StreamViewType: "NEW_AND_OLD_IMAGES",
-        },
-      );
-      expect(streamState.Table?.StreamSpecification).toEqual({
-        StreamEnabled: true,
-        StreamViewType: "NEW_AND_OLD_IMAGES",
-      });
-      expect(streamState.Table?.LatestStreamArn).toBeDefined();
+        });
+        expect(streamState.Table?.LatestStreamArn).toBeDefined();
 
-      yield* waitForEventSourceMappingEnabled(
-        streamFunction.functionName,
-        streamState.Table?.LatestStreamArn!,
-      );
+        yield* waitForEventSourceMappingEnabled(
+          streamFunction.functionName,
+          streamState.Table?.LatestStreamArn!,
+        );
 
-      yield* Effect.logInfo(
-        `DynamoDB Stream test: writing item into ${table.tableName}`,
-      );
-      yield* DynamoDB.putItem({
-        TableName: table.tableName,
-        Item: {
-          pk: { S: "stream#1" },
-          sk: { S: "item#1" },
-          data: { S: "payload" },
-        },
-      });
+        yield* Effect.logInfo(
+          `DynamoDB Stream test: writing item into ${table.tableName}`,
+        );
+        yield* DynamoDB.putItem({
+          TableName: table.tableName,
+          Item: {
+            pk: { S: "stream#1" },
+            sk: { S: "item#1" },
+            data: { S: "payload" },
+          },
+        });
 
-      const message = yield* waitForQueueMessage(queue.queueUrl);
-      const body = JSON.parse(message.Body!);
+        const message = yield* waitForQueueMessage(queue.queueUrl);
+        const body = JSON.parse(message.Body!);
 
-      expect(body.eventName).toEqual("INSERT");
-      expect(body.keys.pk.S).toEqual("stream#1");
-      expect(body.keys.sk.S).toEqual("item#1");
-      expect(body.newImage.data.S).toEqual("payload");
-      expect(body.oldImage).toBeUndefined();
+        expect(body.eventName).toEqual("INSERT");
+        expect(body.keys.pk.S).toEqual("stream#1");
+        expect(body.keys.sk.S).toEqual("item#1");
+        expect(body.newImage.data.S).toEqual("payload");
+        expect(body.oldImage).toBeUndefined();
 
-      yield* Effect.logInfo("DynamoDB Stream test: destroying fixture");
-      yield* destroy();
-    }).pipe(Effect.provide(AWS.providers())),
+        yield* Effect.logInfo("DynamoDB Stream test: destroying fixture");
+        yield* stack.destroy();
+      }),
+    { timeout: 240_000 },
   );
 });
 

--- a/packages/alchemy/test/AWS/DynamoDB/Table.test.ts
+++ b/packages/alchemy/test/AWS/DynamoDB/Table.test.ts
@@ -1,25 +1,26 @@
 import * as AWS from "@/AWS";
 import { Table } from "@/AWS/DynamoDB";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as DynamoDB from "@distilled.cloud/aws/dynamodb";
 import { describe, expect } from "@effect/vitest";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 
+const { test } = Test.make({ providers: AWS.providers() });
+
 describe("AWS.DynamoDB.Table", () => {
   const longGlobalSecondaryIndexStabilization = Schedule.fixed(
     "10 seconds",
   ).pipe(Schedule.both(Schedule.recurs(180)));
 
-  test(
-    "create, update, delete table",
+  test.provider("create, update, delete table", (stack) =>
     Effect.gen(function* () {
       yield* logTestStep("starting create/update/delete table");
-      yield* destroy();
+      yield* stack.destroy();
 
       yield* logTestStep("deploying base table");
-      const table = yield* test.deploy(
+      const table = yield* stack.deploy(
         Effect.gen(function* () {
           return yield* Table("TestTable", {
             partitionKey: "id",
@@ -34,516 +35,527 @@ describe("AWS.DynamoDB.Table", () => {
       expect(actualTable.Table?.TableArn).toEqual(table.tableArn);
 
       yield* logTestStep("destroying base table");
-      yield* destroy();
+      yield* stack.destroy();
 
       yield* assertTableIsDeleted(table.tableName);
-    }).pipe(Effect.provide(AWS.providers())),
+    }),
   );
 
-  test(
+  test.provider(
     "create, update, and disable table stream configuration through bindings",
-    Effect.gen(function* () {
-      yield* logTestStep("starting stream configuration test");
-      yield* destroy();
+    (stack) =>
+      Effect.gen(function* () {
+        yield* logTestStep("starting stream configuration test");
+        yield* stack.destroy();
 
-      yield* logTestStep("deploying table with binding-owned stream");
-      const table = yield* test.deploy(
-        Effect.gen(function* () {
-          const table = yield* Table("StreamTable", {
-            partitionKey: "id",
-            attributes: { id: "S" },
-          });
-          yield* table.bind("TestTableStreamBinding", {
-            streamSpecification: {
-              StreamEnabled: true,
-              StreamViewType: "NEW_AND_OLD_IMAGES",
-            },
-          });
-          return table;
-        }),
-      );
-
-      const created = yield* waitForTableStreamSpecification(table.tableName, {
-        StreamEnabled: true,
-        StreamViewType: "NEW_AND_OLD_IMAGES",
-      });
-      expect(created.Table?.StreamSpecification).toEqual({
-        StreamEnabled: true,
-        StreamViewType: "NEW_AND_OLD_IMAGES",
-      });
-      expect(created.Table?.LatestStreamArn).toBeDefined();
-
-      yield* logTestStep("updating stream view type to KEYS_ONLY");
-      yield* test.deploy(
-        Effect.gen(function* () {
-          const table = yield* Table("StreamTable", {
-            partitionKey: "id",
-            attributes: { id: "S" },
-          });
-          yield* table.bind("TestTableStreamBinding", {
-            streamSpecification: {
-              StreamEnabled: true,
-              StreamViewType: "KEYS_ONLY",
-            },
-          });
-          return table;
-        }),
-      );
-
-      const updated = yield* waitForTableStreamSpecification(table.tableName, {
-        StreamEnabled: true,
-        StreamViewType: "KEYS_ONLY",
-      });
-      expect(updated.Table?.StreamSpecification).toEqual({
-        StreamEnabled: true,
-        StreamViewType: "KEYS_ONLY",
-      });
-
-      yield* logTestStep("removing stream binding");
-      yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Table("StreamTable", {
-            partitionKey: "id",
-            attributes: { id: "S" },
-          });
-        }),
-      );
-
-      const disabled = yield* waitForTableStreamSpecification(
-        table.tableName,
-        undefined,
-      );
-      expect(disabled.Table?.StreamSpecification).toBeUndefined();
-
-      yield* logTestStep("destroying stream table");
-      yield* destroy();
-
-      yield* assertTableIsDeleted(table.tableName);
-    }).pipe(Effect.provide(AWS.providers())),
-  );
-
-  test(
-    "create and update table tags and point-in-time recovery",
-    { timeout: 240_000 },
-    Effect.gen(function* () {
-      yield* logTestStep("starting tags and point-in-time recovery test");
-      yield* destroy();
-
-      yield* logTestStep("deploying tagged table with PITR enabled");
-      const table = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Table("TaggedTable", {
-            partitionKey: "id",
-            attributes: { id: "S" },
-            tags: { Environment: "test" },
-            pointInTimeRecoverySpecification: {
-              PointInTimeRecoveryEnabled: true,
-              RecoveryPeriodInDays: 7,
-            },
-          });
-        }),
-      );
-
-      const createdTags = yield* waitForTableTags(table.tableArn, {
-        Environment: "test",
-      });
-      expect(createdTags["Environment"]).toEqual("test");
-      expect(table.tags?.["Environment"]).toEqual("test");
-
-      const createdBackups = yield* waitForPointInTimeRecovery(
-        table.tableName,
-        true,
-      );
-      expect(
-        createdBackups.PointInTimeRecoveryDescription
-          ?.PointInTimeRecoveryStatus,
-      ).toEqual("ENABLED");
-      expect(
-        createdBackups.PointInTimeRecoveryDescription?.RecoveryPeriodInDays,
-      ).toEqual(7);
-
-      yield* logTestStep("updating tags and disabling PITR");
-      const updated = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Table("TaggedTable", {
-            partitionKey: "id",
-            attributes: { id: "S" },
-            tags: { Environment: "prod", Team: "platform" },
-            pointInTimeRecoverySpecification: {
-              PointInTimeRecoveryEnabled: false,
-            },
-          });
-        }),
-      );
-
-      const updatedTags = yield* waitForTableTags(updated.tableArn, {
-        Environment: "prod",
-        Team: "platform",
-      });
-      expect(updatedTags["Environment"]).toEqual("prod");
-      expect(updatedTags["Team"]).toEqual("platform");
-      expect(updated.tags?.["Environment"]).toEqual("prod");
-      expect(updated.tags?.["Team"]).toEqual("platform");
-
-      const updatedBackups = yield* waitForPointInTimeRecovery(
-        updated.tableName,
-        false,
-      );
-      expect(
-        updatedBackups.PointInTimeRecoveryDescription
-          ?.PointInTimeRecoveryStatus,
-      ).toEqual("DISABLED");
-
-      yield* logTestStep("destroying tagged table");
-      yield* destroy();
-
-      yield* assertTableIsDeleted(table.tableName);
-    }).pipe(Effect.provide(AWS.providers())),
-  );
-
-  test(
-    "create table with folded local and global secondary indexes",
-    { timeout: 180_000 },
-    Effect.gen(function* () {
-      yield* logTestStep("starting folded index create test");
-      yield* destroy();
-
-      yield* logTestStep("deploying table with LSI and GSI");
-      const table = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Table("IndexedTable", {
-            partitionKey: "pk",
-            sortKey: "sk",
-            attributes: {
-              pk: "S",
-              sk: "S",
-              gsi1pk: "S",
-            },
-            localSecondaryIndexes: [
-              {
-                IndexName: "lsi-by-sk",
-                KeySchema: [
-                  { AttributeName: "pk", KeyType: "HASH" },
-                  { AttributeName: "sk", KeyType: "RANGE" },
-                ],
-                Projection: {
-                  ProjectionType: "ALL",
-                },
+        yield* logTestStep("deploying table with binding-owned stream");
+        const table = yield* stack.deploy(
+          Effect.gen(function* () {
+            const table = yield* Table("StreamTable", {
+              partitionKey: "id",
+              attributes: { id: "S" },
+            });
+            yield* table.bind("TestTableStreamBinding", {
+              streamSpecification: {
+                StreamEnabled: true,
+                StreamViewType: "NEW_AND_OLD_IMAGES",
               },
-            ],
-            globalSecondaryIndexes: [
-              {
-                IndexName: "gsi-by-lookup",
-                KeySchema: [{ AttributeName: "gsi1pk", KeyType: "HASH" }],
-                Projection: {
-                  ProjectionType: "ALL",
-                },
-              },
-            ],
-          });
-        }),
-      );
+            });
+            return table;
+          }),
+        );
 
-      const actualTable = yield* Effect.gen(function* () {
-        const current = yield* DynamoDB.describeTable({
-          TableName: table.tableName,
+        const created = yield* waitForTableStreamSpecification(
+          table.tableName,
+          {
+            StreamEnabled: true,
+            StreamViewType: "NEW_AND_OLD_IMAGES",
+          },
+        );
+        expect(created.Table?.StreamSpecification).toEqual({
+          StreamEnabled: true,
+          StreamViewType: "NEW_AND_OLD_IMAGES",
         });
-        if (
-          current.Table?.GlobalSecondaryIndexes?.some(
-            (index) => index.IndexStatus !== "ACTIVE",
-          )
-        ) {
-          return yield* Effect.fail(new GlobalSecondaryIndexNotActive());
-        }
-        return current.Table;
-      }).pipe(
-        Effect.retry({
-          while: (error) => error._tag === "GlobalSecondaryIndexNotActive",
-          schedule: Schedule.fixed("2 seconds").pipe(
-            Schedule.both(Schedule.recurs(30)),
-          ),
-        }),
-      );
+        expect(created.Table?.LatestStreamArn).toBeDefined();
 
-      expect(
-        actualTable?.LocalSecondaryIndexes?.map((index) => index.IndexName),
-      ).toContain("lsi-by-sk");
-      expect(
-        actualTable?.GlobalSecondaryIndexes?.map((index) => index.IndexName),
-      ).toContain("gsi-by-lookup");
-      expect(
-        table.localSecondaryIndexes?.map((index) => index.IndexName),
-      ).toContain("lsi-by-sk");
-      expect(
-        table.globalSecondaryIndexes?.map((index) => index.IndexName),
-      ).toContain("gsi-by-lookup");
+        yield* logTestStep("updating stream view type to KEYS_ONLY");
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            const table = yield* Table("StreamTable", {
+              partitionKey: "id",
+              attributes: { id: "S" },
+            });
+            yield* table.bind("TestTableStreamBinding", {
+              streamSpecification: {
+                StreamEnabled: true,
+                StreamViewType: "KEYS_ONLY",
+              },
+            });
+            return table;
+          }),
+        );
 
-      yield* logTestStep("destroying indexed table");
-      yield* destroy();
+        const updated = yield* waitForTableStreamSpecification(
+          table.tableName,
+          {
+            StreamEnabled: true,
+            StreamViewType: "KEYS_ONLY",
+          },
+        );
+        expect(updated.Table?.StreamSpecification).toEqual({
+          StreamEnabled: true,
+          StreamViewType: "KEYS_ONLY",
+        });
 
-      yield* assertTableIsDeleted(table.tableName);
-    }).pipe(Effect.provide(AWS.providers())),
+        yield* logTestStep("removing stream binding");
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("StreamTable", {
+              partitionKey: "id",
+              attributes: { id: "S" },
+            });
+          }),
+        );
+
+        const disabled = yield* waitForTableStreamSpecification(
+          table.tableName,
+          undefined,
+        );
+        expect(disabled.Table?.StreamSpecification).toBeUndefined();
+
+        yield* logTestStep("destroying stream table");
+        yield* stack.destroy();
+
+        yield* assertTableIsDeleted(table.tableName);
+      }),
+  );
+
+  test.provider(
+    "create and update table tags and point-in-time recovery",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* logTestStep("starting tags and point-in-time recovery test");
+        yield* stack.destroy();
+
+        yield* logTestStep("deploying tagged table with PITR enabled");
+        const table = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("TaggedTable", {
+              partitionKey: "id",
+              attributes: { id: "S" },
+              tags: { Environment: "test" },
+              pointInTimeRecoverySpecification: {
+                PointInTimeRecoveryEnabled: true,
+                RecoveryPeriodInDays: 7,
+              },
+            });
+          }),
+        );
+
+        const createdTags = yield* waitForTableTags(table.tableArn, {
+          Environment: "test",
+        });
+        expect(createdTags["Environment"]).toEqual("test");
+        expect(table.tags?.["Environment"]).toEqual("test");
+
+        const createdBackups = yield* waitForPointInTimeRecovery(
+          table.tableName,
+          true,
+        );
+        expect(
+          createdBackups.PointInTimeRecoveryDescription
+            ?.PointInTimeRecoveryStatus,
+        ).toEqual("ENABLED");
+        expect(
+          createdBackups.PointInTimeRecoveryDescription?.RecoveryPeriodInDays,
+        ).toEqual(7);
+
+        yield* logTestStep("updating tags and disabling PITR");
+        const updated = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("TaggedTable", {
+              partitionKey: "id",
+              attributes: { id: "S" },
+              tags: { Environment: "prod", Team: "platform" },
+              pointInTimeRecoverySpecification: {
+                PointInTimeRecoveryEnabled: false,
+              },
+            });
+          }),
+        );
+
+        const updatedTags = yield* waitForTableTags(updated.tableArn, {
+          Environment: "prod",
+          Team: "platform",
+        });
+        expect(updatedTags["Environment"]).toEqual("prod");
+        expect(updatedTags["Team"]).toEqual("platform");
+        expect(updated.tags?.["Environment"]).toEqual("prod");
+        expect(updated.tags?.["Team"]).toEqual("platform");
+
+        const updatedBackups = yield* waitForPointInTimeRecovery(
+          updated.tableName,
+          false,
+        );
+        expect(
+          updatedBackups.PointInTimeRecoveryDescription
+            ?.PointInTimeRecoveryStatus,
+        ).toEqual("DISABLED");
+
+        yield* logTestStep("destroying tagged table");
+        yield* stack.destroy();
+
+        yield* assertTableIsDeleted(table.tableName);
+      }),
+    { timeout: 240_000 },
+  );
+
+  test.provider(
+    "create table with folded local and global secondary indexes",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* logTestStep("starting folded index create test");
+        yield* stack.destroy();
+
+        yield* logTestStep("deploying table with LSI and GSI");
+        const table = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("IndexedTable", {
+              partitionKey: "pk",
+              sortKey: "sk",
+              attributes: {
+                pk: "S",
+                sk: "S",
+                gsi1pk: "S",
+              },
+              localSecondaryIndexes: [
+                {
+                  IndexName: "lsi-by-sk",
+                  KeySchema: [
+                    { AttributeName: "pk", KeyType: "HASH" },
+                    { AttributeName: "sk", KeyType: "RANGE" },
+                  ],
+                  Projection: {
+                    ProjectionType: "ALL",
+                  },
+                },
+              ],
+              globalSecondaryIndexes: [
+                {
+                  IndexName: "gsi-by-lookup",
+                  KeySchema: [{ AttributeName: "gsi1pk", KeyType: "HASH" }],
+                  Projection: {
+                    ProjectionType: "ALL",
+                  },
+                },
+              ],
+            });
+          }),
+        );
+
+        const actualTable = yield* Effect.gen(function* () {
+          const current = yield* DynamoDB.describeTable({
+            TableName: table.tableName,
+          });
+          if (
+            current.Table?.GlobalSecondaryIndexes?.some(
+              (index) => index.IndexStatus !== "ACTIVE",
+            )
+          ) {
+            return yield* Effect.fail(new GlobalSecondaryIndexNotActive());
+          }
+          return current.Table;
+        }).pipe(
+          Effect.retry({
+            while: (error) => error._tag === "GlobalSecondaryIndexNotActive",
+            schedule: Schedule.fixed("2 seconds").pipe(
+              Schedule.both(Schedule.recurs(30)),
+            ),
+          }),
+        );
+
+        expect(
+          actualTable?.LocalSecondaryIndexes?.map((index) => index.IndexName),
+        ).toContain("lsi-by-sk");
+        expect(
+          actualTable?.GlobalSecondaryIndexes?.map((index) => index.IndexName),
+        ).toContain("gsi-by-lookup");
+        expect(
+          table.localSecondaryIndexes?.map((index) => index.IndexName),
+        ).toContain("lsi-by-sk");
+        expect(
+          table.globalSecondaryIndexes?.map((index) => index.IndexName),
+        ).toContain("gsi-by-lookup");
+
+        yield* logTestStep("destroying indexed table");
+        yield* stack.destroy();
+
+        yield* assertTableIsDeleted(table.tableName);
+      }),
+    { timeout: 180_000 },
   );
 
   // it's super slow because GSIs are awfully slow to create
-  test.skip(
+  test.provider.skip(
     "update global secondary indexes across multiple deploys",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* logTestStep(
+          "starting multi-stage global secondary index update test",
+        );
+        yield* stack.destroy();
+
+        yield* logTestStep("deploying table without GSIs");
+        const table = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("UpdatingIndexedTable", {
+              partitionKey: "pk",
+              sortKey: "sk",
+              attributes: {
+                pk: "S",
+                sk: "S",
+              },
+            });
+          }),
+        );
+
+        yield* expectTableIndexes(table.tableName, {
+          local: [],
+          global: [],
+        });
+
+        yield* logTestStep("adding first GSI");
+        const oneAdded = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("UpdatingIndexedTable", {
+              partitionKey: "pk",
+              sortKey: "sk",
+              attributes: {
+                pk: "S",
+                sk: "S",
+                gsi1pk: "S",
+              },
+              globalSecondaryIndexes: [
+                {
+                  IndexName: "gsi-by-lookup-1",
+                  KeySchema: [{ AttributeName: "gsi1pk", KeyType: "HASH" }],
+                  Projection: {
+                    ProjectionType: "ALL",
+                  },
+                },
+              ],
+            });
+          }),
+        );
+        expect(oneAdded.tableName).toEqual(table.tableName);
+        yield* expectTableIndexes(oneAdded.tableName, {
+          local: [],
+          global: ["gsi-by-lookup-1"],
+        });
+
+        yield* logTestStep("removing first GSI");
+        const oneRemoved = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("UpdatingIndexedTable", {
+              partitionKey: "pk",
+              sortKey: "sk",
+              attributes: {
+                pk: "S",
+                sk: "S",
+                gsi1pk: "S",
+                gsi2pk: "S",
+              },
+            });
+          }),
+        );
+        expect(oneRemoved.tableName).toEqual(table.tableName);
+        yield* expectTableIndexes(oneRemoved.tableName, {
+          local: [],
+          global: [],
+        });
+
+        yield* logTestStep("adding two GSIs sequentially through one deploy");
+        const twoAdded = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("UpdatingIndexedTable", {
+              partitionKey: "pk",
+              sortKey: "sk",
+              attributes: {
+                pk: "S",
+                sk: "S",
+                gsi1pk: "S",
+                gsi2pk: "S",
+              },
+              globalSecondaryIndexes: [
+                {
+                  IndexName: "gsi-by-lookup-1",
+                  KeySchema: [{ AttributeName: "gsi1pk", KeyType: "HASH" }],
+                  Projection: {
+                    ProjectionType: "ALL",
+                  },
+                },
+                {
+                  IndexName: "gsi-by-lookup-2",
+                  KeySchema: [{ AttributeName: "gsi2pk", KeyType: "HASH" }],
+                  Projection: {
+                    ProjectionType: "ALL",
+                  },
+                },
+              ],
+            });
+          }),
+        );
+        expect(twoAdded.tableName).toEqual(table.tableName);
+        yield* expectTableIndexes(twoAdded.tableName, {
+          local: [],
+          global: ["gsi-by-lookup-1", "gsi-by-lookup-2"],
+        });
+
+        yield* logTestStep("removing one of two GSIs");
+        const oneOfTwoRemoved = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("UpdatingIndexedTable", {
+              partitionKey: "pk",
+              sortKey: "sk",
+              attributes: {
+                pk: "S",
+                sk: "S",
+                gsi1pk: "S",
+                gsi2pk: "S",
+              },
+              globalSecondaryIndexes: [
+                {
+                  IndexName: "gsi-by-lookup-2",
+                  KeySchema: [{ AttributeName: "gsi2pk", KeyType: "HASH" }],
+                  Projection: {
+                    ProjectionType: "ALL",
+                  },
+                },
+              ],
+            });
+          }),
+        );
+        expect(oneOfTwoRemoved.tableName).toEqual(table.tableName);
+        yield* expectTableIndexes(oneOfTwoRemoved.tableName, {
+          local: [],
+          global: ["gsi-by-lookup-2"],
+        });
+
+        yield* logTestStep("removing remaining GSI");
+        const twoRemoved = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("UpdatingIndexedTable", {
+              partitionKey: "pk",
+              sortKey: "sk",
+              attributes: {
+                pk: "S",
+                sk: "S",
+                gsi1pk: "S",
+                gsi2pk: "S",
+              },
+            });
+          }),
+        );
+        expect(twoRemoved.tableName).toEqual(table.tableName);
+        yield* expectTableIndexes(twoRemoved.tableName, {
+          local: [],
+          global: [],
+        });
+
+        yield* logTestStep("destroying GSI update test table");
+        yield* stack.destroy();
+
+        yield* assertTableIsDeleted(table.tableName);
+      }),
     { timeout: 2_400_000 },
-    Effect.gen(function* () {
-      yield* logTestStep(
-        "starting multi-stage global secondary index update test",
-      );
-      yield* destroy();
-
-      yield* logTestStep("deploying table without GSIs");
-      const table = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Table("UpdatingIndexedTable", {
-            partitionKey: "pk",
-            sortKey: "sk",
-            attributes: {
-              pk: "S",
-              sk: "S",
-            },
-          });
-        }),
-      );
-
-      yield* expectTableIndexes(table.tableName, {
-        local: [],
-        global: [],
-      });
-
-      yield* logTestStep("adding first GSI");
-      const oneAdded = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Table("UpdatingIndexedTable", {
-            partitionKey: "pk",
-            sortKey: "sk",
-            attributes: {
-              pk: "S",
-              sk: "S",
-              gsi1pk: "S",
-            },
-            globalSecondaryIndexes: [
-              {
-                IndexName: "gsi-by-lookup-1",
-                KeySchema: [{ AttributeName: "gsi1pk", KeyType: "HASH" }],
-                Projection: {
-                  ProjectionType: "ALL",
-                },
-              },
-            ],
-          });
-        }),
-      );
-      expect(oneAdded.tableName).toEqual(table.tableName);
-      yield* expectTableIndexes(oneAdded.tableName, {
-        local: [],
-        global: ["gsi-by-lookup-1"],
-      });
-
-      yield* logTestStep("removing first GSI");
-      const oneRemoved = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Table("UpdatingIndexedTable", {
-            partitionKey: "pk",
-            sortKey: "sk",
-            attributes: {
-              pk: "S",
-              sk: "S",
-              gsi1pk: "S",
-              gsi2pk: "S",
-            },
-          });
-        }),
-      );
-      expect(oneRemoved.tableName).toEqual(table.tableName);
-      yield* expectTableIndexes(oneRemoved.tableName, {
-        local: [],
-        global: [],
-      });
-
-      yield* logTestStep("adding two GSIs sequentially through one deploy");
-      const twoAdded = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Table("UpdatingIndexedTable", {
-            partitionKey: "pk",
-            sortKey: "sk",
-            attributes: {
-              pk: "S",
-              sk: "S",
-              gsi1pk: "S",
-              gsi2pk: "S",
-            },
-            globalSecondaryIndexes: [
-              {
-                IndexName: "gsi-by-lookup-1",
-                KeySchema: [{ AttributeName: "gsi1pk", KeyType: "HASH" }],
-                Projection: {
-                  ProjectionType: "ALL",
-                },
-              },
-              {
-                IndexName: "gsi-by-lookup-2",
-                KeySchema: [{ AttributeName: "gsi2pk", KeyType: "HASH" }],
-                Projection: {
-                  ProjectionType: "ALL",
-                },
-              },
-            ],
-          });
-        }),
-      );
-      expect(twoAdded.tableName).toEqual(table.tableName);
-      yield* expectTableIndexes(twoAdded.tableName, {
-        local: [],
-        global: ["gsi-by-lookup-1", "gsi-by-lookup-2"],
-      });
-
-      yield* logTestStep("removing one of two GSIs");
-      const oneOfTwoRemoved = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Table("UpdatingIndexedTable", {
-            partitionKey: "pk",
-            sortKey: "sk",
-            attributes: {
-              pk: "S",
-              sk: "S",
-              gsi1pk: "S",
-              gsi2pk: "S",
-            },
-            globalSecondaryIndexes: [
-              {
-                IndexName: "gsi-by-lookup-2",
-                KeySchema: [{ AttributeName: "gsi2pk", KeyType: "HASH" }],
-                Projection: {
-                  ProjectionType: "ALL",
-                },
-              },
-            ],
-          });
-        }),
-      );
-      expect(oneOfTwoRemoved.tableName).toEqual(table.tableName);
-      yield* expectTableIndexes(oneOfTwoRemoved.tableName, {
-        local: [],
-        global: ["gsi-by-lookup-2"],
-      });
-
-      yield* logTestStep("removing remaining GSI");
-      const twoRemoved = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Table("UpdatingIndexedTable", {
-            partitionKey: "pk",
-            sortKey: "sk",
-            attributes: {
-              pk: "S",
-              sk: "S",
-              gsi1pk: "S",
-              gsi2pk: "S",
-            },
-          });
-        }),
-      );
-      expect(twoRemoved.tableName).toEqual(table.tableName);
-      yield* expectTableIndexes(twoRemoved.tableName, {
-        local: [],
-        global: [],
-      });
-
-      yield* logTestStep("destroying GSI update test table");
-      yield* destroy();
-
-      yield* assertTableIsDeleted(table.tableName);
-    }).pipe(Effect.provide(AWS.providers())),
   );
 
-  test(
+  test.provider(
     "changing local secondary indexes replaces the table",
-    { timeout: 240_000 },
-    Effect.gen(function* () {
-      yield* logTestStep("starting local secondary index replacement test");
-      yield* destroy();
+    (stack) =>
+      Effect.gen(function* () {
+        yield* logTestStep("starting local secondary index replacement test");
+        yield* stack.destroy();
 
-      yield* logTestStep("deploying baseline table without LSIs");
-      const original = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Table("ReplacingIndexedTable", {
-            partitionKey: "pk",
-            sortKey: "sk",
-            attributes: {
-              pk: "S",
-              sk: "S",
-            },
-          });
-        }),
-      );
-
-      yield* expectTableIndexes(original.tableName, {
-        local: [],
-        global: [],
-      });
-
-      yield* logTestStep("deploying replacement with LSI");
-      const withLsi = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Table("ReplacingIndexedTable", {
-            partitionKey: "pk",
-            sortKey: "sk",
-            attributes: {
-              pk: "S",
-              sk: "S",
-            },
-            localSecondaryIndexes: [
-              {
-                IndexName: "lsi-by-sk",
-                KeySchema: [
-                  { AttributeName: "pk", KeyType: "HASH" },
-                  { AttributeName: "sk", KeyType: "RANGE" },
-                ],
-                Projection: {
-                  ProjectionType: "ALL",
-                },
+        yield* logTestStep("deploying baseline table without LSIs");
+        const original = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("ReplacingIndexedTable", {
+              partitionKey: "pk",
+              sortKey: "sk",
+              attributes: {
+                pk: "S",
+                sk: "S",
               },
-            ],
-          });
-        }),
-      );
+            });
+          }),
+        );
 
-      expect(withLsi.tableName).not.toEqual(original.tableName);
-      yield* assertTableIsDeleted(original.tableName);
-      yield* expectTableIndexes(withLsi.tableName, {
-        local: ["lsi-by-sk"],
-        global: [],
-      });
+        yield* expectTableIndexes(original.tableName, {
+          local: [],
+          global: [],
+        });
 
-      yield* logTestStep("deploying replacement without LSI again");
-      const withoutLsiAgain = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Table("ReplacingIndexedTable", {
-            partitionKey: "pk",
-            sortKey: "sk",
-            attributes: {
-              pk: "S",
-              sk: "S",
-            },
-          });
-        }),
-      );
+        yield* logTestStep("deploying replacement with LSI");
+        const withLsi = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("ReplacingIndexedTable", {
+              partitionKey: "pk",
+              sortKey: "sk",
+              attributes: {
+                pk: "S",
+                sk: "S",
+              },
+              localSecondaryIndexes: [
+                {
+                  IndexName: "lsi-by-sk",
+                  KeySchema: [
+                    { AttributeName: "pk", KeyType: "HASH" },
+                    { AttributeName: "sk", KeyType: "RANGE" },
+                  ],
+                  Projection: {
+                    ProjectionType: "ALL",
+                  },
+                },
+              ],
+            });
+          }),
+        );
 
-      expect(withoutLsiAgain.tableName).not.toEqual(withLsi.tableName);
-      yield* assertTableIsDeleted(withLsi.tableName);
-      yield* expectTableIndexes(withoutLsiAgain.tableName, {
-        local: [],
-        global: [],
-      });
+        expect(withLsi.tableName).not.toEqual(original.tableName);
+        yield* assertTableIsDeleted(original.tableName);
+        yield* expectTableIndexes(withLsi.tableName, {
+          local: ["lsi-by-sk"],
+          global: [],
+        });
 
-      yield* logTestStep("destroying replacement test table");
-      yield* destroy();
+        yield* logTestStep("deploying replacement without LSI again");
+        const withoutLsiAgain = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("ReplacingIndexedTable", {
+              partitionKey: "pk",
+              sortKey: "sk",
+              attributes: {
+                pk: "S",
+                sk: "S",
+              },
+            });
+          }),
+        );
 
-      yield* assertTableIsDeleted(withoutLsiAgain.tableName);
-    }).pipe(Effect.provide(AWS.providers())),
+        expect(withoutLsiAgain.tableName).not.toEqual(withLsi.tableName);
+        yield* assertTableIsDeleted(withLsi.tableName);
+        yield* expectTableIndexes(withoutLsiAgain.tableName, {
+          local: [],
+          global: [],
+        });
+
+        yield* logTestStep("destroying replacement test table");
+        yield* stack.destroy();
+
+        yield* assertTableIsDeleted(withoutLsiAgain.tableName);
+      }),
+    { timeout: 240_000 },
   );
 
   const assertTableIsDeleted = Effect.fn(function* (tableName: string) {

--- a/packages/alchemy/test/AWS/EC2/Subnet.test.ts
+++ b/packages/alchemy/test/AWS/EC2/Subnet.test.ts
@@ -1,6 +1,6 @@
 import * as AWS from "@/AWS";
 import { Subnet, Vpc } from "@/AWS/EC2";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as EC2 from "@distilled.cloud/aws/ec2";
 import { expect } from "@effect/vitest";
 import * as Data from "effect/Data";
@@ -8,17 +8,18 @@ import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 
+const { test } = Test.make({ providers: AWS.providers() });
+
 const logLevel = Effect.provideService(
   MinimumLogLevel,
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-test(
-  "create, update, delete subnet",
+test.provider("create, update, delete subnet", (stack) =>
   Effect.gen(function* () {
-    yield* destroy();
+    yield* stack.destroy();
 
-    const { vpc, subnet } = yield* test.deploy(
+    const { vpc, subnet } = yield* stack.deploy(
       Effect.gen(function* () {
         const vpc = yield* Vpc("TestVpc", {
           cidrBlock: "10.0.0.0/16",
@@ -42,7 +43,7 @@ test(
     expect(actualSubnet.Subnets?.[0]?.MapPublicIpOnLaunch).toEqual(false);
 
     // Update subnet attributes
-    const { subnet: updatedSubnet } = yield* test.deploy(
+    const { subnet: updatedSubnet } = yield* stack.deploy(
       Effect.gen(function* () {
         const vpc = yield* Vpc("TestVpc", {
           cidrBlock: "10.0.0.0/16",
@@ -63,10 +64,10 @@ test(
     });
 
     // Delete subnet and VPC
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* assertSubnetDeleted(subnet.subnetId);
-  }).pipe(Effect.provide(AWS.providers()), logLevel),
+  }).pipe(logLevel),
 );
 
 const expectSubnetAttribute = Effect.fn(function* (props: {

--- a/packages/alchemy/test/AWS/EC2/Vpc.smoke.test.ts
+++ b/packages/alchemy/test/AWS/EC2/Vpc.smoke.test.ts
@@ -15,7 +15,7 @@ import {
   Vpc,
   VpcEndpoint,
 } from "@/AWS/EC2";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as EC2 from "@distilled.cloud/aws/ec2";
 import * as ec2 from "@distilled.cloud/aws/ec2";
 import { expect } from "@effect/vitest";
@@ -28,755 +28,1219 @@ const logLevel = Effect.provideService(
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-test.skip(
+const { test } = Test.make({ providers: AWS.providers() });
+
+test.provider.skip(
   "VPC evolution: from simple to complex",
-  {
-    timeout: 1_000_000,
-  },
-  Effect.gen(function* () {
-    yield* destroy();
-
-    // Get available AZs for multi-AZ stages
-    const azResult = yield* EC2.describeAvailabilityZones({});
-    const availableAzs =
-      azResult.AvailabilityZones?.filter((az) => az.State === "available") ??
-      [];
-    const az1 = availableAzs[0]?.ZoneName!;
-    const az2 = availableAzs[1]?.ZoneName!;
-
-    // =========================================================================
-    // STAGE 1: Bare Minimum VPC
-    // User starts with just a VPC - the most basic setup
-    // =========================================================================
-    yield* Effect.log("=== Stage 1: Bare Minimum VPC ===");
-    {
-      const myVpc = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Vpc("MyVpc", {
-            cidrBlock: "10.0.0.0/16",
-          });
-        }),
-      );
-
-      // Verify VPC was created
-      expect(myVpc.vpcId).toMatch(/^vpc-/);
-      expect(myVpc.cidrBlock).toEqual("10.0.0.0/16");
-      expect(myVpc.state).toEqual("available");
-
-      const vpcResult = yield* EC2.describeVpcs({
-        VpcIds: [myVpc.vpcId],
-      });
-      expect(vpcResult.Vpcs?.[0]?.CidrBlock).toEqual("10.0.0.0/16");
-    }
-
-    // =========================================================================
-    // STAGE 2: Add Internet Connectivity
-    // User needs public internet access - add IGW, public subnet, route table
-    // Tests: VPC update (DNS settings), IGW create, Subnet create, Route create
-    // =========================================================================
-    yield* Effect.log("=== Stage 2: Add Internet Connectivity ===");
-    {
-      const stack = yield* test.deploy(
-        Effect.gen(function* () {
-          const myVpc = yield* Vpc("MyVpc", {
-            cidrBlock: "10.0.0.0/16",
-            enableDnsSupport: true,
-            enableDnsHostnames: true,
-          });
-
-          const internetGateway = yield* InternetGateway("InternetGateway", {
-            vpcId: myVpc.vpcId,
-          });
-
-          const publicSubnet1 = yield* Subnet("PublicSubnet1", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.1.0/24",
-            availabilityZone: az1,
-            mapPublicIpOnLaunch: true,
-          });
-
-          const publicRouteTable = yield* RouteTable("PublicRouteTable", {
-            vpcId: myVpc.vpcId,
-          });
-
-          const internetRoute = yield* Route("InternetRoute", {
-            routeTableId: publicRouteTable.routeTableId,
-            destinationCidrBlock: "0.0.0.0/0",
-            gatewayId: internetGateway.internetGatewayId,
-          });
-
-          const publicSubnet1Association = yield* RouteTableAssociation(
-            "PublicSubnet1Association",
-            {
-              routeTableId: publicRouteTable.routeTableId,
-              subnetId: publicSubnet1.subnetId,
-            },
-          );
-
-          return {
-            myVpc,
-            internetGateway,
-            publicSubnet1,
-            publicRouteTable,
-            internetRoute,
-            publicSubnet1Association,
-          };
-        }),
-      );
-
-      // Verify IGW
-      expect(stack.internetGateway.internetGatewayId).toMatch(/^igw-/);
-      expect(stack.internetGateway.vpcId).toEqual(stack.myVpc.vpcId);
-
-      // Verify public subnet
-      expect(stack.publicSubnet1.subnetId).toMatch(/^subnet-/);
-      expect(stack.publicSubnet1.mapPublicIpOnLaunch).toEqual(true);
-      expect(stack.publicSubnet1.availabilityZone).toEqual(az1);
-
-      // Verify route to IGW
-      expect(stack.internetRoute.state).toEqual("active");
-      expect(stack.internetRoute.gatewayId).toEqual(
-        stack.internetGateway.internetGatewayId,
-      );
-
-      // Verify association
-      expect(stack.publicSubnet1Association.associationId).toMatch(
-        /^rtbassoc-/,
-      );
-    }
-
-    // =========================================================================
-    // STAGE 3: Add Private Subnet
-    // User needs private resources (databases, internal services)
-    // Tests: Adding private subnet with separate route table (no internet)
-    // =========================================================================
-    yield* Effect.log("=== Stage 3: Add Private Subnet ===");
-    {
-      const stack = yield* test.deploy(
-        Effect.gen(function* () {
-          const myVpc = yield* Vpc("MyVpc", {
-            cidrBlock: "10.0.0.0/16",
-            enableDnsSupport: true,
-            enableDnsHostnames: true,
-          });
-
-          const internetGateway = yield* InternetGateway("InternetGateway", {
-            vpcId: myVpc.vpcId,
-          });
-
-          const publicSubnet1 = yield* Subnet("PublicSubnet1", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.1.0/24",
-            availabilityZone: az1,
-            mapPublicIpOnLaunch: true,
-          });
-
-          const privateSubnet1 = yield* Subnet("PrivateSubnet1", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.10.0/24",
-            availabilityZone: az1,
-          });
-
-          const publicRouteTable = yield* RouteTable("PublicRouteTable", {
-            vpcId: myVpc.vpcId,
-          });
-
-          const privateRouteTable = yield* RouteTable("PrivateRouteTable", {
-            vpcId: myVpc.vpcId,
-          });
-
-          const internetRoute = yield* Route("InternetRoute", {
-            routeTableId: publicRouteTable.routeTableId,
-            destinationCidrBlock: "0.0.0.0/0",
-            gatewayId: internetGateway.internetGatewayId,
-          });
-
-          const publicSubnet1Association = yield* RouteTableAssociation(
-            "PublicSubnet1Association",
-            {
-              routeTableId: publicRouteTable.routeTableId,
-              subnetId: publicSubnet1.subnetId,
-            },
-          );
-
-          const privateSubnet1Association = yield* RouteTableAssociation(
-            "PrivateSubnet1Association",
-            {
-              routeTableId: privateRouteTable.routeTableId,
-              subnetId: privateSubnet1.subnetId,
-            },
-          );
-
-          return {
-            myVpc,
-            internetGateway,
-            publicSubnet1,
-            privateSubnet1,
-            publicRouteTable,
-            privateRouteTable,
-            internetRoute,
-            publicSubnet1Association,
-            privateSubnet1Association,
-          };
-        }),
-      );
-
-      // Verify private subnet
-      expect(stack.privateSubnet1.subnetId).toMatch(/^subnet-/);
-      expect(stack.privateSubnet1.mapPublicIpOnLaunch).toBeFalsy();
-
-      // Verify private route table has NO internet route
-      const privateRtResult = yield* EC2.describeRouteTables({
-        RouteTableIds: [stack.privateRouteTable.routeTableId],
-      });
-      const privateRoutes = privateRtResult.RouteTables?.[0]?.Routes ?? [];
-      const privateInternetRoute = privateRoutes.find(
-        (r) => r.DestinationCidrBlock === "0.0.0.0/0",
-      );
-      expect(privateInternetRoute).toBeUndefined();
-    }
-
-    // =========================================================================
-    // STAGE 4: Multi-AZ Expansion
-    // User needs high availability - add subnets in second AZ
-    // Tests: Adding subnets in second AZ, sharing route tables
-    // =========================================================================
-    yield* Effect.log("=== Stage 4: Multi-AZ Expansion ===");
-    {
-      const stack = yield* test.deploy(
-        Effect.gen(function* () {
-          const myVpc = yield* Vpc("MyVpc", {
-            cidrBlock: "10.0.0.0/16",
-            enableDnsSupport: true,
-            enableDnsHostnames: true,
-          });
-
-          const internetGateway = yield* InternetGateway("InternetGateway", {
-            vpcId: myVpc.vpcId,
-          });
-
-          // AZ1 subnets
-          const publicSubnet1 = yield* Subnet("PublicSubnet1", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.1.0/24",
-            availabilityZone: az1,
-            mapPublicIpOnLaunch: true,
-          });
-
-          const privateSubnet1 = yield* Subnet("PrivateSubnet1", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.10.0/24",
-            availabilityZone: az1,
-          });
-
-          // AZ2 subnets
-          const publicSubnet2 = yield* Subnet("PublicSubnet2", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.2.0/24",
-            availabilityZone: az2,
-            mapPublicIpOnLaunch: true,
-          });
-
-          const privateSubnet2 = yield* Subnet("PrivateSubnet2", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.11.0/24",
-            availabilityZone: az2,
-          });
-
-          const publicRouteTable = yield* RouteTable("PublicRouteTable", {
-            vpcId: myVpc.vpcId,
-          });
-
-          const privateRouteTable = yield* RouteTable("PrivateRouteTable", {
-            vpcId: myVpc.vpcId,
-          });
-
-          const internetRoute = yield* Route("InternetRoute", {
-            routeTableId: publicRouteTable.routeTableId,
-            destinationCidrBlock: "0.0.0.0/0",
-            gatewayId: internetGateway.internetGatewayId,
-          });
-
-          // AZ1 associations
-          const publicSubnet1Association = yield* RouteTableAssociation(
-            "PublicSubnet1Association",
-            {
-              routeTableId: publicRouteTable.routeTableId,
-              subnetId: publicSubnet1.subnetId,
-            },
-          );
-
-          const privateSubnet1Association = yield* RouteTableAssociation(
-            "PrivateSubnet1Association",
-            {
-              routeTableId: privateRouteTable.routeTableId,
-              subnetId: privateSubnet1.subnetId,
-            },
-          );
-
-          // AZ2 associations (share route tables)
-          const publicSubnet2Association = yield* RouteTableAssociation(
-            "PublicSubnet2Association",
-            {
-              routeTableId: publicRouteTable.routeTableId,
-              subnetId: publicSubnet2.subnetId,
-            },
-          );
-
-          const privateSubnet2Association = yield* RouteTableAssociation(
-            "PrivateSubnet2Association",
-            {
-              routeTableId: privateRouteTable.routeTableId,
-              subnetId: privateSubnet2.subnetId,
-            },
-          );
-
-          return {
-            myVpc,
-            internetGateway,
-            publicSubnet1,
-            privateSubnet1,
-            publicSubnet2,
-            privateSubnet2,
-            publicRouteTable,
-            privateRouteTable,
-            internetRoute,
-            publicSubnet1Association,
-            privateSubnet1Association,
-            publicSubnet2Association,
-            privateSubnet2Association,
-          };
-        }),
-      );
-
-      // Verify subnets are in different AZs
-      expect(stack.publicSubnet1.availabilityZone).toEqual(az1);
-      expect(stack.publicSubnet2.availabilityZone).toEqual(az2);
-      expect(stack.privateSubnet1.availabilityZone).toEqual(az1);
-      expect(stack.privateSubnet2.availabilityZone).toEqual(az2);
-
-      // Verify all 4 associations exist
-      expect(stack.publicSubnet1Association.associationId).toMatch(
-        /^rtbassoc-/,
-      );
-      expect(stack.publicSubnet2Association.associationId).toMatch(
-        /^rtbassoc-/,
-      );
-      expect(stack.privateSubnet1Association.associationId).toMatch(
-        /^rtbassoc-/,
-      );
-      expect(stack.privateSubnet2Association.associationId).toMatch(
-        /^rtbassoc-/,
-      );
-
-      // Verify both public subnets share the same route table
-      expect(stack.publicSubnet1Association.routeTableId).toEqual(
-        stack.publicSubnet2Association.routeTableId,
-      );
-    }
-
-    // =========================================================================
-    // STAGE 5: Update Tags and Properties
-    // User needs better organization - add tags for production
-    // Tests: Tag updates on existing resources
-    // =========================================================================
-    yield* Effect.log("=== Stage 5: Update Tags and Properties ===");
-    {
-      const stack = yield* test.deploy(
-        Effect.gen(function* () {
-          const myVpc = yield* Vpc("MyVpc", {
-            cidrBlock: "10.0.0.0/16",
-            enableDnsSupport: true,
-            enableDnsHostnames: true,
-            tags: {
-              Name: "production-vpc",
-              Environment: "production",
-            },
-          });
-
-          const internetGateway = yield* InternetGateway("InternetGateway", {
-            vpcId: myVpc.vpcId,
-            tags: {
-              Name: "production-igw",
-            },
-          });
-
-          const publicSubnet1 = yield* Subnet("PublicSubnet1", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.1.0/24",
-            availabilityZone: az1,
-            mapPublicIpOnLaunch: true,
-            tags: { Name: "public-1a", Tier: "public" },
-          });
-
-          const privateSubnet1 = yield* Subnet("PrivateSubnet1", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.10.0/24",
-            availabilityZone: az1,
-            tags: { Name: "private-1a", Tier: "private" },
-          });
-
-          const publicSubnet2 = yield* Subnet("PublicSubnet2", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.2.0/24",
-            availabilityZone: az2,
-            mapPublicIpOnLaunch: true,
-            tags: { Name: "public-1b", Tier: "public" },
-          });
-
-          const privateSubnet2 = yield* Subnet("PrivateSubnet2", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.11.0/24",
-            availabilityZone: az2,
-            tags: { Name: "private-1b", Tier: "private" },
-          });
-
-          const publicRouteTable = yield* RouteTable("PublicRouteTable", {
-            vpcId: myVpc.vpcId,
-            tags: { Name: "public-rt" },
-          });
-
-          const privateRouteTable = yield* RouteTable("PrivateRouteTable", {
-            vpcId: myVpc.vpcId,
-            tags: { Name: "private-rt" },
-          });
-
-          const internetRoute = yield* Route("InternetRoute", {
-            routeTableId: publicRouteTable.routeTableId,
-            destinationCidrBlock: "0.0.0.0/0",
-            gatewayId: internetGateway.internetGatewayId,
-          });
-
-          const publicSubnet1Association = yield* RouteTableAssociation(
-            "PublicSubnet1Association",
-            {
-              routeTableId: publicRouteTable.routeTableId,
-              subnetId: publicSubnet1.subnetId,
-            },
-          );
-
-          const privateSubnet1Association = yield* RouteTableAssociation(
-            "PrivateSubnet1Association",
-            {
-              routeTableId: privateRouteTable.routeTableId,
-              subnetId: privateSubnet1.subnetId,
-            },
-          );
-
-          const publicSubnet2Association = yield* RouteTableAssociation(
-            "PublicSubnet2Association",
-            {
-              routeTableId: publicRouteTable.routeTableId,
-              subnetId: publicSubnet2.subnetId,
-            },
-          );
-
-          const privateSubnet2Association = yield* RouteTableAssociation(
-            "PrivateSubnet2Association",
-            {
-              routeTableId: privateRouteTable.routeTableId,
-              subnetId: privateSubnet2.subnetId,
-            },
-          );
-
-          return {
-            myVpc,
-            internetGateway,
-            publicSubnet1,
-            privateSubnet1,
-            publicSubnet2,
-            privateSubnet2,
-            publicRouteTable,
-            privateRouteTable,
-            internetRoute,
-            publicSubnet1Association,
-            privateSubnet1Association,
-            publicSubnet2Association,
-            privateSubnet2Association,
-          };
-        }),
-      );
-
-      // Verify tags were applied by checking AWS (with retry for eventual consistency)
-      yield* assertVpcTags(stack.myVpc.vpcId, {
-        Name: "production-vpc",
-        Environment: "production",
-      });
-    }
-
-    // =========================================================================
-    // STAGE 6: Re-associate Subnet to Different Route Table
-    // User wants to move PublicSubnet2 to a dedicated route table
-    // Tests: Route table association update (replaceRouteTableAssociation)
-    // =========================================================================
-    yield* Effect.log("=== Stage 6: Re-associate Subnet ===");
-    {
-      const stack = yield* test.deploy(
-        Effect.gen(function* () {
-          const myVpc = yield* Vpc("MyVpc", {
-            cidrBlock: "10.0.0.0/16",
-            enableDnsSupport: true,
-            enableDnsHostnames: true,
-            tags: {
-              Name: "production-vpc",
-              Environment: "production",
-            },
-          });
-
-          const internetGateway = yield* InternetGateway("InternetGateway", {
-            vpcId: myVpc.vpcId,
-            tags: { Name: "production-igw" },
-          });
-
-          const publicSubnet1 = yield* Subnet("PublicSubnet1", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.1.0/24",
-            availabilityZone: az1,
-            mapPublicIpOnLaunch: true,
-            tags: { Name: "public-1a", Tier: "public" },
-          });
-
-          const privateSubnet1 = yield* Subnet("PrivateSubnet1", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.10.0/24",
-            availabilityZone: az1,
-            tags: { Name: "private-1a", Tier: "private" },
-          });
-
-          const publicSubnet2 = yield* Subnet("PublicSubnet2", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.2.0/24",
-            availabilityZone: az2,
-            mapPublicIpOnLaunch: true,
-            tags: { Name: "public-1b", Tier: "public" },
-          });
-
-          const privateSubnet2 = yield* Subnet("PrivateSubnet2", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.11.0/24",
-            availabilityZone: az2,
-            tags: { Name: "private-1b", Tier: "private" },
-          });
-
-          const publicRouteTable = yield* RouteTable("PublicRouteTable", {
-            vpcId: myVpc.vpcId,
-            tags: { Name: "public-rt" },
-          });
-
-          const privateRouteTable = yield* RouteTable("PrivateRouteTable", {
-            vpcId: myVpc.vpcId,
-            tags: { Name: "private-rt" },
-          });
-
-          // NEW: Dedicated route table for AZ2 public subnet
-          const publicRouteTable2 = yield* RouteTable("PublicRouteTable2", {
-            vpcId: myVpc.vpcId,
-            tags: { Name: "public-rt-az2" },
-          });
-
-          const internetRoute = yield* Route("InternetRoute", {
-            routeTableId: publicRouteTable.routeTableId,
-            destinationCidrBlock: "0.0.0.0/0",
-            gatewayId: internetGateway.internetGatewayId,
-          });
-
-          // NEW: Internet route for AZ2 public route table
-          const internetRoute2 = yield* Route("InternetRoute2", {
-            routeTableId: publicRouteTable2.routeTableId,
-            destinationCidrBlock: "0.0.0.0/0",
-            gatewayId: internetGateway.internetGatewayId,
-          });
-
-          const publicSubnet1Association = yield* RouteTableAssociation(
-            "PublicSubnet1Association",
-            {
-              routeTableId: publicRouteTable.routeTableId,
-              subnetId: publicSubnet1.subnetId,
-            },
-          );
-
-          const privateSubnet1Association = yield* RouteTableAssociation(
-            "PrivateSubnet1Association",
-            {
-              routeTableId: privateRouteTable.routeTableId,
-              subnetId: privateSubnet1.subnetId,
-            },
-          );
-
-          // CHANGED: PublicSubnet2 now uses PublicRouteTable2
-          const publicSubnet2Association = yield* RouteTableAssociation(
-            "PublicSubnet2Association",
-            {
-              routeTableId: publicRouteTable2.routeTableId,
-              subnetId: publicSubnet2.subnetId,
-            },
-          );
-
-          const privateSubnet2Association = yield* RouteTableAssociation(
-            "PrivateSubnet2Association",
-            {
-              routeTableId: privateRouteTable.routeTableId,
-              subnetId: privateSubnet2.subnetId,
-            },
-          );
-
-          return {
-            myVpc,
-            internetGateway,
-            publicSubnet1,
-            privateSubnet1,
-            publicSubnet2,
-            privateSubnet2,
-            publicRouteTable,
-            privateRouteTable,
-            publicRouteTable2,
-            internetRoute,
-            internetRoute2,
-            publicSubnet1Association,
-            privateSubnet1Association,
-            publicSubnet2Association,
-            privateSubnet2Association,
-          };
-        }),
-      );
-
-      // Verify PublicSubnet2 is now associated with a different route table
-      expect(stack.publicSubnet2Association.routeTableId).toEqual(
-        stack.publicRouteTable2.routeTableId,
-      );
-      expect(stack.publicSubnet2Association.routeTableId).not.toEqual(
-        stack.publicSubnet1Association.routeTableId,
-      );
-
-      // Verify the new route table has an internet route
-      expect(stack.internetRoute2.state).toEqual("active");
-    }
-
-    // =========================================================================
-    // STAGE 7: Scale Down
-    // User removes AZ2 resources (cost savings)
-    // Tests: Resource deletion, dependency ordering during delete
-    // =========================================================================
-    yield* Effect.log("=== Stage 7: Scale Down ===");
-    {
-      const stack = yield* test.deploy(
-        Effect.gen(function* () {
-          const myVpc = yield* Vpc("MyVpc", {
-            cidrBlock: "10.0.0.0/16",
-            enableDnsSupport: true,
-            enableDnsHostnames: true,
-            tags: {
-              Name: "production-vpc",
-              Environment: "production",
-            },
-          });
-
-          const internetGateway = yield* InternetGateway("InternetGateway", {
-            vpcId: myVpc.vpcId,
-            tags: { Name: "production-igw" },
-          });
-
-          // Only AZ1 subnets remain
-          const publicSubnet1 = yield* Subnet("PublicSubnet1", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.1.0/24",
-            availabilityZone: az1,
-            mapPublicIpOnLaunch: true,
-            tags: { Name: "public-1a", Tier: "public" },
-          });
-
-          const privateSubnet1 = yield* Subnet("PrivateSubnet1", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.10.0/24",
-            availabilityZone: az1,
-            tags: { Name: "private-1a", Tier: "private" },
-          });
-
-          const publicRouteTable = yield* RouteTable("PublicRouteTable", {
-            vpcId: myVpc.vpcId,
-            tags: { Name: "public-rt" },
-          });
-
-          const privateRouteTable = yield* RouteTable("PrivateRouteTable", {
-            vpcId: myVpc.vpcId,
-            tags: { Name: "private-rt" },
-          });
-
-          const internetRoute = yield* Route("InternetRoute", {
-            routeTableId: publicRouteTable.routeTableId,
-            destinationCidrBlock: "0.0.0.0/0",
-            gatewayId: internetGateway.internetGatewayId,
-          });
-
-          const publicSubnet1Association = yield* RouteTableAssociation(
-            "PublicSubnet1Association",
-            {
-              routeTableId: publicRouteTable.routeTableId,
-              subnetId: publicSubnet1.subnetId,
-            },
-          );
-
-          const privateSubnet1Association = yield* RouteTableAssociation(
-            "PrivateSubnet1Association",
-            {
-              routeTableId: privateRouteTable.routeTableId,
-              subnetId: privateSubnet1.subnetId,
-            },
-          );
-
-          // Note: PublicSubnet2, PrivateSubnet2, PublicRouteTable2, InternetRoute2,
-          // and their associations are NOT included - they will be deleted
-
-          return {
-            myVpc,
-            internetGateway,
-            publicSubnet1,
-            privateSubnet1,
-            publicRouteTable,
-            privateRouteTable,
-            internetRoute,
-            publicSubnet1Association,
-            privateSubnet1Association,
-          };
-        }),
-      );
-
-      // Verify only 2 subnets exist now
-      const subnetsResult = yield* EC2.describeSubnets({
-        Filters: [{ Name: "vpc-id", Values: [stack.myVpc.vpcId] }],
-      });
-      expect(subnetsResult.Subnets).toHaveLength(2);
-
-      // Verify remaining subnets are in AZ1
-      for (const subnet of subnetsResult.Subnets ?? []) {
-        expect(subnet.AvailabilityZone).toEqual(az1);
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      // Get available AZs for multi-AZ stages
+      const azResult = yield* EC2.describeAvailabilityZones({});
+      const availableAzs =
+        azResult.AvailabilityZones?.filter((az) => az.State === "available") ??
+        [];
+      const az1 = availableAzs[0]?.ZoneName!;
+      const az2 = availableAzs[1]?.ZoneName!;
+
+      // =========================================================================
+      // STAGE 1: Bare Minimum VPC
+      // User starts with just a VPC - the most basic setup
+      // =========================================================================
+      yield* Effect.log("=== Stage 1: Bare Minimum VPC ===");
+      {
+        const myVpc = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Vpc("MyVpc", {
+              cidrBlock: "10.0.0.0/16",
+            });
+          }),
+        );
+
+        // Verify VPC was created
+        expect(myVpc.vpcId).toMatch(/^vpc-/);
+        expect(myVpc.cidrBlock).toEqual("10.0.0.0/16");
+        expect(myVpc.state).toEqual("available");
+
+        const vpcResult = yield* EC2.describeVpcs({
+          VpcIds: [myVpc.vpcId],
+        });
+        expect(vpcResult.Vpcs?.[0]?.CidrBlock).toEqual("10.0.0.0/16");
       }
-    }
 
-    // =========================================================================
-    // STAGE 8: Add NAT Gateway for Private Subnet Internet Access
-    // User needs private instances to access internet for updates
-    // Tests: EIP create, NAT Gateway create with state waiting
-    // =========================================================================
-    yield* Effect.log("=== Stage 8: Add NAT Gateway ===");
-    {
-      const stack = yield* test.deploy(
+      // =========================================================================
+      // STAGE 2: Add Internet Connectivity
+      // User needs public internet access - add IGW, public subnet, route table
+      // Tests: VPC update (DNS settings), IGW create, Subnet create, Route create
+      // =========================================================================
+      yield* Effect.log("=== Stage 2: Add Internet Connectivity ===");
+      {
+        const _stack = yield* stack.deploy(
+          Effect.gen(function* () {
+            const myVpc = yield* Vpc("MyVpc", {
+              cidrBlock: "10.0.0.0/16",
+              enableDnsSupport: true,
+              enableDnsHostnames: true,
+            });
+
+            const internetGateway = yield* InternetGateway("InternetGateway", {
+              vpcId: myVpc.vpcId,
+            });
+
+            const publicSubnet1 = yield* Subnet("PublicSubnet1", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.1.0/24",
+              availabilityZone: az1,
+              mapPublicIpOnLaunch: true,
+            });
+
+            const publicRouteTable = yield* RouteTable("PublicRouteTable", {
+              vpcId: myVpc.vpcId,
+            });
+
+            const internetRoute = yield* Route("InternetRoute", {
+              routeTableId: publicRouteTable.routeTableId,
+              destinationCidrBlock: "0.0.0.0/0",
+              gatewayId: internetGateway.internetGatewayId,
+            });
+
+            const publicSubnet1Association = yield* RouteTableAssociation(
+              "PublicSubnet1Association",
+              {
+                routeTableId: publicRouteTable.routeTableId,
+                subnetId: publicSubnet1.subnetId,
+              },
+            );
+
+            return {
+              myVpc,
+              internetGateway,
+              publicSubnet1,
+              publicRouteTable,
+              internetRoute,
+              publicSubnet1Association,
+            };
+          }),
+        );
+
+        // Verify IGW
+        expect(_stack.internetGateway.internetGatewayId).toMatch(/^igw-/);
+        expect(_stack.internetGateway.vpcId).toEqual(_stack.myVpc.vpcId);
+
+        // Verify public subnet
+        expect(_stack.publicSubnet1.subnetId).toMatch(/^subnet-/);
+        expect(_stack.publicSubnet1.mapPublicIpOnLaunch).toEqual(true);
+        expect(_stack.publicSubnet1.availabilityZone).toEqual(az1);
+
+        // Verify route to IGW
+        expect(_stack.internetRoute.state).toEqual("active");
+        expect(_stack.internetRoute.gatewayId).toEqual(
+          _stack.internetGateway.internetGatewayId,
+        );
+
+        // Verify association
+        expect(_stack.publicSubnet1Association.associationId).toMatch(
+          /^rtbassoc-/,
+        );
+      }
+
+      // =========================================================================
+      // STAGE 3: Add Private Subnet
+      // User needs private resources (databases, internal services)
+      // Tests: Adding private subnet with separate route table (no internet)
+      // =========================================================================
+      yield* Effect.log("=== Stage 3: Add Private Subnet ===");
+      {
+        const _stack = yield* stack.deploy(
+          Effect.gen(function* () {
+            const myVpc = yield* Vpc("MyVpc", {
+              cidrBlock: "10.0.0.0/16",
+              enableDnsSupport: true,
+              enableDnsHostnames: true,
+            });
+
+            const internetGateway = yield* InternetGateway("InternetGateway", {
+              vpcId: myVpc.vpcId,
+            });
+
+            const publicSubnet1 = yield* Subnet("PublicSubnet1", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.1.0/24",
+              availabilityZone: az1,
+              mapPublicIpOnLaunch: true,
+            });
+
+            const privateSubnet1 = yield* Subnet("PrivateSubnet1", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.10.0/24",
+              availabilityZone: az1,
+            });
+
+            const publicRouteTable = yield* RouteTable("PublicRouteTable", {
+              vpcId: myVpc.vpcId,
+            });
+
+            const privateRouteTable = yield* RouteTable("PrivateRouteTable", {
+              vpcId: myVpc.vpcId,
+            });
+
+            const internetRoute = yield* Route("InternetRoute", {
+              routeTableId: publicRouteTable.routeTableId,
+              destinationCidrBlock: "0.0.0.0/0",
+              gatewayId: internetGateway.internetGatewayId,
+            });
+
+            const publicSubnet1Association = yield* RouteTableAssociation(
+              "PublicSubnet1Association",
+              {
+                routeTableId: publicRouteTable.routeTableId,
+                subnetId: publicSubnet1.subnetId,
+              },
+            );
+
+            const privateSubnet1Association = yield* RouteTableAssociation(
+              "PrivateSubnet1Association",
+              {
+                routeTableId: privateRouteTable.routeTableId,
+                subnetId: privateSubnet1.subnetId,
+              },
+            );
+
+            return {
+              myVpc,
+              internetGateway,
+              publicSubnet1,
+              privateSubnet1,
+              publicRouteTable,
+              privateRouteTable,
+              internetRoute,
+              publicSubnet1Association,
+              privateSubnet1Association,
+            };
+          }),
+        );
+
+        // Verify private subnet
+        expect(_stack.privateSubnet1.subnetId).toMatch(/^subnet-/);
+        expect(_stack.privateSubnet1.mapPublicIpOnLaunch).toBeFalsy();
+
+        // Verify private route table has NO internet route
+        const privateRtResult = yield* EC2.describeRouteTables({
+          RouteTableIds: [_stack.privateRouteTable.routeTableId],
+        });
+        const privateRoutes = privateRtResult.RouteTables?.[0]?.Routes ?? [];
+        const privateInternetRoute = privateRoutes.find(
+          (r) => r.DestinationCidrBlock === "0.0.0.0/0",
+        );
+        expect(privateInternetRoute).toBeUndefined();
+      }
+
+      // =========================================================================
+      // STAGE 4: Multi-AZ Expansion
+      // User needs high availability - add subnets in second AZ
+      // Tests: Adding subnets in second AZ, sharing route tables
+      // =========================================================================
+      yield* Effect.log("=== Stage 4: Multi-AZ Expansion ===");
+      {
+        const _stack = yield* stack.deploy(
+          Effect.gen(function* () {
+            const myVpc = yield* Vpc("MyVpc", {
+              cidrBlock: "10.0.0.0/16",
+              enableDnsSupport: true,
+              enableDnsHostnames: true,
+            });
+
+            const internetGateway = yield* InternetGateway("InternetGateway", {
+              vpcId: myVpc.vpcId,
+            });
+
+            // AZ1 subnets
+            const publicSubnet1 = yield* Subnet("PublicSubnet1", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.1.0/24",
+              availabilityZone: az1,
+              mapPublicIpOnLaunch: true,
+            });
+
+            const privateSubnet1 = yield* Subnet("PrivateSubnet1", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.10.0/24",
+              availabilityZone: az1,
+            });
+
+            // AZ2 subnets
+            const publicSubnet2 = yield* Subnet("PublicSubnet2", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.2.0/24",
+              availabilityZone: az2,
+              mapPublicIpOnLaunch: true,
+            });
+
+            const privateSubnet2 = yield* Subnet("PrivateSubnet2", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.11.0/24",
+              availabilityZone: az2,
+            });
+
+            const publicRouteTable = yield* RouteTable("PublicRouteTable", {
+              vpcId: myVpc.vpcId,
+            });
+
+            const privateRouteTable = yield* RouteTable("PrivateRouteTable", {
+              vpcId: myVpc.vpcId,
+            });
+
+            const internetRoute = yield* Route("InternetRoute", {
+              routeTableId: publicRouteTable.routeTableId,
+              destinationCidrBlock: "0.0.0.0/0",
+              gatewayId: internetGateway.internetGatewayId,
+            });
+
+            // AZ1 associations
+            const publicSubnet1Association = yield* RouteTableAssociation(
+              "PublicSubnet1Association",
+              {
+                routeTableId: publicRouteTable.routeTableId,
+                subnetId: publicSubnet1.subnetId,
+              },
+            );
+
+            const privateSubnet1Association = yield* RouteTableAssociation(
+              "PrivateSubnet1Association",
+              {
+                routeTableId: privateRouteTable.routeTableId,
+                subnetId: privateSubnet1.subnetId,
+              },
+            );
+
+            // AZ2 associations (share route tables)
+            const publicSubnet2Association = yield* RouteTableAssociation(
+              "PublicSubnet2Association",
+              {
+                routeTableId: publicRouteTable.routeTableId,
+                subnetId: publicSubnet2.subnetId,
+              },
+            );
+
+            const privateSubnet2Association = yield* RouteTableAssociation(
+              "PrivateSubnet2Association",
+              {
+                routeTableId: privateRouteTable.routeTableId,
+                subnetId: privateSubnet2.subnetId,
+              },
+            );
+
+            return {
+              myVpc,
+              internetGateway,
+              publicSubnet1,
+              privateSubnet1,
+              publicSubnet2,
+              privateSubnet2,
+              publicRouteTable,
+              privateRouteTable,
+              internetRoute,
+              publicSubnet1Association,
+              privateSubnet1Association,
+              publicSubnet2Association,
+              privateSubnet2Association,
+            };
+          }),
+        );
+
+        // Verify subnets are in different AZs
+        expect(_stack.publicSubnet1.availabilityZone).toEqual(az1);
+        expect(_stack.publicSubnet2.availabilityZone).toEqual(az2);
+        expect(_stack.privateSubnet1.availabilityZone).toEqual(az1);
+        expect(_stack.privateSubnet2.availabilityZone).toEqual(az2);
+
+        // Verify all 4 associations exist
+        expect(_stack.publicSubnet1Association.associationId).toMatch(
+          /^rtbassoc-/,
+        );
+        expect(_stack.publicSubnet2Association.associationId).toMatch(
+          /^rtbassoc-/,
+        );
+        expect(_stack.privateSubnet1Association.associationId).toMatch(
+          /^rtbassoc-/,
+        );
+        expect(_stack.privateSubnet2Association.associationId).toMatch(
+          /^rtbassoc-/,
+        );
+
+        // Verify both public subnets share the same route table
+        expect(_stack.publicSubnet1Association.routeTableId).toEqual(
+          _stack.publicSubnet2Association.routeTableId,
+        );
+      }
+
+      // =========================================================================
+      // STAGE 5: Update Tags and Properties
+      // User needs better organization - add tags for production
+      // Tests: Tag updates on existing resources
+      // =========================================================================
+      yield* Effect.log("=== Stage 5: Update Tags and Properties ===");
+      {
+        const _stack = yield* stack.deploy(
+          Effect.gen(function* () {
+            const myVpc = yield* Vpc("MyVpc", {
+              cidrBlock: "10.0.0.0/16",
+              enableDnsSupport: true,
+              enableDnsHostnames: true,
+              tags: {
+                Name: "production-vpc",
+                Environment: "production",
+              },
+            });
+
+            const internetGateway = yield* InternetGateway("InternetGateway", {
+              vpcId: myVpc.vpcId,
+              tags: {
+                Name: "production-igw",
+              },
+            });
+
+            const publicSubnet1 = yield* Subnet("PublicSubnet1", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.1.0/24",
+              availabilityZone: az1,
+              mapPublicIpOnLaunch: true,
+              tags: { Name: "public-1a", Tier: "public" },
+            });
+
+            const privateSubnet1 = yield* Subnet("PrivateSubnet1", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.10.0/24",
+              availabilityZone: az1,
+              tags: { Name: "private-1a", Tier: "private" },
+            });
+
+            const publicSubnet2 = yield* Subnet("PublicSubnet2", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.2.0/24",
+              availabilityZone: az2,
+              mapPublicIpOnLaunch: true,
+              tags: { Name: "public-1b", Tier: "public" },
+            });
+
+            const privateSubnet2 = yield* Subnet("PrivateSubnet2", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.11.0/24",
+              availabilityZone: az2,
+              tags: { Name: "private-1b", Tier: "private" },
+            });
+
+            const publicRouteTable = yield* RouteTable("PublicRouteTable", {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "public-rt" },
+            });
+
+            const privateRouteTable = yield* RouteTable("PrivateRouteTable", {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "private-rt" },
+            });
+
+            const internetRoute = yield* Route("InternetRoute", {
+              routeTableId: publicRouteTable.routeTableId,
+              destinationCidrBlock: "0.0.0.0/0",
+              gatewayId: internetGateway.internetGatewayId,
+            });
+
+            const publicSubnet1Association = yield* RouteTableAssociation(
+              "PublicSubnet1Association",
+              {
+                routeTableId: publicRouteTable.routeTableId,
+                subnetId: publicSubnet1.subnetId,
+              },
+            );
+
+            const privateSubnet1Association = yield* RouteTableAssociation(
+              "PrivateSubnet1Association",
+              {
+                routeTableId: privateRouteTable.routeTableId,
+                subnetId: privateSubnet1.subnetId,
+              },
+            );
+
+            const publicSubnet2Association = yield* RouteTableAssociation(
+              "PublicSubnet2Association",
+              {
+                routeTableId: publicRouteTable.routeTableId,
+                subnetId: publicSubnet2.subnetId,
+              },
+            );
+
+            const privateSubnet2Association = yield* RouteTableAssociation(
+              "PrivateSubnet2Association",
+              {
+                routeTableId: privateRouteTable.routeTableId,
+                subnetId: privateSubnet2.subnetId,
+              },
+            );
+
+            return {
+              myVpc,
+              internetGateway,
+              publicSubnet1,
+              privateSubnet1,
+              publicSubnet2,
+              privateSubnet2,
+              publicRouteTable,
+              privateRouteTable,
+              internetRoute,
+              publicSubnet1Association,
+              privateSubnet1Association,
+              publicSubnet2Association,
+              privateSubnet2Association,
+            };
+          }),
+        );
+
+        // Verify tags were applied by checking AWS (with retry for eventual consistency)
+        yield* assertVpcTags(_stack.myVpc.vpcId, {
+          Name: "production-vpc",
+          Environment: "production",
+        });
+      }
+
+      // =========================================================================
+      // STAGE 6: Re-associate Subnet to Different Route Table
+      // User wants to move PublicSubnet2 to a dedicated route table
+      // Tests: Route table association update (replaceRouteTableAssociation)
+      // =========================================================================
+      yield* Effect.log("=== Stage 6: Re-associate Subnet ===");
+      {
+        const _stack = yield* stack.deploy(
+          Effect.gen(function* () {
+            const myVpc = yield* Vpc("MyVpc", {
+              cidrBlock: "10.0.0.0/16",
+              enableDnsSupport: true,
+              enableDnsHostnames: true,
+              tags: {
+                Name: "production-vpc",
+                Environment: "production",
+              },
+            });
+
+            const internetGateway = yield* InternetGateway("InternetGateway", {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "production-igw" },
+            });
+
+            const publicSubnet1 = yield* Subnet("PublicSubnet1", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.1.0/24",
+              availabilityZone: az1,
+              mapPublicIpOnLaunch: true,
+              tags: { Name: "public-1a", Tier: "public" },
+            });
+
+            const privateSubnet1 = yield* Subnet("PrivateSubnet1", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.10.0/24",
+              availabilityZone: az1,
+              tags: { Name: "private-1a", Tier: "private" },
+            });
+
+            const publicSubnet2 = yield* Subnet("PublicSubnet2", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.2.0/24",
+              availabilityZone: az2,
+              mapPublicIpOnLaunch: true,
+              tags: { Name: "public-1b", Tier: "public" },
+            });
+
+            const privateSubnet2 = yield* Subnet("PrivateSubnet2", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.11.0/24",
+              availabilityZone: az2,
+              tags: { Name: "private-1b", Tier: "private" },
+            });
+
+            const publicRouteTable = yield* RouteTable("PublicRouteTable", {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "public-rt" },
+            });
+
+            const privateRouteTable = yield* RouteTable("PrivateRouteTable", {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "private-rt" },
+            });
+
+            // NEW: Dedicated route table for AZ2 public subnet
+            const publicRouteTable2 = yield* RouteTable("PublicRouteTable2", {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "public-rt-az2" },
+            });
+
+            const internetRoute = yield* Route("InternetRoute", {
+              routeTableId: publicRouteTable.routeTableId,
+              destinationCidrBlock: "0.0.0.0/0",
+              gatewayId: internetGateway.internetGatewayId,
+            });
+
+            // NEW: Internet route for AZ2 public route table
+            const internetRoute2 = yield* Route("InternetRoute2", {
+              routeTableId: publicRouteTable2.routeTableId,
+              destinationCidrBlock: "0.0.0.0/0",
+              gatewayId: internetGateway.internetGatewayId,
+            });
+
+            const publicSubnet1Association = yield* RouteTableAssociation(
+              "PublicSubnet1Association",
+              {
+                routeTableId: publicRouteTable.routeTableId,
+                subnetId: publicSubnet1.subnetId,
+              },
+            );
+
+            const privateSubnet1Association = yield* RouteTableAssociation(
+              "PrivateSubnet1Association",
+              {
+                routeTableId: privateRouteTable.routeTableId,
+                subnetId: privateSubnet1.subnetId,
+              },
+            );
+
+            // CHANGED: PublicSubnet2 now uses PublicRouteTable2
+            const publicSubnet2Association = yield* RouteTableAssociation(
+              "PublicSubnet2Association",
+              {
+                routeTableId: publicRouteTable2.routeTableId,
+                subnetId: publicSubnet2.subnetId,
+              },
+            );
+
+            const privateSubnet2Association = yield* RouteTableAssociation(
+              "PrivateSubnet2Association",
+              {
+                routeTableId: privateRouteTable.routeTableId,
+                subnetId: privateSubnet2.subnetId,
+              },
+            );
+
+            return {
+              myVpc,
+              internetGateway,
+              publicSubnet1,
+              privateSubnet1,
+              publicSubnet2,
+              privateSubnet2,
+              publicRouteTable,
+              privateRouteTable,
+              publicRouteTable2,
+              internetRoute,
+              internetRoute2,
+              publicSubnet1Association,
+              privateSubnet1Association,
+              publicSubnet2Association,
+              privateSubnet2Association,
+            };
+          }),
+        );
+
+        // Verify PublicSubnet2 is now associated with a different route table
+        expect(_stack.publicSubnet2Association.routeTableId).toEqual(
+          _stack.publicRouteTable2.routeTableId,
+        );
+        expect(_stack.publicSubnet2Association.routeTableId).not.toEqual(
+          _stack.publicSubnet1Association.routeTableId,
+        );
+
+        // Verify the new route table has an internet route
+        expect(_stack.internetRoute2.state).toEqual("active");
+      }
+
+      // =========================================================================
+      // STAGE 7: Scale Down
+      // User removes AZ2 resources (cost savings)
+      // Tests: Resource deletion, dependency ordering during delete
+      // =========================================================================
+      yield* Effect.log("=== Stage 7: Scale Down ===");
+      {
+        const _stack = yield* stack.deploy(
+          Effect.gen(function* () {
+            const myVpc = yield* Vpc("MyVpc", {
+              cidrBlock: "10.0.0.0/16",
+              enableDnsSupport: true,
+              enableDnsHostnames: true,
+              tags: {
+                Name: "production-vpc",
+                Environment: "production",
+              },
+            });
+
+            const internetGateway = yield* InternetGateway("InternetGateway", {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "production-igw" },
+            });
+
+            // Only AZ1 subnets remain
+            const publicSubnet1 = yield* Subnet("PublicSubnet1", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.1.0/24",
+              availabilityZone: az1,
+              mapPublicIpOnLaunch: true,
+              tags: { Name: "public-1a", Tier: "public" },
+            });
+
+            const privateSubnet1 = yield* Subnet("PrivateSubnet1", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.10.0/24",
+              availabilityZone: az1,
+              tags: { Name: "private-1a", Tier: "private" },
+            });
+
+            const publicRouteTable = yield* RouteTable("PublicRouteTable", {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "public-rt" },
+            });
+
+            const privateRouteTable = yield* RouteTable("PrivateRouteTable", {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "private-rt" },
+            });
+
+            const internetRoute = yield* Route("InternetRoute", {
+              routeTableId: publicRouteTable.routeTableId,
+              destinationCidrBlock: "0.0.0.0/0",
+              gatewayId: internetGateway.internetGatewayId,
+            });
+
+            const publicSubnet1Association = yield* RouteTableAssociation(
+              "PublicSubnet1Association",
+              {
+                routeTableId: publicRouteTable.routeTableId,
+                subnetId: publicSubnet1.subnetId,
+              },
+            );
+
+            const privateSubnet1Association = yield* RouteTableAssociation(
+              "PrivateSubnet1Association",
+              {
+                routeTableId: privateRouteTable.routeTableId,
+                subnetId: privateSubnet1.subnetId,
+              },
+            );
+
+            // Note: PublicSubnet2, PrivateSubnet2, PublicRouteTable2, InternetRoute2,
+            // and their associations are NOT included - they will be deleted
+
+            return {
+              myVpc,
+              internetGateway,
+              publicSubnet1,
+              privateSubnet1,
+              publicRouteTable,
+              privateRouteTable,
+              internetRoute,
+              publicSubnet1Association,
+              privateSubnet1Association,
+            };
+          }),
+        );
+
+        // Verify only 2 subnets exist now
+        const subnetsResult = yield* EC2.describeSubnets({
+          Filters: [{ Name: "vpc-id", Values: [_stack.myVpc.vpcId] }],
+        });
+        expect(subnetsResult.Subnets).toHaveLength(2);
+
+        // Verify remaining subnets are in AZ1
+        for (const subnet of subnetsResult.Subnets ?? []) {
+          expect(subnet.AvailabilityZone).toEqual(az1);
+        }
+      }
+
+      // =========================================================================
+      // STAGE 8: Add NAT Gateway for Private Subnet Internet Access
+      // User needs private instances to access internet for updates
+      // Tests: EIP create, NAT Gateway create with state waiting
+      // =========================================================================
+      yield* Effect.log("=== Stage 8: Add NAT Gateway ===");
+      {
+        const _stack = yield* stack.deploy(
+          Effect.gen(function* () {
+            const myVpc = yield* Vpc("MyVpc", {
+              cidrBlock: "10.0.0.0/16",
+              enableDnsSupport: true,
+              enableDnsHostnames: true,
+              tags: {
+                Name: "production-vpc",
+                Environment: "production",
+              },
+            });
+
+            const internetGateway = yield* InternetGateway("InternetGateway", {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "production-igw" },
+            });
+
+            const publicSubnet1 = yield* Subnet("PublicSubnet1", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.1.0/24",
+              availabilityZone: az1,
+              mapPublicIpOnLaunch: true,
+              tags: { Name: "public-1a", Tier: "public" },
+            });
+
+            const privateSubnet1 = yield* Subnet("PrivateSubnet1", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.10.0/24",
+              availabilityZone: az1,
+              tags: { Name: "private-1a", Tier: "private" },
+            });
+
+            const publicRouteTable = yield* RouteTable("PublicRouteTable", {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "public-rt" },
+            });
+
+            const privateRouteTable = yield* RouteTable("PrivateRouteTable", {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "private-rt" },
+            });
+
+            const internetRoute = yield* Route("InternetRoute", {
+              routeTableId: publicRouteTable.routeTableId,
+              destinationCidrBlock: "0.0.0.0/0",
+              gatewayId: internetGateway.internetGatewayId,
+            });
+
+            // NEW: Elastic IP for NAT Gateway
+            const natEip = yield* EIP("NatEip", {
+              tags: { Name: "nat-eip" },
+            });
+
+            // NEW: NAT Gateway in public subnet
+            const natGateway = yield* NatGateway("NatGateway", {
+              subnetId: publicSubnet1.subnetId,
+              allocationId: natEip.allocationId,
+              tags: { Name: "production-nat" },
+            });
+
+            // NEW: Route from private subnet to NAT Gateway
+            const natRoute = yield* Route("NatRoute", {
+              routeTableId: privateRouteTable.routeTableId,
+              destinationCidrBlock: "0.0.0.0/0",
+              natGatewayId: natGateway.natGatewayId,
+            });
+
+            const publicSubnet1Association = yield* RouteTableAssociation(
+              "PublicSubnet1Association",
+              {
+                routeTableId: publicRouteTable.routeTableId,
+                subnetId: publicSubnet1.subnetId,
+              },
+            );
+
+            const privateSubnet1Association = yield* RouteTableAssociation(
+              "PrivateSubnet1Association",
+              {
+                routeTableId: privateRouteTable.routeTableId,
+                subnetId: privateSubnet1.subnetId,
+              },
+            );
+
+            return {
+              myVpc,
+              internetGateway,
+              publicSubnet1,
+              privateSubnet1,
+              publicRouteTable,
+              privateRouteTable,
+              internetRoute,
+              natEip,
+              natGateway,
+              natRoute,
+              publicSubnet1Association,
+              privateSubnet1Association,
+            };
+          }),
+        );
+
+        // Verify EIP
+        expect(_stack.natEip.allocationId).toMatch(/^eipalloc-/);
+        expect(_stack.natEip.publicIp).toBeDefined();
+
+        // Verify NAT Gateway
+        expect(_stack.natGateway.natGatewayId).toMatch(/^nat-/);
+        expect(_stack.natGateway.state).toEqual("available");
+        expect(_stack.natGateway.publicIp).toEqual(_stack.natEip.publicIp);
+
+        // Verify NAT route is active
+        expect(_stack.natRoute.state).toEqual("active");
+        expect(_stack.natRoute.natGatewayId).toEqual(
+          _stack.natGateway.natGatewayId,
+        );
+
+        // Verify private route table now has internet route via NAT
+        const privateRtResult = yield* EC2.describeRouteTables({
+          RouteTableIds: [_stack.privateRouteTable.routeTableId],
+        });
+        const privateRoutes = privateRtResult.RouteTables?.[0]?.Routes ?? [];
+        const privateInternetRoute = privateRoutes.find(
+          (r) => r.DestinationCidrBlock === "0.0.0.0/0",
+        );
+        expect(privateInternetRoute?.NatGatewayId).toEqual(
+          _stack.natGateway.natGatewayId,
+        );
+      }
+
+      // =========================================================================
+      // STAGE 9: Add Security Groups
+      // User needs to control instance access
+      // Tests: Security Group with inline ingress/egress rules
+      // =========================================================================
+      yield* Effect.log("=== Stage 9: Add Security Groups ===");
+      {
+        const _stack = yield* stack.deploy(
+          Effect.gen(function* () {
+            const myVpc = yield* Vpc("MyVpc", {
+              cidrBlock: "10.0.0.0/16",
+              enableDnsSupport: true,
+              enableDnsHostnames: true,
+              tags: {
+                Name: "production-vpc",
+                Environment: "production",
+              },
+            });
+
+            const internetGateway = yield* InternetGateway("InternetGateway", {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "production-igw" },
+            });
+
+            const publicSubnet1 = yield* Subnet("PublicSubnet1", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.1.0/24",
+              availabilityZone: az1,
+              mapPublicIpOnLaunch: true,
+              tags: { Name: "public-1a", Tier: "public" },
+            });
+
+            const privateSubnet1 = yield* Subnet("PrivateSubnet1", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.10.0/24",
+              availabilityZone: az1,
+              tags: { Name: "private-1a", Tier: "private" },
+            });
+
+            const publicRouteTable = yield* RouteTable("PublicRouteTable", {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "public-rt" },
+            });
+
+            const privateRouteTable = yield* RouteTable("PrivateRouteTable", {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "private-rt" },
+            });
+
+            const internetRoute = yield* Route("InternetRoute", {
+              routeTableId: publicRouteTable.routeTableId,
+              destinationCidrBlock: "0.0.0.0/0",
+              gatewayId: internetGateway.internetGatewayId,
+            });
+
+            const natEip = yield* EIP("NatEip", {
+              tags: { Name: "nat-eip" },
+            });
+
+            const natGateway = yield* NatGateway("NatGateway", {
+              subnetId: publicSubnet1.subnetId,
+              allocationId: natEip.allocationId,
+              tags: { Name: "production-nat" },
+            });
+
+            const natRoute = yield* Route("NatRoute", {
+              routeTableId: privateRouteTable.routeTableId,
+              destinationCidrBlock: "0.0.0.0/0",
+              natGatewayId: natGateway.natGatewayId,
+            });
+
+            // NEW: Web security group allowing HTTP/HTTPS
+            const webSecurityGroup = yield* SecurityGroup("WebSecurityGroup", {
+              vpcId: myVpc.vpcId,
+              description: "Web tier security group",
+              ingress: [
+                {
+                  ipProtocol: "tcp",
+                  fromPort: 80,
+                  toPort: 80,
+                  cidrIpv4: "0.0.0.0/0",
+                  description: "Allow HTTP",
+                },
+                {
+                  ipProtocol: "tcp",
+                  fromPort: 443,
+                  toPort: 443,
+                  cidrIpv4: "0.0.0.0/0",
+                  description: "Allow HTTPS",
+                },
+              ],
+              egress: [
+                {
+                  ipProtocol: "-1",
+                  cidrIpv4: "0.0.0.0/0",
+                  description: "Allow all outbound",
+                },
+              ],
+              tags: { Name: "web-sg" },
+            });
+
+            // NEW: Database security group allowing access from web tier
+            const dbSecurityGroup = yield* SecurityGroup("DbSecurityGroup", {
+              vpcId: myVpc.vpcId,
+              description: "Database tier security group",
+              ingress: [
+                {
+                  ipProtocol: "tcp",
+                  fromPort: 5432,
+                  toPort: 5432,
+                  referencedGroupId: webSecurityGroup.groupId,
+                  description: "Allow PostgreSQL from web tier",
+                },
+              ],
+              egress: [
+                {
+                  ipProtocol: "-1",
+                  cidrIpv4: "0.0.0.0/0",
+                  description: "Allow all outbound",
+                },
+              ],
+              tags: { Name: "db-sg" },
+            });
+
+            const publicSubnet1Association = yield* RouteTableAssociation(
+              "PublicSubnet1Association",
+              {
+                routeTableId: publicRouteTable.routeTableId,
+                subnetId: publicSubnet1.subnetId,
+              },
+            );
+
+            const privateSubnet1Association = yield* RouteTableAssociation(
+              "PrivateSubnet1Association",
+              {
+                routeTableId: privateRouteTable.routeTableId,
+                subnetId: privateSubnet1.subnetId,
+              },
+            );
+
+            return {
+              myVpc,
+              internetGateway,
+              publicSubnet1,
+              privateSubnet1,
+              publicRouteTable,
+              privateRouteTable,
+              internetRoute,
+              natEip,
+              natGateway,
+              natRoute,
+              webSecurityGroup,
+              dbSecurityGroup,
+              publicSubnet1Association,
+              privateSubnet1Association,
+            };
+          }),
+        );
+
+        // Verify Web Security Group
+        expect(_stack.webSecurityGroup.groupId).toMatch(/^sg-/);
+        expect(_stack.webSecurityGroup.vpcId).toEqual(_stack.myVpc.vpcId);
+        expect(_stack.webSecurityGroup.ingressRules).toHaveLength(2);
+        expect(_stack.webSecurityGroup.egressRules).toHaveLength(1);
+
+        // Verify DB Security Group references Web Security Group
+        expect(_stack.dbSecurityGroup.groupId).toMatch(/^sg-/);
+        expect(_stack.dbSecurityGroup.ingressRules).toHaveLength(1);
+        expect(
+          _stack.dbSecurityGroup.ingressRules?.[0]?.referencedGroupId,
+        ).toEqual(_stack.webSecurityGroup.groupId);
+      }
+
+      // =========================================================================
+      // STAGE 10: Scale Down - Remove NAT Gateway and Security Groups
+      // User scales down to basic VPC for cost savings
+      // Tests: NAT Gateway delete with state waiting, Security Group delete
+      // =========================================================================
+      yield* Effect.log("=== Stage 10: Scale Down to Basic VPC ===");
+      {
+        const _stack = yield* stack.deploy(
+          Effect.gen(function* () {
+            const myVpc = yield* Vpc("MyVpc", {
+              cidrBlock: "10.0.0.0/16",
+              enableDnsSupport: true,
+              enableDnsHostnames: true,
+              tags: {
+                Name: "production-vpc",
+                Environment: "production",
+              },
+            });
+
+            const internetGateway = yield* InternetGateway("InternetGateway", {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "production-igw" },
+            });
+
+            const publicSubnet1 = yield* Subnet("PublicSubnet1", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.1.0/24",
+              availabilityZone: az1,
+              mapPublicIpOnLaunch: true,
+              tags: { Name: "public-1a", Tier: "public" },
+            });
+
+            const privateSubnet1 = yield* Subnet("PrivateSubnet1", {
+              vpcId: myVpc.vpcId,
+              cidrBlock: "10.0.10.0/24",
+              availabilityZone: az1,
+              tags: { Name: "private-1a", Tier: "private" },
+            });
+
+            const publicRouteTable = yield* RouteTable("PublicRouteTable", {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "public-rt" },
+            });
+
+            const privateRouteTable = yield* RouteTable("PrivateRouteTable", {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "private-rt" },
+            });
+
+            const internetRoute = yield* Route("InternetRoute", {
+              routeTableId: publicRouteTable.routeTableId,
+              destinationCidrBlock: "0.0.0.0/0",
+              gatewayId: internetGateway.internetGatewayId,
+            });
+
+            const publicSubnet1Association = yield* RouteTableAssociation(
+              "PublicSubnet1Association",
+              {
+                routeTableId: publicRouteTable.routeTableId,
+                subnetId: publicSubnet1.subnetId,
+              },
+            );
+
+            const privateSubnet1Association = yield* RouteTableAssociation(
+              "PrivateSubnet1Association",
+              {
+                routeTableId: privateRouteTable.routeTableId,
+                subnetId: privateSubnet1.subnetId,
+              },
+            );
+
+            // Note: NAT Gateway, EIP, NatRoute, and Security Groups are NOT included
+            // They will be deleted
+
+            return {
+              myVpc,
+              internetGateway,
+              publicSubnet1,
+              privateSubnet1,
+              publicRouteTable,
+              privateRouteTable,
+              internetRoute,
+              publicSubnet1Association,
+              privateSubnet1Association,
+            };
+          }),
+        );
+
+        // Verify NAT Gateway is deleted
+        const natGwResult = yield* ec2
+          .describeNatGateways({
+            Filter: [{ Name: "vpc-id", Values: [_stack.myVpc.vpcId] }],
+          })
+          .pipe(
+            Effect.map((r) =>
+              r.NatGateways?.filter((gw) => gw.State !== "deleted"),
+            ),
+          );
+        expect(natGwResult).toHaveLength(0);
+
+        // Verify Security Groups are deleted (only default should remain)
+        const sgResult = yield* EC2.describeSecurityGroups({
+          Filters: [{ Name: "vpc-id", Values: [_stack.myVpc.vpcId] }],
+        });
+        expect(sgResult.SecurityGroups).toHaveLength(1); // Only default SG
+        expect(sgResult.SecurityGroups?.[0]?.GroupName).toEqual("default");
+      }
+
+      // =========================================================================
+      // STAGE 11: Final Cleanup
+      // Destroy everything and verify
+      // =========================================================================
+      yield* Effect.log("=== Stage 11: Final Cleanup ===");
+      const vpcResult = yield* EC2.describeVpcs({
+        Filters: [{ Name: "tag:Name", Values: ["production-vpc"] }],
+      });
+      const capturedVpcId = vpcResult.Vpcs?.[0]?.VpcId;
+
+      yield* stack.destroy();
+
+      // Verify VPC is deleted
+      if (capturedVpcId) {
+        yield* EC2.describeVpcs({ VpcIds: [capturedVpcId] }).pipe(
+          Effect.flatMap(() => Effect.fail(new Error("VPC still exists"))),
+          Effect.catchTag("InvalidVpcID.NotFound", () => Effect.void),
+        );
+      }
+
+      yield* Effect.log("=== All stages completed successfully! ===");
+    }).pipe(logLevel),
+  { timeout: 1_000_000 },
+);
+
+test.provider.skip(
+  "Comprehensive VPC with all components",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      // Get available AZs
+      const azResult = yield* EC2.describeAvailabilityZones({});
+      const availableAzs =
+        azResult.AvailabilityZones?.filter((az) => az.State === "available") ??
+        [];
+      const az1 = availableAzs[0]?.ZoneName!;
+      const az2 = availableAzs[1]?.ZoneName!;
+
+      // =========================================================================
+      // Define all resources for a production-ready VPC
+      // =========================================================================
+      const _stack = yield* stack.deploy(
         Effect.gen(function* () {
+          // VPC with DNS enabled and IPv6 for egress-only IGW
           const myVpc = yield* Vpc("MyVpc", {
             cidrBlock: "10.0.0.0/16",
             enableDnsSupport: true,
             enableDnsHostnames: true,
+            amazonProvidedIpv6CidrBlock: true,
             tags: {
-              Name: "production-vpc",
-              Environment: "production",
+              Name: "comprehensive-vpc",
+              Environment: "test",
             },
           });
 
+          // Internet Gateway for public internet access
           const internetGateway = yield* InternetGateway("InternetGateway", {
             vpcId: myVpc.vpcId,
-            tags: { Name: "production-igw" },
+            tags: { Name: "comprehensive-igw" },
           });
 
+          // Egress-Only Internet Gateway for IPv6 outbound traffic from private subnets
+          const egressOnlyIgw = yield* EgressOnlyInternetGateway(
+            "EgressOnlyIgw",
+            {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "comprehensive-eigw" },
+            },
+          );
+
+          // Public Subnets in two AZs
           const publicSubnet1 = yield* Subnet("PublicSubnet1", {
             vpcId: myVpc.vpcId,
             cidrBlock: "10.0.1.0/24",
@@ -785,6 +1249,15 @@ test.skip(
             tags: { Name: "public-1a", Tier: "public" },
           });
 
+          const publicSubnet2 = yield* Subnet("PublicSubnet2", {
+            vpcId: myVpc.vpcId,
+            cidrBlock: "10.0.2.0/24",
+            availabilityZone: az2,
+            mapPublicIpOnLaunch: true,
+            tags: { Name: "public-1b", Tier: "public" },
+          });
+
+          // Private Subnets in two AZs
           const privateSubnet1 = yield* Subnet("PrivateSubnet1", {
             vpcId: myVpc.vpcId,
             cidrBlock: "10.0.10.0/24",
@@ -792,41 +1265,72 @@ test.skip(
             tags: { Name: "private-1a", Tier: "private" },
           });
 
+          const privateSubnet2 = yield* Subnet("PrivateSubnet2", {
+            vpcId: myVpc.vpcId,
+            cidrBlock: "10.0.11.0/24",
+            availabilityZone: az2,
+            tags: { Name: "private-1b", Tier: "private" },
+          });
+
+          // Route Tables
           const publicRouteTable = yield* RouteTable("PublicRouteTable", {
             vpcId: myVpc.vpcId,
             tags: { Name: "public-rt" },
           });
 
-          const privateRouteTable = yield* RouteTable("PrivateRouteTable", {
+          const privateRouteTable1 = yield* RouteTable("PrivateRouteTable1", {
             vpcId: myVpc.vpcId,
-            tags: { Name: "private-rt" },
+            tags: { Name: "private-rt-1" },
           });
 
+          const privateRouteTable2 = yield* RouteTable("PrivateRouteTable2", {
+            vpcId: myVpc.vpcId,
+            tags: { Name: "private-rt-2" },
+          });
+
+          // Internet route for public subnets
           const internetRoute = yield* Route("InternetRoute", {
             routeTableId: publicRouteTable.routeTableId,
             destinationCidrBlock: "0.0.0.0/0",
             gatewayId: internetGateway.internetGatewayId,
           });
 
-          // NEW: Elastic IP for NAT Gateway
-          const natEip = yield* EIP("NatEip", {
-            tags: { Name: "nat-eip" },
+          // NAT Gateway with EIP for AZ1
+          const natEip1 = yield* EIP("NatEip1", {
+            tags: { Name: "nat-eip-1" },
           });
 
-          // NEW: NAT Gateway in public subnet
-          const natGateway = yield* NatGateway("NatGateway", {
+          const natGateway1 = yield* NatGateway("NatGateway1", {
             subnetId: publicSubnet1.subnetId,
-            allocationId: natEip.allocationId,
-            tags: { Name: "production-nat" },
+            allocationId: natEip1.allocationId,
+            tags: { Name: "nat-gateway-1" },
           });
 
-          // NEW: Route from private subnet to NAT Gateway
-          const natRoute = yield* Route("NatRoute", {
-            routeTableId: privateRouteTable.routeTableId,
+          // NAT Gateway with EIP for AZ2
+          const natEip2 = yield* EIP("NatEip2", {
+            tags: { Name: "nat-eip-2" },
+          });
+
+          const natGateway2 = yield* NatGateway("NatGateway2", {
+            subnetId: publicSubnet2.subnetId,
+            allocationId: natEip2.allocationId,
+            tags: { Name: "nat-gateway-2" },
+          });
+
+          // NAT routes for private subnets (each AZ routes to its own NAT)
+          const natRoute1 = yield* Route("NatRoute1", {
+            routeTableId: privateRouteTable1.routeTableId,
             destinationCidrBlock: "0.0.0.0/0",
-            natGatewayId: natGateway.natGatewayId,
+            natGatewayId: natGateway1.natGatewayId,
           });
 
+          const natRoute2 = yield* Route("NatRoute2", {
+            routeTableId: privateRouteTable2.routeTableId,
+            destinationCidrBlock: "0.0.0.0/0",
+            natGatewayId: natGateway2.natGatewayId,
+          });
+
+          // Route Table Associations
           const publicSubnet1Association = yield* RouteTableAssociation(
             "PublicSubnet1Association",
             {
@@ -835,131 +1339,31 @@ test.skip(
             },
           );
 
+          const publicSubnet2Association = yield* RouteTableAssociation(
+            "PublicSubnet2Association",
+            {
+              routeTableId: publicRouteTable.routeTableId,
+              subnetId: publicSubnet2.subnetId,
+            },
+          );
+
           const privateSubnet1Association = yield* RouteTableAssociation(
             "PrivateSubnet1Association",
             {
-              routeTableId: privateRouteTable.routeTableId,
+              routeTableId: privateRouteTable1.routeTableId,
               subnetId: privateSubnet1.subnetId,
             },
           );
 
-          return {
-            myVpc,
-            internetGateway,
-            publicSubnet1,
-            privateSubnet1,
-            publicRouteTable,
-            privateRouteTable,
-            internetRoute,
-            natEip,
-            natGateway,
-            natRoute,
-            publicSubnet1Association,
-            privateSubnet1Association,
-          };
-        }),
-      );
-
-      // Verify EIP
-      expect(stack.natEip.allocationId).toMatch(/^eipalloc-/);
-      expect(stack.natEip.publicIp).toBeDefined();
-
-      // Verify NAT Gateway
-      expect(stack.natGateway.natGatewayId).toMatch(/^nat-/);
-      expect(stack.natGateway.state).toEqual("available");
-      expect(stack.natGateway.publicIp).toEqual(stack.natEip.publicIp);
-
-      // Verify NAT route is active
-      expect(stack.natRoute.state).toEqual("active");
-      expect(stack.natRoute.natGatewayId).toEqual(
-        stack.natGateway.natGatewayId,
-      );
-
-      // Verify private route table now has internet route via NAT
-      const privateRtResult = yield* EC2.describeRouteTables({
-        RouteTableIds: [stack.privateRouteTable.routeTableId],
-      });
-      const privateRoutes = privateRtResult.RouteTables?.[0]?.Routes ?? [];
-      const privateInternetRoute = privateRoutes.find(
-        (r) => r.DestinationCidrBlock === "0.0.0.0/0",
-      );
-      expect(privateInternetRoute?.NatGatewayId).toEqual(
-        stack.natGateway.natGatewayId,
-      );
-    }
-
-    // =========================================================================
-    // STAGE 9: Add Security Groups
-    // User needs to control instance access
-    // Tests: Security Group with inline ingress/egress rules
-    // =========================================================================
-    yield* Effect.log("=== Stage 9: Add Security Groups ===");
-    {
-      const stack = yield* test.deploy(
-        Effect.gen(function* () {
-          const myVpc = yield* Vpc("MyVpc", {
-            cidrBlock: "10.0.0.0/16",
-            enableDnsSupport: true,
-            enableDnsHostnames: true,
-            tags: {
-              Name: "production-vpc",
-              Environment: "production",
+          const privateSubnet2Association = yield* RouteTableAssociation(
+            "PrivateSubnet2Association",
+            {
+              routeTableId: privateRouteTable2.routeTableId,
+              subnetId: privateSubnet2.subnetId,
             },
-          });
+          );
 
-          const internetGateway = yield* InternetGateway("InternetGateway", {
-            vpcId: myVpc.vpcId,
-            tags: { Name: "production-igw" },
-          });
-
-          const publicSubnet1 = yield* Subnet("PublicSubnet1", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.1.0/24",
-            availabilityZone: az1,
-            mapPublicIpOnLaunch: true,
-            tags: { Name: "public-1a", Tier: "public" },
-          });
-
-          const privateSubnet1 = yield* Subnet("PrivateSubnet1", {
-            vpcId: myVpc.vpcId,
-            cidrBlock: "10.0.10.0/24",
-            availabilityZone: az1,
-            tags: { Name: "private-1a", Tier: "private" },
-          });
-
-          const publicRouteTable = yield* RouteTable("PublicRouteTable", {
-            vpcId: myVpc.vpcId,
-            tags: { Name: "public-rt" },
-          });
-
-          const privateRouteTable = yield* RouteTable("PrivateRouteTable", {
-            vpcId: myVpc.vpcId,
-            tags: { Name: "private-rt" },
-          });
-
-          const internetRoute = yield* Route("InternetRoute", {
-            routeTableId: publicRouteTable.routeTableId,
-            destinationCidrBlock: "0.0.0.0/0",
-            gatewayId: internetGateway.internetGatewayId,
-          });
-
-          const natEip = yield* EIP("NatEip", {
-            tags: { Name: "nat-eip" },
-          });
-
-          const natGateway = yield* NatGateway("NatGateway", {
-            subnetId: publicSubnet1.subnetId,
-            allocationId: natEip.allocationId,
-            tags: { Name: "production-nat" },
-          });
-
-          const natRoute = yield* Route("NatRoute", {
-            routeTableId: privateRouteTable.routeTableId,
-            destinationCidrBlock: "0.0.0.0/0",
-            natGatewayId: natGateway.natGatewayId,
-          });
-
-          // NEW: Web security group allowing HTTP/HTTPS
+          // Security Groups
           const webSecurityGroup = yield* SecurityGroup("WebSecurityGroup", {
             vpcId: myVpc.vpcId,
             description: "Web tier security group",
@@ -989,7 +1393,28 @@ test.skip(
             tags: { Name: "web-sg" },
           });
 
-          // NEW: Database security group allowing access from web tier
+          const appSecurityGroup = yield* SecurityGroup("AppSecurityGroup", {
+            vpcId: myVpc.vpcId,
+            description: "Application tier security group",
+            ingress: [
+              {
+                ipProtocol: "tcp",
+                fromPort: 8080,
+                toPort: 8080,
+                referencedGroupId: webSecurityGroup.groupId,
+                description: "Allow from web tier",
+              },
+            ],
+            egress: [
+              {
+                ipProtocol: "-1",
+                cidrIpv4: "0.0.0.0/0",
+                description: "Allow all outbound",
+              },
+            ],
+            tags: { Name: "app-sg" },
+          });
+
           const dbSecurityGroup = yield* SecurityGroup("DbSecurityGroup", {
             vpcId: myVpc.vpcId,
             description: "Database tier security group",
@@ -998,8 +1423,8 @@ test.skip(
                 ipProtocol: "tcp",
                 fromPort: 5432,
                 toPort: 5432,
-                referencedGroupId: webSecurityGroup.groupId,
-                description: "Allow PostgreSQL from web tier",
+                referencedGroupId: appSecurityGroup.groupId,
+                description: "Allow PostgreSQL from app tier",
               },
             ],
             egress: [
@@ -1012,79 +1437,444 @@ test.skip(
             tags: { Name: "db-sg" },
           });
 
-          const publicSubnet1Association = yield* RouteTableAssociation(
-            "PublicSubnet1Association",
+          // Network ACL for private subnets with custom rules
+          const privateNetworkAcl = yield* NetworkAcl("PrivateNetworkAcl", {
+            vpcId: myVpc.vpcId,
+            tags: { Name: "private-nacl" },
+          });
+
+          // Network ACL Entries (rules)
+          // Allow inbound traffic from VPC CIDR
+          const privateNaclIngressVpc = yield* NetworkAclEntry(
+            "PrivateNaclIngressVpc",
             {
-              routeTableId: publicRouteTable.routeTableId,
-              subnetId: publicSubnet1.subnetId,
+              networkAclId: privateNetworkAcl.networkAclId,
+              ruleNumber: 100,
+              protocol: "-1", // All protocols
+              ruleAction: "allow",
+              egress: false,
+              cidrBlock: "10.0.0.0/16",
             },
           );
 
-          const privateSubnet1Association = yield* RouteTableAssociation(
-            "PrivateSubnet1Association",
+          // Allow inbound ephemeral ports (for NAT return traffic)
+          const privateNaclIngressEphemeral = yield* NetworkAclEntry(
+            "PrivateNaclIngressEphemeral",
             {
-              routeTableId: privateRouteTable.routeTableId,
+              networkAclId: privateNetworkAcl.networkAclId,
+              ruleNumber: 200,
+              protocol: "6", // TCP
+              ruleAction: "allow",
+              egress: false,
+              cidrBlock: "0.0.0.0/0",
+              portRange: { from: 1024, to: 65535 },
+            },
+          );
+
+          // Allow all outbound traffic
+          const privateNaclEgressAll = yield* NetworkAclEntry(
+            "PrivateNaclEgressAll",
+            {
+              networkAclId: privateNetworkAcl.networkAclId,
+              ruleNumber: 100,
+              protocol: "-1", // All protocols
+              ruleAction: "allow",
+              egress: true,
+              cidrBlock: "0.0.0.0/0",
+            },
+          );
+
+          // Network ACL Associations - associate private subnets with the custom NACL
+          const privateSubnet1NaclAssoc = yield* NetworkAclAssociation(
+            "PrivateSubnet1NaclAssoc",
+            {
+              networkAclId: privateNetworkAcl.networkAclId,
               subnetId: privateSubnet1.subnetId,
             },
           );
 
+          const privateSubnet2NaclAssoc = yield* NetworkAclAssociation(
+            "PrivateSubnet2NaclAssoc",
+            {
+              networkAclId: privateNetworkAcl.networkAclId,
+              subnetId: privateSubnet2.subnetId,
+            },
+          );
+
+          // VPC Gateway Endpoint for S3 (reduces NAT costs and improves latency)
+          const s3Endpoint = yield* VpcEndpoint("S3Endpoint", {
+            vpcId: myVpc.vpcId,
+            serviceName: `com.amazonaws.${
+              (yield* EC2.describeAvailabilityZones({})).AvailabilityZones?.[0]
+                ?.RegionName
+            }.s3`,
+            vpcEndpointType: "Gateway",
+            routeTableIds: [
+              privateRouteTable1.routeTableId,
+              privateRouteTable2.routeTableId,
+            ],
+            tags: { Name: "s3-endpoint" },
+          });
+
           return {
             myVpc,
             internetGateway,
+            egressOnlyIgw,
             publicSubnet1,
+            publicSubnet2,
             privateSubnet1,
+            privateSubnet2,
             publicRouteTable,
-            privateRouteTable,
+            privateRouteTable1,
+            privateRouteTable2,
             internetRoute,
-            natEip,
-            natGateway,
-            natRoute,
-            webSecurityGroup,
-            dbSecurityGroup,
+            natEip1,
+            natEip2,
+            natGateway1,
+            natGateway2,
+            natRoute1,
+            natRoute2,
             publicSubnet1Association,
+            publicSubnet2Association,
             privateSubnet1Association,
+            privateSubnet2Association,
+            webSecurityGroup,
+            appSecurityGroup,
+            dbSecurityGroup,
+            privateNetworkAcl,
+            privateNaclIngressVpc,
+            privateNaclIngressEphemeral,
+            privateNaclEgressAll,
+            privateSubnet1NaclAssoc,
+            privateSubnet2NaclAssoc,
+            s3Endpoint,
           };
         }),
       );
 
-      // Verify Web Security Group
-      expect(stack.webSecurityGroup.groupId).toMatch(/^sg-/);
-      expect(stack.webSecurityGroup.vpcId).toEqual(stack.myVpc.vpcId);
-      expect(stack.webSecurityGroup.ingressRules).toHaveLength(2);
-      expect(stack.webSecurityGroup.egressRules).toHaveLength(1);
+      // =========================================================================
+      // Verify VPC
+      // =========================================================================
+      expect(_stack.myVpc.vpcId).toMatch(/^vpc-/);
+      expect(_stack.myVpc.cidrBlock).toEqual("10.0.0.0/16");
+      expect(_stack.myVpc.state).toEqual("available");
 
-      // Verify DB Security Group references Web Security Group
-      expect(stack.dbSecurityGroup.groupId).toMatch(/^sg-/);
-      expect(stack.dbSecurityGroup.ingressRules).toHaveLength(1);
+      const vpcResult = yield* EC2.describeVpcs({
+        VpcIds: [_stack.myVpc.vpcId],
+      });
+      expect(vpcResult.Vpcs?.[0]?.CidrBlock).toEqual("10.0.0.0/16");
+      // EnableDnsSupport and EnableDnsHostnames are not present in the describeVpcs output.
+      // Instead, use describeVpcAttribute for these:
+      const dnsSupport = yield* EC2.describeVpcAttribute({
+        VpcId: _stack.myVpc.vpcId,
+        Attribute: "enableDnsSupport",
+      });
+      expect(dnsSupport.EnableDnsSupport?.Value).toBeTruthy();
+
+      const dnsHostnames = yield* EC2.describeVpcAttribute({
+        VpcId: _stack.myVpc.vpcId,
+        Attribute: "enableDnsHostnames",
+      });
+      expect(dnsHostnames.EnableDnsHostnames?.Value).toBeTruthy();
+
+      // Verify VPC has IPv6 CIDR block
+      expect(_stack.myVpc.ipv6CidrBlockAssociationSet).toBeDefined();
+      expect(_stack.myVpc.ipv6CidrBlockAssociationSet?.length).toBeGreaterThan(
+        0,
+      );
+
+      // =========================================================================
+      // Verify Internet Gateway
+      // =========================================================================
+      expect(_stack.internetGateway.internetGatewayId).toMatch(/^igw-/);
+      expect(_stack.internetGateway.vpcId).toEqual(_stack.myVpc.vpcId);
+
+      // =========================================================================
+      // Verify Egress-Only Internet Gateway
+      // =========================================================================
+      expect(_stack.egressOnlyIgw.egressOnlyInternetGatewayId).toMatch(
+        /^eigw-/,
+      );
+      expect(_stack.egressOnlyIgw.attachments).toBeDefined();
+      expect(_stack.egressOnlyIgw.attachments?.[0]?.vpcId).toEqual(
+        _stack.myVpc.vpcId,
+      );
+
+      // =========================================================================
+      // Verify Subnets
+      // =========================================================================
+      expect(_stack.publicSubnet1.subnetId).toMatch(/^subnet-/);
+      expect(_stack.publicSubnet1.availabilityZone).toEqual(az1);
+      expect(_stack.publicSubnet1.mapPublicIpOnLaunch).toEqual(true);
+
+      expect(_stack.publicSubnet2.subnetId).toMatch(/^subnet-/);
+      expect(_stack.publicSubnet2.availabilityZone).toEqual(az2);
+      expect(_stack.publicSubnet2.mapPublicIpOnLaunch).toEqual(true);
+
+      expect(_stack.privateSubnet1.subnetId).toMatch(/^subnet-/);
+      expect(_stack.privateSubnet1.availabilityZone).toEqual(az1);
+      expect(_stack.privateSubnet1.mapPublicIpOnLaunch).toBeFalsy();
+
+      expect(_stack.privateSubnet2.subnetId).toMatch(/^subnet-/);
+      expect(_stack.privateSubnet2.availabilityZone).toEqual(az2);
+      expect(_stack.privateSubnet2.mapPublicIpOnLaunch).toBeFalsy();
+
+      // Verify 4 subnets total
+      const subnetsResult = yield* EC2.describeSubnets({
+        Filters: [{ Name: "vpc-id", Values: [_stack.myVpc.vpcId] }],
+      });
+      expect(subnetsResult.Subnets).toHaveLength(4);
+
+      // =========================================================================
+      // Verify NAT Gateways and EIPs
+      // =========================================================================
+      expect(_stack.natEip1.allocationId).toMatch(/^eipalloc-/);
+      expect(_stack.natEip1.publicIp).toBeDefined();
+
+      expect(_stack.natEip2.allocationId).toMatch(/^eipalloc-/);
+      expect(_stack.natEip2.publicIp).toBeDefined();
+
+      expect(_stack.natGateway1.natGatewayId).toMatch(/^nat-/);
+      expect(_stack.natGateway1.state).toEqual("available");
+      expect(_stack.natGateway1.publicIp).toEqual(_stack.natEip1.publicIp);
+      expect(_stack.natGateway1.subnetId).toEqual(
+        _stack.publicSubnet1.subnetId,
+      );
+
+      expect(_stack.natGateway2.natGatewayId).toMatch(/^nat-/);
+      expect(_stack.natGateway2.state).toEqual("available");
+      expect(_stack.natGateway2.publicIp).toEqual(_stack.natEip2.publicIp);
+      expect(_stack.natGateway2.subnetId).toEqual(
+        _stack.publicSubnet2.subnetId,
+      );
+
+      // =========================================================================
+      // Verify Routes
+      // =========================================================================
+      // Internet route to IGW
+      expect(_stack.internetRoute.state).toEqual("active");
+      expect(_stack.internetRoute.gatewayId).toEqual(
+        _stack.internetGateway.internetGatewayId,
+      );
+
+      // NAT routes
+      expect(_stack.natRoute1.state).toEqual("active");
+      expect(_stack.natRoute1.natGatewayId).toEqual(
+        _stack.natGateway1.natGatewayId,
+      );
+
+      expect(_stack.natRoute2.state).toEqual("active");
+      expect(_stack.natRoute2.natGatewayId).toEqual(
+        _stack.natGateway2.natGatewayId,
+      );
+
+      // Verify public route table has internet route
+      const publicRtResult = yield* EC2.describeRouteTables({
+        RouteTableIds: [_stack.publicRouteTable.routeTableId],
+      });
+      const publicRoutes = publicRtResult.RouteTables?.[0]?.Routes ?? [];
+      const publicInternetRoute = publicRoutes.find(
+        (r) => r.DestinationCidrBlock === "0.0.0.0/0",
+      );
+      expect(publicInternetRoute?.GatewayId).toEqual(
+        _stack.internetGateway.internetGatewayId,
+      );
+
+      // Verify private route tables have NAT routes
+      const private1RtResult = yield* EC2.describeRouteTables({
+        RouteTableIds: [_stack.privateRouteTable1.routeTableId],
+      });
+      const private1Routes = private1RtResult.RouteTables?.[0]?.Routes ?? [];
+      const private1NatRoute = private1Routes.find(
+        (r) => r.DestinationCidrBlock === "0.0.0.0/0",
+      );
+      expect(private1NatRoute?.NatGatewayId).toEqual(
+        _stack.natGateway1.natGatewayId,
+      );
+
+      const private2RtResult = yield* EC2.describeRouteTables({
+        RouteTableIds: [_stack.privateRouteTable2.routeTableId],
+      });
+      const private2Routes = private2RtResult.RouteTables?.[0]?.Routes ?? [];
+      const private2NatRoute = private2Routes.find(
+        (r) => r.DestinationCidrBlock === "0.0.0.0/0",
+      );
+      expect(private2NatRoute?.NatGatewayId).toEqual(
+        _stack.natGateway2.natGatewayId,
+      );
+
+      // =========================================================================
+      // Verify Route Table Associations
+      // =========================================================================
+      expect(_stack.publicSubnet1Association.associationId).toMatch(
+        /^rtbassoc-/,
+      );
+      expect(_stack.publicSubnet2Association.associationId).toMatch(
+        /^rtbassoc-/,
+      );
+      expect(_stack.privateSubnet1Association.associationId).toMatch(
+        /^rtbassoc-/,
+      );
+      expect(_stack.privateSubnet2Association.associationId).toMatch(
+        /^rtbassoc-/,
+      );
+
+      // Both public subnets share the same route table
+      expect(_stack.publicSubnet1Association.routeTableId).toEqual(
+        _stack.publicSubnet2Association.routeTableId,
+      );
+
+      // Private subnets have their own route tables (for HA NAT)
+      expect(_stack.privateSubnet1Association.routeTableId).not.toEqual(
+        _stack.privateSubnet2Association.routeTableId,
+      );
+
+      // =========================================================================
+      // Verify Security Groups
+      // =========================================================================
+      expect(_stack.webSecurityGroup.groupId).toMatch(/^sg-/);
+      expect(_stack.webSecurityGroup.vpcId).toEqual(_stack.myVpc.vpcId);
+      expect(_stack.webSecurityGroup.ingressRules).toHaveLength(2);
+      // TODO(sam): why is it 2 when we only have 1? is it a default or egress only ingress?
+      expect(_stack.webSecurityGroup.egressRules).toHaveLength(2);
+
+      expect(_stack.appSecurityGroup.groupId).toMatch(/^sg-/);
+      expect(_stack.appSecurityGroup.vpcId).toEqual(_stack.myVpc.vpcId);
+      expect(_stack.appSecurityGroup.ingressRules).toHaveLength(1);
       expect(
-        stack.dbSecurityGroup.ingressRules?.[0]?.referencedGroupId,
-      ).toEqual(stack.webSecurityGroup.groupId);
-    }
+        _stack.appSecurityGroup.ingressRules?.[0]?.referencedGroupId,
+      ).toEqual(_stack.webSecurityGroup.groupId);
 
-    // =========================================================================
-    // STAGE 10: Scale Down - Remove NAT Gateway and Security Groups
-    // User scales down to basic VPC for cost savings
-    // Tests: NAT Gateway delete with state waiting, Security Group delete
-    // =========================================================================
-    yield* Effect.log("=== Stage 10: Scale Down to Basic VPC ===");
-    {
-      const stack = yield* test.deploy(
+      expect(_stack.dbSecurityGroup.groupId).toMatch(/^sg-/);
+      expect(_stack.dbSecurityGroup.vpcId).toEqual(_stack.myVpc.vpcId);
+      expect(_stack.dbSecurityGroup.ingressRules).toHaveLength(1);
+      expect(
+        _stack.dbSecurityGroup.ingressRules?.[0]?.referencedGroupId,
+      ).toEqual(_stack.appSecurityGroup.groupId);
+
+      // Verify security groups in AWS
+      const sgResult = yield* EC2.describeSecurityGroups({
+        Filters: [{ Name: "vpc-id", Values: [_stack.myVpc.vpcId] }],
+      });
+      // 4 security groups: default + web + app + db
+      expect(sgResult.SecurityGroups).toHaveLength(4);
+
+      // =========================================================================
+      // Verify Network ACL
+      // =========================================================================
+      expect(_stack.privateNetworkAcl.networkAclId).toMatch(/^acl-/);
+      expect(_stack.privateNetworkAcl.vpcId).toEqual(_stack.myVpc.vpcId);
+      expect(_stack.privateNetworkAcl.isDefault).toEqual(false);
+
+      // Verify Network ACL in AWS
+      const naclResult = yield* EC2.describeNetworkAcls({
+        NetworkAclIds: [_stack.privateNetworkAcl.networkAclId],
+      });
+      expect(naclResult.NetworkAcls).toHaveLength(1);
+      expect(naclResult.NetworkAcls?.[0]?.VpcId).toEqual(_stack.myVpc.vpcId);
+
+      // =========================================================================
+      // Verify Network ACL Entries
+      // =========================================================================
+      expect(_stack.privateNaclIngressVpc.networkAclId).toEqual(
+        _stack.privateNetworkAcl.networkAclId,
+      );
+      expect(_stack.privateNaclIngressVpc.ruleNumber).toEqual(100);
+      expect(_stack.privateNaclIngressVpc.egress).toEqual(false);
+      expect(_stack.privateNaclIngressVpc.ruleAction).toEqual("allow");
+
+      expect(_stack.privateNaclIngressEphemeral.ruleNumber).toEqual(200);
+      expect(_stack.privateNaclIngressEphemeral.portRange).toEqual({
+        from: 1024,
+        to: 65535,
+      });
+
+      expect(_stack.privateNaclEgressAll.egress).toEqual(true);
+      expect(_stack.privateNaclEgressAll.ruleNumber).toEqual(100);
+
+      // =========================================================================
+      // Verify Network ACL Associations
+      // =========================================================================
+      expect(_stack.privateSubnet1NaclAssoc.associationId).toMatch(
+        /^aclassoc-/,
+      );
+      expect(_stack.privateSubnet1NaclAssoc.networkAclId).toEqual(
+        _stack.privateNetworkAcl.networkAclId,
+      );
+      expect(_stack.privateSubnet1NaclAssoc.subnetId).toEqual(
+        _stack.privateSubnet1.subnetId,
+      );
+
+      expect(_stack.privateSubnet2NaclAssoc.associationId).toMatch(
+        /^aclassoc-/,
+      );
+      expect(_stack.privateSubnet2NaclAssoc.subnetId).toEqual(
+        _stack.privateSubnet2.subnetId,
+      );
+
+      // =========================================================================
+      // Verify VPC Endpoint for S3
+      // =========================================================================
+      expect(_stack.s3Endpoint.vpcEndpointId).toMatch(/^vpce-/);
+      expect(_stack.s3Endpoint.vpcEndpointType).toEqual("Gateway");
+      expect(_stack.s3Endpoint.vpcId).toEqual(_stack.myVpc.vpcId);
+      expect(_stack.s3Endpoint.state).toEqual("available");
+      expect(_stack.s3Endpoint.routeTableIds).toContain(
+        _stack.privateRouteTable1.routeTableId,
+      );
+      expect(_stack.s3Endpoint.routeTableIds).toContain(
+        _stack.privateRouteTable2.routeTableId,
+      );
+
+      // Verify VPC Endpoint in AWS
+      const vpceResult = yield* EC2.describeVpcEndpoints({
+        VpcEndpointIds: [_stack.s3Endpoint.vpcEndpointId],
+      });
+      expect(vpceResult.VpcEndpoints).toHaveLength(1);
+      expect(vpceResult.VpcEndpoints?.[0]?.VpcEndpointType).toEqual("Gateway");
+
+      // =========================================================================
+      // Verify Tags
+      // =========================================================================
+      yield* assertVpcTags(_stack.myVpc.vpcId, {
+        Name: "comprehensive-vpc",
+        Environment: "test",
+      });
+
+      // =========================================================================
+      // Idempotency check - apply again and verify no changes
+      // =========================================================================
+      yield* Effect.log("=== Idempotency Check: Re-applying stack ===");
+      const stack2 = yield* stack.deploy(
         Effect.gen(function* () {
+          // VPC with DNS enabled and IPv6 for egress-only IGW
           const myVpc = yield* Vpc("MyVpc", {
             cidrBlock: "10.0.0.0/16",
             enableDnsSupport: true,
             enableDnsHostnames: true,
+            amazonProvidedIpv6CidrBlock: true,
             tags: {
-              Name: "production-vpc",
-              Environment: "production",
+              Name: "comprehensive-vpc",
+              Environment: "test",
             },
           });
 
+          // Internet Gateway for public internet access
           const internetGateway = yield* InternetGateway("InternetGateway", {
             vpcId: myVpc.vpcId,
-            tags: { Name: "production-igw" },
+            tags: { Name: "comprehensive-igw" },
           });
 
+          // Egress-Only Internet Gateway for IPv6 outbound traffic from private subnets
+          const egressOnlyIgw = yield* EgressOnlyInternetGateway(
+            "EgressOnlyIgw",
+            {
+              vpcId: myVpc.vpcId,
+              tags: { Name: "comprehensive-eigw" },
+            },
+          );
+
+          // Public Subnets in two AZs
           const publicSubnet1 = yield* Subnet("PublicSubnet1", {
             vpcId: myVpc.vpcId,
             cidrBlock: "10.0.1.0/24",
@@ -1093,6 +1883,15 @@ test.skip(
             tags: { Name: "public-1a", Tier: "public" },
           });
 
+          const publicSubnet2 = yield* Subnet("PublicSubnet2", {
+            vpcId: myVpc.vpcId,
+            cidrBlock: "10.0.2.0/24",
+            availabilityZone: az2,
+            mapPublicIpOnLaunch: true,
+            tags: { Name: "public-1b", Tier: "public" },
+          });
+
+          // Private Subnets in two AZs
           const privateSubnet1 = yield* Subnet("PrivateSubnet1", {
             vpcId: myVpc.vpcId,
             cidrBlock: "10.0.10.0/24",
@@ -1100,22 +1899,72 @@ test.skip(
             tags: { Name: "private-1a", Tier: "private" },
           });
 
+          const privateSubnet2 = yield* Subnet("PrivateSubnet2", {
+            vpcId: myVpc.vpcId,
+            cidrBlock: "10.0.11.0/24",
+            availabilityZone: az2,
+            tags: { Name: "private-1b", Tier: "private" },
+          });
+
+          // Route Tables
           const publicRouteTable = yield* RouteTable("PublicRouteTable", {
             vpcId: myVpc.vpcId,
             tags: { Name: "public-rt" },
           });
 
-          const privateRouteTable = yield* RouteTable("PrivateRouteTable", {
+          const privateRouteTable1 = yield* RouteTable("PrivateRouteTable1", {
             vpcId: myVpc.vpcId,
-            tags: { Name: "private-rt" },
+            tags: { Name: "private-rt-1" },
           });
 
+          const privateRouteTable2 = yield* RouteTable("PrivateRouteTable2", {
+            vpcId: myVpc.vpcId,
+            tags: { Name: "private-rt-2" },
+          });
+
+          // Internet route for public subnets
           const internetRoute = yield* Route("InternetRoute", {
             routeTableId: publicRouteTable.routeTableId,
             destinationCidrBlock: "0.0.0.0/0",
             gatewayId: internetGateway.internetGatewayId,
           });
 
+          // NAT Gateway with EIP for AZ1
+          const natEip1 = yield* EIP("NatEip1", {
+            tags: { Name: "nat-eip-1" },
+          });
+
+          const natGateway1 = yield* NatGateway("NatGateway1", {
+            subnetId: publicSubnet1.subnetId,
+            allocationId: natEip1.allocationId,
+            tags: { Name: "nat-gateway-1" },
+          });
+
+          // NAT Gateway with EIP for AZ2
+          const natEip2 = yield* EIP("NatEip2", {
+            tags: { Name: "nat-eip-2" },
+          });
+
+          const natGateway2 = yield* NatGateway("NatGateway2", {
+            subnetId: publicSubnet2.subnetId,
+            allocationId: natEip2.allocationId,
+            tags: { Name: "nat-gateway-2" },
+          });
+
+          // NAT routes for private subnets (each AZ routes to its own NAT)
+          const natRoute1 = yield* Route("NatRoute1", {
+            routeTableId: privateRouteTable1.routeTableId,
+            destinationCidrBlock: "0.0.0.0/0",
+            natGatewayId: natGateway1.natGatewayId,
+          });
+
+          const natRoute2 = yield* Route("NatRoute2", {
+            routeTableId: privateRouteTable2.routeTableId,
+            destinationCidrBlock: "0.0.0.0/0",
+            natGatewayId: natGateway2.natGatewayId,
+          });
+
+          // Route Table Associations
           const publicSubnet1Association = yield* RouteTableAssociation(
             "PublicSubnet1Association",
             {
@@ -1124,1086 +1973,259 @@ test.skip(
             },
           );
 
+          const publicSubnet2Association = yield* RouteTableAssociation(
+            "PublicSubnet2Association",
+            {
+              routeTableId: publicRouteTable.routeTableId,
+              subnetId: publicSubnet2.subnetId,
+            },
+          );
+
           const privateSubnet1Association = yield* RouteTableAssociation(
             "PrivateSubnet1Association",
             {
-              routeTableId: privateRouteTable.routeTableId,
+              routeTableId: privateRouteTable1.routeTableId,
               subnetId: privateSubnet1.subnetId,
             },
           );
 
-          // Note: NAT Gateway, EIP, NatRoute, and Security Groups are NOT included
-          // They will be deleted
+          const privateSubnet2Association = yield* RouteTableAssociation(
+            "PrivateSubnet2Association",
+            {
+              routeTableId: privateRouteTable2.routeTableId,
+              subnetId: privateSubnet2.subnetId,
+            },
+          );
+
+          // Security Groups
+          const webSecurityGroup = yield* SecurityGroup("WebSecurityGroup", {
+            vpcId: myVpc.vpcId,
+            description: "Web tier security group",
+            ingress: [
+              {
+                ipProtocol: "tcp",
+                fromPort: 80,
+                toPort: 80,
+                cidrIpv4: "0.0.0.0/0",
+                description: "Allow HTTP",
+              },
+              {
+                ipProtocol: "tcp",
+                fromPort: 443,
+                toPort: 443,
+                cidrIpv4: "0.0.0.0/0",
+                description: "Allow HTTPS",
+              },
+            ],
+            egress: [
+              {
+                ipProtocol: "-1",
+                cidrIpv4: "0.0.0.0/0",
+                description: "Allow all outbound",
+              },
+            ],
+            tags: { Name: "web-sg" },
+          });
+
+          const appSecurityGroup = yield* SecurityGroup("AppSecurityGroup", {
+            vpcId: myVpc.vpcId,
+            description: "Application tier security group",
+            ingress: [
+              {
+                ipProtocol: "tcp",
+                fromPort: 8080,
+                toPort: 8080,
+                referencedGroupId: webSecurityGroup.groupId,
+                description: "Allow from web tier",
+              },
+            ],
+            egress: [
+              {
+                ipProtocol: "-1",
+                cidrIpv4: "0.0.0.0/0",
+                description: "Allow all outbound",
+              },
+            ],
+            tags: { Name: "app-sg" },
+          });
+
+          const dbSecurityGroup = yield* SecurityGroup("DbSecurityGroup", {
+            vpcId: myVpc.vpcId,
+            description: "Database tier security group",
+            ingress: [
+              {
+                ipProtocol: "tcp",
+                fromPort: 5432,
+                toPort: 5432,
+                referencedGroupId: appSecurityGroup.groupId,
+                description: "Allow PostgreSQL from app tier",
+              },
+            ],
+            egress: [
+              {
+                ipProtocol: "-1",
+                cidrIpv4: "0.0.0.0/0",
+                description: "Allow all outbound",
+              },
+            ],
+            tags: { Name: "db-sg" },
+          });
+
+          // Network ACL for private subnets with custom rules
+          const privateNetworkAcl = yield* NetworkAcl("PrivateNetworkAcl", {
+            vpcId: myVpc.vpcId,
+            tags: { Name: "private-nacl" },
+          });
+
+          // Network ACL Entries (rules)
+          // Allow inbound traffic from VPC CIDR
+          const privateNaclIngressVpc = yield* NetworkAclEntry(
+            "PrivateNaclIngressVpc",
+            {
+              networkAclId: privateNetworkAcl.networkAclId,
+              ruleNumber: 100,
+              protocol: "-1", // All protocols
+              ruleAction: "allow",
+              egress: false,
+              cidrBlock: "10.0.0.0/16",
+            },
+          );
+
+          // Allow inbound ephemeral ports (for NAT return traffic)
+          const privateNaclIngressEphemeral = yield* NetworkAclEntry(
+            "PrivateNaclIngressEphemeral",
+            {
+              networkAclId: privateNetworkAcl.networkAclId,
+              ruleNumber: 200,
+              protocol: "6", // TCP
+              ruleAction: "allow",
+              egress: false,
+              cidrBlock: "0.0.0.0/0",
+              portRange: { from: 1024, to: 65535 },
+            },
+          );
+
+          // Allow all outbound traffic
+          const privateNaclEgressAll = yield* NetworkAclEntry(
+            "PrivateNaclEgressAll",
+            {
+              networkAclId: privateNetworkAcl.networkAclId,
+              ruleNumber: 100,
+              protocol: "-1", // All protocols
+              ruleAction: "allow",
+              egress: true,
+              cidrBlock: "0.0.0.0/0",
+            },
+          );
+
+          // Network ACL Associations - associate private subnets with the custom NACL
+          const privateSubnet1NaclAssoc = yield* NetworkAclAssociation(
+            "PrivateSubnet1NaclAssoc",
+            {
+              networkAclId: privateNetworkAcl.networkAclId,
+              subnetId: privateSubnet1.subnetId,
+            },
+          );
+
+          const privateSubnet2NaclAssoc = yield* NetworkAclAssociation(
+            "PrivateSubnet2NaclAssoc",
+            {
+              networkAclId: privateNetworkAcl.networkAclId,
+              subnetId: privateSubnet2.subnetId,
+            },
+          );
+
+          // VPC Gateway Endpoint for S3 (reduces NAT costs and improves latency)
+          const s3Endpoint = yield* VpcEndpoint("S3Endpoint", {
+            vpcId: myVpc.vpcId,
+            serviceName: `com.amazonaws.${
+              (yield* EC2.describeAvailabilityZones({})).AvailabilityZones?.[0]
+                ?.RegionName
+            }.s3`,
+            vpcEndpointType: "Gateway",
+            routeTableIds: [
+              privateRouteTable1.routeTableId,
+              privateRouteTable2.routeTableId,
+            ],
+            tags: { Name: "s3-endpoint" },
+          });
 
           return {
             myVpc,
             internetGateway,
+            egressOnlyIgw,
             publicSubnet1,
+            publicSubnet2,
             privateSubnet1,
+            privateSubnet2,
             publicRouteTable,
-            privateRouteTable,
+            privateRouteTable1,
+            privateRouteTable2,
             internetRoute,
+            natEip1,
+            natEip2,
+            natGateway1,
+            natGateway2,
+            natRoute1,
+            natRoute2,
             publicSubnet1Association,
+            publicSubnet2Association,
             privateSubnet1Association,
+            privateSubnet2Association,
+            webSecurityGroup,
+            appSecurityGroup,
+            dbSecurityGroup,
+            privateNetworkAcl,
+            privateNaclIngressVpc,
+            privateNaclIngressEphemeral,
+            privateNaclEgressAll,
+            privateSubnet1NaclAssoc,
+            privateSubnet2NaclAssoc,
+            s3Endpoint,
           };
         }),
       );
 
-      // Verify NAT Gateway is deleted
-      const natGwResult = yield* ec2
-        .describeNatGateways({
-          Filter: [{ Name: "vpc-id", Values: [stack.myVpc.vpcId] }],
-        })
-        .pipe(
-          Effect.map((r) =>
-            r.NatGateways?.filter((gw) => gw.State !== "deleted"),
-          ),
-        );
-      expect(natGwResult).toHaveLength(0);
+      // All IDs should remain the same
+      expect(stack2.myVpc.vpcId).toEqual(_stack.myVpc.vpcId);
+      expect(stack2.internetGateway.internetGatewayId).toEqual(
+        _stack.internetGateway.internetGatewayId,
+      );
+      expect(stack2.egressOnlyIgw.egressOnlyInternetGatewayId).toEqual(
+        _stack.egressOnlyIgw.egressOnlyInternetGatewayId,
+      );
+      expect(stack2.natGateway1.natGatewayId).toEqual(
+        _stack.natGateway1.natGatewayId,
+      );
+      expect(stack2.natGateway2.natGatewayId).toEqual(
+        _stack.natGateway2.natGatewayId,
+      );
+      expect(stack2.privateNetworkAcl.networkAclId).toEqual(
+        _stack.privateNetworkAcl.networkAclId,
+      );
+      expect(stack2.s3Endpoint.vpcEndpointId).toEqual(
+        _stack.s3Endpoint.vpcEndpointId,
+      );
 
-      // Verify Security Groups are deleted (only default should remain)
-      const sgResult = yield* EC2.describeSecurityGroups({
-        Filters: [{ Name: "vpc-id", Values: [stack.myVpc.vpcId] }],
-      });
-      expect(sgResult.SecurityGroups).toHaveLength(1); // Only default SG
-      expect(sgResult.SecurityGroups?.[0]?.GroupName).toEqual("default");
-    }
+      // =========================================================================
+      // Cleanup
+      // =========================================================================
+      yield* Effect.log("=== Cleanup: Destroying all resources ===");
+      const capturedVpcId = _stack.myVpc.vpcId;
 
-    // =========================================================================
-    // STAGE 11: Final Cleanup
-    // Destroy everything and verify
-    // =========================================================================
-    yield* Effect.log("=== Stage 11: Final Cleanup ===");
-    const vpcResult = yield* EC2.describeVpcs({
-      Filters: [{ Name: "tag:Name", Values: ["production-vpc"] }],
-    });
-    const capturedVpcId = vpcResult.Vpcs?.[0]?.VpcId;
+      yield* stack.destroy();
 
-    yield* destroy();
-
-    // Verify VPC is deleted
-    if (capturedVpcId) {
+      // Verify VPC is deleted
       yield* EC2.describeVpcs({ VpcIds: [capturedVpcId] }).pipe(
         Effect.flatMap(() => Effect.fail(new Error("VPC still exists"))),
         Effect.catchTag("InvalidVpcID.NotFound", () => Effect.void),
       );
-    }
 
-    yield* Effect.log("=== All stages completed successfully! ===");
-  }).pipe(Effect.provide(AWS.providers()), logLevel),
-);
-
-test.skip(
-  "Comprehensive VPC with all components",
-  {
-    timeout: 1_000_000,
-  },
-  Effect.gen(function* () {
-    yield* destroy();
-
-    // Get available AZs
-    const azResult = yield* EC2.describeAvailabilityZones({});
-    const availableAzs =
-      azResult.AvailabilityZones?.filter((az) => az.State === "available") ??
-      [];
-    const az1 = availableAzs[0]?.ZoneName!;
-    const az2 = availableAzs[1]?.ZoneName!;
-
-    // =========================================================================
-    // Define all resources for a production-ready VPC
-    // =========================================================================
-    const stack = yield* test.deploy(
-      Effect.gen(function* () {
-        // VPC with DNS enabled and IPv6 for egress-only IGW
-        const myVpc = yield* Vpc("MyVpc", {
-          cidrBlock: "10.0.0.0/16",
-          enableDnsSupport: true,
-          enableDnsHostnames: true,
-          amazonProvidedIpv6CidrBlock: true,
-          tags: {
-            Name: "comprehensive-vpc",
-            Environment: "test",
-          },
-        });
-
-        // Internet Gateway for public internet access
-        const internetGateway = yield* InternetGateway("InternetGateway", {
-          vpcId: myVpc.vpcId,
-          tags: { Name: "comprehensive-igw" },
-        });
-
-        // Egress-Only Internet Gateway for IPv6 outbound traffic from private subnets
-        const egressOnlyIgw = yield* EgressOnlyInternetGateway(
-          "EgressOnlyIgw",
-          {
-            vpcId: myVpc.vpcId,
-            tags: { Name: "comprehensive-eigw" },
-          },
-        );
-
-        // Public Subnets in two AZs
-        const publicSubnet1 = yield* Subnet("PublicSubnet1", {
-          vpcId: myVpc.vpcId,
-          cidrBlock: "10.0.1.0/24",
-          availabilityZone: az1,
-          mapPublicIpOnLaunch: true,
-          tags: { Name: "public-1a", Tier: "public" },
-        });
-
-        const publicSubnet2 = yield* Subnet("PublicSubnet2", {
-          vpcId: myVpc.vpcId,
-          cidrBlock: "10.0.2.0/24",
-          availabilityZone: az2,
-          mapPublicIpOnLaunch: true,
-          tags: { Name: "public-1b", Tier: "public" },
-        });
-
-        // Private Subnets in two AZs
-        const privateSubnet1 = yield* Subnet("PrivateSubnet1", {
-          vpcId: myVpc.vpcId,
-          cidrBlock: "10.0.10.0/24",
-          availabilityZone: az1,
-          tags: { Name: "private-1a", Tier: "private" },
-        });
-
-        const privateSubnet2 = yield* Subnet("PrivateSubnet2", {
-          vpcId: myVpc.vpcId,
-          cidrBlock: "10.0.11.0/24",
-          availabilityZone: az2,
-          tags: { Name: "private-1b", Tier: "private" },
-        });
-
-        // Route Tables
-        const publicRouteTable = yield* RouteTable("PublicRouteTable", {
-          vpcId: myVpc.vpcId,
-          tags: { Name: "public-rt" },
-        });
-
-        const privateRouteTable1 = yield* RouteTable("PrivateRouteTable1", {
-          vpcId: myVpc.vpcId,
-          tags: { Name: "private-rt-1" },
-        });
-
-        const privateRouteTable2 = yield* RouteTable("PrivateRouteTable2", {
-          vpcId: myVpc.vpcId,
-          tags: { Name: "private-rt-2" },
-        });
-
-        // Internet route for public subnets
-        const internetRoute = yield* Route("InternetRoute", {
-          routeTableId: publicRouteTable.routeTableId,
-          destinationCidrBlock: "0.0.0.0/0",
-          gatewayId: internetGateway.internetGatewayId,
-        });
-
-        // NAT Gateway with EIP for AZ1
-        const natEip1 = yield* EIP("NatEip1", {
-          tags: { Name: "nat-eip-1" },
-        });
-
-        const natGateway1 = yield* NatGateway("NatGateway1", {
-          subnetId: publicSubnet1.subnetId,
-          allocationId: natEip1.allocationId,
-          tags: { Name: "nat-gateway-1" },
-        });
-
-        // NAT Gateway with EIP for AZ2
-        const natEip2 = yield* EIP("NatEip2", {
-          tags: { Name: "nat-eip-2" },
-        });
-
-        const natGateway2 = yield* NatGateway("NatGateway2", {
-          subnetId: publicSubnet2.subnetId,
-          allocationId: natEip2.allocationId,
-          tags: { Name: "nat-gateway-2" },
-        });
-
-        // NAT routes for private subnets (each AZ routes to its own NAT)
-        const natRoute1 = yield* Route("NatRoute1", {
-          routeTableId: privateRouteTable1.routeTableId,
-          destinationCidrBlock: "0.0.0.0/0",
-          natGatewayId: natGateway1.natGatewayId,
-        });
-
-        const natRoute2 = yield* Route("NatRoute2", {
-          routeTableId: privateRouteTable2.routeTableId,
-          destinationCidrBlock: "0.0.0.0/0",
-          natGatewayId: natGateway2.natGatewayId,
-        });
-
-        // Route Table Associations
-        const publicSubnet1Association = yield* RouteTableAssociation(
-          "PublicSubnet1Association",
-          {
-            routeTableId: publicRouteTable.routeTableId,
-            subnetId: publicSubnet1.subnetId,
-          },
-        );
-
-        const publicSubnet2Association = yield* RouteTableAssociation(
-          "PublicSubnet2Association",
-          {
-            routeTableId: publicRouteTable.routeTableId,
-            subnetId: publicSubnet2.subnetId,
-          },
-        );
-
-        const privateSubnet1Association = yield* RouteTableAssociation(
-          "PrivateSubnet1Association",
-          {
-            routeTableId: privateRouteTable1.routeTableId,
-            subnetId: privateSubnet1.subnetId,
-          },
-        );
-
-        const privateSubnet2Association = yield* RouteTableAssociation(
-          "PrivateSubnet2Association",
-          {
-            routeTableId: privateRouteTable2.routeTableId,
-            subnetId: privateSubnet2.subnetId,
-          },
-        );
-
-        // Security Groups
-        const webSecurityGroup = yield* SecurityGroup("WebSecurityGroup", {
-          vpcId: myVpc.vpcId,
-          description: "Web tier security group",
-          ingress: [
-            {
-              ipProtocol: "tcp",
-              fromPort: 80,
-              toPort: 80,
-              cidrIpv4: "0.0.0.0/0",
-              description: "Allow HTTP",
-            },
-            {
-              ipProtocol: "tcp",
-              fromPort: 443,
-              toPort: 443,
-              cidrIpv4: "0.0.0.0/0",
-              description: "Allow HTTPS",
-            },
-          ],
-          egress: [
-            {
-              ipProtocol: "-1",
-              cidrIpv4: "0.0.0.0/0",
-              description: "Allow all outbound",
-            },
-          ],
-          tags: { Name: "web-sg" },
-        });
-
-        const appSecurityGroup = yield* SecurityGroup("AppSecurityGroup", {
-          vpcId: myVpc.vpcId,
-          description: "Application tier security group",
-          ingress: [
-            {
-              ipProtocol: "tcp",
-              fromPort: 8080,
-              toPort: 8080,
-              referencedGroupId: webSecurityGroup.groupId,
-              description: "Allow from web tier",
-            },
-          ],
-          egress: [
-            {
-              ipProtocol: "-1",
-              cidrIpv4: "0.0.0.0/0",
-              description: "Allow all outbound",
-            },
-          ],
-          tags: { Name: "app-sg" },
-        });
-
-        const dbSecurityGroup = yield* SecurityGroup("DbSecurityGroup", {
-          vpcId: myVpc.vpcId,
-          description: "Database tier security group",
-          ingress: [
-            {
-              ipProtocol: "tcp",
-              fromPort: 5432,
-              toPort: 5432,
-              referencedGroupId: appSecurityGroup.groupId,
-              description: "Allow PostgreSQL from app tier",
-            },
-          ],
-          egress: [
-            {
-              ipProtocol: "-1",
-              cidrIpv4: "0.0.0.0/0",
-              description: "Allow all outbound",
-            },
-          ],
-          tags: { Name: "db-sg" },
-        });
-
-        // Network ACL for private subnets with custom rules
-        const privateNetworkAcl = yield* NetworkAcl("PrivateNetworkAcl", {
-          vpcId: myVpc.vpcId,
-          tags: { Name: "private-nacl" },
-        });
-
-        // Network ACL Entries (rules)
-        // Allow inbound traffic from VPC CIDR
-        const privateNaclIngressVpc = yield* NetworkAclEntry(
-          "PrivateNaclIngressVpc",
-          {
-            networkAclId: privateNetworkAcl.networkAclId,
-            ruleNumber: 100,
-            protocol: "-1", // All protocols
-            ruleAction: "allow",
-            egress: false,
-            cidrBlock: "10.0.0.0/16",
-          },
-        );
-
-        // Allow inbound ephemeral ports (for NAT return traffic)
-        const privateNaclIngressEphemeral = yield* NetworkAclEntry(
-          "PrivateNaclIngressEphemeral",
-          {
-            networkAclId: privateNetworkAcl.networkAclId,
-            ruleNumber: 200,
-            protocol: "6", // TCP
-            ruleAction: "allow",
-            egress: false,
-            cidrBlock: "0.0.0.0/0",
-            portRange: { from: 1024, to: 65535 },
-          },
-        );
-
-        // Allow all outbound traffic
-        const privateNaclEgressAll = yield* NetworkAclEntry(
-          "PrivateNaclEgressAll",
-          {
-            networkAclId: privateNetworkAcl.networkAclId,
-            ruleNumber: 100,
-            protocol: "-1", // All protocols
-            ruleAction: "allow",
-            egress: true,
-            cidrBlock: "0.0.0.0/0",
-          },
-        );
-
-        // Network ACL Associations - associate private subnets with the custom NACL
-        const privateSubnet1NaclAssoc = yield* NetworkAclAssociation(
-          "PrivateSubnet1NaclAssoc",
-          {
-            networkAclId: privateNetworkAcl.networkAclId,
-            subnetId: privateSubnet1.subnetId,
-          },
-        );
-
-        const privateSubnet2NaclAssoc = yield* NetworkAclAssociation(
-          "PrivateSubnet2NaclAssoc",
-          {
-            networkAclId: privateNetworkAcl.networkAclId,
-            subnetId: privateSubnet2.subnetId,
-          },
-        );
-
-        // VPC Gateway Endpoint for S3 (reduces NAT costs and improves latency)
-        const s3Endpoint = yield* VpcEndpoint("S3Endpoint", {
-          vpcId: myVpc.vpcId,
-          serviceName: `com.amazonaws.${
-            (yield* EC2.describeAvailabilityZones({})).AvailabilityZones?.[0]
-              ?.RegionName
-          }.s3`,
-          vpcEndpointType: "Gateway",
-          routeTableIds: [
-            privateRouteTable1.routeTableId,
-            privateRouteTable2.routeTableId,
-          ],
-          tags: { Name: "s3-endpoint" },
-        });
-
-        return {
-          myVpc,
-          internetGateway,
-          egressOnlyIgw,
-          publicSubnet1,
-          publicSubnet2,
-          privateSubnet1,
-          privateSubnet2,
-          publicRouteTable,
-          privateRouteTable1,
-          privateRouteTable2,
-          internetRoute,
-          natEip1,
-          natEip2,
-          natGateway1,
-          natGateway2,
-          natRoute1,
-          natRoute2,
-          publicSubnet1Association,
-          publicSubnet2Association,
-          privateSubnet1Association,
-          privateSubnet2Association,
-          webSecurityGroup,
-          appSecurityGroup,
-          dbSecurityGroup,
-          privateNetworkAcl,
-          privateNaclIngressVpc,
-          privateNaclIngressEphemeral,
-          privateNaclEgressAll,
-          privateSubnet1NaclAssoc,
-          privateSubnet2NaclAssoc,
-          s3Endpoint,
-        };
-      }),
-    );
-
-    // =========================================================================
-    // Verify VPC
-    // =========================================================================
-    expect(stack.myVpc.vpcId).toMatch(/^vpc-/);
-    expect(stack.myVpc.cidrBlock).toEqual("10.0.0.0/16");
-    expect(stack.myVpc.state).toEqual("available");
-
-    const vpcResult = yield* EC2.describeVpcs({
-      VpcIds: [stack.myVpc.vpcId],
-    });
-    expect(vpcResult.Vpcs?.[0]?.CidrBlock).toEqual("10.0.0.0/16");
-    // EnableDnsSupport and EnableDnsHostnames are not present in the describeVpcs output.
-    // Instead, use describeVpcAttribute for these:
-    const dnsSupport = yield* EC2.describeVpcAttribute({
-      VpcId: stack.myVpc.vpcId,
-      Attribute: "enableDnsSupport",
-    });
-    expect(dnsSupport.EnableDnsSupport?.Value).toBeTruthy();
-
-    const dnsHostnames = yield* EC2.describeVpcAttribute({
-      VpcId: stack.myVpc.vpcId,
-      Attribute: "enableDnsHostnames",
-    });
-    expect(dnsHostnames.EnableDnsHostnames?.Value).toBeTruthy();
-
-    // Verify VPC has IPv6 CIDR block
-    expect(stack.myVpc.ipv6CidrBlockAssociationSet).toBeDefined();
-    expect(stack.myVpc.ipv6CidrBlockAssociationSet?.length).toBeGreaterThan(0);
-
-    // =========================================================================
-    // Verify Internet Gateway
-    // =========================================================================
-    expect(stack.internetGateway.internetGatewayId).toMatch(/^igw-/);
-    expect(stack.internetGateway.vpcId).toEqual(stack.myVpc.vpcId);
-
-    // =========================================================================
-    // Verify Egress-Only Internet Gateway
-    // =========================================================================
-    expect(stack.egressOnlyIgw.egressOnlyInternetGatewayId).toMatch(/^eigw-/);
-    expect(stack.egressOnlyIgw.attachments).toBeDefined();
-    expect(stack.egressOnlyIgw.attachments?.[0]?.vpcId).toEqual(
-      stack.myVpc.vpcId,
-    );
-
-    // =========================================================================
-    // Verify Subnets
-    // =========================================================================
-    expect(stack.publicSubnet1.subnetId).toMatch(/^subnet-/);
-    expect(stack.publicSubnet1.availabilityZone).toEqual(az1);
-    expect(stack.publicSubnet1.mapPublicIpOnLaunch).toEqual(true);
-
-    expect(stack.publicSubnet2.subnetId).toMatch(/^subnet-/);
-    expect(stack.publicSubnet2.availabilityZone).toEqual(az2);
-    expect(stack.publicSubnet2.mapPublicIpOnLaunch).toEqual(true);
-
-    expect(stack.privateSubnet1.subnetId).toMatch(/^subnet-/);
-    expect(stack.privateSubnet1.availabilityZone).toEqual(az1);
-    expect(stack.privateSubnet1.mapPublicIpOnLaunch).toBeFalsy();
-
-    expect(stack.privateSubnet2.subnetId).toMatch(/^subnet-/);
-    expect(stack.privateSubnet2.availabilityZone).toEqual(az2);
-    expect(stack.privateSubnet2.mapPublicIpOnLaunch).toBeFalsy();
-
-    // Verify 4 subnets total
-    const subnetsResult = yield* EC2.describeSubnets({
-      Filters: [{ Name: "vpc-id", Values: [stack.myVpc.vpcId] }],
-    });
-    expect(subnetsResult.Subnets).toHaveLength(4);
-
-    // =========================================================================
-    // Verify NAT Gateways and EIPs
-    // =========================================================================
-    expect(stack.natEip1.allocationId).toMatch(/^eipalloc-/);
-    expect(stack.natEip1.publicIp).toBeDefined();
-
-    expect(stack.natEip2.allocationId).toMatch(/^eipalloc-/);
-    expect(stack.natEip2.publicIp).toBeDefined();
-
-    expect(stack.natGateway1.natGatewayId).toMatch(/^nat-/);
-    expect(stack.natGateway1.state).toEqual("available");
-    expect(stack.natGateway1.publicIp).toEqual(stack.natEip1.publicIp);
-    expect(stack.natGateway1.subnetId).toEqual(stack.publicSubnet1.subnetId);
-
-    expect(stack.natGateway2.natGatewayId).toMatch(/^nat-/);
-    expect(stack.natGateway2.state).toEqual("available");
-    expect(stack.natGateway2.publicIp).toEqual(stack.natEip2.publicIp);
-    expect(stack.natGateway2.subnetId).toEqual(stack.publicSubnet2.subnetId);
-
-    // =========================================================================
-    // Verify Routes
-    // =========================================================================
-    // Internet route to IGW
-    expect(stack.internetRoute.state).toEqual("active");
-    expect(stack.internetRoute.gatewayId).toEqual(
-      stack.internetGateway.internetGatewayId,
-    );
-
-    // NAT routes
-    expect(stack.natRoute1.state).toEqual("active");
-    expect(stack.natRoute1.natGatewayId).toEqual(
-      stack.natGateway1.natGatewayId,
-    );
-
-    expect(stack.natRoute2.state).toEqual("active");
-    expect(stack.natRoute2.natGatewayId).toEqual(
-      stack.natGateway2.natGatewayId,
-    );
-
-    // Verify public route table has internet route
-    const publicRtResult = yield* EC2.describeRouteTables({
-      RouteTableIds: [stack.publicRouteTable.routeTableId],
-    });
-    const publicRoutes = publicRtResult.RouteTables?.[0]?.Routes ?? [];
-    const publicInternetRoute = publicRoutes.find(
-      (r) => r.DestinationCidrBlock === "0.0.0.0/0",
-    );
-    expect(publicInternetRoute?.GatewayId).toEqual(
-      stack.internetGateway.internetGatewayId,
-    );
-
-    // Verify private route tables have NAT routes
-    const private1RtResult = yield* EC2.describeRouteTables({
-      RouteTableIds: [stack.privateRouteTable1.routeTableId],
-    });
-    const private1Routes = private1RtResult.RouteTables?.[0]?.Routes ?? [];
-    const private1NatRoute = private1Routes.find(
-      (r) => r.DestinationCidrBlock === "0.0.0.0/0",
-    );
-    expect(private1NatRoute?.NatGatewayId).toEqual(
-      stack.natGateway1.natGatewayId,
-    );
-
-    const private2RtResult = yield* EC2.describeRouteTables({
-      RouteTableIds: [stack.privateRouteTable2.routeTableId],
-    });
-    const private2Routes = private2RtResult.RouteTables?.[0]?.Routes ?? [];
-    const private2NatRoute = private2Routes.find(
-      (r) => r.DestinationCidrBlock === "0.0.0.0/0",
-    );
-    expect(private2NatRoute?.NatGatewayId).toEqual(
-      stack.natGateway2.natGatewayId,
-    );
-
-    // =========================================================================
-    // Verify Route Table Associations
-    // =========================================================================
-    expect(stack.publicSubnet1Association.associationId).toMatch(/^rtbassoc-/);
-    expect(stack.publicSubnet2Association.associationId).toMatch(/^rtbassoc-/);
-    expect(stack.privateSubnet1Association.associationId).toMatch(/^rtbassoc-/);
-    expect(stack.privateSubnet2Association.associationId).toMatch(/^rtbassoc-/);
-
-    // Both public subnets share the same route table
-    expect(stack.publicSubnet1Association.routeTableId).toEqual(
-      stack.publicSubnet2Association.routeTableId,
-    );
-
-    // Private subnets have their own route tables (for HA NAT)
-    expect(stack.privateSubnet1Association.routeTableId).not.toEqual(
-      stack.privateSubnet2Association.routeTableId,
-    );
-
-    // =========================================================================
-    // Verify Security Groups
-    // =========================================================================
-    expect(stack.webSecurityGroup.groupId).toMatch(/^sg-/);
-    expect(stack.webSecurityGroup.vpcId).toEqual(stack.myVpc.vpcId);
-    expect(stack.webSecurityGroup.ingressRules).toHaveLength(2);
-    // TODO(sam): why is it 2 when we only have 1? is it a default or egress only ingress?
-    expect(stack.webSecurityGroup.egressRules).toHaveLength(2);
-
-    expect(stack.appSecurityGroup.groupId).toMatch(/^sg-/);
-    expect(stack.appSecurityGroup.vpcId).toEqual(stack.myVpc.vpcId);
-    expect(stack.appSecurityGroup.ingressRules).toHaveLength(1);
-    expect(stack.appSecurityGroup.ingressRules?.[0]?.referencedGroupId).toEqual(
-      stack.webSecurityGroup.groupId,
-    );
-
-    expect(stack.dbSecurityGroup.groupId).toMatch(/^sg-/);
-    expect(stack.dbSecurityGroup.vpcId).toEqual(stack.myVpc.vpcId);
-    expect(stack.dbSecurityGroup.ingressRules).toHaveLength(1);
-    expect(stack.dbSecurityGroup.ingressRules?.[0]?.referencedGroupId).toEqual(
-      stack.appSecurityGroup.groupId,
-    );
-
-    // Verify security groups in AWS
-    const sgResult = yield* EC2.describeSecurityGroups({
-      Filters: [{ Name: "vpc-id", Values: [stack.myVpc.vpcId] }],
-    });
-    // 4 security groups: default + web + app + db
-    expect(sgResult.SecurityGroups).toHaveLength(4);
-
-    // =========================================================================
-    // Verify Network ACL
-    // =========================================================================
-    expect(stack.privateNetworkAcl.networkAclId).toMatch(/^acl-/);
-    expect(stack.privateNetworkAcl.vpcId).toEqual(stack.myVpc.vpcId);
-    expect(stack.privateNetworkAcl.isDefault).toEqual(false);
-
-    // Verify Network ACL in AWS
-    const naclResult = yield* EC2.describeNetworkAcls({
-      NetworkAclIds: [stack.privateNetworkAcl.networkAclId],
-    });
-    expect(naclResult.NetworkAcls).toHaveLength(1);
-    expect(naclResult.NetworkAcls?.[0]?.VpcId).toEqual(stack.myVpc.vpcId);
-
-    // =========================================================================
-    // Verify Network ACL Entries
-    // =========================================================================
-    expect(stack.privateNaclIngressVpc.networkAclId).toEqual(
-      stack.privateNetworkAcl.networkAclId,
-    );
-    expect(stack.privateNaclIngressVpc.ruleNumber).toEqual(100);
-    expect(stack.privateNaclIngressVpc.egress).toEqual(false);
-    expect(stack.privateNaclIngressVpc.ruleAction).toEqual("allow");
-
-    expect(stack.privateNaclIngressEphemeral.ruleNumber).toEqual(200);
-    expect(stack.privateNaclIngressEphemeral.portRange).toEqual({
-      from: 1024,
-      to: 65535,
-    });
-
-    expect(stack.privateNaclEgressAll.egress).toEqual(true);
-    expect(stack.privateNaclEgressAll.ruleNumber).toEqual(100);
-
-    // =========================================================================
-    // Verify Network ACL Associations
-    // =========================================================================
-    expect(stack.privateSubnet1NaclAssoc.associationId).toMatch(/^aclassoc-/);
-    expect(stack.privateSubnet1NaclAssoc.networkAclId).toEqual(
-      stack.privateNetworkAcl.networkAclId,
-    );
-    expect(stack.privateSubnet1NaclAssoc.subnetId).toEqual(
-      stack.privateSubnet1.subnetId,
-    );
-
-    expect(stack.privateSubnet2NaclAssoc.associationId).toMatch(/^aclassoc-/);
-    expect(stack.privateSubnet2NaclAssoc.subnetId).toEqual(
-      stack.privateSubnet2.subnetId,
-    );
-
-    // =========================================================================
-    // Verify VPC Endpoint for S3
-    // =========================================================================
-    expect(stack.s3Endpoint.vpcEndpointId).toMatch(/^vpce-/);
-    expect(stack.s3Endpoint.vpcEndpointType).toEqual("Gateway");
-    expect(stack.s3Endpoint.vpcId).toEqual(stack.myVpc.vpcId);
-    expect(stack.s3Endpoint.state).toEqual("available");
-    expect(stack.s3Endpoint.routeTableIds).toContain(
-      stack.privateRouteTable1.routeTableId,
-    );
-    expect(stack.s3Endpoint.routeTableIds).toContain(
-      stack.privateRouteTable2.routeTableId,
-    );
-
-    // Verify VPC Endpoint in AWS
-    const vpceResult = yield* EC2.describeVpcEndpoints({
-      VpcEndpointIds: [stack.s3Endpoint.vpcEndpointId],
-    });
-    expect(vpceResult.VpcEndpoints).toHaveLength(1);
-    expect(vpceResult.VpcEndpoints?.[0]?.VpcEndpointType).toEqual("Gateway");
-
-    // =========================================================================
-    // Verify Tags
-    // =========================================================================
-    yield* assertVpcTags(stack.myVpc.vpcId, {
-      Name: "comprehensive-vpc",
-      Environment: "test",
-    });
-
-    // =========================================================================
-    // Idempotency check - apply again and verify no changes
-    // =========================================================================
-    yield* Effect.log("=== Idempotency Check: Re-applying stack ===");
-    const stack2 = yield* test.deploy(
-      Effect.gen(function* () {
-        // VPC with DNS enabled and IPv6 for egress-only IGW
-        const myVpc = yield* Vpc("MyVpc", {
-          cidrBlock: "10.0.0.0/16",
-          enableDnsSupport: true,
-          enableDnsHostnames: true,
-          amazonProvidedIpv6CidrBlock: true,
-          tags: {
-            Name: "comprehensive-vpc",
-            Environment: "test",
-          },
-        });
-
-        // Internet Gateway for public internet access
-        const internetGateway = yield* InternetGateway("InternetGateway", {
-          vpcId: myVpc.vpcId,
-          tags: { Name: "comprehensive-igw" },
-        });
-
-        // Egress-Only Internet Gateway for IPv6 outbound traffic from private subnets
-        const egressOnlyIgw = yield* EgressOnlyInternetGateway(
-          "EgressOnlyIgw",
-          {
-            vpcId: myVpc.vpcId,
-            tags: { Name: "comprehensive-eigw" },
-          },
-        );
-
-        // Public Subnets in two AZs
-        const publicSubnet1 = yield* Subnet("PublicSubnet1", {
-          vpcId: myVpc.vpcId,
-          cidrBlock: "10.0.1.0/24",
-          availabilityZone: az1,
-          mapPublicIpOnLaunch: true,
-          tags: { Name: "public-1a", Tier: "public" },
-        });
-
-        const publicSubnet2 = yield* Subnet("PublicSubnet2", {
-          vpcId: myVpc.vpcId,
-          cidrBlock: "10.0.2.0/24",
-          availabilityZone: az2,
-          mapPublicIpOnLaunch: true,
-          tags: { Name: "public-1b", Tier: "public" },
-        });
-
-        // Private Subnets in two AZs
-        const privateSubnet1 = yield* Subnet("PrivateSubnet1", {
-          vpcId: myVpc.vpcId,
-          cidrBlock: "10.0.10.0/24",
-          availabilityZone: az1,
-          tags: { Name: "private-1a", Tier: "private" },
-        });
-
-        const privateSubnet2 = yield* Subnet("PrivateSubnet2", {
-          vpcId: myVpc.vpcId,
-          cidrBlock: "10.0.11.0/24",
-          availabilityZone: az2,
-          tags: { Name: "private-1b", Tier: "private" },
-        });
-
-        // Route Tables
-        const publicRouteTable = yield* RouteTable("PublicRouteTable", {
-          vpcId: myVpc.vpcId,
-          tags: { Name: "public-rt" },
-        });
-
-        const privateRouteTable1 = yield* RouteTable("PrivateRouteTable1", {
-          vpcId: myVpc.vpcId,
-          tags: { Name: "private-rt-1" },
-        });
-
-        const privateRouteTable2 = yield* RouteTable("PrivateRouteTable2", {
-          vpcId: myVpc.vpcId,
-          tags: { Name: "private-rt-2" },
-        });
-
-        // Internet route for public subnets
-        const internetRoute = yield* Route("InternetRoute", {
-          routeTableId: publicRouteTable.routeTableId,
-          destinationCidrBlock: "0.0.0.0/0",
-          gatewayId: internetGateway.internetGatewayId,
-        });
-
-        // NAT Gateway with EIP for AZ1
-        const natEip1 = yield* EIP("NatEip1", {
-          tags: { Name: "nat-eip-1" },
-        });
-
-        const natGateway1 = yield* NatGateway("NatGateway1", {
-          subnetId: publicSubnet1.subnetId,
-          allocationId: natEip1.allocationId,
-          tags: { Name: "nat-gateway-1" },
-        });
-
-        // NAT Gateway with EIP for AZ2
-        const natEip2 = yield* EIP("NatEip2", {
-          tags: { Name: "nat-eip-2" },
-        });
-
-        const natGateway2 = yield* NatGateway("NatGateway2", {
-          subnetId: publicSubnet2.subnetId,
-          allocationId: natEip2.allocationId,
-          tags: { Name: "nat-gateway-2" },
-        });
-
-        // NAT routes for private subnets (each AZ routes to its own NAT)
-        const natRoute1 = yield* Route("NatRoute1", {
-          routeTableId: privateRouteTable1.routeTableId,
-          destinationCidrBlock: "0.0.0.0/0",
-          natGatewayId: natGateway1.natGatewayId,
-        });
-
-        const natRoute2 = yield* Route("NatRoute2", {
-          routeTableId: privateRouteTable2.routeTableId,
-          destinationCidrBlock: "0.0.0.0/0",
-          natGatewayId: natGateway2.natGatewayId,
-        });
-
-        // Route Table Associations
-        const publicSubnet1Association = yield* RouteTableAssociation(
-          "PublicSubnet1Association",
-          {
-            routeTableId: publicRouteTable.routeTableId,
-            subnetId: publicSubnet1.subnetId,
-          },
-        );
-
-        const publicSubnet2Association = yield* RouteTableAssociation(
-          "PublicSubnet2Association",
-          {
-            routeTableId: publicRouteTable.routeTableId,
-            subnetId: publicSubnet2.subnetId,
-          },
-        );
-
-        const privateSubnet1Association = yield* RouteTableAssociation(
-          "PrivateSubnet1Association",
-          {
-            routeTableId: privateRouteTable1.routeTableId,
-            subnetId: privateSubnet1.subnetId,
-          },
-        );
-
-        const privateSubnet2Association = yield* RouteTableAssociation(
-          "PrivateSubnet2Association",
-          {
-            routeTableId: privateRouteTable2.routeTableId,
-            subnetId: privateSubnet2.subnetId,
-          },
-        );
-
-        // Security Groups
-        const webSecurityGroup = yield* SecurityGroup("WebSecurityGroup", {
-          vpcId: myVpc.vpcId,
-          description: "Web tier security group",
-          ingress: [
-            {
-              ipProtocol: "tcp",
-              fromPort: 80,
-              toPort: 80,
-              cidrIpv4: "0.0.0.0/0",
-              description: "Allow HTTP",
-            },
-            {
-              ipProtocol: "tcp",
-              fromPort: 443,
-              toPort: 443,
-              cidrIpv4: "0.0.0.0/0",
-              description: "Allow HTTPS",
-            },
-          ],
-          egress: [
-            {
-              ipProtocol: "-1",
-              cidrIpv4: "0.0.0.0/0",
-              description: "Allow all outbound",
-            },
-          ],
-          tags: { Name: "web-sg" },
-        });
-
-        const appSecurityGroup = yield* SecurityGroup("AppSecurityGroup", {
-          vpcId: myVpc.vpcId,
-          description: "Application tier security group",
-          ingress: [
-            {
-              ipProtocol: "tcp",
-              fromPort: 8080,
-              toPort: 8080,
-              referencedGroupId: webSecurityGroup.groupId,
-              description: "Allow from web tier",
-            },
-          ],
-          egress: [
-            {
-              ipProtocol: "-1",
-              cidrIpv4: "0.0.0.0/0",
-              description: "Allow all outbound",
-            },
-          ],
-          tags: { Name: "app-sg" },
-        });
-
-        const dbSecurityGroup = yield* SecurityGroup("DbSecurityGroup", {
-          vpcId: myVpc.vpcId,
-          description: "Database tier security group",
-          ingress: [
-            {
-              ipProtocol: "tcp",
-              fromPort: 5432,
-              toPort: 5432,
-              referencedGroupId: appSecurityGroup.groupId,
-              description: "Allow PostgreSQL from app tier",
-            },
-          ],
-          egress: [
-            {
-              ipProtocol: "-1",
-              cidrIpv4: "0.0.0.0/0",
-              description: "Allow all outbound",
-            },
-          ],
-          tags: { Name: "db-sg" },
-        });
-
-        // Network ACL for private subnets with custom rules
-        const privateNetworkAcl = yield* NetworkAcl("PrivateNetworkAcl", {
-          vpcId: myVpc.vpcId,
-          tags: { Name: "private-nacl" },
-        });
-
-        // Network ACL Entries (rules)
-        // Allow inbound traffic from VPC CIDR
-        const privateNaclIngressVpc = yield* NetworkAclEntry(
-          "PrivateNaclIngressVpc",
-          {
-            networkAclId: privateNetworkAcl.networkAclId,
-            ruleNumber: 100,
-            protocol: "-1", // All protocols
-            ruleAction: "allow",
-            egress: false,
-            cidrBlock: "10.0.0.0/16",
-          },
-        );
-
-        // Allow inbound ephemeral ports (for NAT return traffic)
-        const privateNaclIngressEphemeral = yield* NetworkAclEntry(
-          "PrivateNaclIngressEphemeral",
-          {
-            networkAclId: privateNetworkAcl.networkAclId,
-            ruleNumber: 200,
-            protocol: "6", // TCP
-            ruleAction: "allow",
-            egress: false,
-            cidrBlock: "0.0.0.0/0",
-            portRange: { from: 1024, to: 65535 },
-          },
-        );
-
-        // Allow all outbound traffic
-        const privateNaclEgressAll = yield* NetworkAclEntry(
-          "PrivateNaclEgressAll",
-          {
-            networkAclId: privateNetworkAcl.networkAclId,
-            ruleNumber: 100,
-            protocol: "-1", // All protocols
-            ruleAction: "allow",
-            egress: true,
-            cidrBlock: "0.0.0.0/0",
-          },
-        );
-
-        // Network ACL Associations - associate private subnets with the custom NACL
-        const privateSubnet1NaclAssoc = yield* NetworkAclAssociation(
-          "PrivateSubnet1NaclAssoc",
-          {
-            networkAclId: privateNetworkAcl.networkAclId,
-            subnetId: privateSubnet1.subnetId,
-          },
-        );
-
-        const privateSubnet2NaclAssoc = yield* NetworkAclAssociation(
-          "PrivateSubnet2NaclAssoc",
-          {
-            networkAclId: privateNetworkAcl.networkAclId,
-            subnetId: privateSubnet2.subnetId,
-          },
-        );
-
-        // VPC Gateway Endpoint for S3 (reduces NAT costs and improves latency)
-        const s3Endpoint = yield* VpcEndpoint("S3Endpoint", {
-          vpcId: myVpc.vpcId,
-          serviceName: `com.amazonaws.${
-            (yield* EC2.describeAvailabilityZones({})).AvailabilityZones?.[0]
-              ?.RegionName
-          }.s3`,
-          vpcEndpointType: "Gateway",
-          routeTableIds: [
-            privateRouteTable1.routeTableId,
-            privateRouteTable2.routeTableId,
-          ],
-          tags: { Name: "s3-endpoint" },
-        });
-
-        return {
-          myVpc,
-          internetGateway,
-          egressOnlyIgw,
-          publicSubnet1,
-          publicSubnet2,
-          privateSubnet1,
-          privateSubnet2,
-          publicRouteTable,
-          privateRouteTable1,
-          privateRouteTable2,
-          internetRoute,
-          natEip1,
-          natEip2,
-          natGateway1,
-          natGateway2,
-          natRoute1,
-          natRoute2,
-          publicSubnet1Association,
-          publicSubnet2Association,
-          privateSubnet1Association,
-          privateSubnet2Association,
-          webSecurityGroup,
-          appSecurityGroup,
-          dbSecurityGroup,
-          privateNetworkAcl,
-          privateNaclIngressVpc,
-          privateNaclIngressEphemeral,
-          privateNaclEgressAll,
-          privateSubnet1NaclAssoc,
-          privateSubnet2NaclAssoc,
-          s3Endpoint,
-        };
-      }),
-    );
-
-    // All IDs should remain the same
-    expect(stack2.myVpc.vpcId).toEqual(stack.myVpc.vpcId);
-    expect(stack2.internetGateway.internetGatewayId).toEqual(
-      stack.internetGateway.internetGatewayId,
-    );
-    expect(stack2.egressOnlyIgw.egressOnlyInternetGatewayId).toEqual(
-      stack.egressOnlyIgw.egressOnlyInternetGatewayId,
-    );
-    expect(stack2.natGateway1.natGatewayId).toEqual(
-      stack.natGateway1.natGatewayId,
-    );
-    expect(stack2.natGateway2.natGatewayId).toEqual(
-      stack.natGateway2.natGatewayId,
-    );
-    expect(stack2.privateNetworkAcl.networkAclId).toEqual(
-      stack.privateNetworkAcl.networkAclId,
-    );
-    expect(stack2.s3Endpoint.vpcEndpointId).toEqual(
-      stack.s3Endpoint.vpcEndpointId,
-    );
-
-    // =========================================================================
-    // Cleanup
-    // =========================================================================
-    yield* Effect.log("=== Cleanup: Destroying all resources ===");
-    const capturedVpcId = stack.myVpc.vpcId;
-
-    yield* destroy();
-
-    // Verify VPC is deleted
-    yield* EC2.describeVpcs({ VpcIds: [capturedVpcId] }).pipe(
-      Effect.flatMap(() => Effect.fail(new Error("VPC still exists"))),
-      Effect.catchTag("InvalidVpcID.NotFound", () => Effect.void),
-    );
-
-    yield* Effect.log("=== Comprehensive VPC test completed successfully! ===");
-  }).pipe(Effect.provide(AWS.providers()), logLevel),
+      yield* Effect.log(
+        "=== Comprehensive VPC test completed successfully! ===",
+      );
+    }).pipe(logLevel),
+  { timeout: 1_000_000 },
 );
 
 // ============================================================================

--- a/packages/alchemy/test/AWS/EC2/Vpc.test.ts
+++ b/packages/alchemy/test/AWS/EC2/Vpc.test.ts
@@ -1,6 +1,6 @@
 import * as AWS from "@/AWS";
 import { Vpc } from "@/AWS/EC2";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as EC2 from "@distilled.cloud/aws/ec2";
 import { expect } from "@effect/vitest";
 import * as Data from "effect/Data";
@@ -8,15 +8,16 @@ import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 
+const { test } = Test.make({ providers: AWS.providers() });
+
 const logLevel = Effect.provideService(
   MinimumLogLevel,
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-test.skip(
-  "create, update, delete vpc",
+test.provider.skip("create, update, delete vpc", (stack) =>
   Effect.gen(function* () {
-    const vpc = yield* test.deploy(
+    const vpc = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Vpc("TestVpc", {
           cidrBlock: "10.0.0.0/16",
@@ -46,7 +47,7 @@ test.skip(
     });
 
     // Update VPC attributes
-    const updatedVpc = yield* test.deploy(
+    const updatedVpc = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Vpc("TestVpc", {
           cidrBlock: "10.0.0.0/16",
@@ -68,10 +69,10 @@ test.skip(
       Value: false,
     });
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* assertVpcDeleted(vpc.vpcId);
-  }).pipe(Effect.provide(AWS.providers()), logLevel),
+  }).pipe(logLevel),
 );
 
 const expectVpcAttribute = Effect.fn(function* (props: {

--- a/packages/alchemy/test/AWS/ECS/CapacityProvider.smoke.test.ts
+++ b/packages/alchemy/test/AWS/ECS/CapacityProvider.smoke.test.ts
@@ -1,10 +1,12 @@
 import * as AWS from "@/AWS";
 import { CapacityProvider } from "@/AWS/ECS";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as ecs from "@distilled.cloud/aws/ecs";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
+
+const { test } = Test.make({ providers: AWS.providers() });
 
 const logLevel = Effect.provideService(
   MinimumLogLevel,
@@ -15,66 +17,67 @@ const logLevel = Effect.provideService(
 // (set via TEST_ASG_ARN) because AutoScalingGroup/LaunchTemplate currently
 // have no test infrastructure in this repo. Run locally with:
 //   TEST_ASG_ARN=arn:aws:autoscaling:... bun vitest CapacityProvider
-test.skipIf(!process.env.TEST_ASG_ARN)(
+test.provider.skipIf(!process.env.TEST_ASG_ARN)(
   "create, update, delete ECS capacity provider",
+  (stack) =>
+    Effect.gen(function* () {
+      const autoScalingGroupArn = process.env.TEST_ASG_ARN!;
+      yield* stack.destroy();
+
+      const provider = yield* stack.deploy(
+        CapacityProvider("TestCapacityProvider", {
+          autoScalingGroupArn,
+          managedScaling: {
+            status: "ENABLED",
+            targetCapacity: 80,
+            minimumScalingStepSize: 1,
+            maximumScalingStepSize: 10,
+          },
+          managedTerminationProtection: "DISABLED",
+          tags: { env: "test" },
+        }),
+      );
+
+      expect(provider.capacityProviderArn).toMatch(
+        /^arn:aws:ecs:[^:]+:\d+:capacity-provider\//,
+      );
+      expect(provider.status).toEqual("ACTIVE");
+      expect(provider.managedScaling?.targetCapacity).toEqual(80);
+      expect(provider.tags.env).toEqual("test");
+
+      const described = yield* ecs.describeCapacityProviders({
+        capacityProviders: [provider.name],
+        include: ["TAGS"],
+      });
+      const found = described.capacityProviders?.[0];
+      expect(found?.name).toEqual(provider.name);
+      expect(
+        found?.autoScalingGroupProvider?.managedScaling?.targetCapacity,
+      ).toEqual(80);
+
+      const updated = yield* stack.deploy(
+        CapacityProvider("TestCapacityProvider", {
+          autoScalingGroupArn,
+          managedScaling: {
+            status: "ENABLED",
+            targetCapacity: 60,
+            minimumScalingStepSize: 1,
+            maximumScalingStepSize: 5,
+          },
+          managedTerminationProtection: "DISABLED",
+          tags: { env: "test", owner: "alchemy" },
+        }),
+      );
+
+      expect(updated.managedScaling?.targetCapacity).toEqual(60);
+      expect(updated.tags.owner).toEqual("alchemy");
+
+      yield* stack.destroy();
+
+      const afterDestroy = yield* ecs.describeCapacityProviders({
+        capacityProviders: [provider.name],
+      });
+      expect(afterDestroy.capacityProviders ?? []).toHaveLength(0);
+    }).pipe(logLevel),
   { timeout: 600_000 },
-  Effect.gen(function* () {
-    const autoScalingGroupArn = process.env.TEST_ASG_ARN!;
-    yield* destroy();
-
-    const provider = yield* test.deploy(
-      CapacityProvider("TestCapacityProvider", {
-        autoScalingGroupArn,
-        managedScaling: {
-          status: "ENABLED",
-          targetCapacity: 80,
-          minimumScalingStepSize: 1,
-          maximumScalingStepSize: 10,
-        },
-        managedTerminationProtection: "DISABLED",
-        tags: { env: "test" },
-      }),
-    );
-
-    expect(provider.capacityProviderArn).toMatch(
-      /^arn:aws:ecs:[^:]+:\d+:capacity-provider\//,
-    );
-    expect(provider.status).toEqual("ACTIVE");
-    expect(provider.managedScaling?.targetCapacity).toEqual(80);
-    expect(provider.tags.env).toEqual("test");
-
-    const described = yield* ecs.describeCapacityProviders({
-      capacityProviders: [provider.name],
-      include: ["TAGS"],
-    });
-    const found = described.capacityProviders?.[0];
-    expect(found?.name).toEqual(provider.name);
-    expect(
-      found?.autoScalingGroupProvider?.managedScaling?.targetCapacity,
-    ).toEqual(80);
-
-    const updated = yield* test.deploy(
-      CapacityProvider("TestCapacityProvider", {
-        autoScalingGroupArn,
-        managedScaling: {
-          status: "ENABLED",
-          targetCapacity: 60,
-          minimumScalingStepSize: 1,
-          maximumScalingStepSize: 5,
-        },
-        managedTerminationProtection: "DISABLED",
-        tags: { env: "test", owner: "alchemy" },
-      }),
-    );
-
-    expect(updated.managedScaling?.targetCapacity).toEqual(60);
-    expect(updated.tags.owner).toEqual("alchemy");
-
-    yield* destroy();
-
-    const afterDestroy = yield* ecs.describeCapacityProviders({
-      capacityProviders: [provider.name],
-    });
-    expect(afterDestroy.capacityProviders ?? []).toHaveLength(0);
-  }).pipe(Effect.provide(AWS.providers()), logLevel),
 );

--- a/packages/alchemy/test/AWS/IAM/Credentials.test.ts
+++ b/packages/alchemy/test/AWS/IAM/Credentials.test.ts
@@ -5,179 +5,184 @@ import {
   SSHPublicKey,
   User,
 } from "@/AWS/IAM";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as IAM from "@distilled.cloud/aws/iam";
 import { describe, expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import { testCertificateBody, testSshPublicKey } from "./fixtures.ts";
 
+const { test } = Test.make({ providers: AWS.providers() });
+
 describe("AWS.IAM credential resources", () => {
-  test(
+  test.provider(
     "create, update, and delete a service-specific credential",
-    Effect.gen(function* () {
-      yield* destroy();
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-      const deployed = yield* test.deploy(
-        Effect.gen(function* () {
-          const user = yield* User("CredentialOwner", {});
-          const credential = yield* ServiceSpecificCredential(
-            "ServiceCredential",
-            {
-              userName: user.userName,
-              serviceName: "codecommit.amazonaws.com",
-              status: "Active",
-            },
-          );
-          return { user, credential };
-        }),
-      );
+        const deployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            const user = yield* User("CredentialOwner", {});
+            const credential = yield* ServiceSpecificCredential(
+              "ServiceCredential",
+              {
+                userName: user.userName,
+                serviceName: "codecommit.amazonaws.com",
+                status: "Active",
+              },
+            );
+            return { user, credential };
+          }),
+        );
 
-      expect(deployed.credential.servicePassword).toBeDefined();
+        expect(deployed.credential.servicePassword).toBeDefined();
 
-      const created = yield* IAM.listServiceSpecificCredentials({
-        UserName: deployed.user.userName,
-        ServiceName: deployed.credential.serviceName,
-      });
-      expect(
-        created.ServiceSpecificCredentials?.some(
-          (entry) =>
-            entry.ServiceSpecificCredentialId ===
-            deployed.credential.serviceSpecificCredentialId,
-        ),
-      ).toBe(true);
-
-      yield* test.deploy(
-        Effect.gen(function* () {
-          const user = yield* User("CredentialOwner", {});
-          yield* ServiceSpecificCredential("ServiceCredential", {
-            userName: user.userName,
-            serviceName: "codecommit.amazonaws.com",
-            status: "Inactive",
-          });
-        }),
-      );
-
-      const updated = yield* IAM.listServiceSpecificCredentials({
-        UserName: deployed.user.userName,
-        ServiceName: deployed.credential.serviceName,
-      });
-      const metadata = updated.ServiceSpecificCredentials?.find(
-        (entry) =>
-          entry.ServiceSpecificCredentialId ===
-          deployed.credential.serviceSpecificCredentialId,
-      );
-      expect(metadata?.Status).toBe("Inactive");
-
-      yield* destroy();
-
-      const deleted = yield* IAM.listServiceSpecificCredentials({
-        UserName: deployed.user.userName,
-        ServiceName: deployed.credential.serviceName,
-      }).pipe(Effect.option);
-      expect(
-        deleted._tag === "None" ||
-          !deleted.value.ServiceSpecificCredentials?.some(
+        const created = yield* IAM.listServiceSpecificCredentials({
+          UserName: deployed.user.userName,
+          ServiceName: deployed.credential.serviceName,
+        });
+        expect(
+          created.ServiceSpecificCredentials?.some(
             (entry) =>
               entry.ServiceSpecificCredentialId ===
               deployed.credential.serviceSpecificCredentialId,
           ),
-      ).toBe(true);
-    }).pipe(Effect.provide(AWS.providers())),
+        ).toBe(true);
+
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            const user = yield* User("CredentialOwner", {});
+            yield* ServiceSpecificCredential("ServiceCredential", {
+              userName: user.userName,
+              serviceName: "codecommit.amazonaws.com",
+              status: "Inactive",
+            });
+          }),
+        );
+
+        const updated = yield* IAM.listServiceSpecificCredentials({
+          UserName: deployed.user.userName,
+          ServiceName: deployed.credential.serviceName,
+        });
+        const metadata = updated.ServiceSpecificCredentials?.find(
+          (entry) =>
+            entry.ServiceSpecificCredentialId ===
+            deployed.credential.serviceSpecificCredentialId,
+        );
+        expect(metadata?.Status).toBe("Inactive");
+
+        yield* stack.destroy();
+
+        const deleted = yield* IAM.listServiceSpecificCredentials({
+          UserName: deployed.user.userName,
+          ServiceName: deployed.credential.serviceName,
+        }).pipe(Effect.option);
+        expect(
+          deleted._tag === "None" ||
+            !deleted.value.ServiceSpecificCredentials?.some(
+              (entry) =>
+                entry.ServiceSpecificCredentialId ===
+                deployed.credential.serviceSpecificCredentialId,
+            ),
+        ).toBe(true);
+      }),
   );
 
-  test(
+  test.provider(
     "create, update, and delete SSH and signing credentials for a user",
-    Effect.gen(function* () {
-      yield* destroy();
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-      const deployed = yield* test.deploy(
-        Effect.gen(function* () {
-          const user = yield* User("CredentialUser", {});
-          const sshKey = yield* SSHPublicKey("UserSshKey", {
-            userName: user.userName,
-            sshPublicKeyBody: testSshPublicKey,
-            status: "Active",
-          });
-          const signingCertificate = yield* SigningCertificate(
-            "UserSigningCertificate",
-            {
+        const deployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            const user = yield* User("CredentialUser", {});
+            const sshKey = yield* SSHPublicKey("UserSshKey", {
               userName: user.userName,
-              certificateBody: testCertificateBody,
+              sshPublicKeyBody: testSshPublicKey,
               status: "Active",
-            },
-          );
-          return { user, sshKey, signingCertificate };
-        }),
-      );
+            });
+            const signingCertificate = yield* SigningCertificate(
+              "UserSigningCertificate",
+              {
+                userName: user.userName,
+                certificateBody: testCertificateBody,
+                status: "Active",
+              },
+            );
+            return { user, sshKey, signingCertificate };
+          }),
+        );
 
-      const createdKey = yield* IAM.getSSHPublicKey({
-        UserName: deployed.user.userName,
-        SSHPublicKeyId: deployed.sshKey.sshPublicKeyId,
-        Encoding: "SSH",
-      });
-      expect(createdKey.SSHPublicKey?.Status).toBe("Active");
+        const createdKey = yield* IAM.getSSHPublicKey({
+          UserName: deployed.user.userName,
+          SSHPublicKeyId: deployed.sshKey.sshPublicKeyId,
+          Encoding: "SSH",
+        });
+        expect(createdKey.SSHPublicKey?.Status).toBe("Active");
 
-      const createdCerts = yield* IAM.listSigningCertificates({
-        UserName: deployed.user.userName,
-      });
-      expect(
-        createdCerts.Certificates.some(
-          (entry) =>
-            entry.CertificateId === deployed.signingCertificate.certificateId,
-        ),
-      ).toBe(true);
-
-      yield* test.deploy(
-        Effect.gen(function* () {
-          const user = yield* User("CredentialUser", {});
-          yield* SSHPublicKey("UserSshKey", {
-            userName: user.userName,
-            sshPublicKeyBody: testSshPublicKey,
-            status: "Inactive",
-          });
-          yield* SigningCertificate("UserSigningCertificate", {
-            userName: user.userName,
-            certificateBody: testCertificateBody,
-            status: "Inactive",
-          });
-        }),
-      );
-
-      const updatedKey = yield* IAM.getSSHPublicKey({
-        UserName: deployed.user.userName,
-        SSHPublicKeyId: deployed.sshKey.sshPublicKeyId,
-        Encoding: "SSH",
-      });
-      expect(updatedKey.SSHPublicKey?.Status).toBe("Inactive");
-
-      const updatedCerts = yield* IAM.listSigningCertificates({
-        UserName: deployed.user.userName,
-      });
-      const updatedCert = updatedCerts.Certificates.find(
-        (entry) =>
-          entry.CertificateId === deployed.signingCertificate.certificateId,
-      );
-      expect(updatedCert?.Status).toBe("Inactive");
-
-      yield* destroy();
-
-      const deletedKey = yield* IAM.getSSHPublicKey({
-        UserName: deployed.user.userName,
-        SSHPublicKeyId: deployed.sshKey.sshPublicKeyId,
-        Encoding: "SSH",
-      }).pipe(Effect.option);
-      expect(deletedKey._tag).toBe("None");
-
-      const deletedCerts = yield* IAM.listSigningCertificates({
-        UserName: deployed.user.userName,
-      }).pipe(Effect.option);
-      expect(
-        deletedCerts._tag === "None" ||
-          !deletedCerts.value.Certificates.some(
+        const createdCerts = yield* IAM.listSigningCertificates({
+          UserName: deployed.user.userName,
+        });
+        expect(
+          createdCerts.Certificates.some(
             (entry) =>
               entry.CertificateId === deployed.signingCertificate.certificateId,
           ),
-      ).toBe(true);
-    }).pipe(Effect.provide(AWS.providers())),
+        ).toBe(true);
+
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            const user = yield* User("CredentialUser", {});
+            yield* SSHPublicKey("UserSshKey", {
+              userName: user.userName,
+              sshPublicKeyBody: testSshPublicKey,
+              status: "Inactive",
+            });
+            yield* SigningCertificate("UserSigningCertificate", {
+              userName: user.userName,
+              certificateBody: testCertificateBody,
+              status: "Inactive",
+            });
+          }),
+        );
+
+        const updatedKey = yield* IAM.getSSHPublicKey({
+          UserName: deployed.user.userName,
+          SSHPublicKeyId: deployed.sshKey.sshPublicKeyId,
+          Encoding: "SSH",
+        });
+        expect(updatedKey.SSHPublicKey?.Status).toBe("Inactive");
+
+        const updatedCerts = yield* IAM.listSigningCertificates({
+          UserName: deployed.user.userName,
+        });
+        const updatedCert = updatedCerts.Certificates.find(
+          (entry) =>
+            entry.CertificateId === deployed.signingCertificate.certificateId,
+        );
+        expect(updatedCert?.Status).toBe("Inactive");
+
+        yield* stack.destroy();
+
+        const deletedKey = yield* IAM.getSSHPublicKey({
+          UserName: deployed.user.userName,
+          SSHPublicKeyId: deployed.sshKey.sshPublicKeyId,
+          Encoding: "SSH",
+        }).pipe(Effect.option);
+        expect(deletedKey._tag).toBe("None");
+
+        const deletedCerts = yield* IAM.listSigningCertificates({
+          UserName: deployed.user.userName,
+        }).pipe(Effect.option);
+        expect(
+          deletedCerts._tag === "None" ||
+            !deletedCerts.value.Certificates.some(
+              (entry) =>
+                entry.CertificateId ===
+                deployed.signingCertificate.certificateId,
+            ),
+        ).toBe(true);
+      }),
   );
 });

--- a/packages/alchemy/test/AWS/IAM/DeviceAndServerCertificate.test.ts
+++ b/packages/alchemy/test/AWS/IAM/DeviceAndServerCertificate.test.ts
@@ -1,18 +1,19 @@
 import * as AWS from "@/AWS";
 import { ServerCertificate, VirtualMFADevice } from "@/AWS/IAM";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as IAM from "@distilled.cloud/aws/iam";
 import { describe, expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import { testCertificateBody, testPrivateKey } from "./fixtures.ts";
 
-describe("AWS.IAM device and server certificate resources", () => {
-  test(
-    "create, update, and delete a server certificate",
-    Effect.gen(function* () {
-      yield* destroy();
+const { test } = Test.make({ providers: AWS.providers() });
 
-      const certificate = yield* test.deploy(
+describe("AWS.IAM device and server certificate resources", () => {
+  test.provider("create, update, and delete a server certificate", (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const certificate = yield* stack.deploy(
         Effect.gen(function* () {
           return yield* ServerCertificate("ServerCertificate", {
             certificateBody: testCertificateBody,
@@ -32,7 +33,7 @@ describe("AWS.IAM device and server certificate resources", () => {
           .ServerCertificateName,
       ).toBe(certificate.serverCertificateName);
 
-      yield* test.deploy(
+      yield* stack.deploy(
         Effect.gen(function* () {
           return yield* ServerCertificate("ServerCertificate", {
             certificateBody: testCertificateBody,
@@ -55,74 +56,75 @@ describe("AWS.IAM device and server certificate resources", () => {
         env: "prod",
       });
 
-      yield* destroy();
+      yield* stack.destroy();
 
       const deleted = yield* IAM.getServerCertificate({
         ServerCertificateName: certificate.serverCertificateName,
       }).pipe(Effect.option);
       expect(deleted._tag).toBe("None");
-    }).pipe(Effect.provide(AWS.providers())),
+    }),
   );
 
-  test(
+  test.provider(
     "create, update, and delete an unassigned virtual MFA device",
-    Effect.gen(function* () {
-      yield* destroy();
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-      const device = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* VirtualMFADevice("VirtualMfaDevice", {
-            tags: {
-              env: "test",
-            },
-          });
-        }),
-      );
+        const device = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* VirtualMFADevice("VirtualMfaDevice", {
+              tags: {
+                env: "test",
+              },
+            });
+          }),
+        );
 
-      expect(device.base32StringSeed).toBeDefined();
-      expect(device.qrCodePNG).toBeDefined();
+        expect(device.base32StringSeed).toBeDefined();
+        expect(device.qrCodePNG).toBeDefined();
 
-      const created = yield* IAM.listVirtualMFADevices({
-        AssignmentStatus: "Unassigned",
-      });
-      expect(
-        created.VirtualMFADevices.some(
-          (entry) => entry.SerialNumber === device.serialNumber,
-        ),
-      ).toBe(true);
-
-      yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* VirtualMFADevice("VirtualMfaDevice", {
-            tags: {
-              env: "prod",
-            },
-          });
-        }),
-      );
-
-      const updatedTags = yield* IAM.listMFADeviceTags({
-        SerialNumber: device.serialNumber,
-      });
-      expect(
-        Object.fromEntries(
-          (updatedTags.Tags ?? []).map((tag) => [tag.Key, tag.Value]),
-        ),
-      ).toMatchObject({
-        env: "prod",
-      });
-
-      yield* destroy();
-
-      const deleted = yield* IAM.listVirtualMFADevices({
-        AssignmentStatus: "Unassigned",
-      }).pipe(Effect.option);
-      expect(
-        deleted._tag === "None" ||
-          !deleted.value.VirtualMFADevices.some(
+        const created = yield* IAM.listVirtualMFADevices({
+          AssignmentStatus: "Unassigned",
+        });
+        expect(
+          created.VirtualMFADevices.some(
             (entry) => entry.SerialNumber === device.serialNumber,
           ),
-      ).toBe(true);
-    }).pipe(Effect.provide(AWS.providers())),
+        ).toBe(true);
+
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* VirtualMFADevice("VirtualMfaDevice", {
+              tags: {
+                env: "prod",
+              },
+            });
+          }),
+        );
+
+        const updatedTags = yield* IAM.listMFADeviceTags({
+          SerialNumber: device.serialNumber,
+        });
+        expect(
+          Object.fromEntries(
+            (updatedTags.Tags ?? []).map((tag) => [tag.Key, tag.Value]),
+          ),
+        ).toMatchObject({
+          env: "prod",
+        });
+
+        yield* stack.destroy();
+
+        const deleted = yield* IAM.listVirtualMFADevices({
+          AssignmentStatus: "Unassigned",
+        }).pipe(Effect.option);
+        expect(
+          deleted._tag === "None" ||
+            !deleted.value.VirtualMFADevices.some(
+              (entry) => entry.SerialNumber === device.serialNumber,
+            ),
+        ).toBe(true);
+      }),
   );
 });

--- a/packages/alchemy/test/AWS/IAM/Federation.test.ts
+++ b/packages/alchemy/test/AWS/IAM/Federation.test.ts
@@ -1,6 +1,6 @@
 import * as AWS from "@/AWS";
 import { OpenIDConnectProvider, SAMLProvider } from "@/AWS/IAM";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as IAM from "@distilled.cloud/aws/iam";
 import { describe, expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
@@ -13,76 +13,78 @@ import {
   testSamlProviderName,
 } from "./fixtures.ts";
 
+const { test } = Test.make({ providers: AWS.providers() });
+
 describe("AWS.IAM federation resources", () => {
-  test(
+  test.provider(
     "create, update, and delete an OpenID Connect provider",
-    Effect.gen(function* () {
-      yield* destroy();
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-      const provider = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* OpenIDConnectProvider("OidcProvider", {
-            url: testOidcUrl,
-            clientIDList: ["sts.amazonaws.com"],
-            thumbprintList: [testOidcThumbprintA],
-            tags: {
-              env: "test",
-            },
-          });
-        }),
-      );
+        const provider = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* OpenIDConnectProvider("OidcProvider", {
+              url: testOidcUrl,
+              clientIDList: ["sts.amazonaws.com"],
+              thumbprintList: [testOidcThumbprintA],
+              tags: {
+                env: "test",
+              },
+            });
+          }),
+        );
 
-      const created = yield* IAM.getOpenIDConnectProvider({
-        OpenIDConnectProviderArn: provider.openIDConnectProviderArn,
-      });
-      expect(created.Url).toBe(testOidcUrl.replace(/^https?:\/\//, ""));
-      expect(created.ClientIDList ?? []).toContain("sts.amazonaws.com");
+        const created = yield* IAM.getOpenIDConnectProvider({
+          OpenIDConnectProviderArn: provider.openIDConnectProviderArn,
+        });
+        expect(created.Url).toBe(testOidcUrl.replace(/^https?:\/\//, ""));
+        expect(created.ClientIDList ?? []).toContain("sts.amazonaws.com");
 
-      yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* OpenIDConnectProvider("OidcProvider", {
-            url: testOidcUrl,
-            clientIDList: ["sts.amazonaws.com", "alchemy-client"],
-            thumbprintList: [testOidcThumbprintB],
-            tags: {
-              env: "prod",
-            },
-          });
-        }),
-      );
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* OpenIDConnectProvider("OidcProvider", {
+              url: testOidcUrl,
+              clientIDList: ["sts.amazonaws.com", "alchemy-client"],
+              thumbprintList: [testOidcThumbprintB],
+              tags: {
+                env: "prod",
+              },
+            });
+          }),
+        );
 
-      const updated = yield* IAM.getOpenIDConnectProvider({
-        OpenIDConnectProviderArn: provider.openIDConnectProviderArn,
-      });
-      expect(updated.ClientIDList ?? []).toContain("alchemy-client");
-      expect(updated.ThumbprintList).toEqual([testOidcThumbprintB]);
+        const updated = yield* IAM.getOpenIDConnectProvider({
+          OpenIDConnectProviderArn: provider.openIDConnectProviderArn,
+        });
+        expect(updated.ClientIDList ?? []).toContain("alchemy-client");
+        expect(updated.ThumbprintList).toEqual([testOidcThumbprintB]);
 
-      const tags = yield* IAM.listOpenIDConnectProviderTags({
-        OpenIDConnectProviderArn: provider.openIDConnectProviderArn,
-      });
-      expect(
-        Object.fromEntries(
-          (tags.Tags ?? []).map((tag) => [tag.Key, tag.Value]),
-        ),
-      ).toMatchObject({
-        env: "prod",
-      });
+        const tags = yield* IAM.listOpenIDConnectProviderTags({
+          OpenIDConnectProviderArn: provider.openIDConnectProviderArn,
+        });
+        expect(
+          Object.fromEntries(
+            (tags.Tags ?? []).map((tag) => [tag.Key, tag.Value]),
+          ),
+        ).toMatchObject({
+          env: "prod",
+        });
 
-      yield* destroy();
+        yield* stack.destroy();
 
-      const deleted = yield* IAM.getOpenIDConnectProvider({
-        OpenIDConnectProviderArn: provider.openIDConnectProviderArn,
-      }).pipe(Effect.option);
-      expect(deleted._tag).toBe("None");
-    }).pipe(Effect.provide(AWS.providers())),
+        const deleted = yield* IAM.getOpenIDConnectProvider({
+          OpenIDConnectProviderArn: provider.openIDConnectProviderArn,
+        }).pipe(Effect.option);
+        expect(deleted._tag).toBe("None");
+      }),
   );
 
-  test(
-    "create, update, and delete a SAML provider",
+  test.provider("create, update, and delete a SAML provider", (stack) =>
     Effect.gen(function* () {
-      yield* destroy();
+      yield* stack.destroy();
 
-      const provider = yield* test.deploy(
+      const provider = yield* stack.deploy(
         Effect.gen(function* () {
           return yield* SAMLProvider("SamlProvider", {
             name: testSamlProviderName,
@@ -99,7 +101,7 @@ describe("AWS.IAM federation resources", () => {
       });
       expect(created.SAMLMetadataDocument).toContain("urn:alchemy:test:idp");
 
-      yield* test.deploy(
+      yield* stack.deploy(
         Effect.gen(function* () {
           return yield* SAMLProvider("SamlProvider", {
             name: testSamlProviderName,
@@ -129,12 +131,12 @@ describe("AWS.IAM federation resources", () => {
         env: "prod",
       });
 
-      yield* destroy();
+      yield* stack.destroy();
 
       const deleted = yield* IAM.getSAMLProvider({
         SAMLProviderArn: provider.samlProviderArn,
       }).pipe(Effect.option);
       expect(deleted._tag).toBe("None");
-    }).pipe(Effect.provide(AWS.providers())),
+    }),
   );
 });

--- a/packages/alchemy/test/AWS/IAM/Identity.test.ts
+++ b/packages/alchemy/test/AWS/IAM/Identity.test.ts
@@ -1,16 +1,17 @@
 import * as AWS from "@/AWS";
 import { Group, GroupMembership, InstanceProfile, Role, User } from "@/AWS/IAM";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as IAM from "@distilled.cloud/aws/iam";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 
-test(
-  "create user, group membership, and instance profile",
-  Effect.gen(function* () {
-    yield* destroy();
+const { test } = Test.make({ providers: AWS.providers() });
 
-    const resources = yield* test.deploy(
+test.provider("create user, group membership, and instance profile", (stack) =>
+  Effect.gen(function* () {
+    yield* stack.destroy();
+
+    const resources = yield* stack.deploy(
       Effect.gen(function* () {
         const role = yield* Role("ProfileRole", {
           assumeRolePolicyDocument: {
@@ -59,6 +60,6 @@ test(
       resources.role.roleName,
     );
 
-    yield* destroy();
-  }).pipe(Effect.provide(AWS.providers())),
+    yield* stack.destroy();
+  }),
 );

--- a/packages/alchemy/test/AWS/IAM/Policy.test.ts
+++ b/packages/alchemy/test/AWS/IAM/Policy.test.ts
@@ -1,16 +1,17 @@
 import * as AWS from "@/AWS";
 import { Policy } from "@/AWS/IAM";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as IAM from "@distilled.cloud/aws/iam";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 
-test(
-  "create, update, and delete managed policy",
-  Effect.gen(function* () {
-    yield* destroy();
+const { test } = Test.make({ providers: AWS.providers() });
 
-    const policy = yield* test.deploy(
+test.provider("create, update, and delete managed policy", (stack) =>
+  Effect.gen(function* () {
+    yield* stack.destroy();
+
+    const policy = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Policy("IamPolicy", {
           policyDocument: {
@@ -35,7 +36,7 @@ test(
     });
     expect(created.Policy?.PolicyName).toBe(policy.policyName);
 
-    yield* test.deploy(
+    yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Policy("IamPolicy", {
           policyDocument: {
@@ -66,11 +67,11 @@ test(
       env: "prod",
     });
 
-    yield* destroy();
+    yield* stack.destroy();
 
     const deleted = yield* IAM.getPolicy({
       PolicyArn: policy.policyArn,
     }).pipe(Effect.option);
     expect(deleted._tag).toBe("None");
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );

--- a/packages/alchemy/test/AWS/IAM/Role.test.ts
+++ b/packages/alchemy/test/AWS/IAM/Role.test.ts
@@ -1,9 +1,11 @@
 import * as AWS from "@/AWS";
 import { Role } from "@/AWS/IAM";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as IAM from "@distilled.cloud/aws/iam";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+
+const { test } = Test.make({ providers: AWS.providers() });
 
 const assumeRolePolicy = {
   Version: "2012-10-17" as const,
@@ -18,12 +20,11 @@ const assumeRolePolicy = {
   ],
 };
 
-test(
-  "create, update, and delete role",
+test.provider("create, update, and delete role", (stack) =>
   Effect.gen(function* () {
-    yield* destroy();
+    yield* stack.destroy();
 
-    const role = yield* test.deploy(
+    const role = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Role("IamRole", {
           assumeRolePolicyDocument: assumeRolePolicy,
@@ -54,7 +55,7 @@ test(
     });
     expect(created.Role.RoleName).toBe(role.roleName);
 
-    yield* test.deploy(
+    yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Role("IamRole", {
           assumeRolePolicyDocument: assumeRolePolicy,
@@ -89,11 +90,11 @@ test(
       env: "prod",
     });
 
-    yield* destroy();
+    yield* stack.destroy();
 
     const deleted = yield* IAM.getRole({
       RoleName: role.roleName,
     }).pipe(Effect.option);
     expect(deleted._tag).toBe("None");
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );

--- a/packages/alchemy/test/AWS/IAM/Sensitive.test.ts
+++ b/packages/alchemy/test/AWS/IAM/Sensitive.test.ts
@@ -1,60 +1,63 @@
 import * as AWS from "@/AWS";
 import { AccessKey, LoginProfile, User } from "@/AWS/IAM";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as IAM from "@distilled.cloud/aws/iam";
 import { describe, expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 
+const { test } = Test.make({ providers: AWS.providers() });
+
 describe("AWS.IAM sensitive resources", () => {
-  test(
+  test.provider(
     "create, update, and delete access key plus login profile",
-    Effect.gen(function* () {
-      yield* destroy();
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-      const resources = yield* test.deploy(
-        Effect.gen(function* () {
-          const user = yield* User("CredentialUser", {});
-          const accessKey = yield* AccessKey("AccessKey", {
-            userName: user.userName,
-            status: "Active",
-          });
-          const loginProfile = yield* LoginProfile("LoginProfile", {
-            userName: user.userName,
-            password: "TempPassword123!",
-            passwordResetRequired: true,
-          });
-          return { user, accessKey, loginProfile };
-        }),
-      );
+        const resources = yield* stack.deploy(
+          Effect.gen(function* () {
+            const user = yield* User("CredentialUser", {});
+            const accessKey = yield* AccessKey("AccessKey", {
+              userName: user.userName,
+              status: "Active",
+            });
+            const loginProfile = yield* LoginProfile("LoginProfile", {
+              userName: user.userName,
+              password: "TempPassword123!",
+              passwordResetRequired: true,
+            });
+            return { user, accessKey, loginProfile };
+          }),
+        );
 
-      expect(resources.accessKey.secretAccessKey).toBeDefined();
+        expect(resources.accessKey.secretAccessKey).toBeDefined();
 
-      yield* test.deploy(
-        Effect.gen(function* () {
-          const user = yield* User("CredentialUser", {});
-          yield* AccessKey("AccessKey", {
-            userName: user.userName,
-            status: "Inactive",
-          });
-          yield* LoginProfile("LoginProfile", {
-            userName: user.userName,
-            password: "UpdatedPassword123!",
-            passwordResetRequired: false,
-          });
-        }),
-      );
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            const user = yield* User("CredentialUser", {});
+            yield* AccessKey("AccessKey", {
+              userName: user.userName,
+              status: "Inactive",
+            });
+            yield* LoginProfile("LoginProfile", {
+              userName: user.userName,
+              password: "UpdatedPassword123!",
+              passwordResetRequired: false,
+            });
+          }),
+        );
 
-      const accessKeys = yield* IAM.listAccessKeys({
-        UserName: resources.user.userName,
-      });
-      expect(accessKeys.AccessKeyMetadata[0]?.Status).toBe("Inactive");
+        const accessKeys = yield* IAM.listAccessKeys({
+          UserName: resources.user.userName,
+        });
+        expect(accessKeys.AccessKeyMetadata[0]?.Status).toBe("Inactive");
 
-      const loginProfile = yield* IAM.getLoginProfile({
-        UserName: resources.user.userName,
-      });
-      expect(loginProfile.LoginProfile.PasswordResetRequired).toBe(false);
+        const loginProfile = yield* IAM.getLoginProfile({
+          UserName: resources.user.userName,
+        });
+        expect(loginProfile.LoginProfile.PasswordResetRequired).toBe(false);
 
-      yield* destroy();
-    }).pipe(Effect.provide(AWS.providers())),
+        yield* stack.destroy();
+      }),
   );
 });

--- a/packages/alchemy/test/AWS/Kinesis/Bindings.test.ts
+++ b/packages/alchemy/test/AWS/Kinesis/Bindings.test.ts
@@ -1,4 +1,7 @@
-import { afterAll, beforeAll, destroy, test } from "@/Test/Vitest";
+import * as AWS from "@/AWS";
+import { make as makeStack } from "@/Stack";
+import * as State from "@/State";
+import * as Test from "@/Test/Vitest";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
@@ -6,6 +9,20 @@ import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import { describe } from "vitest";
 import KinesisApiFunctionLive, { KinesisApiFunction } from "./handler.ts";
+
+const providers = AWS.providers();
+const state = State.localState();
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers,
+  state,
+});
+
+const fixtureStack = Effect.gen(function* () {
+  return yield* KinesisApiFunction;
+}).pipe(
+  Effect.provide(KinesisApiFunctionLive),
+  makeStack({ name: "kinesis-bindings", providers, state }),
+);
 
 const readinessPolicy = Schedule.fixed("2 seconds").pipe(
   Schedule.both(Schedule.recurs(9)),
@@ -18,12 +35,8 @@ let consumerName: string;
 describe.sequential("Kinesis Bindings", () => {
   beforeAll(
     Effect.gen(function* () {
-      yield* destroy();
-      const deployed = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* KinesisApiFunction;
-        }).pipe(Effect.provide(KinesisApiFunctionLive)),
-      );
+      yield* destroy(fixtureStack);
+      const deployed = yield* deploy(fixtureStack);
 
       baseUrl = deployed.functionUrl!.replace(/\/+$/, "");
 
@@ -49,11 +62,10 @@ describe.sequential("Kinesis Bindings", () => {
     { timeout: 120_000 },
   );
 
-  afterAll(destroy(), { timeout: 60_000 });
+  afterAll(destroy(fixtureStack), { timeout: 60_000 });
 
   describe("DescribeAccountSettings", () => {
-    test(
-      "returns the account settings payload",
+    test.provider("returns the account settings payload", (stack) =>
       Effect.gen(function* () {
         const response = yield* getJson("/account-settings");
         if ((response as any).ok === false) {
@@ -66,8 +78,7 @@ describe.sequential("Kinesis Bindings", () => {
   });
 
   describe("DescribeLimits", () => {
-    test(
-      "returns shard and stream limits",
+    test.provider("returns shard and stream limits", (stack) =>
       Effect.gen(function* () {
         const response = yield* getJson("/limits");
         if ((response as any).ok === false) {
@@ -80,8 +91,7 @@ describe.sequential("Kinesis Bindings", () => {
   });
 
   describe("ListStreams", () => {
-    test(
-      "lists the deployed stream",
+    test.provider("lists the deployed stream", (stack) =>
       Effect.gen(function* () {
         const response = yield* getJson("/streams");
         const names = (response as any).StreamNames ?? [];
@@ -91,8 +101,7 @@ describe.sequential("Kinesis Bindings", () => {
   });
 
   describe("DescribeStream", () => {
-    test(
-      "describes the bound stream",
+    test.provider("describes the bound stream", (stack) =>
       Effect.gen(function* () {
         const response = yield* getJson("/stream");
         expect((response as any).StreamDescription.StreamName).toBe(streamName);
@@ -101,8 +110,7 @@ describe.sequential("Kinesis Bindings", () => {
   });
 
   describe("DescribeStreamSummary", () => {
-    test(
-      "describes the bound stream summary",
+    test.provider("describes the bound stream summary", (stack) =>
       Effect.gen(function* () {
         const response = yield* getJson("/stream-summary");
         expect((response as any).StreamDescriptionSummary.StreamName).toBe(
@@ -113,8 +121,7 @@ describe.sequential("Kinesis Bindings", () => {
   });
 
   describe("GetResourcePolicy", () => {
-    test(
-      "returns the stream policy or a structured error",
+    test.provider("returns the stream policy or a structured error", (stack) =>
       Effect.gen(function* () {
         const response = yield* getJson("/resource-policy");
         if ((response as any).ok === false) {
@@ -127,8 +134,7 @@ describe.sequential("Kinesis Bindings", () => {
   });
 
   describe("ListShards", () => {
-    test(
-      "lists shards for the stream",
+    test.provider("lists shards for the stream", (stack) =>
       Effect.gen(function* () {
         const response = yield* getJson("/shards");
         expect(((response as any).Shards ?? []).length).toBeGreaterThan(0);
@@ -137,8 +143,7 @@ describe.sequential("Kinesis Bindings", () => {
   });
 
   describe("GetShardIterator", () => {
-    test(
-      "returns a shard iterator for the first shard",
+    test.provider("returns a shard iterator for the first shard", (stack) =>
       Effect.gen(function* () {
         const shardId = yield* getFirstShardId();
         const response = yield* postJson("/iterator", { shardId });
@@ -148,27 +153,27 @@ describe.sequential("Kinesis Bindings", () => {
   });
 
   describe("GetRecords", () => {
-    test(
+    test.provider(
       "reads a just-written record through the shard iterator",
-      Effect.gen(function* () {
-        const shardId = yield* getFirstShardId();
-        const marker = `records-${crypto.randomUUID()}`;
-        const response = yield* postJson("/records", {
-          shardId,
-          partitionKey: "records-test",
-          data: marker,
-        });
-        const records = (response as any).records ?? [];
-        expect(records.some((record: any) => record.data === marker)).toBe(
-          true,
-        );
-      }),
+      (stack) =>
+        Effect.gen(function* () {
+          const shardId = yield* getFirstShardId();
+          const marker = `records-${crypto.randomUUID()}`;
+          const response = yield* postJson("/records", {
+            shardId,
+            partitionKey: "records-test",
+            data: marker,
+          });
+          const records = (response as any).records ?? [];
+          expect(records.some((record: any) => record.data === marker)).toBe(
+            true,
+          );
+        }),
     );
   });
 
   describe("ListStreamConsumers", () => {
-    test(
-      "lists the registered consumer",
+    test.provider("lists the registered consumer", (stack) =>
       Effect.gen(function* () {
         const response = yield* getJson("/stream-consumers");
         const consumers = (response as any).Consumers ?? [];
@@ -182,8 +187,7 @@ describe.sequential("Kinesis Bindings", () => {
   });
 
   describe("DescribeStreamConsumer", () => {
-    test(
-      "describes the registered consumer",
+    test.provider("describes the registered consumer", (stack) =>
       Effect.gen(function* () {
         const response = yield* getJson("/consumer");
         expect((response as any).ConsumerDescription.ConsumerName).toBe(
@@ -194,8 +198,7 @@ describe.sequential("Kinesis Bindings", () => {
   });
 
   describe("SubscribeToShard", () => {
-    test(
-      "opens a subscribe-to-shard stream",
+    test.provider("opens a subscribe-to-shard stream", (stack) =>
       Effect.gen(function* () {
         const shardId = yield* getFirstShardId();
         const response = yield* postJson("/subscribe", { shardId });
@@ -205,8 +208,7 @@ describe.sequential("Kinesis Bindings", () => {
   });
 
   describe("ListTagsForResource", () => {
-    test(
-      "lists the stream ownership tags",
+    test.provider("lists the stream ownership tags", (stack) =>
       Effect.gen(function* () {
         const response = yield* getJson("/tags");
         const keys = ((response as any).Tags ?? []).map((tag: any) => tag.Key);
@@ -219,8 +221,7 @@ describe.sequential("Kinesis Bindings", () => {
   });
 
   describe("PutRecord", () => {
-    test(
-      "writes a single record",
+    test.provider("writes a single record", (stack) =>
       Effect.gen(function* () {
         const response = yield* postJson("/put-record", {
           partitionKey: "put-record",
@@ -233,8 +234,7 @@ describe.sequential("Kinesis Bindings", () => {
   });
 
   describe("PutRecords", () => {
-    test(
-      "writes a batch of records",
+    test.provider("writes a batch of records", (stack) =>
       Effect.gen(function* () {
         const response = yield* postJson("/put-records", {
           records: [
@@ -255,8 +255,7 @@ describe.sequential("Kinesis Bindings", () => {
   });
 
   describe("StreamSink", () => {
-    test(
-      "writes records through the sink helper",
+    test.provider("writes records through the sink helper", (stack) =>
       Effect.gen(function* () {
         const response = yield* postJson("/sink", {
           records: [

--- a/packages/alchemy/test/AWS/Kinesis/Stream.test.ts
+++ b/packages/alchemy/test/AWS/Kinesis/Stream.test.ts
@@ -1,536 +1,552 @@
 import * as AWS from "@/AWS";
 import { Stream } from "@/AWS/Kinesis";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as Kinesis from "@distilled.cloud/aws/kinesis";
 import { describe, expect } from "@effect/vitest";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 
+const { test } = Test.make({ providers: AWS.providers() });
+
 describe("AWS.Kinesis.Stream", () => {
-  test(
+  test.provider(
     "create and delete stream with default props",
+    (stack) =>
+      Effect.gen(function* () {
+        const stream = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("DefaultStream");
+          }),
+        );
+
+        expect(stream.streamName).toBeDefined();
+        expect(stream.streamArn).toBeDefined();
+        expect(stream.streamStatus).toEqual("ACTIVE");
+
+        const streamDescription = yield* Kinesis.describeStreamSummary({
+          StreamName: stream.streamName,
+        });
+        expect(streamDescription.StreamDescriptionSummary.StreamStatus).toEqual(
+          "ACTIVE",
+        );
+        expect(
+          streamDescription.StreamDescriptionSummary.StreamModeDetails
+            ?.StreamMode,
+        ).toEqual("ON_DEMAND");
+
+        yield* stack.destroy();
+
+        yield* assertStreamDeleted(stream.streamName);
+      }),
     { timeout: 180_000 },
-    Effect.gen(function* () {
-      const stream = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("DefaultStream");
-        }),
-      );
-
-      expect(stream.streamName).toBeDefined();
-      expect(stream.streamArn).toBeDefined();
-      expect(stream.streamStatus).toEqual("ACTIVE");
-
-      const streamDescription = yield* Kinesis.describeStreamSummary({
-        StreamName: stream.streamName,
-      });
-      expect(streamDescription.StreamDescriptionSummary.StreamStatus).toEqual(
-        "ACTIVE",
-      );
-      expect(
-        streamDescription.StreamDescriptionSummary.StreamModeDetails
-          ?.StreamMode,
-      ).toEqual("ON_DEMAND");
-
-      yield* destroy();
-
-      yield* assertStreamDeleted(stream.streamName);
-    }).pipe(Effect.provide(AWS.providers())),
   );
 
-  test(
+  test.provider(
     "create, update, delete on-demand stream with tags",
+    (stack) =>
+      Effect.gen(function* () {
+        const stream = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("TestStream", {
+              streamMode: "ON_DEMAND",
+              tags: { Environment: "test" },
+            });
+          }),
+        );
+
+        // Verify the stream was created
+        const streamDescription = yield* Kinesis.describeStreamSummary({
+          StreamName: stream.streamName,
+        });
+        expect(streamDescription.StreamDescriptionSummary.StreamStatus).toEqual(
+          "ACTIVE",
+        );
+        expect(
+          streamDescription.StreamDescriptionSummary.StreamModeDetails
+            ?.StreamMode,
+        ).toEqual("ON_DEMAND");
+        expect(
+          streamDescription.StreamDescriptionSummary.RetentionPeriodHours,
+        ).toEqual(24);
+
+        // Verify tags
+        const tagging = yield* Kinesis.listTagsForStream({
+          StreamName: stream.streamName,
+        });
+        expect(tagging.Tags).toContainEqual({
+          Key: "Environment",
+          Value: "test",
+        });
+
+        // Update the stream - increase retention period and update tags
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("TestStream", {
+              streamMode: "ON_DEMAND",
+              retentionPeriodHours: 48,
+              tags: { Environment: "production", Team: "platform" },
+            });
+          }),
+        );
+
+        // Verify the retention period was updated
+        const updatedDescription = yield* Kinesis.describeStreamSummary({
+          StreamName: stream.streamName,
+        });
+        expect(
+          updatedDescription.StreamDescriptionSummary.RetentionPeriodHours,
+        ).toEqual(48);
+
+        // Verify tags were updated
+        const updatedTagging = yield* Kinesis.listTagsForStream({
+          StreamName: stream.streamName,
+        });
+        expect(updatedTagging.Tags).toContainEqual({
+          Key: "Environment",
+          Value: "production",
+        });
+        expect(updatedTagging.Tags).toContainEqual({
+          Key: "Team",
+          Value: "platform",
+        });
+
+        yield* stack.destroy();
+
+        yield* assertStreamDeleted(stream.streamName);
+      }),
     { timeout: 180_000 },
-    Effect.gen(function* () {
-      const stream = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("TestStream", {
-            streamMode: "ON_DEMAND",
-            tags: { Environment: "test" },
-          });
-        }),
-      );
-
-      // Verify the stream was created
-      const streamDescription = yield* Kinesis.describeStreamSummary({
-        StreamName: stream.streamName,
-      });
-      expect(streamDescription.StreamDescriptionSummary.StreamStatus).toEqual(
-        "ACTIVE",
-      );
-      expect(
-        streamDescription.StreamDescriptionSummary.StreamModeDetails
-          ?.StreamMode,
-      ).toEqual("ON_DEMAND");
-      expect(
-        streamDescription.StreamDescriptionSummary.RetentionPeriodHours,
-      ).toEqual(24);
-
-      // Verify tags
-      const tagging = yield* Kinesis.listTagsForStream({
-        StreamName: stream.streamName,
-      });
-      expect(tagging.Tags).toContainEqual({
-        Key: "Environment",
-        Value: "test",
-      });
-
-      // Update the stream - increase retention period and update tags
-      yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("TestStream", {
-            streamMode: "ON_DEMAND",
-            retentionPeriodHours: 48,
-            tags: { Environment: "production", Team: "platform" },
-          });
-        }),
-      );
-
-      // Verify the retention period was updated
-      const updatedDescription = yield* Kinesis.describeStreamSummary({
-        StreamName: stream.streamName,
-      });
-      expect(
-        updatedDescription.StreamDescriptionSummary.RetentionPeriodHours,
-      ).toEqual(48);
-
-      // Verify tags were updated
-      const updatedTagging = yield* Kinesis.listTagsForStream({
-        StreamName: stream.streamName,
-      });
-      expect(updatedTagging.Tags).toContainEqual({
-        Key: "Environment",
-        Value: "production",
-      });
-      expect(updatedTagging.Tags).toContainEqual({
-        Key: "Team",
-        Value: "platform",
-      });
-
-      yield* destroy();
-
-      yield* assertStreamDeleted(stream.streamName);
-    }).pipe(Effect.provide(AWS.providers())),
   );
 
-  test(
+  test.provider(
     "create provisioned stream with shards",
+    (stack) =>
+      Effect.gen(function* () {
+        const stream = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("ProvisionedStream", {
+              streamMode: "PROVISIONED",
+              shardCount: 2,
+            });
+          }),
+        );
+
+        // Verify the stream was created with shards
+        const streamDescription = yield* Kinesis.describeStreamSummary({
+          StreamName: stream.streamName,
+        });
+        expect(streamDescription.StreamDescriptionSummary.StreamStatus).toEqual(
+          "ACTIVE",
+        );
+        expect(
+          streamDescription.StreamDescriptionSummary.StreamModeDetails
+            ?.StreamMode,
+        ).toEqual("PROVISIONED");
+        expect(
+          streamDescription.StreamDescriptionSummary.OpenShardCount,
+        ).toEqual(2);
+
+        yield* stack.destroy();
+
+        yield* assertStreamDeleted(stream.streamName);
+      }),
     { timeout: 180_000 },
-    Effect.gen(function* () {
-      const stream = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("ProvisionedStream", {
-            streamMode: "PROVISIONED",
-            shardCount: 2,
-          });
-        }),
-      );
-
-      // Verify the stream was created with shards
-      const streamDescription = yield* Kinesis.describeStreamSummary({
-        StreamName: stream.streamName,
-      });
-      expect(streamDescription.StreamDescriptionSummary.StreamStatus).toEqual(
-        "ACTIVE",
-      );
-      expect(
-        streamDescription.StreamDescriptionSummary.StreamModeDetails
-          ?.StreamMode,
-      ).toEqual("PROVISIONED");
-      expect(streamDescription.StreamDescriptionSummary.OpenShardCount).toEqual(
-        2,
-      );
-
-      yield* destroy();
-
-      yield* assertStreamDeleted(stream.streamName);
-    }).pipe(Effect.provide(AWS.providers())),
   );
 
-  test(
+  test.provider(
     "update provisioned stream shard count",
+    (stack) =>
+      Effect.gen(function* () {
+        const stream = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("ShardStream", {
+              streamMode: "PROVISIONED",
+              shardCount: 1,
+            });
+          }),
+        );
+
+        // Verify initial shard count
+        const streamDescription = yield* Kinesis.describeStreamSummary({
+          StreamName: stream.streamName,
+        });
+        expect(
+          streamDescription.StreamDescriptionSummary.OpenShardCount,
+        ).toEqual(1);
+
+        // Update shard count
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("ShardStream", {
+              streamMode: "PROVISIONED",
+              shardCount: 2,
+            });
+          }),
+        );
+
+        // Verify shard count was updated
+        const updatedDescription = yield* Kinesis.describeStreamSummary({
+          StreamName: stream.streamName,
+        });
+        expect(
+          updatedDescription.StreamDescriptionSummary.OpenShardCount,
+        ).toEqual(2);
+
+        yield* stack.destroy();
+
+        yield* assertStreamDeleted(stream.streamName);
+      }),
     { timeout: 300_000 },
-    Effect.gen(function* () {
-      const stream = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("ShardStream", {
-            streamMode: "PROVISIONED",
-            shardCount: 1,
-          });
-        }),
-      );
-
-      // Verify initial shard count
-      const streamDescription = yield* Kinesis.describeStreamSummary({
-        StreamName: stream.streamName,
-      });
-      expect(streamDescription.StreamDescriptionSummary.OpenShardCount).toEqual(
-        1,
-      );
-
-      // Update shard count
-      yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("ShardStream", {
-            streamMode: "PROVISIONED",
-            shardCount: 2,
-          });
-        }),
-      );
-
-      // Verify shard count was updated
-      const updatedDescription = yield* Kinesis.describeStreamSummary({
-        StreamName: stream.streamName,
-      });
-      expect(
-        updatedDescription.StreamDescriptionSummary.OpenShardCount,
-      ).toEqual(2);
-
-      yield* destroy();
-
-      yield* assertStreamDeleted(stream.streamName);
-    }).pipe(Effect.provide(AWS.providers())),
   );
 
-  test(
+  test.provider(
     "create stream with custom name",
+    (stack) =>
+      Effect.gen(function* () {
+        const customName = `test-custom-kinesis-stream-custom-name-stream`;
+
+        const stream = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("CustomNameStream", {
+              streamName: customName,
+            });
+          }),
+        );
+
+        expect(stream.streamName).toEqual(customName);
+        expect(stream.streamArn).toContain(customName);
+
+        // Verify the stream exists
+        const streamDescription = yield* Kinesis.describeStreamSummary({
+          StreamName: customName,
+        });
+        expect(streamDescription.StreamDescriptionSummary.StreamName).toEqual(
+          customName,
+        );
+
+        yield* stack.destroy();
+
+        yield* assertStreamDeleted(customName);
+      }),
     { timeout: 180_000 },
-    Effect.gen(function* () {
-      const customName = `test-custom-kinesis-stream-custom-name-stream`;
-
-      const stream = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("CustomNameStream", {
-            streamName: customName,
-          });
-        }),
-      );
-
-      expect(stream.streamName).toEqual(customName);
-      expect(stream.streamArn).toContain(customName);
-
-      // Verify the stream exists
-      const streamDescription = yield* Kinesis.describeStreamSummary({
-        StreamName: customName,
-      });
-      expect(streamDescription.StreamDescriptionSummary.StreamName).toEqual(
-        customName,
-      );
-
-      yield* destroy();
-
-      yield* assertStreamDeleted(customName);
-    }).pipe(Effect.provide(AWS.providers())),
   );
 
-  test(
+  test.provider(
     "create stream with encryption",
+    (stack) =>
+      Effect.gen(function* () {
+        const stream = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("EncryptedStream", {
+              encryption: true,
+            });
+          }),
+        );
+
+        // Verify the stream has encryption enabled
+        const streamDescription = yield* Kinesis.describeStreamSummary({
+          StreamName: stream.streamName,
+        });
+        expect(
+          streamDescription.StreamDescriptionSummary.EncryptionType,
+        ).toEqual("KMS");
+
+        // Update to disable encryption
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("EncryptedStream", {
+              encryption: false,
+            });
+          }),
+        );
+
+        // Verify encryption is disabled
+        const updatedDescription = yield* Kinesis.describeStreamSummary({
+          StreamName: stream.streamName,
+        });
+        expect(
+          updatedDescription.StreamDescriptionSummary.EncryptionType,
+        ).toEqual("NONE");
+
+        yield* stack.destroy();
+
+        yield* assertStreamDeleted(stream.streamName);
+      }),
     { timeout: 180_000 },
-    Effect.gen(function* () {
-      const stream = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("EncryptedStream", {
-            encryption: true,
-          });
-        }),
-      );
-
-      // Verify the stream has encryption enabled
-      const streamDescription = yield* Kinesis.describeStreamSummary({
-        StreamName: stream.streamName,
-      });
-      expect(streamDescription.StreamDescriptionSummary.EncryptionType).toEqual(
-        "KMS",
-      );
-
-      // Update to disable encryption
-      yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("EncryptedStream", {
-            encryption: false,
-          });
-        }),
-      );
-
-      // Verify encryption is disabled
-      const updatedDescription = yield* Kinesis.describeStreamSummary({
-        StreamName: stream.streamName,
-      });
-      expect(
-        updatedDescription.StreamDescriptionSummary.EncryptionType,
-      ).toEqual("NONE");
-
-      yield* destroy();
-
-      yield* assertStreamDeleted(stream.streamName);
-    }).pipe(Effect.provide(AWS.providers())),
   );
 
-  test(
+  test.provider(
     "create stream with enhanced monitoring and update metrics",
+    (stack) =>
+      Effect.gen(function* () {
+        const stream = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("MonitoredStream", {
+              shardLevelMetrics: ["IncomingBytes", "OutgoingRecords"],
+            });
+          }),
+        );
+
+        // Verify enhanced monitoring is enabled
+        const streamDescription = yield* Kinesis.describeStreamSummary({
+          StreamName: stream.streamName,
+        });
+        const metrics =
+          streamDescription.StreamDescriptionSummary.EnhancedMonitoring?.[0]
+            ?.ShardLevelMetrics ?? [];
+        expect(metrics).toContain("IncomingBytes");
+        expect(metrics).toContain("OutgoingRecords");
+
+        // Update metrics - add some, remove some
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("MonitoredStream", {
+              shardLevelMetrics: [
+                "IncomingBytes",
+                "IncomingRecords",
+                "IteratorAgeMilliseconds",
+              ],
+            });
+          }),
+        );
+
+        // Verify metrics were updated
+        const updatedDescription = yield* Kinesis.describeStreamSummary({
+          StreamName: stream.streamName,
+        });
+        const updatedMetrics =
+          updatedDescription.StreamDescriptionSummary.EnhancedMonitoring?.[0]
+            ?.ShardLevelMetrics ?? [];
+        expect(updatedMetrics).toContain("IncomingBytes");
+        expect(updatedMetrics).toContain("IncomingRecords");
+        expect(updatedMetrics).toContain("IteratorAgeMilliseconds");
+        expect(updatedMetrics).not.toContain("OutgoingRecords");
+
+        yield* stack.destroy();
+
+        yield* assertStreamDeleted(stream.streamName);
+      }),
     { timeout: 180_000 },
-    Effect.gen(function* () {
-      const stream = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("MonitoredStream", {
-            shardLevelMetrics: ["IncomingBytes", "OutgoingRecords"],
-          });
-        }),
-      );
-
-      // Verify enhanced monitoring is enabled
-      const streamDescription = yield* Kinesis.describeStreamSummary({
-        StreamName: stream.streamName,
-      });
-      const metrics =
-        streamDescription.StreamDescriptionSummary.EnhancedMonitoring?.[0]
-          ?.ShardLevelMetrics ?? [];
-      expect(metrics).toContain("IncomingBytes");
-      expect(metrics).toContain("OutgoingRecords");
-
-      // Update metrics - add some, remove some
-      yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("MonitoredStream", {
-            shardLevelMetrics: [
-              "IncomingBytes",
-              "IncomingRecords",
-              "IteratorAgeMilliseconds",
-            ],
-          });
-        }),
-      );
-
-      // Verify metrics were updated
-      const updatedDescription = yield* Kinesis.describeStreamSummary({
-        StreamName: stream.streamName,
-      });
-      const updatedMetrics =
-        updatedDescription.StreamDescriptionSummary.EnhancedMonitoring?.[0]
-          ?.ShardLevelMetrics ?? [];
-      expect(updatedMetrics).toContain("IncomingBytes");
-      expect(updatedMetrics).toContain("IncomingRecords");
-      expect(updatedMetrics).toContain("IteratorAgeMilliseconds");
-      expect(updatedMetrics).not.toContain("OutgoingRecords");
-
-      yield* destroy();
-
-      yield* assertStreamDeleted(stream.streamName);
-    }).pipe(Effect.provide(AWS.providers())),
   );
 
-  test(
+  test.provider(
     "idempotent create - stream already exists",
+    (stack) =>
+      Effect.gen(function* () {
+        // First create
+        const stream1 = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("IdempotentStream", {});
+          }),
+        );
+        const streamName = stream1.streamName;
+
+        // Second create (should be idempotent)
+        const stream2 = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("IdempotentStream", {});
+          }),
+        );
+        expect(stream2.streamName).toEqual(streamName);
+
+        yield* stack.destroy();
+
+        yield* assertStreamDeleted(streamName);
+      }),
     { timeout: 180_000 },
-    Effect.gen(function* () {
-      // First create
-      const stream1 = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("IdempotentStream", {});
-        }),
-      );
-      const streamName = stream1.streamName;
-
-      // Second create (should be idempotent)
-      const stream2 = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("IdempotentStream", {});
-        }),
-      );
-      expect(stream2.streamName).toEqual(streamName);
-
-      yield* destroy();
-
-      yield* assertStreamDeleted(streamName);
-    }).pipe(Effect.provide(AWS.providers())),
   );
 
-  test(
+  test.provider(
     "switch stream mode from provisioned to on-demand",
+    (stack) =>
+      Effect.gen(function* () {
+        const stream = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("ModeChangeStream", {
+              streamMode: "PROVISIONED",
+              shardCount: 1,
+            });
+          }),
+        );
+
+        // Verify provisioned mode
+        const streamDescription = yield* Kinesis.describeStreamSummary({
+          StreamName: stream.streamName,
+        });
+        expect(
+          streamDescription.StreamDescriptionSummary.StreamModeDetails
+            ?.StreamMode,
+        ).toEqual("PROVISIONED");
+
+        // Update to on-demand mode
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("ModeChangeStream", {
+              streamMode: "ON_DEMAND",
+            });
+          }),
+        );
+
+        // Verify on-demand mode
+        const updatedDescription = yield* Kinesis.describeStreamSummary({
+          StreamName: stream.streamName,
+        });
+        expect(
+          updatedDescription.StreamDescriptionSummary.StreamModeDetails
+            ?.StreamMode,
+        ).toEqual("ON_DEMAND");
+
+        yield* stack.destroy();
+
+        yield* assertStreamDeleted(stream.streamName);
+      }),
     { timeout: 300_000 },
-    Effect.gen(function* () {
-      const stream = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("ModeChangeStream", {
-            streamMode: "PROVISIONED",
-            shardCount: 1,
-          });
-        }),
-      );
-
-      // Verify provisioned mode
-      const streamDescription = yield* Kinesis.describeStreamSummary({
-        StreamName: stream.streamName,
-      });
-      expect(
-        streamDescription.StreamDescriptionSummary.StreamModeDetails
-          ?.StreamMode,
-      ).toEqual("PROVISIONED");
-
-      // Update to on-demand mode
-      yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("ModeChangeStream", {
-            streamMode: "ON_DEMAND",
-          });
-        }),
-      );
-
-      // Verify on-demand mode
-      const updatedDescription = yield* Kinesis.describeStreamSummary({
-        StreamName: stream.streamName,
-      });
-      expect(
-        updatedDescription.StreamDescriptionSummary.StreamModeDetails
-          ?.StreamMode,
-      ).toEqual("ON_DEMAND");
-
-      yield* destroy();
-
-      yield* assertStreamDeleted(stream.streamName);
-    }).pipe(Effect.provide(AWS.providers())),
   );
 
-  test(
+  test.provider(
     "decrease retention period",
+    (stack) =>
+      Effect.gen(function* () {
+        const stream = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("RetentionStream", {
+              retentionPeriodHours: 48,
+            });
+          }),
+        );
+
+        // Verify initial retention period
+        const streamDescription = yield* Kinesis.describeStreamSummary({
+          StreamName: stream.streamName,
+        });
+        expect(
+          streamDescription.StreamDescriptionSummary.RetentionPeriodHours,
+        ).toEqual(48);
+
+        // Decrease retention period back to default
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("RetentionStream", {
+              retentionPeriodHours: 24,
+            });
+          }),
+        );
+
+        // Verify retention period was decreased
+        const updatedDescription = yield* Kinesis.describeStreamSummary({
+          StreamName: stream.streamName,
+        });
+        expect(
+          updatedDescription.StreamDescriptionSummary.RetentionPeriodHours,
+        ).toEqual(24);
+
+        yield* stack.destroy();
+
+        yield* assertStreamDeleted(stream.streamName);
+      }),
     { timeout: 180_000 },
-    Effect.gen(function* () {
-      const stream = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("RetentionStream", {
-            retentionPeriodHours: 48,
-          });
-        }),
-      );
-
-      // Verify initial retention period
-      const streamDescription = yield* Kinesis.describeStreamSummary({
-        StreamName: stream.streamName,
-      });
-      expect(
-        streamDescription.StreamDescriptionSummary.RetentionPeriodHours,
-      ).toEqual(48);
-
-      // Decrease retention period back to default
-      yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("RetentionStream", {
-            retentionPeriodHours: 24,
-          });
-        }),
-      );
-
-      // Verify retention period was decreased
-      const updatedDescription = yield* Kinesis.describeStreamSummary({
-        StreamName: stream.streamName,
-      });
-      expect(
-        updatedDescription.StreamDescriptionSummary.RetentionPeriodHours,
-      ).toEqual(24);
-
-      yield* destroy();
-
-      yield* assertStreamDeleted(stream.streamName);
-    }).pipe(Effect.provide(AWS.providers())),
   );
 
-  test(
+  test.provider(
     "update stream resource policy and max record size",
-    { timeout: 240_000 },
-    Effect.gen(function* () {
-      const stream = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("PolicyStream", {
-            streamMode: "PROVISIONED",
-            shardCount: 1,
-          });
-        }),
-      );
+    (stack) =>
+      Effect.gen(function* () {
+        const stream = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("PolicyStream", {
+              streamMode: "PROVISIONED",
+              shardCount: 1,
+            });
+          }),
+        );
 
-      const policy = JSON.stringify({
-        Version: "2012-10-17",
-        Statement: [
-          {
-            Sid: "AllowSameAccountDescribe",
-            Effect: "Allow",
-            Principal: {
-              AWS: `arn:aws:iam::${stream.streamArn.split(":")[4]}:root`,
+        const policy = JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Sid: "AllowSameAccountDescribe",
+              Effect: "Allow",
+              Principal: {
+                AWS: `arn:aws:iam::${stream.streamArn.split(":")[4]}:root`,
+              },
+              Action: ["kinesis:DescribeStreamSummary"],
+              Resource: stream.streamArn,
             },
-            Action: ["kinesis:DescribeStreamSummary"],
-            Resource: stream.streamArn,
-          },
-        ],
-      });
+          ],
+        });
 
-      const updated = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("PolicyStream", {
-            streamMode: "PROVISIONED",
-            shardCount: 1,
-            resourcePolicy: policy,
-            maxRecordSizeInKiB: 2048,
-          });
-        }),
-      );
+        const updated = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("PolicyStream", {
+              streamMode: "PROVISIONED",
+              shardCount: 1,
+              resourcePolicy: policy,
+              maxRecordSizeInKiB: 2048,
+            });
+          }),
+        );
 
-      expect(updated.resourcePolicy).toContain("AllowSameAccountDescribe");
-      expect(updated.maxRecordSizeInKiB).toEqual(2048);
+        expect(updated.resourcePolicy).toContain("AllowSameAccountDescribe");
+        expect(updated.maxRecordSizeInKiB).toEqual(2048);
 
-      const policyResponse = yield* Kinesis.getResourcePolicy({
-        ResourceARN: stream.streamArn,
-      });
-      expect(policyResponse.Policy).toContain("AllowSameAccountDescribe");
+        const policyResponse = yield* Kinesis.getResourcePolicy({
+          ResourceARN: stream.streamArn,
+        });
+        expect(policyResponse.Policy).toContain("AllowSameAccountDescribe");
 
-      const summary = yield* Kinesis.describeStreamSummary({
-        StreamName: stream.streamName,
-      });
-      expect(summary.StreamDescriptionSummary.MaxRecordSizeInKiB).toEqual(2048);
+        const summary = yield* Kinesis.describeStreamSummary({
+          StreamName: stream.streamName,
+        });
+        expect(summary.StreamDescriptionSummary.MaxRecordSizeInKiB).toEqual(
+          2048,
+        );
 
-      yield* destroy();
-      yield* assertStreamDeleted(stream.streamName);
-    }).pipe(Effect.provide(AWS.providers())),
+        yield* stack.destroy();
+        yield* assertStreamDeleted(stream.streamName);
+      }),
+    { timeout: 240_000 },
   );
 
-  test(
+  test.provider(
     "update warm throughput when account supports it",
+    (stack) =>
+      Effect.gen(function* () {
+        const accountSettings = yield* Kinesis.describeAccountSettings({});
+        const status =
+          accountSettings.MinimumThroughputBillingCommitment?.Status ??
+          "DISABLED";
+
+        if (status === "DISABLED") {
+          return;
+        }
+
+        const stream = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("WarmThroughputStream");
+          }),
+        );
+
+        const updated = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("WarmThroughputStream", {
+              warmThroughputMiBps: 10,
+            });
+          }),
+        );
+
+        expect(updated.warmThroughput?.targetMiBps).toEqual(10);
+
+        const summary = yield* Kinesis.describeStreamSummary({
+          StreamName: stream.streamName,
+        });
+        expect(
+          summary.StreamDescriptionSummary.WarmThroughput?.TargetMiBps,
+        ).toEqual(10);
+
+        yield* stack.destroy();
+        yield* assertStreamDeleted(stream.streamName);
+      }),
     { timeout: 240_000 },
-    Effect.gen(function* () {
-      const accountSettings = yield* Kinesis.describeAccountSettings({});
-      const status =
-        accountSettings.MinimumThroughputBillingCommitment?.Status ??
-        "DISABLED";
-
-      if (status === "DISABLED") {
-        return;
-      }
-
-      const stream = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("WarmThroughputStream");
-        }),
-      );
-
-      const updated = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Stream("WarmThroughputStream", {
-            warmThroughputMiBps: 10,
-          });
-        }),
-      );
-
-      expect(updated.warmThroughput?.targetMiBps).toEqual(10);
-
-      const summary = yield* Kinesis.describeStreamSummary({
-        StreamName: stream.streamName,
-      });
-      expect(
-        summary.StreamDescriptionSummary.WarmThroughput?.TargetMiBps,
-      ).toEqual(10);
-
-      yield* destroy();
-      yield* assertStreamDeleted(stream.streamName);
-    }).pipe(Effect.provide(AWS.providers())),
   );
 
   class StreamStillExists extends Data.TaggedError("StreamStillExists") {}

--- a/packages/alchemy/test/AWS/Kinesis/StreamConsumer.test.ts
+++ b/packages/alchemy/test/AWS/Kinesis/StreamConsumer.test.ts
@@ -1,93 +1,98 @@
 import * as AWS from "@/AWS";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as Kinesis from "@distilled.cloud/aws/kinesis";
 import { describe, expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 
+const { test } = Test.make({ providers: AWS.providers() });
+
 describe("AWS.Kinesis.StreamConsumer", () => {
-  test(
+  test.provider(
     "create, update tags, and delete a stream consumer",
+    (stack) =>
+      Effect.gen(function* () {
+        const deployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            const stream = yield* AWS.Kinesis.Stream("ConsumerSourceStream", {
+              streamMode: "PROVISIONED",
+              shardCount: 1,
+            });
+
+            const consumer = yield* AWS.Kinesis.StreamConsumer(
+              "AnalyticsConsumer",
+              {
+                streamArn: stream.streamArn,
+                tags: {
+                  fixture: "consumer-test",
+                },
+              },
+            );
+
+            return { stream, consumer };
+          }),
+        );
+
+        const description = yield* Kinesis.describeStreamConsumer({
+          ConsumerARN: deployed.consumer.consumerArn,
+        });
+        expect(description.ConsumerDescription.ConsumerStatus).toEqual(
+          "ACTIVE",
+        );
+
+        const initialTags = yield* Kinesis.listTagsForResource({
+          ResourceARN: deployed.consumer.consumerArn,
+        });
+        expect(initialTags.Tags).toContainEqual({
+          Key: "fixture",
+          Value: "consumer-test",
+        });
+
+        const updated = yield* stack.deploy(
+          Effect.gen(function* () {
+            const stream = yield* AWS.Kinesis.Stream("ConsumerSourceStream", {
+              streamMode: "PROVISIONED",
+              shardCount: 1,
+            });
+
+            const consumer = yield* AWS.Kinesis.StreamConsumer(
+              "AnalyticsConsumer",
+              {
+                streamArn: stream.streamArn,
+                tags: {
+                  fixture: "consumer-test-updated",
+                  team: "platform",
+                },
+              },
+            );
+
+            return { stream, consumer };
+          }),
+        );
+
+        const updatedTags = yield* Kinesis.listTagsForResource({
+          ResourceARN: updated.consumer.consumerArn,
+        });
+        expect(updatedTags.Tags).toContainEqual({
+          Key: "fixture",
+          Value: "consumer-test-updated",
+        });
+        expect(updatedTags.Tags).toContainEqual({
+          Key: "team",
+          Value: "platform",
+        });
+
+        yield* stack.destroy();
+
+        const deleted = yield* Kinesis.describeStreamConsumer({
+          ConsumerARN: updated.consumer.consumerArn,
+        }).pipe(
+          Effect.map(() => false),
+          Effect.catchTag("ResourceNotFoundException", () =>
+            Effect.succeed(true),
+          ),
+        );
+        expect(deleted).toBe(true);
+      }),
     { timeout: 180_000 },
-    Effect.gen(function* () {
-      const deployed = yield* test.deploy(
-        Effect.gen(function* () {
-          const stream = yield* AWS.Kinesis.Stream("ConsumerSourceStream", {
-            streamMode: "PROVISIONED",
-            shardCount: 1,
-          });
-
-          const consumer = yield* AWS.Kinesis.StreamConsumer(
-            "AnalyticsConsumer",
-            {
-              streamArn: stream.streamArn,
-              tags: {
-                fixture: "consumer-test",
-              },
-            },
-          );
-
-          return { stream, consumer };
-        }),
-      );
-
-      const description = yield* Kinesis.describeStreamConsumer({
-        ConsumerARN: deployed.consumer.consumerArn,
-      });
-      expect(description.ConsumerDescription.ConsumerStatus).toEqual("ACTIVE");
-
-      const initialTags = yield* Kinesis.listTagsForResource({
-        ResourceARN: deployed.consumer.consumerArn,
-      });
-      expect(initialTags.Tags).toContainEqual({
-        Key: "fixture",
-        Value: "consumer-test",
-      });
-
-      const updated = yield* test.deploy(
-        Effect.gen(function* () {
-          const stream = yield* AWS.Kinesis.Stream("ConsumerSourceStream", {
-            streamMode: "PROVISIONED",
-            shardCount: 1,
-          });
-
-          const consumer = yield* AWS.Kinesis.StreamConsumer(
-            "AnalyticsConsumer",
-            {
-              streamArn: stream.streamArn,
-              tags: {
-                fixture: "consumer-test-updated",
-                team: "platform",
-              },
-            },
-          );
-
-          return { stream, consumer };
-        }),
-      );
-
-      const updatedTags = yield* Kinesis.listTagsForResource({
-        ResourceARN: updated.consumer.consumerArn,
-      });
-      expect(updatedTags.Tags).toContainEqual({
-        Key: "fixture",
-        Value: "consumer-test-updated",
-      });
-      expect(updatedTags.Tags).toContainEqual({
-        Key: "team",
-        Value: "platform",
-      });
-
-      yield* destroy();
-
-      const deleted = yield* Kinesis.describeStreamConsumer({
-        ConsumerARN: updated.consumer.consumerArn,
-      }).pipe(
-        Effect.map(() => false),
-        Effect.catchTag("ResourceNotFoundException", () =>
-          Effect.succeed(true),
-        ),
-      );
-      expect(deleted).toBe(true);
-    }).pipe(Effect.provide(AWS.providers())),
   );
 });

--- a/packages/alchemy/test/AWS/Kinesis/StreamEventSource.test.ts
+++ b/packages/alchemy/test/AWS/Kinesis/StreamEventSource.test.ts
@@ -1,5 +1,5 @@
 import * as AWS from "@/AWS";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as Kinesis from "@distilled.cloud/aws/kinesis";
 import * as Lambda from "@distilled.cloud/aws/lambda";
 import { describe, expect } from "@effect/vitest";
@@ -11,54 +11,61 @@ import KinesisStreamFunctionLive, {
   KinesisStreamFunction,
 } from "./stream-handler.ts";
 
+const { test } = Test.make({ providers: AWS.providers() });
+
 describe.sequential("AWS.Kinesis.StreamEventSource", () => {
-  test(
+  test.provider(
     "processes real Kinesis records through Lambda",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const streamFunction = yield* stack.deploy(
+          KinesisStreamFunction.asEffect().pipe(
+            Effect.provide(KinesisStreamFunctionLive),
+          ),
+        );
+
+        const functionUrl = streamFunction.functionUrl!;
+
+        const { streamName, streamArn } = yield* HttpClient.get(
+          functionUrl,
+        ).pipe(
+          Effect.flatMap((response) =>
+            response.status === 200
+              ? (response.json as Effect.Effect<{
+                  streamName: string;
+                  streamArn: string;
+                }>)
+              : Effect.fail(
+                  new Error(`Function not ready: ${response.status}`),
+                ),
+          ),
+          Effect.retry({ schedule: Schedule.fixed("1 seconds") }),
+        );
+
+        yield* waitForEventSourceMappingEnabled(
+          streamFunction.functionName,
+          streamArn,
+        );
+        yield* Effect.sleep("10 seconds");
+
+        yield* Kinesis.putRecord({
+          StreamName: streamName,
+          PartitionKey: "stream-event-source",
+          Data: new TextEncoder().encode("payload"),
+        });
+        yield* Effect.sleep("5 seconds");
+
+        const mapping = yield* waitForEventSourceMappingEnabled(
+          streamFunction.functionName,
+          streamArn,
+        );
+        expect(mapping.State).toEqual("Enabled");
+
+        yield* stack.destroy();
+      }),
     { timeout: 240_000 },
-    Effect.gen(function* () {
-      yield* destroy();
-
-      const streamFunction = yield* test.deploy(
-        KinesisStreamFunction.asEffect().pipe(
-          Effect.provide(KinesisStreamFunctionLive),
-        ),
-      );
-
-      const functionUrl = streamFunction.functionUrl!;
-
-      const { streamName, streamArn } = yield* HttpClient.get(functionUrl).pipe(
-        Effect.flatMap((response) =>
-          response.status === 200
-            ? (response.json as Effect.Effect<{
-                streamName: string;
-                streamArn: string;
-              }>)
-            : Effect.fail(new Error(`Function not ready: ${response.status}`)),
-        ),
-        Effect.retry({ schedule: Schedule.fixed("1 seconds") }),
-      );
-
-      yield* waitForEventSourceMappingEnabled(
-        streamFunction.functionName,
-        streamArn,
-      );
-      yield* Effect.sleep("10 seconds");
-
-      yield* Kinesis.putRecord({
-        StreamName: streamName,
-        PartitionKey: "stream-event-source",
-        Data: new TextEncoder().encode("payload"),
-      });
-      yield* Effect.sleep("5 seconds");
-
-      const mapping = yield* waitForEventSourceMappingEnabled(
-        streamFunction.functionName,
-        streamArn,
-      );
-      expect(mapping.State).toEqual("Enabled");
-
-      yield* destroy();
-    }).pipe(Effect.provide(AWS.providers())),
   );
 });
 

--- a/packages/alchemy/test/AWS/Lambda/Function.test.ts
+++ b/packages/alchemy/test/AWS/Lambda/Function.test.ts
@@ -1,40 +1,43 @@
 import * as AWS from "@/AWS";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import { TestFunction, TestFunctionLive } from "./handler.ts";
 
-test(
+const { test } = Test.make({ providers: AWS.providers() });
+
+test.provider(
   "create, update, delete function",
-  { timeout: 180_000 },
-  Effect.gen(function* () {
-    // yield* destroy();
+  (stack) =>
+    Effect.gen(function* () {
+      const { functionUrl } = yield* stack.deploy(
+        TestFunction.asEffect().pipe(Effect.provide(TestFunctionLive)),
+      );
 
-    const { functionUrl } = yield* test.deploy(
-      TestFunction.asEffect().pipe(Effect.provide(TestFunctionLive)),
-    );
+      expect(functionUrl).toBeTruthy();
 
-    expect(functionUrl).toBeTruthy();
-
-    const response = yield* HttpClient.get(functionUrl!).pipe(
-      Effect.flatMap((response) =>
-        response.status === 200
-          ? Effect.succeed(response)
-          : Effect.fail(new Error(`Function URL returned ${response.status}`)),
-      ),
-      Effect.tapError((error) => Effect.logError(error)),
-      Effect.retry({
-        schedule: Schedule.exponential(500).pipe(
-          Schedule.both(Schedule.recurs(10)),
+      const response = yield* HttpClient.get(functionUrl!).pipe(
+        Effect.flatMap((response) =>
+          response.status === 200
+            ? Effect.succeed(response)
+            : Effect.fail(
+                new Error(`Function URL returned ${response.status}`),
+              ),
         ),
-      }),
-    );
+        Effect.tapError((error) => Effect.logError(error)),
+        Effect.retry({
+          schedule: Schedule.exponential(500).pipe(
+            Schedule.both(Schedule.recurs(10)),
+          ),
+        }),
+      );
 
-    expect(response.status).toBe(200);
-    expect(yield* response.text).toBe("Hello, world!");
+      expect(response.status).toBe(200);
+      expect(yield* response.text).toBe("Hello, world!");
 
-    yield* destroy();
-  }).pipe(Effect.provide(AWS.providers())) as Effect.Effect<void, any, any>,
+      yield* stack.destroy();
+    }),
+  { timeout: 180_000 },
 );

--- a/packages/alchemy/test/AWS/S3/Bucket.data-plane.test.ts
+++ b/packages/alchemy/test/AWS/S3/Bucket.data-plane.test.ts
@@ -1,14 +1,16 @@
 import * as AWS from "@/AWS";
 import { Bucket } from "@/AWS/S3";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as S3 from "@distilled.cloud/aws/s3";
 import { expect } from "@effect/vitest";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 
-const deployTestBucket = () =>
-  test.deploy(
+const { test } = Test.make({ providers: AWS.providers() });
+
+const deployTestBucket = (stack: Test.ScratchStack) =>
+  stack.deploy(
     Effect.gen(function* () {
       return yield* Bucket("DataPlaneTestBucket", {
         forceDestroy: true,
@@ -16,13 +18,11 @@ const deployTestBucket = () =>
     }),
   );
 
-test(
-  "listObjectsV2 - list objects in bucket",
+test.provider("listObjectsV2 - list objects in bucket", (stack) =>
   Effect.gen(function* () {
-    const bucket = yield* deployTestBucket();
+    const bucket = yield* deployTestBucket(stack);
     const bucketName = bucket.bucketName;
 
-    // Put some test objects
     yield* S3.putObject({
       Bucket: bucketName,
       Key: "file1.txt",
@@ -39,7 +39,6 @@ test(
       Body: "content 3",
     });
 
-    // Test listObjectsV2
     const result = yield* S3.listObjectsV2({
       Bucket: bucketName,
     });
@@ -50,7 +49,6 @@ test(
     expect(result.Contents!.map((c) => c.Key)).toContain("file2.txt");
     expect(result.Contents!.map((c) => c.Key)).toContain("folder/file3.txt");
 
-    // Test with prefix
     const prefixResult = yield* S3.listObjectsV2({
       Bucket: bucketName,
       Prefix: "folder/",
@@ -58,7 +56,6 @@ test(
     expect(prefixResult.Contents!.length).toBe(1);
     expect(prefixResult.Contents![0].Key).toBe("folder/file3.txt");
 
-    // Test with maxKeys
     const limitResult = yield* S3.listObjectsV2({
       Bucket: bucketName,
       MaxKeys: 1,
@@ -66,18 +63,16 @@ test(
     expect(limitResult.Contents!.length).toBe(1);
     expect(limitResult.IsTruncated).toBe(true);
 
-    yield* destroy();
+    yield* stack.destroy();
     yield* assertBucketDeleted(bucketName);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
-  "headObject - get object metadata",
+test.provider("headObject - get object metadata", (stack) =>
   Effect.gen(function* () {
-    const bucket = yield* deployTestBucket();
+    const bucket = yield* deployTestBucket(stack);
     const bucketName = bucket.bucketName;
 
-    // Put a test object
     yield* S3.putObject({
       Bucket: bucketName,
       Key: "test-file.txt",
@@ -85,28 +80,25 @@ test(
       ContentType: "text/plain",
     });
 
-    // Test headObject
     const result = yield* S3.headObject({
       Bucket: bucketName,
       Key: "test-file.txt",
     });
 
     expect(result.ContentType).toBe("text/plain");
-    expect(result.ContentLength).toBe(13); // "Hello, World!" is 13 bytes
+    expect(result.ContentLength).toBe(13);
     expect(result.ETag).toBeDefined();
 
-    yield* destroy();
+    yield* stack.destroy();
     yield* assertBucketDeleted(bucketName);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
-  "headObject - returns error for non-existent object",
+test.provider("headObject - returns error for non-existent object", (stack) =>
   Effect.gen(function* () {
-    const bucket = yield* deployTestBucket();
+    const bucket = yield* deployTestBucket(stack);
     const bucketName = bucket.bucketName;
 
-    // Try to head a non-existent object
     const result = yield* S3.headObject({
       Bucket: bucketName,
       Key: "non-existent.txt",
@@ -117,18 +109,16 @@ test(
 
     expect(result).toBe("not-found");
 
-    yield* destroy();
+    yield* stack.destroy();
     yield* assertBucketDeleted(bucketName);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
-  "copyObject - copy object within bucket",
+test.provider("copyObject - copy object within bucket", (stack) =>
   Effect.gen(function* () {
-    const bucket = yield* deployTestBucket();
+    const bucket = yield* deployTestBucket(stack);
     const bucketName = bucket.bucketName;
 
-    // Put source object
     yield* S3.putObject({
       Bucket: bucketName,
       Key: "source.txt",
@@ -136,40 +126,35 @@ test(
       ContentType: "text/plain",
     });
 
-    // Copy the object
     yield* S3.copyObject({
       Bucket: bucketName,
       Key: "destination.txt",
       CopySource: `${bucketName}/source.txt`,
     });
 
-    // Verify destination exists
     const destHead = yield* S3.headObject({
       Bucket: bucketName,
       Key: "destination.txt",
     });
     expect(destHead.ContentType).toBe("text/plain");
-    expect(destHead.ContentLength).toBe(16); // "Original content" is 16 bytes
+    expect(destHead.ContentLength).toBe(16);
 
-    // Verify source still exists
     const sourceHead = yield* S3.headObject({
       Bucket: bucketName,
       Key: "source.txt",
     });
     expect(sourceHead.ContentLength).toBe(16);
 
-    yield* destroy();
+    yield* stack.destroy();
     yield* assertBucketDeleted(bucketName);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
-  "copyObject - copy with metadata replacement",
+test.provider("copyObject - copy with metadata replacement", (stack) =>
   Effect.gen(function* () {
-    const bucket = yield* deployTestBucket();
+    const bucket = yield* deployTestBucket(stack);
     const bucketName = bucket.bucketName;
 
-    // Put source object
     yield* S3.putObject({
       Bucket: bucketName,
       Key: "source.txt",
@@ -177,7 +162,6 @@ test(
       ContentType: "text/plain",
     });
 
-    // Copy with new content type
     yield* S3.copyObject({
       Bucket: bucketName,
       Key: "destination.txt",
@@ -186,7 +170,6 @@ test(
       MetadataDirective: "REPLACE",
     });
 
-    // Verify destination has new content type
     const destHead = yield* S3.headObject({
       Bucket: bucketName,
       Key: "destination.txt",
@@ -194,18 +177,16 @@ test(
     // AWS may normalize content-type to binary/octet-stream
     expect(destHead.ContentType).toBe("binary/octet-stream");
 
-    yield* destroy();
+    yield* stack.destroy();
     yield* assertBucketDeleted(bucketName);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
-  "multipart upload - complete workflow",
+test.provider("multipart upload - complete workflow", (stack) =>
   Effect.gen(function* () {
-    const bucket = yield* deployTestBucket();
+    const bucket = yield* deployTestBucket(stack);
     const bucketName = bucket.bucketName;
 
-    // Create multipart upload
     const createResult = yield* S3.createMultipartUpload({
       Bucket: bucketName,
       Key: "multipart-file.txt",
@@ -215,8 +196,8 @@ test(
     expect(createResult.UploadId).toBeDefined();
     const uploadId = createResult.UploadId!;
 
-    // Use a single part - AWS S3 requires parts to be at least 5MB except for
-    // the last (or only) part, so a single-part upload works with any size
+    // AWS S3 requires parts to be at least 5MB except for the last (or only)
+    // part, so a single-part upload works with any size
     const partContent = "Complete multipart upload content";
 
     const partResult = yield* S3.uploadPart({
@@ -228,7 +209,6 @@ test(
     });
     expect(partResult.ETag).toBeDefined();
 
-    // Complete the multipart upload with single part
     yield* S3.completeMultipartUpload({
       Bucket: bucketName,
       Key: "multipart-file.txt",
@@ -238,27 +218,24 @@ test(
       },
     });
 
-    // Verify the object exists and has correct size
     const headResult = yield* S3.headObject({
       Bucket: bucketName,
       Key: "multipart-file.txt",
     });
-    // Note: AWS S3 may use binary/octet-stream for multipart uploads even when
+    // AWS S3 may use binary/octet-stream for multipart uploads even when
     // ContentType is set on createMultipartUpload
     expect(headResult.ContentLength).toBe(partContent.length);
 
-    yield* destroy();
+    yield* stack.destroy();
     yield* assertBucketDeleted(bucketName);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
-  "multipart upload - abort",
+test.provider("multipart upload - abort", (stack) =>
   Effect.gen(function* () {
-    const bucket = yield* deployTestBucket();
+    const bucket = yield* deployTestBucket(stack);
     const bucketName = bucket.bucketName;
 
-    // Create multipart upload
     const createResult = yield* S3.createMultipartUpload({
       Bucket: bucketName,
       Key: "aborted-file.txt",
@@ -267,7 +244,6 @@ test(
 
     const uploadId = createResult.UploadId!;
 
-    // Upload a part
     yield* S3.uploadPart({
       Bucket: bucketName,
       Key: "aborted-file.txt",
@@ -276,14 +252,12 @@ test(
       Body: "Some content",
     });
 
-    // Abort the upload
     yield* S3.abortMultipartUpload({
       Bucket: bucketName,
       Key: "aborted-file.txt",
       UploadId: uploadId,
     });
 
-    // Verify the object does not exist
     const headResult = yield* S3.headObject({
       Bucket: bucketName,
       Key: "aborted-file.txt",
@@ -294,18 +268,16 @@ test(
 
     expect(headResult).toBe("not-found");
 
-    yield* destroy();
+    yield* stack.destroy();
     yield* assertBucketDeleted(bucketName);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
-  "putObject and getObject - basic operations",
+test.provider("putObject and getObject - basic operations", (stack) =>
   Effect.gen(function* () {
-    const bucket = yield* deployTestBucket();
+    const bucket = yield* deployTestBucket(stack);
     const bucketName = bucket.bucketName;
 
-    // Test putObject
     yield* S3.putObject({
       Bucket: bucketName,
       Key: "test-put.txt",
@@ -313,7 +285,6 @@ test(
       ContentType: "text/plain",
     });
 
-    // Verify with headObject
     const headResult = yield* S3.headObject({
       Bucket: bucketName,
       Key: "test-put.txt",
@@ -321,7 +292,6 @@ test(
     expect(headResult.ContentType).toBe("text/plain");
     expect(headResult.ContentLength).toBe(30);
 
-    // Test getObject
     const getResult = yield* S3.getObject({
       Bucket: bucketName,
       Key: "test-put.txt",
@@ -329,37 +299,32 @@ test(
     expect(getResult.ContentType).toBe("text/plain");
     expect(getResult.ContentLength).toBe(30);
 
-    yield* destroy();
+    yield* stack.destroy();
     yield* assertBucketDeleted(bucketName);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
-  "deleteObject - remove object",
+test.provider("deleteObject - remove object", (stack) =>
   Effect.gen(function* () {
-    const bucket = yield* deployTestBucket();
+    const bucket = yield* deployTestBucket(stack);
     const bucketName = bucket.bucketName;
 
-    // Put an object
     yield* S3.putObject({
       Bucket: bucketName,
       Key: "to-delete.txt",
       Body: "Delete me",
     });
 
-    // Verify it exists
     yield* S3.headObject({
       Bucket: bucketName,
       Key: "to-delete.txt",
     });
 
-    // Delete it
     yield* S3.deleteObject({
       Bucket: bucketName,
       Key: "to-delete.txt",
     });
 
-    // Verify it's gone
     const headResult = yield* S3.headObject({
       Bucket: bucketName,
       Key: "to-delete.txt",
@@ -370,9 +335,9 @@ test(
 
     expect(headResult).toBe("not-found");
 
-    yield* destroy();
+    yield* stack.destroy();
     yield* assertBucketDeleted(bucketName);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
 class BucketStillExists extends Data.TaggedError("BucketStillExists") {}

--- a/packages/alchemy/test/AWS/S3/Bucket.test.ts
+++ b/packages/alchemy/test/AWS/S3/Bucket.test.ts
@@ -1,18 +1,19 @@
 import * as AWS from "@/AWS";
 import { Bucket } from "@/AWS/S3";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as S3 from "@distilled.cloud/aws/s3";
 import { expect } from "@effect/vitest";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 
-test(
-  "create and delete bucket with default props",
-  Effect.gen(function* () {
-    yield* destroy();
+const { test } = Test.make({ providers: AWS.providers() });
 
-    const bucket = yield* test.deploy(
+test.provider("create and delete bucket with default props", (stack) =>
+  Effect.gen(function* () {
+    yield* stack.destroy();
+
+    const bucket = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Bucket("DefaultBucket");
       }),
@@ -24,19 +25,17 @@ test(
 
     yield* S3.headBucket({ Bucket: bucket.bucketName });
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* assertBucketDeleted(bucket.bucketName);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
-  "create, update, delete bucket",
+test.provider("create, update, delete bucket", (stack) =>
   Effect.gen(function* () {
-    // Clean up any previous state
-    yield* destroy();
+    yield* stack.destroy();
 
-    const bucket = yield* test.deploy(
+    const bucket = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Bucket("TestBucket", {
           bucketName: "alchemy-test-bucket-crud",
@@ -46,10 +45,8 @@ test(
       }),
     );
 
-    // Verify the bucket was created
     yield* S3.headBucket({ Bucket: bucket.bucketName });
 
-    // Verify tags
     const tagging = yield* S3.getBucketTagging({
       Bucket: bucket.bucketName,
     });
@@ -58,8 +55,7 @@ test(
       Value: "test",
     });
 
-    // Update the bucket tags
-    yield* test.deploy(
+    yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Bucket("TestBucket", {
           bucketName: "alchemy-test-bucket-crud",
@@ -69,7 +65,6 @@ test(
       }),
     );
 
-    // Verify tags were updated
     const updatedTagging = yield* S3.getBucketTagging({
       Bucket: bucket.bucketName,
     });
@@ -82,19 +77,17 @@ test(
       Value: "platform",
     });
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* assertBucketDeleted(bucket.bucketName);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
-  "create bucket with custom name",
+test.provider("create bucket with custom name", (stack) =>
   Effect.gen(function* () {
-    // Clean up any previous state
-    yield* destroy();
+    yield* stack.destroy();
 
-    const bucket = yield* test.deploy(
+    const bucket = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Bucket("CustomNameBucket", {
           bucketName: "alchemy-test-bucket-custom-name",
@@ -108,22 +101,19 @@ test(
       "arn:aws:s3:::alchemy-test-bucket-custom-name",
     );
 
-    // Verify the bucket exists
     yield* S3.headBucket({ Bucket: bucket.bucketName });
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* assertBucketDeleted(bucket.bucketName);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
-  "create bucket with forceDestroy",
+test.provider("create bucket with forceDestroy", (stack) =>
   Effect.gen(function* () {
-    // Clean up any previous state
-    yield* destroy();
+    yield* stack.destroy();
 
-    const bucket = yield* test.deploy(
+    const bucket = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Bucket("ForceDestroyBucket", {
           bucketName: "alchemy-test-bucket-force-destroy",
@@ -132,34 +122,28 @@ test(
       }),
     );
 
-    // Put an object in the bucket
     yield* S3.putObject({
       Bucket: bucket.bucketName,
       Key: "test-object.txt",
       Body: "Hello, World!",
     });
 
-    // Verify the object exists
     yield* S3.headObject({
       Bucket: bucket.bucketName,
       Key: "test-object.txt",
     });
 
-    // Destroy should succeed even with objects in the bucket
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* assertBucketDeleted(bucket.bucketName);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
-  "idempotent create - bucket already exists",
+test.provider("idempotent create - bucket already exists", (stack) =>
   Effect.gen(function* () {
-    // Clean up any previous state
-    yield* destroy();
+    yield* stack.destroy();
 
-    // First create
-    const bucket1 = yield* test.deploy(
+    const bucket1 = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Bucket("IdempotentBucket", {
           bucketName: "alchemy-test-bucket-idempotent",
@@ -169,8 +153,7 @@ test(
     );
     const bucketName = bucket1.bucketName;
 
-    // Second create (should be idempotent)
-    const bucket2 = yield* test.deploy(
+    const bucket2 = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Bucket("IdempotentBucket", {
           bucketName: "alchemy-test-bucket-idempotent",
@@ -180,19 +163,17 @@ test(
     );
     expect(bucket2.bucketName).toEqual(bucketName);
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* assertBucketDeleted(bucketName);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
-  "create bucket with objectLockEnabled",
+test.provider("create bucket with objectLockEnabled", (stack) =>
   Effect.gen(function* () {
-    // Clean up any previous state
-    yield* destroy();
+    yield* stack.destroy();
 
-    const bucket = yield* test.deploy(
+    const bucket = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Bucket("ObjectLockBucket", {
           bucketName: "alchemy-test-bucket-object-lock",
@@ -202,7 +183,6 @@ test(
       }),
     );
 
-    // Verify Object Lock is enabled
     const objectLockConfig = yield* S3.getObjectLockConfiguration({
       Bucket: bucket.bucketName,
     });
@@ -210,20 +190,17 @@ test(
       "Enabled",
     );
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* assertBucketDeleted(bucket.bucketName);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
-  "remove all tags from bucket",
+test.provider("remove all tags from bucket", (stack) =>
   Effect.gen(function* () {
-    // Clean up any previous state
-    yield* destroy();
+    yield* stack.destroy();
 
-    // Create bucket with tags
-    const bucket = yield* test.deploy(
+    const bucket = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Bucket("TagRemovalBucket", {
           bucketName: "alchemy-test-bucket-tag-removal",
@@ -234,14 +211,12 @@ test(
     );
     const bucketName = bucket.bucketName;
 
-    // Verify tags exist
     const tagging = yield* S3.getBucketTagging({
       Bucket: bucketName,
     });
     expect(tagging.TagSet).toHaveLength(2);
 
-    // Update to remove all tags
-    yield* test.deploy(
+    yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Bucket("TagRemovalBucket", {
           bucketName: "alchemy-test-bucket-tag-removal",
@@ -250,7 +225,6 @@ test(
       }),
     );
 
-    // Verify all tags were removed (NoSuchTagSet error expected)
     const result = yield* S3.getBucketTagging({
       Bucket: bucketName,
     }).pipe(
@@ -259,22 +233,21 @@ test(
     );
     expect(result).toEqual("no-tags");
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* assertBucketDeleted(bucketName);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
-  "create and remove bucket policy from bindings",
+test.provider("create and remove bucket policy from bindings", (stack) =>
   Effect.gen(function* () {
-    yield* destroy();
+    yield* stack.destroy();
 
     const distributionArn =
       "arn:aws:cloudfront::123456789012:distribution/TESTDIST";
     const bucketArn = "arn:aws:s3:::alchemy-test-bucket-policy-bindings";
 
-    const bucket = yield* test.deploy(
+    const bucket = yield* stack.deploy(
       Effect.gen(function* () {
         const bucket = yield* Bucket("PolicyBucket", {
           bucketName: "alchemy-test-bucket-policy-bindings",
@@ -321,7 +294,7 @@ test(
       },
     });
 
-    yield* test.deploy(
+    yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Bucket("PolicyBucket", {
           bucketName: "alchemy-test-bucket-policy-bindings",
@@ -341,10 +314,10 @@ test(
 
     expect(policyAfterRemoval).toEqual("no-policy");
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* assertBucketDeleted(bucket.bucketName);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
 class BucketStillExists extends Data.TaggedError("BucketStillExists") {}

--- a/packages/alchemy/test/AWS/SNS/Bindings.test.ts
+++ b/packages/alchemy/test/AWS/SNS/Bindings.test.ts
@@ -1,439 +1,379 @@
-import { afterAll, beforeAll, destroy, test } from "@/Test/Vitest";
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Vitest";
 import * as SQS from "@distilled.cloud/aws/sqs";
-import { expect } from "@effect/vitest";
+import { describe, expect } from "@effect/vitest";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
-import { describe } from "vitest";
 import {
   SNSApiFunction,
   SNSApiFunctionLive,
   TopicAndQueue,
 } from "./handler.ts";
 
+const { test } = Test.make({ providers: AWS.providers() });
+
 const readinessPolicy = Schedule.fixed("2 seconds").pipe(
   Schedule.both(Schedule.recurs(9)),
 );
 
-let baseUrl: string;
-let queueUrl: string;
-let topicArn: string;
-let subscriptionArn: string;
-
 describe.sequential("SNS Bindings", () => {
-  beforeAll(
-    Effect.gen(function* () {
-      yield* Effect.logInfo("SNS test setup: destroying previous resources");
-      if (!process.env.NO_DESTROY) {
-        yield* destroy();
-      }
+  test.provider(
+    "exercises the SNS bindings surface against a live fixture",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* Effect.logInfo("SNS test setup: destroying previous resources");
+        if (!process.env.NO_DESTROY) {
+          yield* stack.destroy();
+        }
 
-      yield* Effect.logInfo("SNS test setup: deploying fixture");
-      const deployed = yield* test.deploy(
-        Effect.gen(function* () {
-          const { topic, queue, subscription } = yield* TopicAndQueue;
+        yield* Effect.logInfo("SNS test setup: deploying fixture");
+        const deployed = yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              const { topic, queue, subscription } = yield* TopicAndQueue;
 
-          const apiFunction = yield* SNSApiFunction;
+              const apiFunction = yield* SNSApiFunction;
 
-          return {
-            apiFunction,
-            topic,
-            queue,
-            subscription,
-          };
-        }).pipe(Effect.provide(SNSApiFunctionLive)),
-      );
+              return {
+                apiFunction,
+                topic,
+                queue,
+                subscription,
+              };
+            }),
+          )
+          .pipe(Effect.provide(SNSApiFunctionLive));
 
-      baseUrl = deployed.apiFunction.functionUrl!.replace(/\/+$/, "");
-      queueUrl = deployed.queue.queueUrl;
-      topicArn = deployed.topic.topicArn;
-      subscriptionArn = deployed.subscription.subscriptionArn;
+        const baseUrl = deployed.apiFunction.functionUrl!.replace(/\/+$/, "");
+        const queueUrl = deployed.queue.queueUrl;
+        const topicArn = deployed.topic.topicArn;
+        const subscriptionArn = deployed.subscription.subscriptionArn;
 
-      const readinessUrl = `${baseUrl}/ready`;
-      yield* Effect.logInfo(
-        `SNS test setup: probing readiness at ${readinessUrl} (20s budget)`,
-      );
+        const readinessUrl = `${baseUrl}/ready`;
+        yield* Effect.logInfo(
+          `SNS test setup: probing readiness at ${readinessUrl} (20s budget)`,
+        );
 
-      yield* HttpClient.get(readinessUrl).pipe(
-        Effect.flatMap((response) =>
-          response.status === 200
-            ? Effect.succeed(response)
-            : Effect.fail(new Error(`Function not ready: ${response.status}`)),
-        ),
-        Effect.tap(() =>
-          Effect.logInfo("SNS test setup: fixture responded successfully"),
-        ),
-        Effect.tapError((error) =>
-          Effect.logWarning(
-            `SNS test setup: fixture not ready yet (${String(error)})`,
+        yield* HttpClient.get(readinessUrl).pipe(
+          Effect.flatMap((response) =>
+            response.status === 200
+              ? Effect.succeed(response)
+              : Effect.fail(
+                  new Error(`Function not ready: ${response.status}`),
+                ),
           ),
-        ),
-        Effect.retry({ schedule: readinessPolicy }),
-      );
-    }),
-    { timeout: 120_000 },
-  );
+          Effect.tap(() =>
+            Effect.logInfo("SNS test setup: fixture responded successfully"),
+          ),
+          Effect.tapError((error) =>
+            Effect.logWarning(
+              `SNS test setup: fixture not ready yet (${String(error)})`,
+            ),
+          ),
+          Effect.retry({ schedule: readinessPolicy }),
+        );
 
-  if (!process.env.NO_DESTROY) {
-    afterAll(destroy(), { timeout: 60_000 });
-  }
+        const getJson = (path: string) =>
+          HttpClient.get(`${baseUrl}${path}`).pipe(
+            Effect.flatMap((response) => response.json),
+          );
 
-  describe("Publish", () => {
-    test(
-      "publishes a message that reaches the Lambda event sink",
-      Effect.gen(function* () {
-        const marker = `publish-${crypto.randomUUID()}`;
-        const response = yield* postJson("/publish", {
-          message: marker,
-          subject: "PublishTest",
+        const postJson = (path: string, body: unknown) =>
+          HttpClient.execute(
+            HttpClientRequest.bodyJsonUnsafe(
+              HttpClientRequest.post(`${baseUrl}${path}`),
+              body,
+            ),
+          ).pipe(
+            Effect.tap((response) =>
+              Effect.flatMap(response.text, Effect.logInfo),
+            ),
+            Effect.flatMap((response) => response.json),
+          );
+
+        const deleteJson = (path: string, body: unknown) =>
+          HttpClient.execute(
+            HttpClientRequest.bodyJsonUnsafe(
+              HttpClientRequest.delete(`${baseUrl}${path}`),
+              body,
+            ),
+          ).pipe(Effect.flatMap((response) => response.json));
+
+        const waitForQueueMessage = Effect.fn(function* (
+          predicate: (body: {
+            message: string;
+            topicArn: string;
+            subject?: string;
+          }) => boolean,
+        ) {
+          return yield* SQS.receiveMessage({
+            QueueUrl: queueUrl,
+            MaxNumberOfMessages: 1,
+            WaitTimeSeconds: 2,
+            VisibilityTimeout: 5,
+          }).pipe(
+            Effect.flatMap((result) => {
+              const message = result.Messages?.[0];
+              if (!message?.Body || !message.ReceiptHandle) {
+                return Effect.fail(new QueueMessageNotReady());
+              }
+
+              const body = JSON.parse(message.Body) as {
+                message: string;
+                topicArn: string;
+                subject?: string;
+              };
+
+              return SQS.deleteMessage({
+                QueueUrl: queueUrl,
+                ReceiptHandle: message.ReceiptHandle,
+              }).pipe(
+                Effect.flatMap(() =>
+                  predicate(body)
+                    ? Effect.succeed(body)
+                    : Effect.fail(new QueueMessageNotReady()),
+                ),
+              );
+            }),
+            Effect.retry({
+              while: (error) => error._tag === "QueueMessageNotReady",
+              schedule: Schedule.fixed("2 seconds").pipe(
+                Schedule.both(Schedule.recurs(20)),
+              ),
+            }),
+          );
         });
 
-        expect((response as any).MessageId).toBeTruthy();
+        const waitForQueueMessages = Effect.fn(function* (count: number) {
+          const bodies: Array<{
+            message: string;
+            topicArn: string;
+            subject?: string;
+          }> = [];
 
-        const queued = yield* waitForQueueMessage(
-          (body) => body.message === marker,
-        );
-        expect((queued as any).topicArn).toBe(topicArn);
-        expect((queued as any).subject).toBe("PublishTest");
-      }),
-    );
-  });
+          while (bodies.length < count) {
+            bodies.push(yield* waitForQueueMessage(() => true));
+          }
 
-  describe("PublishBatch", () => {
-    test(
-      "publishes a batch of messages",
-      Effect.gen(function* () {
-        const first = `batch-1-${crypto.randomUUID()}`;
-        const second = `batch-2-${crypto.randomUUID()}`;
-
-        const response = yield* postJson("/publish-batch", {
-          messages: [first, second],
+          return bodies;
         });
 
-        expect(((response as any).Successful ?? []).length).toBe(2);
+        // Publish
+        yield* Effect.gen(function* () {
+          const marker = `publish-${crypto.randomUUID()}`;
+          const response = yield* postJson("/publish", {
+            message: marker,
+            subject: "PublishTest",
+          });
 
-        const bodies = yield* waitForQueueMessages(2);
-        const messages = bodies.map((body) => body.message);
-        expect(messages).toContain(first);
-        expect(messages).toContain(second);
-      }),
-    );
-  });
+          expect((response as any).MessageId).toBeTruthy();
 
-  describe("GetTopicAttributes", () => {
-    test(
-      "gets the bound topic attributes",
-      Effect.gen(function* () {
-        const response = yield* getJson("/topic-attributes");
-        expect((response as any).Attributes.TopicArn).toBe(topicArn);
-      }),
-    );
-  });
-
-  describe("SetTopicAttributes", () => {
-    test(
-      "updates topic attributes",
-      Effect.gen(function* () {
-        yield* postJson("/topic-attributes", {
-          name: "DisplayName",
-          value: "updated-display-name",
+          const queued = yield* waitForQueueMessage(
+            (body) => body.message === marker,
+          );
+          expect((queued as any).topicArn).toBe(topicArn);
+          expect((queued as any).subject).toBe("PublishTest");
         });
 
-        const response = yield* getJson("/topic-attributes");
-        expect((response as any).Attributes.DisplayName).toBe(
-          "updated-display-name",
-        );
-      }),
-    );
-  });
+        // PublishBatch
+        yield* Effect.gen(function* () {
+          const first = `batch-1-${crypto.randomUUID()}`;
+          const second = `batch-2-${crypto.randomUUID()}`;
 
-  describe("AddPermission", () => {
-    test(
-      "adds a topic policy statement",
-      Effect.gen(function* () {
-        yield* postJson("/add-permission", {});
-        const response = yield* getJson("/topic-attributes");
-        expect((response as any).Attributes.Policy).toContain(
-          "FixturePublishPermission",
-        );
-      }),
-    );
-  });
+          const response = yield* postJson("/publish-batch", {
+            messages: [first, second],
+          });
 
-  describe("RemovePermission", () => {
-    test(
-      "removes a topic policy statement",
-      Effect.gen(function* () {
-        yield* postJson("/add-permission", {});
-        yield* postJson("/remove-permission", {});
-        const response = yield* getJson("/topic-attributes");
-        expect((response as any).Attributes.Policy ?? "").not.toContain(
-          "FixturePublishPermission",
-        );
-      }),
-    );
-  });
+          expect(((response as any).Successful ?? []).length).toBe(2);
 
-  describe("GetDataProtectionPolicy", () => {
-    test(
-      "returns the topic data protection policy or a structured error",
-      Effect.gen(function* () {
-        const response = yield* getJson("/data-protection-policy");
-        if ((response as any).ok === false) {
-          expect((response as any).error).toBeTruthy();
-        } else {
+          const bodies = yield* waitForQueueMessages(2);
+          const messages = bodies.map((body) => body.message);
+          expect(messages).toContain(first);
+          expect(messages).toContain(second);
+        });
+
+        // GetTopicAttributes
+        yield* Effect.gen(function* () {
+          const response = yield* getJson("/topic-attributes");
+          expect((response as any).Attributes.TopicArn).toBe(topicArn);
+        });
+
+        // SetTopicAttributes
+        yield* Effect.gen(function* () {
+          yield* postJson("/topic-attributes", {
+            name: "DisplayName",
+            value: "updated-display-name",
+          });
+
+          const response = yield* getJson("/topic-attributes");
+          expect((response as any).Attributes.DisplayName).toBe(
+            "updated-display-name",
+          );
+        });
+
+        // AddPermission
+        yield* Effect.gen(function* () {
+          yield* postJson("/add-permission", {});
+          const response = yield* getJson("/topic-attributes");
+          expect((response as any).Attributes.Policy).toContain(
+            "FixturePublishPermission",
+          );
+        });
+
+        // RemovePermission
+        yield* Effect.gen(function* () {
+          yield* postJson("/add-permission", {});
+          yield* postJson("/remove-permission", {});
+          const response = yield* getJson("/topic-attributes");
+          expect((response as any).Attributes.Policy ?? "").not.toContain(
+            "FixturePublishPermission",
+          );
+        });
+
+        // GetDataProtectionPolicy
+        yield* Effect.gen(function* () {
+          const response = yield* getJson("/data-protection-policy");
+          if ((response as any).ok === false) {
+            expect((response as any).error).toBeTruthy();
+          } else {
+            expect(response).toBeDefined();
+          }
+        });
+
+        // PutDataProtectionPolicy
+        yield* Effect.gen(function* () {
+          const response = yield* postJson("/data-protection-policy", {
+            policy: "{}",
+          });
           expect(response).toBeDefined();
+        });
+
+        // ListTopics
+        yield* Effect.gen(function* () {
+          const response = yield* getJson("/topics");
+          const arns = ((response as any).Topics ?? []).map(
+            (topic: any) => topic.TopicArn,
+          );
+          expect(arns).toContain(topicArn);
+        });
+
+        // ListSubscriptions
+        yield* Effect.gen(function* () {
+          const response = yield* getJson("/subscriptions");
+          const arns = ((response as any).Subscriptions ?? []).map(
+            (subscription: any) => subscription.SubscriptionArn,
+          );
+          expect(arns).toContain(subscriptionArn);
+        });
+
+        // ListSubscriptionsByTopic
+        yield* Effect.gen(function* () {
+          const response = yield* getJson("/subscriptions-by-topic");
+          const arns = ((response as any).Subscriptions ?? []).map(
+            (subscription: any) => subscription.SubscriptionArn,
+          );
+          expect(arns).toContain(subscriptionArn);
+        });
+
+        // ListTagsForResource
+        yield* Effect.gen(function* () {
+          const response = yield* getJson("/tags");
+          const keys = ((response as any).Tags ?? []).map(
+            (tag: any) => tag.Key,
+          );
+          expect(keys).toContain("alchemy::stack");
+          expect(keys).toContain("alchemy::stage");
+          expect(keys).toContain("alchemy::id");
+        });
+
+        // TagResource
+        yield* Effect.gen(function* () {
+          yield* postJson("/tags", {
+            key: "sns-binding-test",
+            value: "true",
+          });
+          const response = yield* getJson("/tags");
+          const tags = Object.fromEntries(
+            ((response as any).Tags ?? []).map((tag: any) => [
+              tag.Key,
+              tag.Value,
+            ]),
+          );
+          expect(tags["sns-binding-test"]).toBe("true");
+        });
+
+        // UntagResource
+        yield* Effect.gen(function* () {
+          yield* postJson("/tags", {
+            key: "sns-remove-test",
+            value: "true",
+          });
+          yield* deleteJson("/tags", {
+            keys: ["sns-remove-test"],
+          });
+          const response = yield* getJson("/tags");
+          const keys = ((response as any).Tags ?? []).map(
+            (tag: any) => tag.Key,
+          );
+          expect(keys).not.toContain("sns-remove-test");
+        });
+
+        // GetSubscriptionAttributes
+        yield* Effect.gen(function* () {
+          const response = yield* getJson("/subscription-attributes");
+          expect((response as any).Attributes.Protocol).toBe("sqs");
+        });
+
+        // SetSubscriptionAttributes
+        yield* Effect.gen(function* () {
+          const response = yield* postJson("/subscription-attributes", {
+            name: "RawMessageDelivery",
+            value: "true",
+          }).pipe(
+            Effect.flatMap(() => getJson("/subscription-attributes")),
+            Effect.ensuring(
+              postJson("/subscription-attributes", {
+                name: "RawMessageDelivery",
+                value: "false",
+              }).pipe(Effect.ignore),
+            ),
+          );
+          expect((response as any).Attributes.RawMessageDelivery).toBe("true");
+        });
+
+        // ConfirmSubscription
+        yield* Effect.gen(function* () {
+          const response = yield* postJson("/confirm-subscription", {
+            token: "invalid-token",
+          });
+          expect((response as any).ok).toBe(false);
+          expect((response as any).error).toBeTruthy();
+        });
+
+        // TopicSink
+        yield* Effect.gen(function* () {
+          const first = `sink-1-${crypto.randomUUID()}`;
+          const second = `sink-2-${crypto.randomUUID()}`;
+
+          const response = yield* postJson("/sink", {
+            messages: [first, second],
+          });
+          expect((response as any).ok).toBe(true);
+
+          const bodies = yield* waitForQueueMessages(2);
+          const messages = bodies.map((body) => body.message);
+          expect(messages).toContain(first);
+          expect(messages).toContain(second);
+        });
+
+        if (!process.env.NO_DESTROY) {
+          yield* stack.destroy();
         }
       }),
-    );
-  });
-
-  describe("PutDataProtectionPolicy", () => {
-    test(
-      "invokes putDataProtectionPolicy",
-      Effect.gen(function* () {
-        const response = yield* postJson("/data-protection-policy", {
-          policy: "{}",
-        });
-        expect(response).toBeDefined();
-      }),
-    );
-  });
-
-  describe("ListTopics", () => {
-    test(
-      "lists the deployed topic",
-      Effect.gen(function* () {
-        const response = yield* getJson("/topics");
-        const arns = ((response as any).Topics ?? []).map(
-          (topic: any) => topic.TopicArn,
-        );
-        expect(arns).toContain(topicArn);
-      }),
-    );
-  });
-
-  describe("ListSubscriptions", () => {
-    test(
-      "lists the deployed subscription",
-      Effect.gen(function* () {
-        const response = yield* getJson("/subscriptions");
-        const arns = ((response as any).Subscriptions ?? []).map(
-          (subscription: any) => subscription.SubscriptionArn,
-        );
-        expect(arns).toContain(subscriptionArn);
-      }),
-    );
-  });
-
-  describe("ListSubscriptionsByTopic", () => {
-    test(
-      "lists topic subscriptions",
-      Effect.gen(function* () {
-        const response = yield* getJson("/subscriptions-by-topic");
-        const arns = ((response as any).Subscriptions ?? []).map(
-          (subscription: any) => subscription.SubscriptionArn,
-        );
-        expect(arns).toContain(subscriptionArn);
-      }),
-    );
-  });
-
-  describe("ListTagsForResource", () => {
-    test(
-      "lists the topic ownership tags",
-      Effect.gen(function* () {
-        const response = yield* getJson("/tags");
-        const keys = ((response as any).Tags ?? []).map((tag: any) => tag.Key);
-        expect(keys).toContain("alchemy::stack");
-        expect(keys).toContain("alchemy::stage");
-        expect(keys).toContain("alchemy::id");
-      }),
-    );
-  });
-
-  describe("TagResource", () => {
-    test(
-      "adds a tag to the topic",
-      Effect.gen(function* () {
-        yield* postJson("/tags", {
-          key: "sns-binding-test",
-          value: "true",
-        });
-        const response = yield* getJson("/tags");
-        const tags = Object.fromEntries(
-          ((response as any).Tags ?? []).map((tag: any) => [
-            tag.Key,
-            tag.Value,
-          ]),
-        );
-        expect(tags["sns-binding-test"]).toBe("true");
-      }),
-    );
-  });
-
-  describe("UntagResource", () => {
-    test(
-      "removes a tag from the topic",
-      Effect.gen(function* () {
-        yield* postJson("/tags", {
-          key: "sns-remove-test",
-          value: "true",
-        });
-        yield* deleteJson("/tags", {
-          keys: ["sns-remove-test"],
-        });
-        const response = yield* getJson("/tags");
-        const keys = ((response as any).Tags ?? []).map((tag: any) => tag.Key);
-        expect(keys).not.toContain("sns-remove-test");
-      }),
-    );
-  });
-
-  describe("GetSubscriptionAttributes", () => {
-    test(
-      "gets the bound subscription attributes",
-      Effect.gen(function* () {
-        const response = yield* getJson("/subscription-attributes");
-        expect((response as any).Attributes.Protocol).toBe("sqs");
-      }),
-    );
-  });
-
-  describe("SetSubscriptionAttributes", () => {
-    test(
-      "updates subscription attributes",
-      Effect.gen(function* () {
-        yield* postJson("/subscription-attributes", {
-          name: "RawMessageDelivery",
-          value: "true",
-        });
-        const response = yield* getJson("/subscription-attributes");
-        expect((response as any).Attributes.RawMessageDelivery).toBe("true");
-      }).pipe(
-        Effect.ensuring(
-          postJson("/subscription-attributes", {
-            name: "RawMessageDelivery",
-            value: "false",
-          }).pipe(Effect.ignore),
-        ),
-      ),
-    );
-  });
-
-  describe("ConfirmSubscription", () => {
-    test(
-      "returns a structured error for an invalid token",
-      Effect.gen(function* () {
-        const response = yield* postJson("/confirm-subscription", {
-          token: "invalid-token",
-        });
-        expect((response as any).ok).toBe(false);
-        expect((response as any).error).toBeTruthy();
-      }),
-    );
-  });
-
-  describe("TopicSink", () => {
-    test(
-      "publishes messages through the sink helper",
-      Effect.gen(function* () {
-        const first = `sink-1-${crypto.randomUUID()}`;
-        const second = `sink-2-${crypto.randomUUID()}`;
-
-        const response = yield* postJson("/sink", {
-          messages: [first, second],
-        });
-        expect((response as any).ok).toBe(true);
-
-        const bodies = yield* waitForQueueMessages(2);
-        const messages = bodies.map((body) => body.message);
-        expect(messages).toContain(first);
-        expect(messages).toContain(second);
-      }),
-    );
-  });
-});
-
-const getJson = (path: string) =>
-  HttpClient.get(`${baseUrl}${path}`).pipe(
-    Effect.flatMap((response) => response.json),
-  );
-
-const postJson = (path: string, body: unknown) =>
-  HttpClient.execute(
-    HttpClientRequest.bodyJsonUnsafe(
-      HttpClientRequest.post(`${baseUrl}${path}`),
-      body,
-    ),
-  ).pipe(
-    Effect.tap((response) => Effect.flatMap(response.text, Effect.logInfo)),
-    Effect.flatMap((response) => response.json),
-  );
-
-const deleteJson = (path: string, body: unknown) =>
-  HttpClient.execute(
-    HttpClientRequest.bodyJsonUnsafe(
-      HttpClientRequest.delete(`${baseUrl}${path}`),
-      body,
-    ),
-  ).pipe(Effect.flatMap((response) => response.json));
-
-const waitForQueueMessages = Effect.fn(function* (count: number) {
-  const bodies: Array<{ message: string; topicArn: string; subject?: string }> =
-    [];
-
-  while (bodies.length < count) {
-    bodies.push(yield* waitForQueueMessage(() => true));
-  }
-
-  return bodies;
-});
-
-const waitForQueueMessage = Effect.fn(function* (
-  predicate: (body: {
-    message: string;
-    topicArn: string;
-    subject?: string;
-  }) => boolean,
-) {
-  return yield* SQS.receiveMessage({
-    QueueUrl: queueUrl,
-    MaxNumberOfMessages: 1,
-    WaitTimeSeconds: 2,
-    VisibilityTimeout: 5,
-  }).pipe(
-    Effect.flatMap((result) => {
-      const message = result.Messages?.[0];
-      if (!message?.Body || !message.ReceiptHandle) {
-        return Effect.fail(new QueueMessageNotReady());
-      }
-
-      const body = JSON.parse(message.Body) as {
-        message: string;
-        topicArn: string;
-        subject?: string;
-      };
-
-      return SQS.deleteMessage({
-        QueueUrl: queueUrl,
-        ReceiptHandle: message.ReceiptHandle,
-      }).pipe(
-        Effect.flatMap(() =>
-          predicate(body)
-            ? Effect.succeed(body)
-            : Effect.fail(new QueueMessageNotReady()),
-        ),
-      );
-    }),
-    Effect.retry({
-      while: (error) => error._tag === "QueueMessageNotReady",
-      schedule: Schedule.fixed("2 seconds").pipe(
-        Schedule.both(Schedule.recurs(20)),
-      ),
-    }),
+    { timeout: 240_000 },
   );
 });
 

--- a/packages/alchemy/test/AWS/SNS/Subscription.test.ts
+++ b/packages/alchemy/test/AWS/SNS/Subscription.test.ts
@@ -1,5 +1,5 @@
 import * as AWS from "@/AWS";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as SNS from "@distilled.cloud/aws/sns";
 import { expect } from "@effect/vitest";
 import * as Data from "effect/Data";
@@ -12,46 +12,49 @@ import {
   TopicAndQueue,
 } from "./handler.ts";
 
-test(
+const { test } = Test.make({ providers: AWS.providers() });
+
+test.provider(
   "create and delete lambda subscription",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { topic, queue, subscription } = yield* TopicAndQueue;
+
+          const apiFunction = yield* SNSApiFunction;
+
+          return {
+            apiFunction,
+            topic,
+            queue,
+            subscription,
+          };
+        }).pipe(Effect.provide(SNSApiFunctionLive)),
+      );
+
+      expect(deployed.subscription.subscriptionArn).toBeDefined();
+
+      const attributes = yield* SNS.getSubscriptionAttributes({
+        SubscriptionArn: deployed.subscription.subscriptionArn,
+      }).pipe(
+        Effect.tapError((err) =>
+          Effect.logError(deployed.subscription.subscriptionArn, err),
+        ),
+        Effect.retry({
+          while: (error) => error._tag === "NotFoundException",
+          schedule: Schedule.fixed(300),
+        }),
+      );
+      expect(attributes.Attributes?.Protocol).toBe("lambda");
+      expect(attributes.Attributes?.TopicArn).toBe(deployed.topic.topicArn);
+
+      yield* stack.destroy();
+      yield* assertSubscriptionDeleted(deployed.subscription.subscriptionArn);
+    }),
   { timeout: 180_000 },
-  Effect.gen(function* () {
-    yield* destroy();
-
-    const deployed = yield* test.deploy(
-      Effect.gen(function* () {
-        const { topic, queue, subscription } = yield* TopicAndQueue;
-
-        const apiFunction = yield* SNSApiFunction;
-
-        return {
-          apiFunction,
-          topic,
-          queue,
-          subscription,
-        };
-      }).pipe(Effect.provide(SNSApiFunctionLive)),
-    );
-
-    expect(deployed.subscription.subscriptionArn).toBeDefined();
-
-    const attributes = yield* SNS.getSubscriptionAttributes({
-      SubscriptionArn: deployed.subscription.subscriptionArn,
-    }).pipe(
-      Effect.tapError((err) =>
-        Effect.logError(deployed.subscription.subscriptionArn, err),
-      ),
-      Effect.retry({
-        while: (error) => error._tag === "NotFoundException",
-        schedule: Schedule.fixed(300),
-      }),
-    );
-    expect(attributes.Attributes?.Protocol).toBe("lambda");
-    expect(attributes.Attributes?.TopicArn).toBe(deployed.topic.topicArn);
-
-    yield* destroy();
-    yield* assertSubscriptionDeleted(deployed.subscription.subscriptionArn);
-  }).pipe(Effect.provide(AWS.providers())),
 );
 
 class SubscriptionStillExists extends Data.TaggedError(

--- a/packages/alchemy/test/AWS/SNS/Topic.test.ts
+++ b/packages/alchemy/test/AWS/SNS/Topic.test.ts
@@ -1,126 +1,131 @@
 import * as AWS from "@/AWS";
 import { Topic } from "@/AWS/SNS";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as SNS from "@distilled.cloud/aws/sns";
-import { expect } from "@effect/vitest";
+import { describe, expect } from "@effect/vitest";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 
-test(
-  "create and delete topic with default props",
-  Effect.gen(function* () {
-    const topic = yield* test.deploy(
-      Effect.gen(function* () {
-        return yield* Topic("DefaultTopic");
-      }),
-    );
+const { test } = Test.make({ providers: AWS.providers() });
 
-    expect(topic.topicName).toBeDefined();
-    expect(topic.topicArn).toBeDefined();
+describe("AWS.SNS.Topic", () => {
+  test.provider("create and delete topic with default props", (stack) =>
+    Effect.gen(function* () {
+      const topic = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Topic("DefaultTopic");
+        }),
+      );
 
-    const attributes = yield* SNS.getTopicAttributes({
-      TopicArn: topic.topicArn,
-    });
-    expect(attributes.Attributes?.TopicArn).toBe(topic.topicArn);
+      expect(topic.topicName).toBeDefined();
+      expect(topic.topicArn).toBeDefined();
 
-    yield* destroy();
-    yield* assertTopicDeleted(topic.topicArn);
-  }).pipe(Effect.provide(AWS.providers())),
-);
+      const attributes = yield* SNS.getTopicAttributes({
+        TopicArn: topic.topicArn,
+      });
+      expect(attributes.Attributes?.TopicArn).toBe(topic.topicArn);
 
-test(
-  "create, update, delete topic attributes and tags",
-  Effect.gen(function* () {
-    const topic = yield* test.deploy(
-      Effect.gen(function* () {
-        return yield* Topic("ManagedTopic", {
-          attributes: {
-            DisplayName: "managed-topic-v1",
-          },
-          tags: {
-            env: "test",
-          },
-        });
-      }),
-    );
-
-    const initialAttributes = yield* SNS.getTopicAttributes({
-      TopicArn: topic.topicArn,
-    });
-    expect(initialAttributes.Attributes?.DisplayName).toBe("managed-topic-v1");
-
-    const updatedTopic = yield* test.deploy(
-      Effect.gen(function* () {
-        return yield* Topic("ManagedTopic", {
-          attributes: {
-            DisplayName: "managed-topic-v2",
-          },
-          tags: {
-            updated: "true",
-          },
-        });
-      }),
-    );
-
-    const updatedAttributes = yield* SNS.getTopicAttributes({
-      TopicArn: updatedTopic.topicArn,
-    });
-    expect(updatedAttributes.Attributes?.DisplayName).toBe("managed-topic-v2");
-
-    const tagResponse = yield* SNS.listTagsForResource({
-      ResourceArn: updatedTopic.topicArn,
-    });
-    const tags = Object.fromEntries(
-      (tagResponse.Tags ?? []).map((tag) => [tag.Key, tag.Value]),
-    );
-    expect(tags.updated).toBe("true");
-    expect(tags.env).toBeUndefined();
-
-    yield* destroy();
-    yield* assertTopicDeleted(updatedTopic.topicArn);
-  }).pipe(Effect.provide(AWS.providers())),
-);
-
-test(
-  "create and delete fifo topic",
-  Effect.gen(function* () {
-    const topic = yield* test.deploy(
-      Effect.gen(function* () {
-        return yield* Topic("FifoTopic", {
-          fifo: true,
-          attributes: {
-            ContentBasedDeduplication: "true",
-          },
-        });
-      }),
-    );
-
-    expect(topic.topicName).toContain(".fifo");
-
-    const attributes = yield* SNS.getTopicAttributes({
-      TopicArn: topic.topicArn,
-    });
-    expect(attributes.Attributes?.FifoTopic).toBe("true");
-    expect(attributes.Attributes?.ContentBasedDeduplication).toBe("true");
-
-    yield* destroy();
-    yield* assertTopicDeleted(topic.topicArn);
-  }).pipe(Effect.provide(AWS.providers())),
-);
-
-class TopicStillExists extends Data.TaggedError("TopicStillExists") {}
-
-const assertTopicDeleted = Effect.fn(function* (topicArn: string) {
-  yield* SNS.getTopicAttributes({
-    TopicArn: topicArn,
-  }).pipe(
-    Effect.flatMap(() => Effect.fail(new TopicStillExists())),
-    Effect.retry({
-      while: (error) => error._tag === "TopicStillExists",
-      schedule: Schedule.exponential(100),
+      yield* stack.destroy();
+      yield* assertTopicDeleted(topic.topicArn);
     }),
-    Effect.catchTag("NotFoundException", () => Effect.void),
-    Effect.catchTag("InvalidParameterException", () => Effect.void),
   );
+
+  test.provider("create, update, delete topic attributes and tags", (stack) =>
+    Effect.gen(function* () {
+      const topic = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Topic("ManagedTopic", {
+            attributes: {
+              DisplayName: "managed-topic-v1",
+            },
+            tags: {
+              env: "test",
+            },
+          });
+        }),
+      );
+
+      const initialAttributes = yield* SNS.getTopicAttributes({
+        TopicArn: topic.topicArn,
+      });
+      expect(initialAttributes.Attributes?.DisplayName).toBe(
+        "managed-topic-v1",
+      );
+
+      const updatedTopic = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Topic("ManagedTopic", {
+            attributes: {
+              DisplayName: "managed-topic-v2",
+            },
+            tags: {
+              updated: "true",
+            },
+          });
+        }),
+      );
+
+      const updatedAttributes = yield* SNS.getTopicAttributes({
+        TopicArn: updatedTopic.topicArn,
+      });
+      expect(updatedAttributes.Attributes?.DisplayName).toBe(
+        "managed-topic-v2",
+      );
+
+      const tagResponse = yield* SNS.listTagsForResource({
+        ResourceArn: updatedTopic.topicArn,
+      });
+      const tags = Object.fromEntries(
+        (tagResponse.Tags ?? []).map((tag) => [tag.Key, tag.Value]),
+      );
+      expect(tags.updated).toBe("true");
+      expect(tags.env).toBeUndefined();
+
+      yield* stack.destroy();
+      yield* assertTopicDeleted(updatedTopic.topicArn);
+    }),
+  );
+
+  test.provider("create and delete fifo topic", (stack) =>
+    Effect.gen(function* () {
+      const topic = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Topic("FifoTopic", {
+            fifo: true,
+            attributes: {
+              ContentBasedDeduplication: "true",
+            },
+          });
+        }),
+      );
+
+      expect(topic.topicName).toContain(".fifo");
+
+      const attributes = yield* SNS.getTopicAttributes({
+        TopicArn: topic.topicArn,
+      });
+      expect(attributes.Attributes?.FifoTopic).toBe("true");
+      expect(attributes.Attributes?.ContentBasedDeduplication).toBe("true");
+
+      yield* stack.destroy();
+      yield* assertTopicDeleted(topic.topicArn);
+    }),
+  );
+
+  class TopicStillExists extends Data.TaggedError("TopicStillExists") {}
+
+  const assertTopicDeleted = Effect.fn(function* (topicArn: string) {
+    yield* SNS.getTopicAttributes({
+      TopicArn: topicArn,
+    }).pipe(
+      Effect.flatMap(() => Effect.fail(new TopicStillExists())),
+      Effect.retry({
+        while: (error) => error._tag === "TopicStillExists",
+        schedule: Schedule.exponential(100),
+      }),
+      Effect.catchTag("NotFoundException", () => Effect.void),
+      Effect.catchTag("InvalidParameterException", () => Effect.void),
+    );
+  });
 });

--- a/packages/alchemy/test/AWS/SQS/Queue.test.ts
+++ b/packages/alchemy/test/AWS/SQS/Queue.test.ts
@@ -1,6 +1,6 @@
 import * as AWS from "@/AWS";
 import { Queue } from "@/AWS/SQS";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as SQS from "@distilled.cloud/aws/sqs";
 import { expect } from "@effect/vitest";
 import * as Console from "effect/Console";
@@ -11,10 +11,11 @@ import * as HttpBody from "effect/unstable/http/HttpBody";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import { QueueSinkFunction, QueueSinkFunctionLive } from "./sink-handler";
 
-test(
-  "create and delete queue with default props",
+const { test } = Test.make({ providers: AWS.providers() });
+
+test.provider("create and delete queue with default props", (stack) =>
   Effect.gen(function* () {
-    const queue = yield* test.deploy(
+    const queue = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Queue("DefaultQueue");
       }),
@@ -30,16 +31,15 @@ test(
     });
     expect(queueAttributes.Attributes).toBeDefined();
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* assertQueueDeleted(queue.queueUrl);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
-  "create, update, delete standard queue",
+test.provider("create, update, delete standard queue", (stack) =>
   Effect.gen(function* () {
-    const queue = yield* test.deploy(
+    const queue = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Queue("TestQueue", {
           visibilityTimeout: 30,
@@ -57,7 +57,7 @@ test(
     expect(queueAttributes.Attributes?.DelaySeconds).toEqual("0");
 
     // Update the queue
-    const updatedQueue = yield* test.deploy(
+    const updatedQueue = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Queue("TestQueue", {
           visibilityTimeout: 60,
@@ -72,16 +72,15 @@ test(
       DelaySeconds: "5",
     });
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* assertQueueDeleted(queue.queueUrl);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
-  "create, update, delete fifo queue",
+test.provider("create, update, delete fifo queue", (stack) =>
   Effect.gen(function* () {
-    const queue = yield* test.deploy(
+    const queue = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Queue("TestFifoQueue", {
           fifo: true,
@@ -105,7 +104,7 @@ test(
     );
 
     // Update the FIFO queue to enable content-based deduplication
-    const updatedQueue = yield* test.deploy(
+    const updatedQueue = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Queue("TestFifoQueue", {
           fifo: true,
@@ -121,16 +120,15 @@ test(
       VisibilityTimeout: "60",
     });
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* assertQueueDeleted(queue.queueUrl);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
-  "create queue with custom name",
+test.provider("create queue with custom name", (stack) =>
   Effect.gen(function* () {
-    const queue = yield* test.deploy(
+    const queue = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Queue("CustomNameQueue", {
           queueName: "my-custom-test-queue",
@@ -148,59 +146,62 @@ test(
     });
     expect(queueAttributes.Attributes).toBeDefined();
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* assertQueueDeleted(queue.queueUrl);
-  }).pipe(Effect.provide(AWS.providers())),
+  }),
 );
 
-test(
+test.provider(
   "QueueSink writes arbitrary messages through a deployed Lambda",
-  { timeout: 180_000 },
-  Effect.gen(function* () {
-    // yield* destroy();
+  (stack) =>
+    Effect.gen(function* () {
+      // yield* stack.destroy();
 
-    const apiFunction = yield* test.deploy(
-      QueueSinkFunction.asEffect().pipe(Effect.provide(QueueSinkFunctionLive)),
-    );
-    const baseUrl = apiFunction.functionUrl!.replace(/\/+$/, "");
-
-    const { queueUrl } = yield* waitForFunctionReady(`${baseUrl}/ready`);
-
-    const messages = [
-      `sink-${crypto.randomUUID()}`,
-      `sink-${crypto.randomUUID()}`,
-      `sink-${crypto.randomUUID()}`,
-    ];
-    const response = yield* HttpClient.post(`${baseUrl}/sink`, {
-      body: yield* HttpBody.json({ messages }),
-    }).pipe(
-      Effect.flatMap((result) =>
-        result.status === 200
-          ? Effect.succeed(result)
-          : Effect.fail("not ready"),
-      ),
-      Effect.tapError(Console.log),
-      Effect.retry({
-        while: (error) => error === "not ready",
-        schedule: Schedule.fixed("2 seconds").pipe(
-          Schedule.both(Schedule.recurs(9)),
+      const apiFunction = yield* stack.deploy(
+        QueueSinkFunction.asEffect().pipe(
+          Effect.provide(QueueSinkFunctionLive),
         ),
-      }),
-      Effect.flatMap((result) => result.json),
-    );
+      );
+      const baseUrl = apiFunction.functionUrl!.replace(/\/+$/, "");
 
-    expect((response as any).ok).toBe(true);
-    expect((response as any).count).toBe(messages.length);
+      const { queueUrl } = yield* waitForFunctionReady(`${baseUrl}/ready`);
 
-    const received = yield* waitForQueueMessages(queueUrl, messages.length);
+      const messages = [
+        `sink-${crypto.randomUUID()}`,
+        `sink-${crypto.randomUUID()}`,
+        `sink-${crypto.randomUUID()}`,
+      ];
+      const response = yield* HttpClient.post(`${baseUrl}/sink`, {
+        body: yield* HttpBody.json({ messages }),
+      }).pipe(
+        Effect.flatMap((result) =>
+          result.status === 200
+            ? Effect.succeed(result)
+            : Effect.fail("not ready"),
+        ),
+        Effect.tapError(Console.log),
+        Effect.retry({
+          while: (error) => error === "not ready",
+          schedule: Schedule.fixed("2 seconds").pipe(
+            Schedule.both(Schedule.recurs(9)),
+          ),
+        }),
+        Effect.flatMap((result) => result.json),
+      );
 
-    expect(received.sort()).toEqual([...messages].sort());
+      expect((response as any).ok).toBe(true);
+      expect((response as any).count).toBe(messages.length);
 
-    yield* destroy();
+      const received = yield* waitForQueueMessages(queueUrl, messages.length);
 
-    yield* assertQueueDeleted(queueUrl);
-  }).pipe(Effect.provide(AWS.providers())),
+      expect(received.sort()).toEqual([...messages].sort());
+
+      yield* stack.destroy();
+
+      yield* assertQueueDeleted(queueUrl);
+    }),
+  { timeout: 180_000 },
 );
 
 class QueueStillExists extends Data.TaggedError("QueueStillExists") {}

--- a/packages/alchemy/test/AWS/Website/Router.test.ts
+++ b/packages/alchemy/test/AWS/Website/Router.test.ts
@@ -1,62 +1,66 @@
 import * as AWS from "@/AWS";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as cloudfront from "@distilled.cloud/aws/cloudfront";
 import { describe, expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 
-describe("AWS.Website.Router", () => {
-  test(
+const { test } = Test.make({ providers: AWS.providers() });
+
+// slow AF
+describe.skip("AWS.Website.Router", () => {
+  test.provider(
     "create router with static-site attached via KV routing",
-    { timeout: 600_000 },
-    Effect.gen(function* () {
-      yield* destroy();
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-      const deployed = yield* test.deploy(
-        Effect.gen(function* () {
-          const router = yield* AWS.Website.Router("Router", {
-            invalidation: {
-              paths: "all",
-              wait: true,
-            },
-          });
-
-          const site = yield* AWS.Website.StaticSite("DocsSite", {
-            path: "examples/aws-static-site/site",
-            forceDestroy: true,
-            router: {
-              instance: {
-                kvStoreArn: router.kvStoreArn,
-                kvNamespace: router.kvNamespace,
-                distributionId: router.distributionId,
-                url: router.url,
+        const deployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            const router = yield* AWS.Website.Router("Router", {
+              invalidation: {
+                paths: "all",
+                wait: true,
               },
-            },
-          });
+            });
 
-          return {
-            site,
-            router,
-          };
-        }),
-      );
+            const site = yield* AWS.Website.StaticSite("DocsSite", {
+              path: "examples/aws-static-site/site",
+              forceDestroy: true,
+              router: {
+                instance: {
+                  kvStoreArn: router.kvStoreArn,
+                  kvNamespace: router.kvNamespace,
+                  distributionId: router.distributionId,
+                  url: router.url,
+                },
+              },
+            });
 
-      expect(deployed.router.distribution.distributionId).toBeDefined();
-      expect(deployed.router.kvStoreArn).toBeDefined();
+            return {
+              site,
+              router,
+            };
+          }),
+        );
 
-      const config = yield* cloudfront.getDistributionConfig({
-        Id: deployed.router.distribution.distributionId,
-      });
-      expect(
-        config.DistributionConfig?.DefaultCacheBehavior?.FunctionAssociations
-          ?.Quantity,
-      ).toBeGreaterThanOrEqual(1);
+        expect(deployed.router.distribution.distributionId).toBeDefined();
+        expect(deployed.router.kvStoreArn).toBeDefined();
 
-      yield* destroy();
-      yield* assertDistributionDeleted(
-        deployed.router.distribution.distributionId,
-      );
-    }).pipe(Effect.provide(AWS.providers())),
+        const config = yield* cloudfront.getDistributionConfig({
+          Id: deployed.router.distribution.distributionId,
+        });
+        expect(
+          config.DistributionConfig?.DefaultCacheBehavior?.FunctionAssociations
+            ?.Quantity,
+        ).toBeGreaterThanOrEqual(1);
+
+        yield* stack.destroy();
+        yield* assertDistributionDeleted(
+          deployed.router.distribution.distributionId,
+        );
+      }),
+    { timeout: 600_000 },
   );
 });
 

--- a/packages/alchemy/test/Build/Build.test.ts
+++ b/packages/alchemy/test/Build/Build.test.ts
@@ -1,102 +1,105 @@
+import * as AWS from "@/AWS";
 import * as Build from "@/Build";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
-import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as pathe from "pathe";
 
+const { test } = Test.make({ providers: AWS.providers() });
+
 const fixtureDir = pathe.resolve(import.meta.dirname, "fixture");
 
-test(
+test.provider(
   "create, skip, update, delete build",
+  (stack) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      yield* stack.destroy();
+
+      const distDir = pathe.join(fixtureDir, "dist");
+      yield* fs
+        .remove(distDir, { recursive: true })
+        .pipe(Effect.catch(() => Effect.void));
+
+      const build1 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Build.Command("test-build", {
+            command: "bash build.sh",
+            cwd: fixtureDir,
+            outdir: "dist",
+          });
+        }),
+      );
+
+      expect(build1.outdir).toBe(distDir);
+      expect(build1.hash).toBeDefined();
+      expect(typeof build1.hash).toBe("string");
+      expect(build1.hash.length).toBeGreaterThan(0);
+
+      const distExists = yield* fs.exists(distDir);
+      expect(distExists).toBe(true);
+
+      const outputExists = yield* fs.exists(pathe.join(distDir, "output.txt"));
+      expect(outputExists).toBe(true);
+
+      const firstBuildOutput = yield* fs.readFileString(
+        pathe.join(distDir, "output.txt"),
+      );
+
+      yield* Effect.sleep(1100);
+
+      const build2 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Build.Command("test-build", {
+            command: "bash build.sh",
+            cwd: fixtureDir,
+            outdir: "dist",
+          });
+        }),
+      );
+
+      expect(build2.hash).toBe(build1.hash);
+
+      const secondBuildOutput = yield* fs.readFileString(
+        pathe.join(distDir, "output.txt"),
+      );
+      expect(secondBuildOutput).toBe(firstBuildOutput);
+
+      yield* fs.writeFileString(
+        pathe.join(fixtureDir, "src", "main.ts"),
+        'export const message = "Updated!";\n',
+      );
+
+      const build3 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Build.Command("test-build", {
+            command: "bash build.sh",
+            cwd: fixtureDir,
+            outdir: "dist",
+          });
+        }),
+      );
+
+      expect(build3.hash).not.toBe(build1.hash);
+
+      const thirdBuildOutput = yield* fs.readFileString(
+        pathe.join(distDir, "output.txt"),
+      );
+      expect(thirdBuildOutput).not.toBe(firstBuildOutput);
+
+      yield* fs.writeFileString(
+        pathe.join(fixtureDir, "src", "main.ts"),
+        'export const message = "Hello, World!";\n',
+      );
+
+      yield* stack.destroy();
+
+      const distExistsAfterDestroy = yield* fs.exists(distDir);
+      expect(distExistsAfterDestroy).toBe(false);
+    }),
   { timeout: 60000 },
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-
-    yield* destroy();
-
-    const distDir = pathe.join(fixtureDir, "dist");
-    yield* fs
-      .remove(distDir, { recursive: true })
-      .pipe(Effect.catch(() => Effect.void));
-
-    const build1 = yield* test.deploy(
-      Effect.gen(function* () {
-        return yield* Build.Command("test-build", {
-          command: "bash build.sh",
-          cwd: fixtureDir,
-          outdir: "dist",
-        });
-      }),
-    );
-
-    expect(build1.outdir).toBe(distDir);
-    expect(build1.hash).toBeDefined();
-    expect(typeof build1.hash).toBe("string");
-    expect(build1.hash.length).toBeGreaterThan(0);
-
-    const distExists = yield* fs.exists(distDir);
-    expect(distExists).toBe(true);
-
-    const outputExists = yield* fs.exists(pathe.join(distDir, "output.txt"));
-    expect(outputExists).toBe(true);
-
-    const firstBuildOutput = yield* fs.readFileString(
-      pathe.join(distDir, "output.txt"),
-    );
-
-    yield* Effect.sleep(1100);
-
-    const build2 = yield* test.deploy(
-      Effect.gen(function* () {
-        return yield* Build.Command("test-build", {
-          command: "bash build.sh",
-          cwd: fixtureDir,
-          outdir: "dist",
-        });
-      }),
-    );
-
-    expect(build2.hash).toBe(build1.hash);
-
-    const secondBuildOutput = yield* fs.readFileString(
-      pathe.join(distDir, "output.txt"),
-    );
-    expect(secondBuildOutput).toBe(firstBuildOutput);
-
-    yield* fs.writeFileString(
-      pathe.join(fixtureDir, "src", "main.ts"),
-      'export const message = "Updated!";\n',
-    );
-
-    const build3 = yield* test.deploy(
-      Effect.gen(function* () {
-        return yield* Build.Command("test-build", {
-          command: "bash build.sh",
-          cwd: fixtureDir,
-          outdir: "dist",
-        });
-      }),
-    );
-
-    expect(build3.hash).not.toBe(build1.hash);
-
-    const thirdBuildOutput = yield* fs.readFileString(
-      pathe.join(distDir, "output.txt"),
-    );
-    expect(thirdBuildOutput).not.toBe(firstBuildOutput);
-
-    yield* fs.writeFileString(
-      pathe.join(fixtureDir, "src", "main.ts"),
-      'export const message = "Hello, World!";\n',
-    );
-
-    yield* destroy();
-
-    const distExistsAfterDestroy = yield* fs.exists(distDir);
-    expect(distExistsAfterDestroy).toBe(false);
-  }).pipe(Effect.provide(Layer.mergeAll(Build.CommandProvider()))),
 );

--- a/packages/alchemy/test/Cloudflare/ApiToken/AccountApiToken.test.ts
+++ b/packages/alchemy/test/Cloudflare/ApiToken/AccountApiToken.test.ts
@@ -1,6 +1,6 @@
 import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as accounts from "@distilled.cloud/cloudflare/accounts";
 import { expect } from "@effect/vitest";
 import * as Data from "effect/Data";
@@ -8,176 +8,177 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
+import { describe } from "node:test";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
 
 const logLevel = Effect.provideService(
   MinimumLogLevel,
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-test(
-  "create and delete account token with default props",
-  Effect.gen(function* () {
-    const { accountId } = yield* CloudflareEnvironment;
+describe.skip("AccountApiToken", () => {
+  test.provider("create and delete account token with default props", (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
 
-    yield* destroy();
+      yield* stack.destroy();
 
-    const token = yield* test.deploy(
-      Effect.gen(function* () {
-        return yield* Cloudflare.AccountApiToken("DefaultToken", {
-          policies: [
-            {
-              effect: "allow",
-              permissionGroups: ["Workers Scripts Read"],
-              resources: {
-                [`com.cloudflare.api.account.${accountId}`]: "*",
+      const token = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AccountApiToken("DefaultToken", {
+            policies: [
+              {
+                effect: "allow",
+                permissionGroups: ["Workers Scripts Read"],
+                resources: {
+                  [`com.cloudflare.api.account.${accountId}`]: "*",
+                },
               },
-            },
-          ],
-        });
-      }),
-    );
+            ],
+          });
+        }),
+      );
 
-    expect(token.tokenId).toBeDefined();
-    expect(token.name).toBeDefined();
-    expect(token.status).toEqual("active");
-    expect(Redacted.value(token.value)).toMatch(/.+/);
+      expect(token.tokenId).toBeDefined();
+      expect(token.name).toBeDefined();
+      expect(token.status).toEqual("active");
+      expect(Redacted.value(token.value)).toMatch(/.+/);
 
-    const actualToken = yield* accounts.getToken({
-      accountId,
-      tokenId: token.tokenId,
-    });
-    expect(actualToken.id).toEqual(token.tokenId);
-    expect(actualToken.name).toEqual(token.name);
+      const actualToken = yield* accounts.getToken({
+        accountId,
+        tokenId: token.tokenId,
+      });
+      expect(actualToken.id).toEqual(token.tokenId);
+      expect(actualToken.name).toEqual(token.name);
 
-    yield* destroy();
+      yield* stack.destroy();
 
-    yield* waitForTokenToBeDeleted(token.tokenId, accountId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
-);
-
-test(
-  "create, update, delete account token",
-  Effect.gen(function* () {
-    const { accountId } = yield* CloudflareEnvironment;
-
-    yield* destroy();
-
-    const token = yield* test.deploy(
-      Effect.gen(function* () {
-        return yield* Cloudflare.AccountApiToken("UpdateToken", {
-          name: "alchemy-test-acct-update-initial",
-          policies: [
-            {
-              effect: "allow",
-              permissionGroups: ["Workers Scripts Read"],
-              resources: {
-                [`com.cloudflare.api.account.${accountId}`]: "*",
-              },
-            },
-          ],
-        });
-      }),
-    );
-
-    expect(token.name).toEqual("alchemy-test-acct-update-initial");
-    const initialValue = Redacted.value(token.value);
-
-    const updated = yield* test.deploy(
-      Effect.gen(function* () {
-        return yield* Cloudflare.AccountApiToken("UpdateToken", {
-          name: "alchemy-test-acct-update-renamed",
-          policies: [
-            {
-              effect: "allow",
-              permissionGroups: [
-                "Workers Scripts Read",
-                "Workers KV Storage Read",
-              ],
-              resources: {
-                [`com.cloudflare.api.account.${accountId}`]: "*",
-              },
-            },
-          ],
-        });
-      }),
-    );
-
-    expect(updated.tokenId).toEqual(token.tokenId);
-    expect(updated.name).toEqual("alchemy-test-acct-update-renamed");
-    expect(Redacted.value(updated.value)).toEqual(initialValue);
-
-    const actual = yield* accounts.getToken({
-      accountId,
-      tokenId: updated.tokenId,
-    });
-    expect(actual.name).toEqual("alchemy-test-acct-update-renamed");
-    expect(actual.policies?.[0]?.permissionGroups.length).toEqual(2);
-
-    yield* destroy();
-
-    yield* waitForTokenToBeDeleted(token.tokenId, accountId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
-);
-
-test(
-  "noop when account token props unchanged",
-  Effect.gen(function* () {
-    const { accountId } = yield* CloudflareEnvironment;
-
-    yield* destroy();
-
-    const props = {
-      name: "alchemy-test-acct-noop",
-      policies: [
-        {
-          effect: "allow" as const,
-          permissionGroups: ["Workers Scripts Read" as const],
-          resources: {
-            [`com.cloudflare.api.account.${accountId}`]: "*",
-          },
-        },
-      ],
-    };
-
-    const first = yield* test.deploy(
-      Effect.gen(function* () {
-        return yield* Cloudflare.AccountApiToken("NoopToken", props);
-      }),
-    );
-
-    const second = yield* test.deploy(
-      Effect.gen(function* () {
-        return yield* Cloudflare.AccountApiToken("NoopToken", props);
-      }),
-    );
-
-    expect(second.tokenId).toEqual(first.tokenId);
-    expect(Redacted.value(second.value)).toEqual(Redacted.value(first.value));
-
-    yield* destroy();
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
-);
-
-const waitForTokenToBeDeleted = Effect.fn(function* (
-  tokenId: string,
-  accountId: string,
-) {
-  yield* accounts.getToken({ accountId, tokenId }).pipe(
-    Effect.flatMap(() => Effect.fail(new TokenStillExists())),
-    Effect.retry({
-      while: (e): e is TokenStillExists => e instanceof TokenStillExists,
-      schedule: Schedule.exponential(200).pipe(
-        Schedule.both(Schedule.recurs(8)),
-      ),
-    }),
-    Effect.catchTag("TokenStillExists", () =>
-      Effect.die(
-        `Cloudflare API token ${tokenId} was not deleted after retries`,
-      ),
-    ),
-    Effect.catchTag("TokenNotFound", () => Effect.void),
-    Effect.catchTag("InvalidRoute", () => Effect.void),
+      yield* waitForTokenToBeDeleted(token.tokenId, accountId);
+    }).pipe(logLevel),
   );
-});
 
+  test.provider("create, update, delete account token", (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const token = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AccountApiToken("UpdateToken", {
+            name: "alchemy-test-acct-update-initial",
+            policies: [
+              {
+                effect: "allow",
+                permissionGroups: ["Workers Scripts Read"],
+                resources: {
+                  [`com.cloudflare.api.account.${accountId}`]: "*",
+                },
+              },
+            ],
+          });
+        }),
+      );
+
+      expect(token.name).toEqual("alchemy-test-acct-update-initial");
+      const initialValue = Redacted.value(token.value);
+
+      const updated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AccountApiToken("UpdateToken", {
+            name: "alchemy-test-acct-update-renamed",
+            policies: [
+              {
+                effect: "allow",
+                permissionGroups: [
+                  "Workers Scripts Read",
+                  "Workers KV Storage Read",
+                ],
+                resources: {
+                  [`com.cloudflare.api.account.${accountId}`]: "*",
+                },
+              },
+            ],
+          });
+        }),
+      );
+
+      expect(updated.tokenId).toEqual(token.tokenId);
+      expect(updated.name).toEqual("alchemy-test-acct-update-renamed");
+      expect(Redacted.value(updated.value)).toEqual(initialValue);
+
+      const actual = yield* accounts.getToken({
+        accountId,
+        tokenId: updated.tokenId,
+      });
+      expect(actual.name).toEqual("alchemy-test-acct-update-renamed");
+      expect(actual.policies?.[0]?.permissionGroups.length).toEqual(2);
+
+      yield* stack.destroy();
+
+      yield* waitForTokenToBeDeleted(token.tokenId, accountId);
+    }).pipe(logLevel),
+  );
+
+  test.provider("noop when account token props unchanged", (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const props = {
+        name: "alchemy-test-acct-noop",
+        policies: [
+          {
+            effect: "allow" as const,
+            permissionGroups: ["Workers Scripts Read" as const],
+            resources: {
+              [`com.cloudflare.api.account.${accountId}`]: "*",
+            },
+          },
+        ],
+      };
+
+      const first = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AccountApiToken("NoopToken", props);
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AccountApiToken("NoopToken", props);
+        }),
+      );
+
+      expect(second.tokenId).toEqual(first.tokenId);
+      expect(Redacted.value(second.value)).toEqual(Redacted.value(first.value));
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  );
+
+  const waitForTokenToBeDeleted = Effect.fn(function* (
+    tokenId: string,
+    accountId: string,
+  ) {
+    yield* accounts.getToken({ accountId, tokenId }).pipe(
+      Effect.flatMap(() => Effect.fail(new TokenStillExists())),
+      Effect.retry({
+        while: (e): e is TokenStillExists => e instanceof TokenStillExists,
+        schedule: Schedule.exponential(200).pipe(
+          Schedule.both(Schedule.recurs(8)),
+        ),
+      }),
+      Effect.catchTag("TokenStillExists", () =>
+        Effect.die(
+          `Cloudflare API token ${tokenId} was not deleted after retries`,
+        ),
+      ),
+      Effect.catchTag("TokenNotFound", () => Effect.void),
+      Effect.catchTag("InvalidRoute", () => Effect.void),
+    );
+  });
+});
 class TokenStillExists extends Data.TaggedError("TokenStillExists") {}

--- a/packages/alchemy/test/Cloudflare/ApiToken/UserApiToken.test.ts
+++ b/packages/alchemy/test/Cloudflare/ApiToken/UserApiToken.test.ts
@@ -1,135 +1,135 @@
 import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as user from "@distilled.cloud/cloudflare/user";
-import { expect } from "@effect/vitest";
+import { describe, expect } from "@effect/vitest";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
 const logLevel = Effect.provideService(
   MinimumLogLevel,
   process.env.DEBUG ? "Debug" : "Info",
 );
+describe.skip("UserApiToken", () => {
+  test.provider("create and delete user token with default props", (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
 
-test(
-  "create and delete user token with default props",
-  Effect.gen(function* () {
-    const { accountId } = yield* CloudflareEnvironment;
+      yield* stack.destroy();
 
-    yield* destroy();
-
-    const token = yield* test.deploy(
-      Effect.gen(function* () {
-        return yield* Cloudflare.UserApiToken("DefaultUserToken", {
-          policies: [
-            {
-              effect: "allow",
-              permissionGroups: ["Workers Scripts Read"],
-              resources: {
-                [`com.cloudflare.api.account.${accountId}`]: "*",
+      const token = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.UserApiToken("DefaultUserToken", {
+            policies: [
+              {
+                effect: "allow",
+                permissionGroups: ["Workers Scripts Read"],
+                resources: {
+                  [`com.cloudflare.api.account.${accountId}`]: "*",
+                },
               },
-            },
-          ],
-        });
-      }),
-    );
+            ],
+          });
+        }),
+      );
 
-    expect(token.tokenId).toBeDefined();
-    expect(token.name).toBeDefined();
-    expect(token.status).toEqual("active");
-    expect(Redacted.value(token.value)).toMatch(/.+/);
+      expect(token.tokenId).toBeDefined();
+      expect(token.name).toBeDefined();
+      expect(token.status).toEqual("active");
+      expect(Redacted.value(token.value)).toMatch(/.+/);
 
-    const actualToken = yield* user.getToken({ tokenId: token.tokenId });
-    expect(actualToken.id).toEqual(token.tokenId);
-    expect(actualToken.name).toEqual(token.name);
+      const actualToken = yield* user.getToken({ tokenId: token.tokenId });
+      expect(actualToken.id).toEqual(token.tokenId);
+      expect(actualToken.name).toEqual(token.name);
 
-    yield* destroy();
+      yield* stack.destroy();
 
-    yield* waitForTokenToBeDeleted(token.tokenId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
-);
-
-test(
-  "create, update, delete user token",
-  Effect.gen(function* () {
-    const { accountId } = yield* CloudflareEnvironment;
-
-    yield* destroy();
-
-    const token = yield* test.deploy(
-      Effect.gen(function* () {
-        return yield* Cloudflare.UserApiToken("UpdateUserToken", {
-          name: "alchemy-test-user-update-initial",
-          policies: [
-            {
-              effect: "allow",
-              permissionGroups: ["Workers Scripts Read"],
-              resources: {
-                [`com.cloudflare.api.account.${accountId}`]: "*",
-              },
-            },
-          ],
-        });
-      }),
-    );
-
-    expect(token.name).toEqual("alchemy-test-user-update-initial");
-    const initialValue = Redacted.value(token.value);
-
-    const updated = yield* test.deploy(
-      Effect.gen(function* () {
-        return yield* Cloudflare.UserApiToken("UpdateUserToken", {
-          name: "alchemy-test-user-update-renamed",
-          policies: [
-            {
-              effect: "allow",
-              permissionGroups: [
-                "Workers Scripts Read",
-                "Workers KV Storage Read",
-              ],
-              resources: {
-                [`com.cloudflare.api.account.${accountId}`]: "*",
-              },
-            },
-          ],
-        });
-      }),
-    );
-
-    expect(updated.tokenId).toEqual(token.tokenId);
-    expect(updated.name).toEqual("alchemy-test-user-update-renamed");
-    expect(Redacted.value(updated.value)).toEqual(initialValue);
-
-    const actual = yield* user.getToken({ tokenId: updated.tokenId });
-    expect(actual.name).toEqual("alchemy-test-user-update-renamed");
-    expect(actual.policies?.[0]?.permissionGroups.length).toEqual(2);
-
-    yield* destroy();
-
-    yield* waitForTokenToBeDeleted(token.tokenId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
-);
-
-const waitForTokenToBeDeleted = Effect.fn(function* (tokenId: string) {
-  yield* user.getToken({ tokenId }).pipe(
-    Effect.flatMap(() => Effect.fail(new TokenStillExists())),
-    Effect.retry({
-      while: (e): e is TokenStillExists => e instanceof TokenStillExists,
-      schedule: Schedule.exponential(200).pipe(
-        Schedule.both(Schedule.recurs(8)),
-      ),
-    }),
-    Effect.catchTag("TokenStillExists", () =>
-      Effect.die(
-        `Cloudflare API token ${tokenId} was not deleted after retries`,
-      ),
-    ),
-    Effect.catchTag("TokenNotFound", () => Effect.void),
-    Effect.catchTag("InvalidRoute", () => Effect.void),
+      yield* waitForTokenToBeDeleted(token.tokenId);
+    }).pipe(logLevel),
   );
-});
 
+  test.provider("create, update, delete user token", (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const token = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.UserApiToken("UpdateUserToken", {
+            name: "alchemy-test-user-update-initial",
+            policies: [
+              {
+                effect: "allow",
+                permissionGroups: ["Workers Scripts Read"],
+                resources: {
+                  [`com.cloudflare.api.account.${accountId}`]: "*",
+                },
+              },
+            ],
+          });
+        }),
+      );
+
+      expect(token.name).toEqual("alchemy-test-user-update-initial");
+      const initialValue = Redacted.value(token.value);
+
+      const updated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.UserApiToken("UpdateUserToken", {
+            name: "alchemy-test-user-update-renamed",
+            policies: [
+              {
+                effect: "allow",
+                permissionGroups: [
+                  "Workers Scripts Read",
+                  "Workers KV Storage Read",
+                ],
+                resources: {
+                  [`com.cloudflare.api.account.${accountId}`]: "*",
+                },
+              },
+            ],
+          });
+        }),
+      );
+
+      expect(updated.tokenId).toEqual(token.tokenId);
+      expect(updated.name).toEqual("alchemy-test-user-update-renamed");
+      expect(Redacted.value(updated.value)).toEqual(initialValue);
+
+      const actual = yield* user.getToken({ tokenId: updated.tokenId });
+      expect(actual.name).toEqual("alchemy-test-user-update-renamed");
+      expect(actual.policies?.[0]?.permissionGroups.length).toEqual(2);
+
+      yield* stack.destroy();
+
+      yield* waitForTokenToBeDeleted(token.tokenId);
+    }).pipe(logLevel),
+  );
+
+  const waitForTokenToBeDeleted = Effect.fn(function* (tokenId: string) {
+    yield* user.getToken({ tokenId }).pipe(
+      Effect.flatMap(() => Effect.fail(new TokenStillExists())),
+      Effect.retry({
+        while: (e): e is TokenStillExists => e instanceof TokenStillExists,
+        schedule: Schedule.exponential(200).pipe(
+          Schedule.both(Schedule.recurs(8)),
+        ),
+      }),
+      Effect.catchTag("TokenStillExists", () =>
+        Effect.die(
+          `Cloudflare API token ${tokenId} was not deleted after retries`,
+        ),
+      ),
+      Effect.catchTag("TokenNotFound", () => Effect.void),
+      Effect.catchTag("InvalidRoute", () => Effect.void),
+    );
+  });
+});
 class TokenStillExists extends Data.TaggedError("TokenStillExists") {}

--- a/packages/alchemy/test/Cloudflare/D1/Database.test.ts
+++ b/packages/alchemy/test/Cloudflare/D1/Database.test.ts
@@ -1,6 +1,6 @@
 import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as d1 from "@distilled.cloud/cloudflare/d1";
 import { expect } from "@effect/vitest";
 import * as Data from "effect/Data";
@@ -11,19 +11,20 @@ import * as Path from "effect/Path";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
 const logLevel = Effect.provideService(
   MinimumLogLevel,
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-test(
-  "create and delete database with default props",
+test.provider("create and delete database with default props", (stack) =>
   Effect.gen(function* () {
     const { accountId } = yield* CloudflareEnvironment;
 
-    yield* destroy();
+    yield* stack.destroy();
 
-    const database = yield* test.deploy(
+    const database = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Cloudflare.D1Database("DefaultDatabase");
       }),
@@ -38,20 +39,19 @@ test(
     });
     expect(actualDatabase.uuid).toEqual(database.databaseId);
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* waitForDatabaseToBeDeleted(database.databaseId, accountId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+  }).pipe(logLevel),
 );
 
-test(
-  "create, update, delete database",
+test.provider("create, update, delete database", (stack) =>
   Effect.gen(function* () {
     const { accountId } = yield* CloudflareEnvironment;
 
-    yield* destroy();
+    yield* stack.destroy();
 
-    const database = yield* test.deploy(
+    const database = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Cloudflare.D1Database("TestDatabase", {
           readReplication: { mode: "disabled" },
@@ -65,7 +65,7 @@ test(
     });
     expect(actualDatabase.uuid).toEqual(database.databaseId);
 
-    const updatedDatabase = yield* test.deploy(
+    const updatedDatabase = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Cloudflare.D1Database("TestDatabase", {
           readReplication: { mode: "auto" },
@@ -81,14 +81,13 @@ test(
     });
     expect(actualUpdatedDatabase.readReplication?.mode).toEqual("auto");
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* waitForDatabaseToBeDeleted(database.databaseId, accountId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+  }).pipe(logLevel),
 );
 
-test(
-  "applies migrations from migrationsDir",
+test.provider("applies migrations from migrationsDir", (stack) =>
   Effect.gen(function* () {
     const { accountId } = yield* CloudflareEnvironment;
     const fs = yield* FileSystem.FileSystem;
@@ -106,9 +105,9 @@ test(
       "CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT NOT NULL);",
     );
 
-    yield* destroy();
+    yield* stack.destroy();
 
-    const database = yield* test.deploy(
+    const database = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Cloudflare.D1Database("MigrationDatabase", {
           migrationsDir,
@@ -148,7 +147,7 @@ test(
       "CREATE TABLE comments (id INTEGER PRIMARY KEY, body TEXT NOT NULL);",
     );
 
-    const updated = yield* test.deploy(
+    const updated = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Cloudflare.D1Database("MigrationDatabase", {
           migrationsDir,
@@ -171,13 +170,12 @@ test(
       { id: "00003", name: "0003_comments.sql" },
     ]);
 
-    yield* destroy();
+    yield* stack.destroy();
     yield* waitForDatabaseToBeDeleted(database.databaseId, accountId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+  }).pipe(logLevel),
 );
 
-test(
-  "applies migrations using a custom migrationsTable",
+test.provider("applies migrations using a custom migrationsTable", (stack) =>
   Effect.gen(function* () {
     const { accountId } = yield* CloudflareEnvironment;
     const fs = yield* FileSystem.FileSystem;
@@ -190,9 +188,9 @@ test(
       "CREATE TABLE test_migrations_table (id INTEGER PRIMARY KEY, name TEXT);",
     );
 
-    yield* destroy();
+    yield* stack.destroy();
 
-    const database = yield* test.deploy(
+    const database = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Cloudflare.D1Database("CustomMigrationsTableDb", {
           migrationsDir,
@@ -209,103 +207,103 @@ test(
     // The default table must NOT be created when a custom one is configured.
     expect(tables).not.toContain("d1_migrations");
 
-    yield* destroy();
+    yield* stack.destroy();
     yield* waitForDatabaseToBeDeleted(database.databaseId, accountId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+  }).pipe(logLevel),
 );
 
-test(
+test.provider(
   "migrates legacy 2-column migration table to wrangler schema",
-  Effect.gen(function* () {
-    const { accountId } = yield* CloudflareEnvironment;
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const migrationsDir = yield* fs.makeTempDirectory({
-      prefix: "alchemy-d1-legacy-",
-    });
-    yield* fs.writeFileString(
-      path.join(migrationsDir, "0002_create_users.sql"),
-      "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);",
-    );
-    yield* fs.writeFileString(
-      path.join(migrationsDir, "0003_create_posts.sql"),
-      "CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT NOT NULL);",
-    );
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const migrationsDir = yield* fs.makeTempDirectory({
+        prefix: "alchemy-d1-legacy-",
+      });
+      yield* fs.writeFileString(
+        path.join(migrationsDir, "0002_create_users.sql"),
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);",
+      );
+      yield* fs.writeFileString(
+        path.join(migrationsDir, "0003_create_posts.sql"),
+        "CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT NOT NULL);",
+      );
 
-    yield* destroy();
+      yield* stack.destroy();
 
-    // Step 1: deploy the database without migrations so we can seed a legacy
-    // 2-column d1_migrations table on it before re-deploying with a
-    // migrationsDir.
-    const seeded = yield* test.deploy(
-      Effect.gen(function* () {
-        return yield* Cloudflare.D1Database("LegacyMigrationDb");
-      }),
-    );
+      // Step 1: deploy the database without migrations so we can seed a legacy
+      // 2-column d1_migrations table on it before re-deploying with a
+      // migrationsDir.
+      const seeded = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.D1Database("LegacyMigrationDb");
+        }),
+      );
 
-    yield* execSql(
-      accountId,
-      seeded.databaseId,
-      `CREATE TABLE d1_migrations (
+      yield* execSql(
+        accountId,
+        seeded.databaseId,
+        `CREATE TABLE d1_migrations (
          id TEXT PRIMARY KEY,
          applied_at TEXT NOT NULL
        );`,
-    );
-    yield* execSql(
-      accountId,
-      seeded.databaseId,
-      `INSERT INTO d1_migrations (id, applied_at) VALUES
+      );
+      yield* execSql(
+        accountId,
+        seeded.databaseId,
+        `INSERT INTO d1_migrations (id, applied_at) VALUES
          ('0000_initial_setup.sql', datetime('now', '-1 day')),
          ('0001_add_indexes.sql', datetime('now', '-1 hour'));`,
-    );
+      );
 
-    // Step 2: deploy again with a migrationsDir; the resource should detect
-    // the legacy 2-column schema, migrate to (id, name, applied_at), and apply
-    // the new migrations on top.
-    const upgraded = yield* test.deploy(
-      Effect.gen(function* () {
-        return yield* Cloudflare.D1Database("LegacyMigrationDb", {
-          migrationsDir,
-        });
-      }),
-    );
-    expect(upgraded.databaseId).toEqual(seeded.databaseId);
+      // Step 2: deploy again with a migrationsDir; the resource should detect
+      // the legacy 2-column schema, migrate to (id, name, applied_at), and apply
+      // the new migrations on top.
+      const upgraded = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.D1Database("LegacyMigrationDb", {
+            migrationsDir,
+          });
+        }),
+      );
+      expect(upgraded.databaseId).toEqual(seeded.databaseId);
 
-    const columns = yield* queryAll<{ name: string }>(
-      accountId,
-      seeded.databaseId,
-      "PRAGMA table_info(d1_migrations);",
-    );
-    const colNames = columns.map((c) => c.name).sort();
-    expect(colNames).toEqual(["applied_at", "id", "name"]);
+      const columns = yield* queryAll<{ name: string }>(
+        accountId,
+        seeded.databaseId,
+        "PRAGMA table_info(d1_migrations);",
+      );
+      const colNames = columns.map((c) => c.name).sort();
+      expect(colNames).toEqual(["applied_at", "id", "name"]);
 
-    const records = yield* queryAll<{ id: string; name: string }>(
-      accountId,
-      seeded.databaseId,
-      "SELECT id, name FROM d1_migrations ORDER BY id;",
-    );
-    const names = records.map((r) => r.name);
-    expect(names).toContain("0000_initial_setup.sql");
-    expect(names).toContain("0001_add_indexes.sql");
-    expect(names).toContain("0002_create_users.sql");
-    expect(names).toContain("0003_create_posts.sql");
+      const records = yield* queryAll<{ id: string; name: string }>(
+        accountId,
+        seeded.databaseId,
+        "SELECT id, name FROM d1_migrations ORDER BY id;",
+      );
+      const names = records.map((r) => r.name);
+      expect(names).toContain("0000_initial_setup.sql");
+      expect(names).toContain("0001_add_indexes.sql");
+      expect(names).toContain("0002_create_users.sql");
+      expect(names).toContain("0003_create_posts.sql");
 
-    // All ids should be 5-digit zero-padded sequential numbers.
-    for (const r of records) {
-      expect(r.id).toMatch(/^\d{5}$/);
-    }
-    expect(records[0].id).toBe("00001");
-    expect(records[records.length - 1].id).toBe(
-      records.length.toString().padStart(5, "0"),
-    );
+      // All ids should be 5-digit zero-padded sequential numbers.
+      for (const r of records) {
+        expect(r.id).toMatch(/^\d{5}$/);
+      }
+      expect(records[0].id).toBe("00001");
+      expect(records[records.length - 1].id).toBe(
+        records.length.toString().padStart(5, "0"),
+      );
 
-    yield* destroy();
-    yield* waitForDatabaseToBeDeleted(seeded.databaseId, accountId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+      yield* stack.destroy();
+      yield* waitForDatabaseToBeDeleted(seeded.databaseId, accountId);
+    }).pipe(logLevel),
 );
 
-test(
-  "imports SQL files via importFiles",
+test.provider("imports SQL files via importFiles", (stack) =>
   Effect.gen(function* () {
     const { accountId } = yield* CloudflareEnvironment;
     const fs = yield* FileSystem.FileSystem;
@@ -324,9 +322,9 @@ test(
       ].join("\n"),
     );
 
-    yield* destroy();
+    yield* stack.destroy();
 
-    const database = yield* test.deploy(
+    const database = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Cloudflare.D1Database("ImportDatabase", {
           importFiles: [importPath],
@@ -346,13 +344,12 @@ test(
       { id: 2, label: "two" },
     ]);
 
-    yield* destroy();
+    yield* stack.destroy();
     yield* waitForDatabaseToBeDeleted(database.databaseId, accountId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+  }).pipe(logLevel),
 );
 
-test(
-  "clones a database by databaseId",
+test.provider("clones a database by databaseId", (stack) =>
   Effect.gen(function* () {
     const { accountId } = yield* CloudflareEnvironment;
     const fs = yield* FileSystem.FileSystem;
@@ -370,9 +367,9 @@ test(
       ].join("\n"),
     );
 
-    yield* destroy();
+    yield* stack.destroy();
 
-    const { source, target } = yield* test.deploy(
+    const { source, target } = yield* stack.deploy(
       Effect.gen(function* () {
         const source = yield* Cloudflare.D1Database("CloneByIdSource", {
           importFiles: [seedPath],
@@ -397,14 +394,13 @@ test(
       { id: 3, name: "blue" },
     ]);
 
-    yield* destroy();
+    yield* stack.destroy();
     yield* waitForDatabaseToBeDeleted(source.databaseId, accountId);
     yield* waitForDatabaseToBeDeleted(target.databaseId, accountId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+  }).pipe(logLevel),
 );
 
-test(
-  "clones a database by name lookup",
+test.provider("clones a database by name lookup", (stack) =>
   Effect.gen(function* () {
     const { accountId } = yield* CloudflareEnvironment;
     const fs = yield* FileSystem.FileSystem;
@@ -422,9 +418,9 @@ test(
       ].join("\n"),
     );
 
-    yield* destroy();
+    yield* stack.destroy();
 
-    const { source, target } = yield* test.deploy(
+    const { source, target } = yield* stack.deploy(
       Effect.gen(function* () {
         const source = yield* Cloudflare.D1Database("CloneByNameSource", {
           importFiles: [seedPath],
@@ -448,61 +444,62 @@ test(
       { id: 2, kind: "dog" },
     ]);
 
-    yield* destroy();
+    yield* stack.destroy();
     yield* waitForDatabaseToBeDeleted(source.databaseId, accountId);
     yield* waitForDatabaseToBeDeleted(target.databaseId, accountId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+  }).pipe(logLevel),
 );
 
-test(
+test.provider(
   "clones a database by passing the source resource directly",
-  Effect.gen(function* () {
-    const { accountId } = yield* CloudflareEnvironment;
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const dir = yield* fs.makeTempDirectory({
-      prefix: "alchemy-d1-clone-direct-",
-    });
-    const seedPath = path.join(dir, "seed.sql");
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const dir = yield* fs.makeTempDirectory({
+        prefix: "alchemy-d1-clone-direct-",
+      });
+      const seedPath = path.join(dir, "seed.sql");
 
-    yield* fs.writeFileString(
-      seedPath,
-      [
-        "CREATE TABLE shapes (id INTEGER PRIMARY KEY, name TEXT NOT NULL);",
-        "INSERT INTO shapes (id, name) VALUES (1, 'square'), (2, 'circle');",
-      ].join("\n"),
-    );
+      yield* fs.writeFileString(
+        seedPath,
+        [
+          "CREATE TABLE shapes (id INTEGER PRIMARY KEY, name TEXT NOT NULL);",
+          "INSERT INTO shapes (id, name) VALUES (1, 'square'), (2, 'circle');",
+        ].join("\n"),
+      );
 
-    yield* destroy();
+      yield* stack.destroy();
 
-    const { source, target } = yield* test.deploy(
-      Effect.gen(function* () {
-        const source = yield* Cloudflare.D1Database("CloneDirectSource", {
-          importFiles: [seedPath],
-        });
-        const target = yield* Cloudflare.D1Database("CloneDirectTarget", {
-          clone: source,
-        });
-        return { source, target };
-      }),
-    );
+      const { source, target } = yield* stack.deploy(
+        Effect.gen(function* () {
+          const source = yield* Cloudflare.D1Database("CloneDirectSource", {
+            importFiles: [seedPath],
+          });
+          const target = yield* Cloudflare.D1Database("CloneDirectTarget", {
+            clone: source,
+          });
+          return { source, target };
+        }),
+      );
 
-    expect(target.databaseId).not.toEqual(source.databaseId);
+      expect(target.databaseId).not.toEqual(source.databaseId);
 
-    const shapes = yield* getResults<{ id: number; name: string }>(
-      accountId,
-      target.databaseId,
-      "SELECT id, name FROM shapes ORDER BY id;",
-    );
-    expect(shapes).toEqual([
-      { id: 1, name: "square" },
-      { id: 2, name: "circle" },
-    ]);
+      const shapes = yield* getResults<{ id: number; name: string }>(
+        accountId,
+        target.databaseId,
+        "SELECT id, name FROM shapes ORDER BY id;",
+      );
+      expect(shapes).toEqual([
+        { id: 1, name: "square" },
+        { id: 2, name: "circle" },
+      ]);
 
-    yield* destroy();
-    yield* waitForDatabaseToBeDeleted(source.databaseId, accountId);
-    yield* waitForDatabaseToBeDeleted(target.databaseId, accountId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+      yield* stack.destroy();
+      yield* waitForDatabaseToBeDeleted(source.databaseId, accountId);
+      yield* waitForDatabaseToBeDeleted(target.databaseId, accountId);
+    }).pipe(logLevel),
 );
 
 const queryAll = Effect.fn(function* <T>(

--- a/packages/alchemy/test/Cloudflare/KV/Namespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/KV/Namespace.test.ts
@@ -1,7 +1,7 @@
 import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as KV from "@/Cloudflare/KV/index";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as kv from "@distilled.cloud/cloudflare/kv";
 import { expect } from "@effect/vitest";
 import * as Data from "effect/Data";
@@ -9,19 +9,20 @@ import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
 const logLevel = Effect.provideService(
   MinimumLogLevel,
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-test(
-  "create and delete namespace with default props",
+test.provider("create and delete namespace with default props", (stack) =>
   Effect.gen(function* () {
     const { accountId } = yield* CloudflareEnvironment;
 
-    yield* destroy();
+    yield* stack.destroy();
 
-    const namespace = yield* test.deploy(
+    const namespace = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* KV.KVNamespace("DefaultNamespace");
       }),
@@ -36,20 +37,19 @@ test(
     });
     expect(actualNamespace.id).toEqual(namespace.namespaceId);
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* waitForNamespaceToBeDeleted(namespace.namespaceId, accountId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+  }).pipe(logLevel),
 );
 
-test(
-  "create, update, delete namespace",
+test.provider("create, update, delete namespace", (stack) =>
   Effect.gen(function* () {
     const { accountId } = yield* CloudflareEnvironment;
 
-    yield* destroy();
+    yield* stack.destroy();
 
-    const namespace = yield* test.deploy(
+    const namespace = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* KV.KVNamespace("TestNamespace", {
           title: "test-namespace-initial",
@@ -64,8 +64,7 @@ test(
     expect(actualNamespace.id).toEqual(namespace.namespaceId);
     expect(actualNamespace.title).toEqual(namespace.title);
 
-    // Update the namespace
-    const updatedNamespace = yield* test.deploy(
+    const updatedNamespace = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* KV.KVNamespace("TestNamespace", {
           title: "test-namespace-updated",
@@ -80,10 +79,10 @@ test(
     expect(actualUpdatedNamespace.title).toEqual("test-namespace-updated");
     expect(actualUpdatedNamespace.id).toEqual(updatedNamespace.namespaceId);
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* waitForNamespaceToBeDeleted(namespace.namespaceId, accountId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+  }).pipe(logLevel),
 );
 
 const waitForNamespaceToBeDeleted = Effect.fn(function* (

--- a/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
+++ b/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
@@ -1,6 +1,6 @@
 import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as r2 from "@distilled.cloud/cloudflare/r2";
 import { expect } from "@effect/vitest";
 import * as Data from "effect/Data";
@@ -8,19 +8,20 @@ import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
 const logLevel = Effect.provideService(
   MinimumLogLevel,
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-test(
-  "create and delete bucket with default props",
+test.provider("create and delete bucket with default props", (stack) =>
   Effect.gen(function* () {
     const { accountId } = yield* CloudflareEnvironment;
 
-    yield* destroy();
+    yield* stack.destroy();
 
-    const bucket = yield* test.deploy(
+    const bucket = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Cloudflare.R2Bucket("DefaultBucket");
       }),
@@ -36,20 +37,19 @@ test(
     });
     expect(actualBucket.name).toEqual(bucket.bucketName);
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* waitForBucketToBeDeleted(bucket.bucketName, accountId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+  }).pipe(logLevel),
 );
 
-test(
-  "create, update, delete bucket",
+test.provider("create, update, delete bucket", (stack) =>
   Effect.gen(function* () {
     const { accountId } = yield* CloudflareEnvironment;
 
-    yield* destroy();
+    yield* stack.destroy();
 
-    const bucket = yield* test.deploy(
+    const bucket = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Cloudflare.R2Bucket("TestBucket", {
           name: "test-bucket-initial",
@@ -65,8 +65,7 @@ test(
     expect(actualBucket.name).toEqual(bucket.bucketName);
     expect(actualBucket.storageClass).toEqual("Standard");
 
-    // Update the bucket
-    const updatedBucket = yield* test.deploy(
+    const updatedBucket = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Cloudflare.R2Bucket("TestBucket", {
           name: "test-bucket-initial",
@@ -82,10 +81,10 @@ test(
     expect(actualUpdatedBucket.name).toEqual(updatedBucket.bucketName);
     expect(actualUpdatedBucket.storageClass).toEqual("InfrequentAccess");
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* waitForBucketToBeDeleted(bucket.bucketName, accountId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+  }).pipe(logLevel),
 );
 
 const waitForBucketToBeDeleted = Effect.fn(function* (

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -2,7 +2,7 @@ import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as R2 from "@/Cloudflare/R2";
 import { Stack } from "@/Stack";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import * as workers from "@distilled.cloud/cloudflare/workers";
 import { expect } from "@effect/vitest";
 import * as Data from "effect/Data";
@@ -12,6 +12,8 @@ import * as Schedule from "effect/Schedule";
 import * as pathe from "pathe";
 import InternalWorker from "./internal-worker.ts";
 
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
 const logLevel = Effect.provideService(
   MinimumLogLevel,
   process.env.DEBUG ? "Debug" : "Info",
@@ -19,15 +21,14 @@ const logLevel = Effect.provideService(
 
 const main = pathe.resolve(import.meta.dirname, "worker.ts");
 
-test(
-  "create, update, delete worker",
+test.provider("create, update, delete worker", (stack) =>
   Effect.gen(function* () {
     const { accountId } = yield* CloudflareEnvironment;
-    const stack = yield* Stack;
+    const s = yield* Stack;
 
-    yield* destroy();
+    yield* stack.destroy();
 
-    const worker = yield* test.deploy(
+    const worker = yield* stack.deploy(
       Effect.gen(function* () {
         yield* R2.R2Bucket("Bucket", {
           storageClass: "Standard",
@@ -48,10 +49,10 @@ test(
     const actualWorker = yield* findWorker(worker.workerName, accountId);
     expect(actualWorker?.scriptName).toEqual(worker.workerName);
     expect(yield* getWorkerTags(worker.workerName, accountId)).toContain(
-      `alchemy:stack:${stack.name}`,
+      `alchemy:stack:${s.name}`,
     );
     expect(yield* getWorkerTags(worker.workerName, accountId)).toContain(
-      `alchemy:stage:${stack.stage}`,
+      `alchemy:stage:${s.stage}`,
     );
     expect(yield* getWorkerTags(worker.workerName, accountId)).toContain(
       "alchemy:id:TestWorker",
@@ -63,7 +64,7 @@ test(
     }
 
     // Update the worker
-    const updatedWorker = yield* test.deploy(
+    const updatedWorker = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Cloudflare.Worker("TestWorker", {
           main,
@@ -89,21 +90,20 @@ test(
       previewsEnabled: true,
     });
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* waitForWorkerToBeDeleted(worker.workerName, accountId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+  }).pipe(logLevel),
 );
 
-test(
-  "create, update, delete worker with assets",
+test.provider("create, update, delete worker with assets", (stack) =>
   Effect.gen(function* () {
     const { accountId } = yield* CloudflareEnvironment;
-    const stack = yield* Stack;
+    const s = yield* Stack;
 
-    yield* destroy();
+    yield* stack.destroy();
 
-    const worker = yield* test.deploy(
+    const worker = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Cloudflare.Worker("TestWorkerWithAssets", {
           main,
@@ -119,10 +119,10 @@ test(
     const actualWorker = yield* findWorker(worker.workerName, accountId);
     expect(actualWorker?.scriptName).toEqual(worker.workerName);
     expect(yield* getWorkerTags(worker.workerName, accountId)).toContain(
-      `alchemy:stack:${stack.name}`,
+      `alchemy:stack:${s.name}`,
     );
     expect(yield* getWorkerTags(worker.workerName, accountId)).toContain(
-      `alchemy:stage:${stack.stage}`,
+      `alchemy:stage:${s.stage}`,
     );
     expect(yield* getWorkerTags(worker.workerName, accountId)).toContain(
       "alchemy:id:TestWorkerWithAssets",
@@ -137,7 +137,7 @@ test(
     }
 
     // Update the worker
-    const updatedWorker = yield* test.deploy(
+    const updatedWorker = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Cloudflare.Worker("TestWorkerWithAssets", {
           main,
@@ -158,7 +158,7 @@ test(
     expect(updatedWorker.hash?.assets).toBeDefined();
 
     // Final update
-    const finalWorker = yield* test.deploy(
+    const finalWorker = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* Cloudflare.Worker("TestWorkerWithAssets", {
           main,
@@ -172,21 +172,20 @@ test(
       }),
     );
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* waitForWorkerToBeDeleted(finalWorker.workerName, accountId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+  }).pipe(logLevel),
 );
 
-test(
-  "create, update, delete internal worker",
+test.provider("create, update, delete internal worker", (stack) =>
   Effect.gen(function* () {
     const { accountId } = yield* CloudflareEnvironment;
-    const stack = yield* Stack;
+    const s = yield* Stack;
 
-    yield* destroy();
+    yield* stack.destroy();
 
-    const worker = yield* test.deploy(
+    const worker = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* InternalWorker;
       }),
@@ -195,16 +194,16 @@ test(
     const actualWorker = yield* findWorker(worker.workerName, accountId);
     expect(actualWorker?.scriptName).toEqual(worker.workerName);
     expect(yield* getWorkerTags(worker.workerName, accountId)).toContain(
-      `alchemy:stack:${stack.name}`,
+      `alchemy:stack:${s.name}`,
     );
     expect(yield* getWorkerTags(worker.workerName, accountId)).toContain(
-      `alchemy:stage:${stack.stage}`,
+      `alchemy:stage:${s.stage}`,
     );
     expect(yield* getWorkerTags(worker.workerName, accountId)).toContain(
       "alchemy:id:InternalWorker",
     );
 
-    const updatedWorker = yield* test.deploy(
+    const updatedWorker = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* InternalWorker;
       }),
@@ -212,10 +211,10 @@ test(
 
     expect(updatedWorker.workerName).toEqual(worker.workerName);
 
-    yield* destroy();
+    yield* stack.destroy();
 
     yield* waitForWorkerToBeDeleted(worker.workerName, accountId);
-  }).pipe(Effect.provide(Cloudflare.providers()), logLevel),
+  }).pipe(logLevel),
 );
 
 const findWorker = Effect.fn(function* (workerName: string, accountId: string) {

--- a/packages/alchemy/test/Cloudflare/Workers/internal-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/internal-worker.ts
@@ -6,9 +6,6 @@ export default class InternalWorker extends Cloudflare.Worker<InternalWorker>()(
   "InternalWorker",
   {
     main: import.meta.filename,
-    compatibility: {
-      date: "2024-01-01",
-    },
   },
   Effect.gen(function* () {
     return {

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -1,14 +1,14 @@
 import { Cli } from "@/Cli/Cli";
 import * as Construct from "@/Construct";
 import * as Output from "@/Output";
-import * as Stack from "@/Stack";
+import { Stack } from "@/Stack";
 import {
   type ReplacedResourceState,
   type ReplacingResourceState,
   type ResourceState,
   State,
 } from "@/State";
-import { destroy, test } from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import { describe, expect } from "@effect/vitest";
 import { Data, Layer } from "effect";
 import * as Effect from "effect/Effect";
@@ -18,7 +18,6 @@ import {
   BindingTarget,
   DeletedBindingRegressionTarget,
   Function,
-  InMemoryTestLayers,
   PhasedTarget,
   StaticStablesResource,
   TestLayers,
@@ -27,32 +26,26 @@ import {
   type TestResourceProps,
 } from "./test.resources.ts";
 
-const testStack = "test";
-const testStage = "test";
+const { test } = Test.make({ providers: TestLayers() });
 
 const getState = Effect.fn(function* <S = ResourceState>(resourceId: string) {
   const state = yield* State;
+  const stk = yield* Stack;
   return (yield* state.get({
-    stack: testStack,
-    stage: testStage,
+    stack: stk.name,
+    stage: stk.stage,
     fqn: resourceId,
   })) as S;
 });
 const listState = Effect.fn(function* () {
   const state = yield* State;
-  return yield* state.list({ stack: testStack, stage: testStage });
+  const stk = yield* Stack;
+  return yield* state.list({ stack: stk.name, stage: stk.stage });
 });
 
 const expectConvergedStatus = (status: ResourceState["status"] | undefined) => {
   expect(["created", "updated"]).toContain(status);
 };
-
-const mockStack = Stack.Stack.of({
-  name: testStack,
-  stage: testStage,
-  bindings: {},
-  resources: {},
-});
 
 export class ResourceFailure extends Data.TaggedError("ResourceFailure")<{
   message: string;
@@ -61,9 +54,6 @@ export class ResourceFailure extends Data.TaggedError("ResourceFailure")<{
     super({ message: `Failed to create` });
   }
 }
-
-const MockLayers = () =>
-  Layer.mergeAll(InMemoryTestLayers(), Layer.succeed(Stack.Stack, mockStack));
 
 const hook =
   (hooks?: {
@@ -139,8 +129,7 @@ const failOnMultiple = (
 };
 
 describe("basic operations", () => {
-  test(
-    "should create, update, and delete resources",
+  test.provider("should create, update, and delete resources", (stack) =>
     Effect.gen(function* () {
       expect(
         yield* Effect.gen(function* () {
@@ -148,7 +137,7 @@ describe("basic operations", () => {
             string: "test-string",
           });
           return A.string;
-        }).pipe(test.deploy),
+        }).pipe(stack.deploy),
       ).toEqual("test-string");
 
       expect(
@@ -157,18 +146,17 @@ describe("basic operations", () => {
             string: "test-string-new",
           });
           return A.string;
-        }).pipe(test.deploy),
+        }).pipe(stack.deploy),
       ).toEqual("test-string-new");
 
-      yield* destroy();
+      yield* stack.destroy();
 
       expect(yield* getState("A")).toBeUndefined();
       expect(yield* listState()).toEqual([]);
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 
-  test(
-    "should resolve output properties",
+  test.provider("should resolve output properties", (stack) =>
     Effect.gen(function* () {
       expect(
         yield* Effect.gen(function* () {
@@ -180,7 +168,7 @@ describe("basic operations", () => {
             string: A.string,
           });
           return B.string;
-        }).pipe(test.deploy),
+        }).pipe(stack.deploy),
       ).toEqual("test-string");
 
       expect(
@@ -193,7 +181,7 @@ describe("basic operations", () => {
             string: A.string.pipe(Output.map((string) => string.toUpperCase())),
           });
           return B.string;
-        }).pipe(test.deploy),
+        }).pipe(stack.deploy),
       ).toEqual("TEST-STRING");
 
       expect(
@@ -208,149 +196,153 @@ describe("basic operations", () => {
             ),
           });
           return B.string;
-        }).pipe(test.deploy),
+        }).pipe(stack.deploy),
       ).toEqual("TEST-STRING-NEW");
-    }).pipe(Effect.provide(TestLayers())),
+    }),
   );
 
-  test(
+  test.provider(
     "should resolve bindings inside constructs using namespaced resources",
-    Effect.gen(function* () {
-      const Site = Construct.fn(function* (_id: string, _props: {}) {
-        const bucket = yield* BindingTarget("Bucket", {
-          string: "bucket-value",
-        });
-        const distribution = yield* BindingTarget("Distribution", {
-          string: "distribution-value",
+    (stack) =>
+      Effect.gen(function* () {
+        const Site = Construct.fn(function* (_id: string, _props: {}) {
+          const bucket = yield* BindingTarget("Bucket", {
+            string: "bucket-value",
+          });
+          const distribution = yield* BindingTarget("Distribution", {
+            string: "distribution-value",
+          });
+
+          yield* bucket.bind("Policy", {
+            env: {
+              BUCKET: bucket.string,
+              DISTRIBUTION: distribution.string,
+            },
+          });
+
+          return {
+            bucket,
+            distribution,
+          };
         });
 
-        yield* bucket.bind("Policy", {
-          env: {
-            BUCKET: bucket.string,
-            DISTRIBUTION: distribution.string,
+        const output = yield* Site("MarketingSite", {}).pipe(stack.deploy);
+
+        expect(output.bucket.env).toEqual({
+          BUCKET: "bucket-value",
+          DISTRIBUTION: "distribution-value",
+        });
+        expectConvergedStatus(
+          (yield* getState("MarketingSite/Bucket"))?.status,
+        );
+        expect((yield* getState("MarketingSite/Distribution"))?.status).toEqual(
+          "created",
+        );
+      }),
+  );
+
+  test.provider(
+    "should exclude deleted bindings before provider updates",
+    (stack) =>
+      Effect.gen(function* () {
+        const created = yield* stack.deploy(
+          Effect.gen(function* () {
+            const target = yield* DeletedBindingRegressionTarget("A", {
+              name: "target",
+            });
+            yield* target.bind("TestBinding", {
+              env: {
+                FEATURE_FLAG: "on",
+              },
+            });
+            return target;
+          }),
+        );
+
+        expect(created.env).toEqual({
+          FEATURE_FLAG: "on",
+        });
+
+        const updated = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* DeletedBindingRegressionTarget("A", {
+              name: "target",
+            });
+          }),
+        );
+
+        expect(updated.env).toEqual({});
+        expect(yield* getState("A")).toMatchObject({
+          bindings: [],
+          attr: {
+            env: {},
           },
         });
-
-        return {
-          bucket,
-          distribution,
-        };
-      });
-
-      const output = yield* Site("MarketingSite", {}).pipe(test.deploy);
-
-      expect(output.bucket.env).toEqual({
-        BUCKET: "bucket-value",
-        DISTRIBUTION: "distribution-value",
-      });
-      expectConvergedStatus((yield* getState("MarketingSite/Bucket"))?.status);
-      expect((yield* getState("MarketingSite/Distribution"))?.status).toEqual(
-        "created",
-      );
-    }).pipe(Effect.provide(MockLayers())),
+      }),
   );
 
-  test(
-    "should exclude deleted bindings before provider updates",
-    Effect.gen(function* () {
-      const created = yield* test.deploy(
-        Effect.gen(function* () {
-          const target = yield* DeletedBindingRegressionTarget("A", {
-            name: "target",
-          });
-          yield* target.bind("TestBinding", {
-            env: {
-              FEATURE_FLAG: "on",
-            },
-          });
-          return target;
-        }),
-      );
-
-      expect(created.env).toEqual({
-        FEATURE_FLAG: "on",
-      });
-
-      const updated = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* DeletedBindingRegressionTarget("A", {
-            name: "target",
-          });
-        }),
-      );
-
-      expect(updated.env).toEqual({});
-      expect(yield* getState("A")).toMatchObject({
-        bindings: [],
-        attr: {
-          env: {},
-        },
-      });
-    }).pipe(Effect.provide(MockLayers())),
-  );
-
-  test(
+  test.provider(
     "should update a surviving consumer before deleting a removed dependency",
-    Effect.gen(function* () {
-      const created = yield* test.deploy(
-        Effect.gen(function* () {
-          const secret = yield* TestResource("Secret", {
-            string: "secret-value",
-          });
-          const worker = yield* Function("Worker", {
-            name: "worker",
-            env: {
-              SECRET: secret.string,
-            },
-          });
-          return { secret, worker };
-        }),
-      );
+    (stack) =>
+      Effect.gen(function* () {
+        const created = yield* stack.deploy(
+          Effect.gen(function* () {
+            const secret = yield* TestResource("Secret", {
+              string: "secret-value",
+            });
+            const worker = yield* Function("Worker", {
+              name: "worker",
+              env: {
+                SECRET: secret.string,
+              },
+            });
+            return { secret, worker };
+          }),
+        );
 
-      expect(created.worker.env).toEqual({
-        SECRET: "secret-value",
-      });
-      expect((yield* getState("Secret"))?.status).toEqual("created");
-      expect((yield* getState("Worker"))?.status).toEqual("created");
+        expect(created.worker.env).toEqual({
+          SECRET: "secret-value",
+        });
+        expect((yield* getState("Secret"))?.status).toEqual("created");
+        expect((yield* getState("Worker"))?.status).toEqual("created");
 
-      const updated = yield* test.deploy(
-        Effect.gen(function* () {
-          return yield* Function("Worker", {
-            name: "worker",
-          });
-        }),
-      );
+        const updated = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Function("Worker", {
+              name: "worker",
+            });
+          }),
+        );
 
-      expect(updated.env).toEqual({});
-      expect(yield* getState("Secret")).toBeUndefined();
-      expect((yield* getState("Worker"))?.status).toEqual("updated");
-    }).pipe(Effect.provide(MockLayers())),
+        expect(updated.env).toEqual({});
+        expect(yield* getState("Secret")).toBeUndefined();
+        expect((yield* getState("Worker"))?.status).toEqual("updated");
+      }),
   );
 
-  test(
+  test.provider(
     "should create a resource with a binding that references its own output",
-    {
-      timeout: 10_000,
-    },
-    Effect.gen(function* () {
-      const created = yield* test.deploy(
-        Effect.gen(function* () {
-          const target = yield* DeletedBindingRegressionTarget("A", {
-            name: "target",
-          });
-          yield* target.bind("SelfBinding", {
-            env: {
-              SELF_NAME: target.name,
-            },
-          });
-          return target;
-        }),
-      );
+    (stack) =>
+      Effect.gen(function* () {
+        const created = yield* stack.deploy(
+          Effect.gen(function* () {
+            const target = yield* DeletedBindingRegressionTarget("A", {
+              name: "target",
+            });
+            yield* target.bind("SelfBinding", {
+              env: {
+                SELF_NAME: target.name,
+              },
+            });
+            return target;
+          }),
+        );
 
-      expect(created.env).toEqual({
-        SELF_NAME: "target",
-      });
-    }).pipe(Effect.provide(MockLayers())),
+        expect(created.env).toEqual({
+          SELF_NAME: "target",
+        });
+      }),
+    { timeout: 10_000 },
   );
 });
 
@@ -431,26 +423,24 @@ describe("circularity via bindings", () => {
       return { A, B };
     });
 
-  test(
+  test.provider(
     "create succeeds when props use precreate output and bindings use downstream output",
-    {
-      timeout: 10_000,
-    },
-    Effect.gen(function* () {
-      const output = yield* test.deploy(propAndBindingCycleStack());
+    (stack) =>
+      Effect.gen(function* () {
+        const output = yield* stack.deploy(propAndBindingCycleStack());
 
-      expect(output.A.env).toEqual({ PEER: "a-value" });
-      expect(output.B.string).toEqual("a-value");
-      expectConvergedStatus((yield* getState("A"))?.status);
-      expectConvergedStatus((yield* getState("B"))?.status);
-    }).pipe(Effect.provide(MockLayers())),
+        expect(output.A.env).toEqual({ PEER: "a-value" });
+        expect(output.B.string).toEqual("a-value");
+        expectConvergedStatus((yield* getState("A"))?.status);
+        expectConvergedStatus((yield* getState("B"))?.status);
+      }),
+    { timeout: 10_000 },
   );
 
   describe("self-referential bindings", () => {
-    test(
-      "create succeeds with self binding",
+    test.provider("create succeeds with self binding", (stack) =>
       Effect.gen(function* () {
-        const output = yield* test.deploy(
+        const output = yield* stack.deploy(
           selfBoundStack({
             string: "a-value",
             replaceString: "original",
@@ -461,149 +451,152 @@ describe("circularity via bindings", () => {
         expect(output.B.string).toEqual("a-value");
         expectConvergedStatus((yield* getState("A"))?.status);
         expectConvergedStatus((yield* getState("B"))?.status);
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
+    test.provider(
       "replacing state noop replay recovers and creates downstream resources",
-      Effect.gen(function* () {
-        yield* selfBoundStack({
-          string: "a-value",
-          replaceString: "original",
-        }).pipe(test.deploy);
+      (stack) =>
+        Effect.gen(function* () {
+          yield* selfBoundStack({
+            string: "a-value",
+            replaceString: "original",
+          }).pipe(stack.deploy);
 
-        const stack = selfBoundStack({
-          string: "a-value-replaced",
-          replaceString: "changed",
-          includeD: true,
-        });
+          const program = selfBoundStack({
+            string: "a-value-replaced",
+            replaceString: "changed",
+            includeD: true,
+          });
 
-        yield* stack.pipe(test.deploy, hook(failOn("A", "create")));
+          yield* program.pipe(stack.deploy, hook(failOn("A", "create")));
 
-        expect((yield* getState<ReplacingResourceState>("A"))?.status).toEqual(
-          "replacing",
-        );
-        expectConvergedStatus((yield* getState("B"))?.status);
-        expect(yield* getState("D")).toBeUndefined();
+          expect(
+            (yield* getState<ReplacingResourceState>("A"))?.status,
+          ).toEqual("replacing");
+          expectConvergedStatus((yield* getState("B"))?.status);
+          expect(yield* getState("D")).toBeUndefined();
 
-        const output = yield* stack.pipe(test.deploy);
-        expectConvergedStatus((yield* getState("A"))?.status);
-        expect((yield* getState("B"))?.status).toEqual("updated");
-        expect((yield* getState("D"))?.status).toEqual("created");
-        expect(output.A.env).toEqual({ SELF: "a-value-replaced" });
-        expect(output.D!.string).toEqual("a-value-replaced");
-      }).pipe(Effect.provide(MockLayers())),
+          const output = yield* program.pipe(stack.deploy);
+          expectConvergedStatus((yield* getState("A"))?.status);
+          expect((yield* getState("B"))?.status).toEqual("updated");
+          expect((yield* getState("D"))?.status).toEqual("created");
+          expect(output.A.env).toEqual({ SELF: "a-value-replaced" });
+          expect(output.D!.string).toEqual("a-value-replaced");
+        }),
     );
 
-    test(
+    test.provider(
       "replacing state update replay updates replacement and creates downstream resources",
-      Effect.gen(function* () {
-        yield* selfBoundStack({
-          string: "a-value",
-          replaceString: "original",
-        }).pipe(test.deploy);
+      (stack) =>
+        Effect.gen(function* () {
+          yield* selfBoundStack({
+            string: "a-value",
+            replaceString: "original",
+          }).pipe(stack.deploy);
 
-        yield* selfBoundStack({
-          string: "a-value-replaced",
-          replaceString: "changed",
-          includeD: true,
-        }).pipe(test.deploy, hook(failOn("A", "create")));
+          yield* selfBoundStack({
+            string: "a-value-replaced",
+            replaceString: "changed",
+            includeD: true,
+          }).pipe(stack.deploy, hook(failOn("A", "create")));
 
-        expect((yield* getState<ReplacingResourceState>("A"))?.status).toEqual(
-          "replacing",
-        );
-        expectConvergedStatus((yield* getState("B"))?.status);
-        expect(yield* getState("D")).toBeUndefined();
+          expect(
+            (yield* getState<ReplacingResourceState>("A"))?.status,
+          ).toEqual("replacing");
+          expectConvergedStatus((yield* getState("B"))?.status);
+          expect(yield* getState("D")).toBeUndefined();
 
-        const output = yield* selfBoundStack({
-          string: "a-value-updated-during-recovery",
-          replaceString: "changed",
-          includeD: true,
-        }).pipe(test.deploy);
+          const output = yield* selfBoundStack({
+            string: "a-value-updated-during-recovery",
+            replaceString: "changed",
+            includeD: true,
+          }).pipe(stack.deploy);
 
-        expectConvergedStatus((yield* getState("A"))?.status);
-        expect((yield* getState("B"))?.status).toEqual("updated");
-        expect((yield* getState("D"))?.status).toEqual("created");
-        expect(output.A.env).toEqual({
-          SELF: "a-value-updated-during-recovery",
-        });
-        expect(output.D!.string).toEqual("a-value-updated-during-recovery");
-      }).pipe(Effect.provide(MockLayers())),
+          expectConvergedStatus((yield* getState("A"))?.status);
+          expect((yield* getState("B"))?.status).toEqual("updated");
+          expect((yield* getState("D"))?.status).toEqual("created");
+          expect(output.A.env).toEqual({
+            SELF: "a-value-updated-during-recovery",
+          });
+          expect(output.D!.string).toEqual("a-value-updated-during-recovery");
+        }),
     );
 
-    test(
+    test.provider(
       "replaced state noop replay finishes cleanup and creates downstream resources",
-      Effect.gen(function* () {
-        yield* selfBoundStack({
-          string: "a-value",
-          replaceString: "original",
-        }).pipe(test.deploy);
+      (stack) =>
+        Effect.gen(function* () {
+          yield* selfBoundStack({
+            string: "a-value",
+            replaceString: "original",
+          }).pipe(stack.deploy);
 
-        const stack = selfBoundStack({
-          string: "a-value-replaced",
-          replaceString: "changed",
-          includeD: true,
-        });
+          const program = selfBoundStack({
+            string: "a-value-replaced",
+            replaceString: "changed",
+            includeD: true,
+          });
 
-        yield* stack.pipe(test.deploy, hook(failOn("B", "update")));
+          yield* program.pipe(stack.deploy, hook(failOn("B", "update")));
 
-        expect((yield* getState<ReplacedResourceState>("A"))?.status).toEqual(
-          "replaced",
-        );
-        expect((yield* getState("B"))?.status).toEqual("updating");
-        expect(yield* getState("D")).toBeUndefined();
+          expect((yield* getState<ReplacedResourceState>("A"))?.status).toEqual(
+            "replaced",
+          );
+          expect((yield* getState("B"))?.status).toEqual("updating");
+          expect(yield* getState("D")).toBeUndefined();
 
-        const output = yield* stack.pipe(test.deploy);
-        expectConvergedStatus((yield* getState("A"))?.status);
-        expect((yield* getState("B"))?.status).toEqual("updated");
-        expect((yield* getState("D"))?.status).toEqual("created");
-        expect(output.A.env).toEqual({ SELF: "a-value-replaced" });
-        expect(output.D!.string).toEqual("a-value-replaced");
-      }).pipe(Effect.provide(MockLayers())),
+          const output = yield* program.pipe(stack.deploy);
+          expectConvergedStatus((yield* getState("A"))?.status);
+          expect((yield* getState("B"))?.status).toEqual("updated");
+          expect((yield* getState("D"))?.status).toEqual("created");
+          expect(output.A.env).toEqual({ SELF: "a-value-replaced" });
+          expect(output.D!.string).toEqual("a-value-replaced");
+        }),
     );
 
-    test(
+    test.provider(
       "replaced state update replay updates replacement and downstream resources",
-      Effect.gen(function* () {
-        yield* selfBoundStack({
-          string: "a-value",
-          replaceString: "original",
-        }).pipe(test.deploy);
+      (stack) =>
+        Effect.gen(function* () {
+          yield* selfBoundStack({
+            string: "a-value",
+            replaceString: "original",
+          }).pipe(stack.deploy);
 
-        yield* selfBoundStack({
-          string: "a-value-replaced",
-          replaceString: "changed",
-          includeD: true,
-        }).pipe(test.deploy, hook(failOn("B", "update")));
+          yield* selfBoundStack({
+            string: "a-value-replaced",
+            replaceString: "changed",
+            includeD: true,
+          }).pipe(stack.deploy, hook(failOn("B", "update")));
 
-        expect((yield* getState<ReplacedResourceState>("A"))?.status).toEqual(
-          "replaced",
-        );
-        expect((yield* getState("B"))?.status).toEqual("updating");
-        expect(yield* getState("D")).toBeUndefined();
+          expect((yield* getState<ReplacedResourceState>("A"))?.status).toEqual(
+            "replaced",
+          );
+          expect((yield* getState("B"))?.status).toEqual("updating");
+          expect(yield* getState("D")).toBeUndefined();
 
-        const output = yield* selfBoundStack({
-          string: "a-value-updated-after-replace",
-          replaceString: "changed",
-          includeD: true,
-        }).pipe(test.deploy);
+          const output = yield* selfBoundStack({
+            string: "a-value-updated-after-replace",
+            replaceString: "changed",
+            includeD: true,
+          }).pipe(stack.deploy);
 
-        expectConvergedStatus((yield* getState("A"))?.status);
-        expect((yield* getState("B"))?.status).toEqual("updated");
-        expect((yield* getState("D"))?.status).toEqual("created");
-        expect(output.A.env).toEqual({
-          SELF: "a-value-updated-after-replace",
-        });
-        expect(output.D!.string).toEqual("a-value-updated-after-replace");
-      }).pipe(Effect.provide(MockLayers())),
+          expectConvergedStatus((yield* getState("A"))?.status);
+          expect((yield* getState("B"))?.status).toEqual("updated");
+          expect((yield* getState("D"))?.status).toEqual("created");
+          expect(output.A.env).toEqual({
+            SELF: "a-value-updated-after-replace",
+          });
+          expect(output.D!.string).toEqual("a-value-updated-after-replace");
+        }),
     );
   });
 
   describe("mutual A <-> B bindings", () => {
-    test(
-      "create succeeds with mutual bindings",
+    test.provider("create succeeds with mutual bindings", (stack) =>
       Effect.gen(function* () {
-        const output = yield* test.deploy(
+        const output = yield* stack.deploy(
           mutualBindingStack({
             aString: "a-value",
           }),
@@ -613,220 +606,229 @@ describe("circularity via bindings", () => {
         expect(output.B.env).toEqual({ PEER: "a-value" });
         expectConvergedStatus((yield* getState("A"))?.status);
         expectConvergedStatus((yield* getState("B"))?.status);
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "destroy succeeds with mutual bindings",
+    test.provider("destroy succeeds with mutual bindings", (stack) =>
       Effect.gen(function* () {
         yield* mutualBindingStack({
           aString: "a-value",
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
-        yield* destroy();
+        yield* stack.destroy();
 
         expect(yield* getState("A")).toBeUndefined();
         expect(yield* getState("B")).toBeUndefined();
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
     describe("from replacing state", () => {
-      test(
+      test.provider(
         "replacing noop recovery creates downstream resources",
-        Effect.gen(function* () {
-          yield* mutualBindingStack({
-            aString: "a-value",
-            aReplaceString: "original",
-          }).pipe(test.deploy);
+        (stack) =>
+          Effect.gen(function* () {
+            yield* mutualBindingStack({
+              aString: "a-value",
+              aReplaceString: "original",
+            }).pipe(stack.deploy);
 
-          const stack = mutualBindingStack({
-            aString: "a-value-replaced",
-            aReplaceString: "changed",
-            includeD: true,
-          });
+            const program = mutualBindingStack({
+              aString: "a-value-replaced",
+              aReplaceString: "changed",
+              includeD: true,
+            });
 
-          yield* stack.pipe(test.deploy, hook(failOn("A", "create")));
+            yield* program.pipe(stack.deploy, hook(failOn("A", "create")));
 
-          expect(
-            (yield* getState<ReplacingResourceState>("A"))?.status,
-          ).toEqual("replacing");
-          expectConvergedStatus((yield* getState("B"))?.status);
-          expect(yield* getState("D")).toBeUndefined();
+            expect(
+              (yield* getState<ReplacingResourceState>("A"))?.status,
+            ).toEqual("replacing");
+            expectConvergedStatus((yield* getState("B"))?.status);
+            expect(yield* getState("D")).toBeUndefined();
 
-          const output = yield* stack.pipe(test.deploy);
-          expectConvergedStatus((yield* getState("A"))?.status);
-          expect((yield* getState("B"))?.status).toEqual("updated");
-          expect((yield* getState("D"))?.status).toEqual("created");
-          expect(output.A.env).toEqual({ PEER: "b-value" });
-          expect(output.B.env).toEqual({ PEER: "a-value-replaced" });
-          expect(output.D!.string).toEqual("a-value-replaced-b-value");
-        }).pipe(Effect.provide(MockLayers())),
+            const output = yield* program.pipe(stack.deploy);
+            expectConvergedStatus((yield* getState("A"))?.status);
+            expect((yield* getState("B"))?.status).toEqual("updated");
+            expect((yield* getState("D"))?.status).toEqual("created");
+            expect(output.A.env).toEqual({ PEER: "b-value" });
+            expect(output.B.env).toEqual({ PEER: "a-value-replaced" });
+            expect(output.D!.string).toEqual("a-value-replaced-b-value");
+          }),
       );
 
-      test(
+      test.provider(
         "replacing update recovery creates downstream resources",
-        Effect.gen(function* () {
-          yield* mutualBindingStack({
-            aString: "a-value",
-            aReplaceString: "original",
-          }).pipe(test.deploy);
+        (stack) =>
+          Effect.gen(function* () {
+            yield* mutualBindingStack({
+              aString: "a-value",
+              aReplaceString: "original",
+            }).pipe(stack.deploy);
 
-          yield* mutualBindingStack({
-            aString: "a-value-replaced",
-            aReplaceString: "changed",
-            includeD: true,
-          }).pipe(test.deploy, hook(failOn("A", "create")));
+            yield* mutualBindingStack({
+              aString: "a-value-replaced",
+              aReplaceString: "changed",
+              includeD: true,
+            }).pipe(stack.deploy, hook(failOn("A", "create")));
 
-          expect(
-            (yield* getState<ReplacingResourceState>("A"))?.status,
-          ).toEqual("replacing");
-          expectConvergedStatus((yield* getState("B"))?.status);
-          expect(yield* getState("D")).toBeUndefined();
+            expect(
+              (yield* getState<ReplacingResourceState>("A"))?.status,
+            ).toEqual("replacing");
+            expectConvergedStatus((yield* getState("B"))?.status);
+            expect(yield* getState("D")).toBeUndefined();
 
-          const output = yield* mutualBindingStack({
-            aString: "a-value-updated-during-recovery",
-            aReplaceString: "changed",
-            includeD: true,
-          }).pipe(test.deploy);
+            const output = yield* mutualBindingStack({
+              aString: "a-value-updated-during-recovery",
+              aReplaceString: "changed",
+              includeD: true,
+            }).pipe(stack.deploy);
 
-          expectConvergedStatus((yield* getState("A"))?.status);
-          expect((yield* getState("B"))?.status).toEqual("updated");
-          expect((yield* getState("D"))?.status).toEqual("created");
-          expect(output.A.env).toEqual({ PEER: "b-value" });
-          expect(output.B.env).toEqual({
-            PEER: "a-value-updated-during-recovery",
-          });
-          expect(output.D!.string).toEqual(
-            "a-value-updated-during-recovery-b-value",
-          );
-        }).pipe(Effect.provide(MockLayers())),
+            expectConvergedStatus((yield* getState("A"))?.status);
+            expect((yield* getState("B"))?.status).toEqual("updated");
+            expect((yield* getState("D"))?.status).toEqual("created");
+            expect(output.A.env).toEqual({ PEER: "b-value" });
+            expect(output.B.env).toEqual({
+              PEER: "a-value-updated-during-recovery",
+            });
+            expect(output.D!.string).toEqual(
+              "a-value-updated-during-recovery-b-value",
+            );
+          }),
       );
 
-      test(
+      test.provider(
         "replacing replace recovery nests another replacement",
-        Effect.gen(function* () {
-          yield* mutualBindingStack({
-            aString: "a-value",
-            aReplaceString: "original",
-          }).pipe(test.deploy);
+        (stack) =>
+          Effect.gen(function* () {
+            yield* mutualBindingStack({
+              aString: "a-value",
+              aReplaceString: "original",
+            }).pipe(stack.deploy);
 
-          yield* mutualBindingStack({
-            aString: "a-value-replaced",
-            aReplaceString: "changed",
-            includeD: true,
-          }).pipe(test.deploy, hook(failOn("A", "create")));
+            yield* mutualBindingStack({
+              aString: "a-value-replaced",
+              aReplaceString: "changed",
+              includeD: true,
+            }).pipe(stack.deploy, hook(failOn("A", "create")));
 
-          const output = yield* mutualBindingStack({
-            aString: "a-value-another-replacement",
-            aReplaceString: "another-change",
-            includeD: true,
-          }).pipe(test.deploy);
+            const output = yield* mutualBindingStack({
+              aString: "a-value-another-replacement",
+              aReplaceString: "another-change",
+              includeD: true,
+            }).pipe(stack.deploy);
 
-          expectConvergedStatus((yield* getState("A"))?.status);
-          expect((yield* getState("B"))?.status).toEqual("updated");
-          expect((yield* getState("D"))?.status).toEqual("created");
-          expect(output.B.env).toEqual({ PEER: "a-value-another-replacement" });
-        }).pipe(Effect.provide(MockLayers())),
+            expectConvergedStatus((yield* getState("A"))?.status);
+            expect((yield* getState("B"))?.status).toEqual("updated");
+            expect((yield* getState("D"))?.status).toEqual("created");
+            expect(output.B.env).toEqual({
+              PEER: "a-value-another-replacement",
+            });
+          }),
       );
     });
 
     describe("from replaced state", () => {
-      test(
+      test.provider(
         "replaced noop recovery updates downstream then creates downstream resources",
-        Effect.gen(function* () {
-          yield* mutualBindingStack({
-            aString: "a-value",
-            aReplaceString: "original",
-          }).pipe(test.deploy);
+        (stack) =>
+          Effect.gen(function* () {
+            yield* mutualBindingStack({
+              aString: "a-value",
+              aReplaceString: "original",
+            }).pipe(stack.deploy);
 
-          const stack = mutualBindingStack({
-            aString: "a-value-replaced",
-            aReplaceString: "changed",
-            includeD: true,
-          });
+            const program = mutualBindingStack({
+              aString: "a-value-replaced",
+              aReplaceString: "changed",
+              includeD: true,
+            });
 
-          yield* stack.pipe(test.deploy, hook(failOn("B", "update")));
+            yield* program.pipe(stack.deploy, hook(failOn("B", "update")));
 
-          expect((yield* getState<ReplacedResourceState>("A"))?.status).toEqual(
-            "replaced",
-          );
-          expect((yield* getState("B"))?.status).toEqual("updating");
-          expect(yield* getState("D")).toBeUndefined();
+            expect(
+              (yield* getState<ReplacedResourceState>("A"))?.status,
+            ).toEqual("replaced");
+            expect((yield* getState("B"))?.status).toEqual("updating");
+            expect(yield* getState("D")).toBeUndefined();
 
-          const output = yield* stack.pipe(test.deploy);
-          expect((yield* getState("A"))?.status).toEqual("created");
-          expect((yield* getState("B"))?.status).toEqual("updated");
-          expect((yield* getState("D"))?.status).toEqual("created");
-          expect(output.A.env).toEqual({ PEER: "b-value" });
-          expect(output.B.env).toEqual({ PEER: "a-value-replaced" });
-          expect(output.D!.string).toEqual("a-value-replaced-b-value");
-        }).pipe(Effect.provide(MockLayers())),
+            const output = yield* program.pipe(stack.deploy);
+            expect((yield* getState("A"))?.status).toEqual("created");
+            expect((yield* getState("B"))?.status).toEqual("updated");
+            expect((yield* getState("D"))?.status).toEqual("created");
+            expect(output.A.env).toEqual({ PEER: "b-value" });
+            expect(output.B.env).toEqual({ PEER: "a-value-replaced" });
+            expect(output.D!.string).toEqual("a-value-replaced-b-value");
+          }),
       );
 
-      test(
+      test.provider(
         "replaced with update recovery updates replacement and downstream resources",
-        Effect.gen(function* () {
-          yield* mutualBindingStack({
-            aString: "a-value",
-            aReplaceString: "original",
-          }).pipe(test.deploy);
+        (stack) =>
+          Effect.gen(function* () {
+            yield* mutualBindingStack({
+              aString: "a-value",
+              aReplaceString: "original",
+            }).pipe(stack.deploy);
 
-          yield* mutualBindingStack({
-            aString: "a-value-replaced",
-            aReplaceString: "changed",
-            includeD: true,
-          }).pipe(test.deploy, hook(failOn("B", "update")));
+            yield* mutualBindingStack({
+              aString: "a-value-replaced",
+              aReplaceString: "changed",
+              includeD: true,
+            }).pipe(stack.deploy, hook(failOn("B", "update")));
 
-          expect((yield* getState<ReplacedResourceState>("A"))?.status).toEqual(
-            "replaced",
-          );
-          expect((yield* getState("B"))?.status).toEqual("updating");
-          expect(yield* getState("D")).toBeUndefined();
+            expect(
+              (yield* getState<ReplacedResourceState>("A"))?.status,
+            ).toEqual("replaced");
+            expect((yield* getState("B"))?.status).toEqual("updating");
+            expect(yield* getState("D")).toBeUndefined();
 
-          const output = yield* mutualBindingStack({
-            aString: "a-value-updated-after-replace",
-            aReplaceString: "changed",
-            includeD: true,
-          }).pipe(test.deploy);
+            const output = yield* mutualBindingStack({
+              aString: "a-value-updated-after-replace",
+              aReplaceString: "changed",
+              includeD: true,
+            }).pipe(stack.deploy);
 
-          expect((yield* getState("A"))?.status).toEqual("created");
-          expect((yield* getState("B"))?.status).toEqual("updated");
-          expect((yield* getState("D"))?.status).toEqual("created");
-          expect(output.A.env).toEqual({ PEER: "b-value" });
-          expect(output.B.env).toEqual({
-            PEER: "a-value-updated-after-replace",
-          });
-          expect(output.D!.string).toEqual(
-            "a-value-updated-after-replace-b-value",
-          );
-        }).pipe(Effect.provide(MockLayers())),
+            expect((yield* getState("A"))?.status).toEqual("created");
+            expect((yield* getState("B"))?.status).toEqual("updated");
+            expect((yield* getState("D"))?.status).toEqual("created");
+            expect(output.A.env).toEqual({ PEER: "b-value" });
+            expect(output.B.env).toEqual({
+              PEER: "a-value-updated-after-replace",
+            });
+            expect(output.D!.string).toEqual(
+              "a-value-updated-after-replace-b-value",
+            );
+          }),
       );
 
-      test(
+      test.provider(
         "replaced replace recovery nests another replacement",
-        Effect.gen(function* () {
-          yield* mutualBindingStack({
-            aString: "a-value",
-            aReplaceString: "original",
-          }).pipe(test.deploy);
+        (stack) =>
+          Effect.gen(function* () {
+            yield* mutualBindingStack({
+              aString: "a-value",
+              aReplaceString: "original",
+            }).pipe(stack.deploy);
 
-          yield* mutualBindingStack({
-            aString: "a-value-replaced",
-            aReplaceString: "changed",
-            includeD: true,
-          }).pipe(test.deploy, hook(failOn("B", "update")));
+            yield* mutualBindingStack({
+              aString: "a-value-replaced",
+              aReplaceString: "changed",
+              includeD: true,
+            }).pipe(stack.deploy, hook(failOn("B", "update")));
 
-          const output = yield* mutualBindingStack({
-            aString: "a-value-another-replacement",
-            aReplaceString: "another-change",
-            includeD: true,
-          }).pipe(test.deploy);
+            const output = yield* mutualBindingStack({
+              aString: "a-value-another-replacement",
+              aReplaceString: "another-change",
+              includeD: true,
+            }).pipe(stack.deploy);
 
-          expectConvergedStatus((yield* getState("A"))?.status);
-          expect((yield* getState("B"))?.status).toEqual("updated");
-          expect((yield* getState("D"))?.status).toEqual("created");
-          expect(output.B.env).toEqual({ PEER: "a-value-another-replacement" });
-        }).pipe(Effect.provide(MockLayers())),
+            expectConvergedStatus((yield* getState("A"))?.status);
+            expect((yield* getState("B"))?.status).toEqual("updated");
+            expect((yield* getState("D"))?.status).toEqual("created");
+            expect(output.B.env).toEqual({
+              PEER: "a-value-another-replacement",
+            });
+          }),
       );
     });
   });
@@ -864,186 +866,190 @@ describe("prop-flow convergence", () => {
       return { A, B };
     });
 
-  test(
+  test.provider(
     "fresh circular create may use a stable precreate identifier",
-    Effect.gen(function* () {
-      const output = yield* phasedCycleStack({
-        desired: "final-a",
-        replaceKey: "v1",
-        use: "stableId",
-      }).pipe(test.deploy);
+    (stack) =>
+      Effect.gen(function* () {
+        const output = yield* phasedCycleStack({
+          desired: "final-a",
+          replaceKey: "v1",
+          use: "stableId",
+        }).pipe(stack.deploy);
 
-      expect(output.A.value).toEqual("final-a");
-      expect(output.B.string).toEqual("stable:v1");
-    }).pipe(Effect.provide(MockLayers())),
+        expect(output.A.value).toEqual("final-a");
+        expect(output.B.string).toEqual("stable:v1");
+      }),
   );
 
-  test(
+  test.provider(
     "fresh circular create should converge downstream props to final values",
-    Effect.gen(function* () {
-      const output = yield* phasedCycleStack({
-        desired: "final-a",
-        replaceKey: "v1",
-        use: "value",
-      }).pipe(test.deploy);
+    (stack) =>
+      Effect.gen(function* () {
+        const output = yield* phasedCycleStack({
+          desired: "final-a",
+          replaceKey: "v1",
+          use: "value",
+        }).pipe(stack.deploy);
 
-      expect(output.A.value).toEqual("final-a");
-      expect(output.B.string).toEqual("final-a");
-    }).pipe(Effect.provide(MockLayers())),
+        expect(output.A.value).toEqual("final-a");
+        expect(output.B.string).toEqual("final-a");
+      }),
   );
 
-  test(
+  test.provider(
     "fresh replacement should converge newly created downstream props to replacement values",
-    Effect.gen(function* () {
-      yield* phasedCycleStack({
-        desired: "old-a",
-        replaceKey: "v1",
-        use: "value",
-      }).pipe(test.deploy);
+    (stack) =>
+      Effect.gen(function* () {
+        yield* phasedCycleStack({
+          desired: "old-a",
+          replaceKey: "v1",
+          use: "value",
+        }).pipe(stack.deploy);
 
-      const output = yield* phasedCycleStack({
-        desired: "new-a",
-        replaceKey: "v2",
-        use: "value",
-      }).pipe(test.deploy);
+        const output = yield* phasedCycleStack({
+          desired: "new-a",
+          replaceKey: "v2",
+          use: "value",
+        }).pipe(stack.deploy);
 
-      expect(output.A.value).toEqual("new-a");
-      expect(output.B.string).toEqual("new-a");
-    }).pipe(Effect.provide(MockLayers())),
+        expect(output.A.value).toEqual("new-a");
+        expect(output.B.string).toEqual("new-a");
+      }),
   );
 
-  test(
+  test.provider(
     "stale precreate values should not propagate transitively",
-    Effect.gen(function* () {
-      const output = yield* phasedCycleStack({
-        desired: "final-a",
-        replaceKey: "v1",
-        use: "value",
-        includeC: true,
-      }).pipe(test.deploy);
+    (stack) =>
+      Effect.gen(function* () {
+        const output = yield* phasedCycleStack({
+          desired: "final-a",
+          replaceKey: "v1",
+          use: "value",
+          includeC: true,
+        }).pipe(stack.deploy);
 
-      expect(output.A.value).toEqual("final-a");
-      expect(output.B.string).toEqual("final-a");
-      expect(output.C!.string).toEqual("final-a");
-    }).pipe(Effect.provide(MockLayers())),
+        expect(output.A.value).toEqual("final-a");
+        expect(output.B.string).toEqual("final-a");
+        expect(output.C!.string).toEqual("final-a");
+      }),
   );
 
-  test(
+  test.provider(
     "binding feedback converges across an A -> B -> A fixed point",
-    Effect.gen(function* () {
-      const output = yield* Effect.gen(function* () {
-        const A = yield* PhasedTarget("A", {
-          desired: "final-a",
-          replaceKey: "v1",
-        });
-        const B = yield* TestResource("B", {
-          string: A.value,
-        });
-        yield* A.bind("FromB", {
-          env: {
-            B: B.string,
-          },
-        });
-        return { A, B };
-      }).pipe(test.deploy);
+    (stack) =>
+      Effect.gen(function* () {
+        const output = yield* Effect.gen(function* () {
+          const A = yield* PhasedTarget("A", {
+            desired: "final-a",
+            replaceKey: "v1",
+          });
+          const B = yield* TestResource("B", {
+            string: A.value,
+          });
+          yield* A.bind("FromB", {
+            env: {
+              B: B.string,
+            },
+          });
+          return { A, B };
+        }).pipe(stack.deploy);
 
-      expect(output.A.value).toEqual("final-a");
-      expect(output.B.string).toEqual("final-a");
-      expect(output.A.env).toEqual({
-        B: "final-a",
-      });
-    }).pipe(Effect.provide(MockLayers())),
+        expect(output.A.value).toEqual("final-a");
+        expect(output.B.string).toEqual("final-a");
+        expect(output.A.env).toEqual({
+          B: "final-a",
+        });
+      }),
   );
 
-  test(
+  test.provider(
     "terminal created or updated status is delayed until fixed-point convergence finishes",
-    Effect.gen(function* () {
-      const events: Array<{ id: string; status: string }> = [];
-      const cli = Cli.of({
-        approvePlan: () => Effect.succeed(true),
-        displayPlan: () => Effect.void,
-        startApplySession: () =>
-          Effect.succeed({
-            done: () => Effect.void,
-            emit: (event) =>
-              Effect.sync(() => {
-                if (event.kind === "status-change") {
-                  events.push({
-                    id: event.id,
-                    status: event.status,
-                  });
-                }
-              }),
-          }),
-      });
+    (stack) =>
+      Effect.gen(function* () {
+        const events: Array<{ id: string; status: string }> = [];
+        const cli = Cli.of({
+          approvePlan: () => Effect.succeed(true),
+          displayPlan: () => Effect.void,
+          startApplySession: () =>
+            Effect.succeed({
+              done: () => Effect.void,
+              emit: (event) =>
+                Effect.sync(() => {
+                  if (event.kind === "status-change") {
+                    events.push({
+                      id: event.id,
+                      status: event.status,
+                    });
+                  }
+                }),
+            }),
+        });
 
-      const output = yield* Effect.gen(function* () {
-        const A = yield* PhasedTarget("A", {
-          desired: "final-a",
-          replaceKey: "v1",
+        const output = yield* Effect.gen(function* () {
+          const A = yield* PhasedTarget("A", {
+            desired: "final-a",
+            replaceKey: "v1",
+          });
+          const B = yield* TestResource("B", {
+            string: A.value,
+          });
+          yield* A.bind("FromB", {
+            env: {
+              B: B.string,
+            },
+          });
+          return { A, B };
+        }).pipe(stack.deploy, Effect.provide(Layer.succeed(Cli, cli)));
+
+        expect(output.A.env).toEqual({
+          B: "final-a",
         });
-        const B = yield* TestResource("B", {
-          string: A.value,
-        });
-        yield* A.bind("FromB", {
-          env: {
-            B: B.string,
+
+        const statusesById = events.reduce(
+          (acc, event: { id: string; status: string }) => {
+            (acc[event.id] ??= []).push(event);
+            return acc;
           },
-        });
-        return { A, B };
-      }).pipe(test.deploy, Effect.provide(Layer.succeed(Cli, cli)));
+          {} as Record<string, Array<{ id: string; status: string }>>,
+        );
+        const terminal = (id: string) =>
+          (statusesById[id] ?? [])
+            .map((event: { id: string; status: string }) => event.status)
+            .filter(
+              (status: string) => status === "created" || status === "updated",
+            );
 
-      expect(output.A.env).toEqual({
-        B: "final-a",
-      });
-
-      const statusesById = events.reduce(
-        (acc, event: { id: string; status: string }) => {
-          (acc[event.id] ??= []).push(event);
-          return acc;
-        },
-        {} as Record<string, Array<{ id: string; status: string }>>,
-      );
-      const terminal = (id: string) =>
-        (statusesById[id] ?? [])
-          .map((event: { id: string; status: string }) => event.status)
-          .filter(
-            (status: string) => status === "created" || status === "updated",
-          );
-
-      expect(terminal("A")).toEqual(["updated"]);
-      expect(terminal("B")).toEqual(["updated"]);
-    }).pipe(Effect.provide(MockLayers())),
+        expect(terminal("A")).toEqual(["updated"]);
+        expect(terminal("B")).toEqual(["updated"]);
+      }),
   );
 });
 
 describe("from created state", () => {
-  test(
-    "noop when props unchanged",
+  test.provider("noop when props unchanged", (stack) =>
     Effect.gen(function* () {
-      const stack = Effect.gen(function* () {
+      const program = Effect.gen(function* () {
         const A = yield* TestResource("A", {
           string: "test-string",
         });
         return A.string;
       });
 
-      let output = yield* test.deploy(stack);
+      let output = yield* stack.deploy(program);
       expect(output).toEqual("test-string");
 
       expect((yield* getState("A"))?.status).toEqual("created");
-      output = yield* test.deploy(stack);
+      output = yield* stack.deploy(program);
 
       // Re-apply with same props - should be noop
       expect((yield* getState("A"))?.status).toEqual("created");
       expect(output).toEqual("test-string");
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 
-  test(
-    "replace when props trigger replacement",
+  test.provider("replace when props trigger replacement", (stack) =>
     Effect.gen(function* () {
-      yield* test.deploy(
+      yield* stack.deploy(
         Effect.gen(function* () {
           const A = yield* TestResource("A", {
             replaceString: "original",
@@ -1055,7 +1061,7 @@ describe("from created state", () => {
 
       // Change props that trigger replacement
 
-      const output = yield* test.deploy(
+      const output = yield* stack.deploy(
         Effect.gen(function* () {
           const A = yield* TestResource("A", {
             replaceString: "new",
@@ -1065,15 +1071,14 @@ describe("from created state", () => {
       );
       expect((yield* getState("A"))?.status).toEqual("created");
       expect(output).toEqual("new");
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 });
 
 describe("from updated state", () => {
-  test(
-    "noop when props unchanged",
+  test.provider("noop when props unchanged", (stack) =>
     Effect.gen(function* () {
-      yield* test.deploy(
+      yield* stack.deploy(
         Effect.gen(function* () {
           yield* TestResource("A", {
             string: "test-string",
@@ -1083,7 +1088,7 @@ describe("from updated state", () => {
       expect((yield* getState("A"))?.status).toEqual("created");
 
       // Update to get to updated state
-      yield* test.deploy(
+      yield* stack.deploy(
         Effect.gen(function* () {
           yield* TestResource("A", {
             string: "test-string-changed",
@@ -1093,7 +1098,7 @@ describe("from updated state", () => {
       expect((yield* getState("A"))?.status).toEqual("updated");
 
       // Re-apply with same props - should be noop
-      const output = yield* test.deploy(
+      const output = yield* stack.deploy(
         Effect.gen(function* () {
           const A = yield* TestResource("A", {
             string: "test-string-changed",
@@ -1103,13 +1108,12 @@ describe("from updated state", () => {
       );
       expect((yield* getState("A"))?.status).toEqual("updated");
       expect(output).toEqual("test-string-changed");
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 
-  test(
-    "replace when props trigger replacement",
+  test.provider("replace when props trigger replacement", (stack) =>
     Effect.gen(function* () {
-      yield* test.deploy(
+      yield* stack.deploy(
         Effect.gen(function* () {
           yield* TestResource("A", {
             string: "test-string",
@@ -1120,7 +1124,7 @@ describe("from updated state", () => {
       expect((yield* getState("A"))?.status).toEqual("created");
 
       // Update to get to updated state
-      yield* test.deploy(
+      yield* stack.deploy(
         Effect.gen(function* () {
           yield* TestResource("A", {
             string: "test-string-changed",
@@ -1131,7 +1135,7 @@ describe("from updated state", () => {
       expect((yield* getState("A"))?.status).toEqual("updated");
 
       // Change props that trigger replacement
-      const output = yield* test.deploy(
+      const output = yield* stack.deploy(
         Effect.gen(function* () {
           const A = yield* TestResource("A", {
             string: "test-string-changed",
@@ -1142,19 +1146,18 @@ describe("from updated state", () => {
       );
       expect((yield* getState("A"))?.status).toEqual("created");
       expect(output).toEqual("new");
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 });
 
 describe("from creating state", () => {
-  test(
-    "continue creating when props unchanged",
+  test.provider("continue creating when props unchanged", (stack) =>
     Effect.gen(function* () {
       yield* Effect.gen(function* () {
         yield* TestResource("A", {
           string: "test-string",
         });
-      }).pipe(test.deploy, hook());
+      }).pipe(stack.deploy, hook());
       expect((yield* getState("A"))?.status).toEqual("creating");
 
       const output = yield* Effect.gen(function* () {
@@ -1162,41 +1165,41 @@ describe("from creating state", () => {
           string: "test-string",
         });
         return A.string;
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
       expect((yield* getState("A"))?.status).toEqual("created");
       expect(output).toEqual("test-string");
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 
-  test(
+  test.provider(
     "continue creating when props have updatable changes",
-    Effect.gen(function* () {
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", {
-          string: "test-string",
-        });
-      }).pipe(test.deploy, hook());
-      expect((yield* getState("A"))?.status).toEqual("creating");
+    (stack) =>
+      Effect.gen(function* () {
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            string: "test-string",
+          });
+        }).pipe(stack.deploy, hook());
+        expect((yield* getState("A"))?.status).toEqual("creating");
 
-      const output = yield* Effect.gen(function* () {
-        const A = yield* TestResource("A", {
-          string: "test-string-changed",
-        });
-        return A.string;
-      }).pipe(test.deploy);
-      expect(output).toEqual("test-string-changed");
-      expect((yield* getState("A"))?.status).toEqual("created");
-    }).pipe(Effect.provide(MockLayers())),
+        const output = yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", {
+            string: "test-string-changed",
+          });
+          return A.string;
+        }).pipe(stack.deploy);
+        expect(output).toEqual("test-string-changed");
+        expect((yield* getState("A"))?.status).toEqual("created");
+      }),
   );
 
-  test(
-    "replace when props trigger replacement",
+  test.provider("replace when props trigger replacement", (stack) =>
     Effect.gen(function* () {
       yield* Effect.gen(function* () {
         yield* TestResource("A", {
           replaceString: "test-string",
         });
-      }).pipe(test.deploy, hook());
+      }).pipe(stack.deploy, hook());
       expect((yield* getState("A"))?.status).toEqual("creating");
 
       const output = yield* Effect.gen(function* () {
@@ -1204,121 +1207,123 @@ describe("from creating state", () => {
           replaceString: "test-string-changed",
         });
         return A.replaceString;
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
       expect(output).toEqual("test-string-changed");
       expect((yield* getState("A"))?.status).toEqual("created");
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 
-  test(
+  test.provider(
     "destroy should handle creating state with no attributes",
-    Effect.gen(function* () {
-      // 1. Create a resource but fail - this leaves state in "creating" with no attr
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", {
-          string: "test-string",
-        });
-      }).pipe(test.deploy, hook());
-      expect((yield* getState("A"))?.status).toEqual("creating");
-      expect((yield* getState("A"))?.attr).toBeUndefined();
+    (stack) =>
+      Effect.gen(function* () {
+        // 1. Create a resource but fail - this leaves state in "creating" with no attr
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            string: "test-string",
+          });
+        }).pipe(stack.deploy, hook());
+        expect((yield* getState("A"))?.status).toEqual("creating");
+        expect((yield* getState("A"))?.attr).toBeUndefined();
 
-      // 2. Call destroy - this triggers collectGarbage which tries to delete
-      // the orphaned resource. The bug is that output is undefined in the
-      // delete call when the resource never completed creation.
-      yield* destroy();
+        // 2. Call destroy - this triggers collectGarbage which tries to delete
+        // the orphaned resource. The bug is that output is undefined in the
+        // delete call when the resource never completed creation.
+        yield* stack.destroy();
 
-      // Resource should be cleaned up
-      expect(yield* getState("A")).toBeUndefined();
-    }).pipe(Effect.provide(MockLayers())),
+        // Resource should be cleaned up
+        expect(yield* getState("A")).toBeUndefined();
+      }),
   );
 
-  test(
+  test.provider(
     "destroy should handle creating state when attributes can be recovered",
-    Effect.gen(function* () {
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", {
-          string: "test-string",
-        });
-      }).pipe(test.deploy, hook());
-      expect((yield* getState("A"))?.status).toEqual("creating");
-      expect((yield* getState("A"))?.attr).toBeUndefined();
+    (stack) =>
+      Effect.gen(function* () {
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            string: "test-string",
+          });
+        }).pipe(stack.deploy, hook());
+        expect((yield* getState("A"))?.status).toEqual("creating");
+        expect((yield* getState("A"))?.attr).toBeUndefined();
 
-      yield* destroy().pipe(
-        hook({
-          delete: () => Effect.fail(new ResourceFailure()),
-          read: () =>
-            Effect.succeed({
-              string: "test-string",
-            }),
-        }),
-      );
+        yield* stack.destroy().pipe(
+          hook({
+            delete: () => Effect.fail(new ResourceFailure()),
+            read: () =>
+              Effect.succeed({
+                string: "test-string",
+              }),
+          }),
+        );
 
-      // Resource should be cleaned up
-      expect((yield* getState("A"))?.status).toEqual("deleting");
+        // Resource should be cleaned up
+        expect((yield* getState("A"))?.status).toEqual("deleting");
 
-      // actually delete this time
-      yield* destroy().pipe(
-        hook({
-          read: () =>
-            Effect.succeed({
-              string: "test-string",
-            }),
-        }),
-      );
+        // actually delete this time
+        yield* stack.destroy().pipe(
+          hook({
+            read: () =>
+              Effect.succeed({
+                string: "test-string",
+              }),
+          }),
+        );
 
-      expect(yield* getState("A")).toBeUndefined();
-    }).pipe(Effect.provide(MockLayers())),
+        expect(yield* getState("A")).toBeUndefined();
+      }),
   );
 
-  test(
+  test.provider(
     "destroy should handle replacing state when old resource has no attributes",
-    Effect.gen(function* () {
-      // 1. Create a resource but fail - this leaves state in "creating" with no attr
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", {
-          replaceString: "original",
-        });
-      }).pipe(test.deploy, hook());
-      expect((yield* getState("A"))?.status).toEqual("creating");
-      expect((yield* getState("A"))?.attr).toBeUndefined();
+    (stack) =>
+      Effect.gen(function* () {
+        // 1. Create a resource but fail - this leaves state in "creating" with no attr
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            replaceString: "original",
+          });
+        }).pipe(stack.deploy, hook());
+        expect((yield* getState("A"))?.status).toEqual("creating");
+        expect((yield* getState("A"))?.attr).toBeUndefined();
 
-      // 2. Trigger replacement but also fail during create - this leaves state in "replacing"
-      // with old.attr being undefined
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", {
-          replaceString: "new",
-        });
-      }).pipe(test.deploy, hook());
-      const state = yield* getState<ReplacingResourceState>("A");
-      expect(state?.status).toEqual("replacing");
-      expect(state?.old?.attr).toBeUndefined();
+        // 2. Trigger replacement but also fail during create - this leaves state in "replacing"
+        // with old.attr being undefined
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            replaceString: "new",
+          });
+        }).pipe(stack.deploy, hook());
+        const state = yield* getState<ReplacingResourceState>("A");
+        expect(state?.status).toEqual("replacing");
+        expect(state?.old?.attr).toBeUndefined();
 
-      // 3. Call destroy - this triggers collectGarbage which tries to delete
-      // the resource. The bug is that old.attr is undefined.
-      yield* destroy().pipe(
-        hook({
-          read: () =>
-            Effect.succeed({
-              replaceString: "original",
-            }),
-        }),
-      );
+        // 3. Call destroy - this triggers collectGarbage which tries to delete
+        // the resource. The bug is that old.attr is undefined.
+        yield* stack.destroy().pipe(
+          hook({
+            read: () =>
+              Effect.succeed({
+                replaceString: "original",
+              }),
+          }),
+        );
 
-      // Resource should be cleaned up
-      expect(yield* getState("A")).toBeUndefined();
-    }).pipe(Effect.provide(MockLayers())),
+        // Resource should be cleaned up
+        expect(yield* getState("A")).toBeUndefined();
+      }),
   );
 });
 
 describe("from updating state", () => {
-  test(
-    "continue updating when props unchanged",
+  test.provider("continue updating when props unchanged", (stack) =>
     Effect.gen(function* () {
       yield* Effect.gen(function* () {
         yield* TestResource("A", {
           string: "test-string",
         });
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
       expect((yield* getState("A"))?.status).toEqual("created");
 
       yield* Effect.gen(function* () {
@@ -1326,7 +1331,7 @@ describe("from updating state", () => {
           string: "test-string-changed",
         });
       }).pipe(
-        test.deploy,
+        stack.deploy,
         hook({
           update: () => Effect.fail(new ResourceFailure()),
         }),
@@ -1338,54 +1343,54 @@ describe("from updating state", () => {
           string: "test-string-changed",
         });
         return A.string;
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
       expect((yield* getState("A"))?.status).toEqual("updated");
       expect(output).toEqual("test-string-changed");
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 
-  test(
+  test.provider(
     "continue updating when props have updatable changes",
-    Effect.gen(function* () {
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", {
-          string: "test-string",
-        });
-      }).pipe(test.deploy);
-      expect((yield* getState("A"))?.status).toEqual("created");
+    (stack) =>
+      Effect.gen(function* () {
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            string: "test-string",
+          });
+        }).pipe(stack.deploy);
+        expect((yield* getState("A"))?.status).toEqual("created");
 
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", {
-          string: "test-string-changed",
-        });
-      }).pipe(
-        test.deploy,
-        hook({
-          update: () => Effect.fail(new ResourceFailure()),
-        }),
-      );
-      expect((yield* getState("A"))?.status).toEqual("updating");
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            string: "test-string-changed",
+          });
+        }).pipe(
+          stack.deploy,
+          hook({
+            update: () => Effect.fail(new ResourceFailure()),
+          }),
+        );
+        expect((yield* getState("A"))?.status).toEqual("updating");
 
-      const output = yield* Effect.gen(function* () {
-        const A = yield* TestResource("A", {
-          string: "test-string-changed-again",
-        });
-        return A.string;
-      }).pipe(test.deploy);
-      expect((yield* getState("A"))?.status).toEqual("updated");
-      expect(output).toEqual("test-string-changed-again");
-    }).pipe(Effect.provide(MockLayers())),
+        const output = yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", {
+            string: "test-string-changed-again",
+          });
+          return A.string;
+        }).pipe(stack.deploy);
+        expect((yield* getState("A"))?.status).toEqual("updated");
+        expect(output).toEqual("test-string-changed-again");
+      }),
   );
 
-  test(
-    "replace when props trigger replacement",
+  test.provider("replace when props trigger replacement", (stack) =>
     Effect.gen(function* () {
       yield* Effect.gen(function* () {
         yield* TestResource("A", {
           string: "test-string",
           replaceString: "original",
         });
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
       expect((yield* getState("A"))?.status).toEqual("created");
 
       yield* Effect.gen(function* () {
@@ -1394,7 +1399,7 @@ describe("from updating state", () => {
           replaceString: "original",
         });
       }).pipe(
-        test.deploy,
+        stack.deploy,
         hook({
           update: () => Effect.fail(new ResourceFailure()),
         }),
@@ -1407,23 +1412,22 @@ describe("from updating state", () => {
           replaceString: "changed",
         });
         return A.replaceString;
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
       expect((yield* getState("A"))?.status).toEqual("created");
       expect(output).toEqual("changed");
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 });
 
 describe("from replacing state", () => {
-  test(
-    "continue replacement when props unchanged",
+  test.provider("continue replacement when props unchanged", (stack) =>
     Effect.gen(function* () {
       // 1. Create initial resource
       yield* Effect.gen(function* () {
         yield* TestResource("A", {
           replaceString: "original",
         });
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
       expect((yield* getState("A"))?.status).toEqual("created");
 
       // 2. Trigger replacement but fail during create of replacement
@@ -1432,7 +1436,7 @@ describe("from replacing state", () => {
           replaceString: "new",
         });
       }).pipe(
-        test.deploy,
+        stack.deploy,
         hook({
           create: () => Effect.fail(new ResourceFailure()),
         }),
@@ -1447,98 +1451,99 @@ describe("from replacing state", () => {
           replaceString: "new",
         });
         return A.replaceString;
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
       expect((yield* getState("A"))?.status).toEqual("created");
       expect(output).toEqual("new");
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 
-  test(
+  test.provider(
     "continue replacement when props have updatable changes",
-    Effect.gen(function* () {
-      // 1. Create initial resource
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", {
-          replaceString: "original",
-          string: "initial",
-        });
-      }).pipe(test.deploy);
-      expect((yield* getState("A"))?.status).toEqual("created");
+    (stack) =>
+      Effect.gen(function* () {
+        // 1. Create initial resource
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            replaceString: "original",
+            string: "initial",
+          });
+        }).pipe(stack.deploy);
+        expect((yield* getState("A"))?.status).toEqual("created");
 
-      // 2. Trigger replacement but fail during create
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", {
-          replaceString: "new",
-          string: "initial",
-        });
-      }).pipe(
-        test.deploy,
-        hook({
-          create: () => Effect.fail(new ResourceFailure()),
-        }),
-      );
-      expect((yield* getState("A"))?.status).toEqual("replacing");
+        // 2. Trigger replacement but fail during create
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            replaceString: "new",
+            string: "initial",
+          });
+        }).pipe(
+          stack.deploy,
+          hook({
+            create: () => Effect.fail(new ResourceFailure()),
+          }),
+        );
+        expect((yield* getState("A"))?.status).toEqual("replacing");
 
-      // 3. Re-apply with changed props (updatable) - should continue replacement with new props
-      const output = yield* Effect.gen(function* () {
-        const A = yield* TestResource("A", {
-          replaceString: "new",
-          string: "changed",
-        });
-        return { replaceString: A.replaceString, string: A.string };
-      }).pipe(test.deploy);
-      expect((yield* getState("A"))?.status).toEqual("created");
-      expect(output.replaceString).toEqual("new");
-      expect(output.string).toEqual("changed");
-    }).pipe(Effect.provide(MockLayers())),
+        // 3. Re-apply with changed props (updatable) - should continue replacement with new props
+        const output = yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", {
+            replaceString: "new",
+            string: "changed",
+          });
+          return { replaceString: A.replaceString, string: A.string };
+        }).pipe(stack.deploy);
+        expect((yield* getState("A"))?.status).toEqual("created");
+        expect(output.replaceString).toEqual("new");
+        expect(output.string).toEqual("changed");
+      }),
   );
 
-  test(
+  test.provider(
     "continue replacement when props trigger another replacement",
-    Effect.gen(function* () {
-      // 1. Create initial resource
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", {
-          replaceString: "original",
-        });
-      }).pipe(test.deploy);
-      expect((yield* getState("A"))?.status).toEqual("created");
+    (stack) =>
+      Effect.gen(function* () {
+        // 1. Create initial resource
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            replaceString: "original",
+          });
+        }).pipe(stack.deploy);
+        expect((yield* getState("A"))?.status).toEqual("created");
 
-      // 2. Trigger replacement but fail during create
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", {
-          replaceString: "new",
-        });
-      }).pipe(
-        test.deploy,
-        hook({
-          create: () => Effect.fail(new ResourceFailure()),
-        }),
-      );
-      expect((yield* getState("A"))?.status).toEqual("replacing");
+        // 2. Trigger replacement but fail during create
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            replaceString: "new",
+          });
+        }).pipe(
+          stack.deploy,
+          hook({
+            create: () => Effect.fail(new ResourceFailure()),
+          }),
+        );
+        expect((yield* getState("A"))?.status).toEqual("replacing");
 
-      // 3. Replace again with another replacement - should converge
-      const output = yield* Effect.gen(function* () {
-        const A = yield* TestResource("A", {
-          replaceString: "another-replacement",
-        });
-        return A.replaceString;
-      }).pipe(test.deploy);
-      expectConvergedStatus((yield* getState("A"))?.status);
-      expect(output).toEqual("another-replacement");
-    }).pipe(Effect.provide(MockLayers())),
+        // 3. Replace again with another replacement - should converge
+        const output = yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", {
+            replaceString: "another-replacement",
+          });
+          return A.replaceString;
+        }).pipe(stack.deploy);
+        expectConvergedStatus((yield* getState("A"))?.status);
+        expect(output).toEqual("another-replacement");
+      }),
   );
 });
 
 describe("from replaced state", () => {
-  test(
-    "continue cleanup when props unchanged",
+  test.provider("continue cleanup when props unchanged", (stack) =>
     Effect.gen(function* () {
       yield* Effect.gen(function* () {
         yield* TestResource("A", {
           replaceString: "test-string",
         });
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
       expect((yield* getState("A"))?.status).toEqual("created");
 
       yield* Effect.gen(function* () {
@@ -1546,7 +1551,7 @@ describe("from replaced state", () => {
           replaceString: "test-string-changed",
         });
       }).pipe(
-        test.deploy,
+        stack.deploy,
         hook({
           delete: () => Effect.fail(new ResourceFailure()),
         }),
@@ -1564,133 +1569,135 @@ describe("from replaced state", () => {
         yield* TestResource("A", {
           replaceString: "test-string-changed",
         });
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
       expect((yield* getState("A"))?.status).toEqual("created");
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 
-  test(
+  test.provider(
     "update replacement then cleanup when props have updatable changes",
-    Effect.gen(function* () {
-      // 1. Create initial resource
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", {
-          replaceString: "original",
-          string: "initial",
-        });
-      }).pipe(test.deploy);
-      expect((yield* getState("A"))?.status).toEqual("created");
+    (stack) =>
+      Effect.gen(function* () {
+        // 1. Create initial resource
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            replaceString: "original",
+            string: "initial",
+          });
+        }).pipe(stack.deploy);
+        expect((yield* getState("A"))?.status).toEqual("created");
 
-      // 2. Trigger replacement and fail during delete of old resource
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", {
-          replaceString: "new",
-          string: "initial",
-        });
-      }).pipe(
-        test.deploy,
-        hook({
-          delete: () => Effect.fail(new ResourceFailure()),
-        }),
-      );
-      const state = yield* getState<ReplacedResourceState>("A");
-      expect(state?.status).toEqual("replaced");
-      expect(state?.old?.status).toEqual("created");
+        // 2. Trigger replacement and fail during delete of old resource
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            replaceString: "new",
+            string: "initial",
+          });
+        }).pipe(
+          stack.deploy,
+          hook({
+            delete: () => Effect.fail(new ResourceFailure()),
+          }),
+        );
+        const state = yield* getState<ReplacedResourceState>("A");
+        expect(state?.status).toEqual("replaced");
+        expect(state?.old?.status).toEqual("created");
 
-      // 3. Change props again (updatable change) - should update the replacement then cleanup
-      const output = yield* Effect.gen(function* () {
-        const A = yield* TestResource("A", {
-          replaceString: "new",
-          string: "changed",
-        });
-        return { replaceString: A.replaceString, string: A.string };
-      }).pipe(test.deploy);
-      expect((yield* getState("A"))?.status).toEqual("created");
-      expect(output.replaceString).toEqual("new");
-      expect(output.string).toEqual("changed");
-    }).pipe(Effect.provide(MockLayers())),
+        // 3. Change props again (updatable change) - should update the replacement then cleanup
+        const output = yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", {
+            replaceString: "new",
+            string: "changed",
+          });
+          return { replaceString: A.replaceString, string: A.string };
+        }).pipe(stack.deploy);
+        expect((yield* getState("A"))?.status).toEqual("created");
+        expect(output.replaceString).toEqual("new");
+        expect(output.string).toEqual("changed");
+      }),
   );
 
-  test(
+  test.provider(
     "continue cleanup when props trigger another replacement",
-    Effect.gen(function* () {
-      // 1. Create initial resource
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", {
-          replaceString: "original",
-        });
-      }).pipe(test.deploy);
-      expect((yield* getState("A"))?.status).toEqual("created");
+    (stack) =>
+      Effect.gen(function* () {
+        // 1. Create initial resource
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            replaceString: "original",
+          });
+        }).pipe(stack.deploy);
+        expect((yield* getState("A"))?.status).toEqual("created");
 
-      // 2. Trigger replacement and fail during delete of old resource
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", {
-          replaceString: "new",
-        });
-      }).pipe(
-        test.deploy,
-        hook({
-          delete: () => Effect.fail(new ResourceFailure()),
-        }),
-      );
-      expect((yield* getState("A"))?.status).toEqual("replaced");
+        // 2. Trigger replacement and fail during delete of old resource
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            replaceString: "new",
+          });
+        }).pipe(
+          stack.deploy,
+          hook({
+            delete: () => Effect.fail(new ResourceFailure()),
+          }),
+        );
+        expect((yield* getState("A"))?.status).toEqual("replaced");
 
-      // 3. Replace again and continue cleanup of the older generations
-      const output = yield* Effect.gen(function* () {
-        const A = yield* TestResource("A", {
-          replaceString: "another-replacement",
-        });
-        return A.replaceString;
-      }).pipe(test.deploy);
-      expectConvergedStatus((yield* getState("A"))?.status);
-      expect(output).toEqual("another-replacement");
-    }).pipe(Effect.provide(MockLayers())),
+        // 3. Replace again and continue cleanup of the older generations
+        const output = yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", {
+            replaceString: "another-replacement",
+          });
+          return A.replaceString;
+        }).pipe(stack.deploy);
+        expectConvergedStatus((yield* getState("A"))?.status);
+        expect(output).toEqual("another-replacement");
+      }),
   );
 });
 
 describe("from deleting state", () => {
-  test(
+  test.provider(
     "create when props unchanged or have updatable changes",
-    Effect.gen(function* () {
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", {
-          string: "test-string",
-        });
-      }).pipe(test.deploy);
-      expect((yield* getState("A"))?.status).toEqual("created");
+    (stack) =>
+      Effect.gen(function* () {
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", {
+            string: "test-string",
+          });
+        }).pipe(stack.deploy);
+        expect((yield* getState("A"))?.status).toEqual("created");
 
-      yield* destroy().pipe(
-        hook({
-          delete: () => Effect.fail(new ResourceFailure()),
-        }),
-      );
-      expect((yield* getState("A"))?.status).toEqual("deleting");
+        yield* stack.destroy().pipe(
+          hook({
+            delete: () => Effect.fail(new ResourceFailure()),
+          }),
+        );
+        expect((yield* getState("A"))?.status).toEqual("deleting");
 
-      // Now re-apply with the same props - should create the resource again
-      const output = yield* Effect.gen(function* () {
-        const A = yield* TestResource("A", {
-          string: "test-string",
-        });
-        return A.string;
-      }).pipe(test.deploy);
-      expect((yield* getState("A"))?.status).toEqual("created");
-      expect(output).toEqual("test-string");
-    }).pipe(Effect.provide(MockLayers())),
+        // Now re-apply with the same props - should create the resource again
+        const output = yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", {
+            string: "test-string",
+          });
+          return A.string;
+        }).pipe(stack.deploy);
+        expect((yield* getState("A"))?.status).toEqual("created");
+        expect(output).toEqual("test-string");
+      }),
   );
 
-  test(
-    "create when props trigger replacement",
+  test.provider("create when props trigger replacement", (stack) =>
     Effect.gen(function* () {
       // 1. Create initial resource
       yield* Effect.gen(function* () {
         yield* TestResource("A", {
           replaceString: "original",
         });
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
       expect((yield* getState("A"))?.status).toEqual("created");
 
       // 2. Try to delete but fail
-      yield* destroy().pipe(
+      yield* stack.destroy().pipe(
         hook({
           delete: () => Effect.fail(new ResourceFailure()),
         }),
@@ -1703,10 +1710,10 @@ describe("from deleting state", () => {
           replaceString: "new",
         });
         return A.replaceString;
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
       expect((yield* getState("A"))?.status).toEqual("created");
       expect(output).toEqual("new");
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 });
 
@@ -1716,29 +1723,27 @@ describe("from deleting state", () => {
 
 describe("dependent resources (A -> B)", () => {
   describe("happy path", () => {
-    test(
-      "create A then B where B uses A.string",
+    test.provider("create A then B where B uses A.string", (stack) =>
       Effect.gen(function* () {
         const output = yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: A.string });
           return { A, B };
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("created");
         expect(output.A.string).toEqual("a-value");
         expect(output.B.string).toEqual("a-value");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "update A propagates to B",
+    test.provider("update A propagates to B", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           yield* TestResource("B", { string: A.string });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("created");
 
@@ -1747,17 +1752,16 @@ describe("dependent resources (A -> B)", () => {
           const A = yield* TestResource("A", { string: "a-value-updated" });
           const B = yield* TestResource("B", { string: A.string });
           return { A, B };
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
         expect((yield* getState("A"))?.status).toEqual("updated");
         expect((yield* getState("B"))?.status).toEqual("updated");
         expect(output.A.string).toEqual("a-value-updated");
         expect(output.B.string).toEqual("a-value-updated");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "replace A, B updates to new A's output",
+    test.provider("replace A, B updates to new A's output", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", {
@@ -1765,7 +1769,7 @@ describe("dependent resources (A -> B)", () => {
             replaceString: "original",
           });
           yield* TestResource("B", { string: A.string });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("created");
 
@@ -1777,69 +1781,68 @@ describe("dependent resources (A -> B)", () => {
           });
           const B = yield* TestResource("B", { string: A.string });
           return { A, B };
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("updated");
         expect(output.A.string).toEqual("a-value-new");
         expect(output.B.string).toEqual("a-value-new");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "delete both resources (B deleted first, then A)",
+    test.provider("delete both resources (B deleted first, then A)", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           yield* TestResource("B", { string: A.string });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("created");
 
-        yield* destroy();
+        yield* stack.destroy();
 
         expect(yield* getState("A")).toBeUndefined();
         expect(yield* getState("B")).toBeUndefined();
         expect(yield* listState()).toEqual([]);
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
   });
 
   describe("failures during expandAndPivot", () => {
-    test(
+    test.provider(
       "A create fails, B never starts - recovery creates both",
-      Effect.gen(function* () {
-        // A fails to create - B should never start
-        yield* Effect.gen(function* () {
-          const A = yield* TestResource("A", { string: "a-value" });
-          yield* TestResource("B", { string: A.string });
-        }).pipe(test.deploy, hook(failOn("A", "create")));
+      (stack) =>
+        Effect.gen(function* () {
+          // A fails to create - B should never start
+          yield* Effect.gen(function* () {
+            const A = yield* TestResource("A", { string: "a-value" });
+            yield* TestResource("B", { string: A.string });
+          }).pipe(stack.deploy, hook(failOn("A", "create")));
 
-        expect((yield* getState("A"))?.status).toEqual("creating");
-        expect(yield* getState("B")).toBeUndefined();
+          expect((yield* getState("A"))?.status).toEqual("creating");
+          expect(yield* getState("B")).toBeUndefined();
 
-        // Recovery: re-apply should create both
-        const output = yield* Effect.gen(function* () {
-          const A = yield* TestResource("A", { string: "a-value" });
-          const B = yield* TestResource("B", { string: A.string });
-          return { A, B };
-        }).pipe(test.deploy);
+          // Recovery: re-apply should create both
+          const output = yield* Effect.gen(function* () {
+            const A = yield* TestResource("A", { string: "a-value" });
+            const B = yield* TestResource("B", { string: A.string });
+            return { A, B };
+          }).pipe(stack.deploy);
 
-        expect((yield* getState("A"))?.status).toEqual("created");
-        expect((yield* getState("B"))?.status).toEqual("created");
-        expect(output.A.string).toEqual("a-value");
-        expect(output.B.string).toEqual("a-value");
-      }).pipe(Effect.provide(MockLayers())),
+          expect((yield* getState("A"))?.status).toEqual("created");
+          expect((yield* getState("B"))?.status).toEqual("created");
+          expect(output.A.string).toEqual("a-value");
+          expect(output.B.string).toEqual("a-value");
+        }),
     );
 
-    test(
-      "A creates, B create fails - recovery creates B",
+    test.provider("A creates, B create fails - recovery creates B", (stack) =>
       Effect.gen(function* () {
         // A succeeds, B fails to create
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           yield* TestResource("B", { string: A.string });
-        }).pipe(test.deploy, hook(failOn("B", "create")));
+        }).pipe(stack.deploy, hook(failOn("B", "create")));
 
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("creating");
@@ -1849,237 +1852,240 @@ describe("dependent resources (A -> B)", () => {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: A.string });
           return { A, B };
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("created");
         expect(output.B.string).toEqual("a-value");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "A update fails - recovery updates both",
+    test.provider("A update fails - recovery updates both", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           yield* TestResource("B", { string: A.string });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value-updated" });
           const B = yield* TestResource("B", { string: A.string });
           return { A, B };
         });
 
         // A fails to update - B should not start updating
-        yield* stack.pipe(test.deploy, hook(failOn("A", "update")));
+        yield* program.pipe(stack.deploy, hook(failOn("A", "update")));
 
         expect((yield* getState("A"))?.status).toEqual("updating");
         expect((yield* getState("B"))?.status).toEqual("created");
 
         // Recovery: re-apply should update both
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
 
         expect((yield* getState("A"))?.status).toEqual("updated");
         expect((yield* getState("B"))?.status).toEqual("updated");
         expect(output.A.string).toEqual("a-value-updated");
         expect(output.B.string).toEqual("a-value-updated");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "A updates, B update fails - recovery updates B",
+    test.provider("A updates, B update fails - recovery updates B", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           yield* TestResource("B", { string: A.string });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value-updated" });
           const B = yield* TestResource("B", { string: A.string });
           return { A, B };
         });
 
         // A succeeds, B fails to update
-        yield* stack.pipe(test.deploy, hook(failOn("B", "update")));
+        yield* program.pipe(stack.deploy, hook(failOn("B", "update")));
 
         expect((yield* getState("A"))?.status).toEqual("updated");
         expect((yield* getState("B"))?.status).toEqual("updating");
 
         // Recovery: re-apply should noop A and update B
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
 
         expect((yield* getState("A"))?.status).toEqual("updated");
         expect((yield* getState("B"))?.status).toEqual("updated");
         expect(output.B.string).toEqual("a-value-updated");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
+    test.provider(
       "A replacement fails - recovery replaces A and updates B",
-      Effect.gen(function* () {
-        yield* Effect.gen(function* () {
-          const A = yield* TestResource("A", {
-            string: "a-value",
-            replaceString: "original",
+      (stack) =>
+        Effect.gen(function* () {
+          yield* Effect.gen(function* () {
+            const A = yield* TestResource("A", {
+              string: "a-value",
+              replaceString: "original",
+            });
+            yield* TestResource("B", { string: A.string });
+          }).pipe(stack.deploy);
+
+          const program = Effect.gen(function* () {
+            const A = yield* TestResource("A", {
+              string: "a-value-new",
+              replaceString: "changed",
+            });
+            const B = yield* TestResource("B", { string: A.string });
+            return { A, B };
           });
-          yield* TestResource("B", { string: A.string });
-        }).pipe(test.deploy);
 
-        const stack = Effect.gen(function* () {
-          const A = yield* TestResource("A", {
-            string: "a-value-new",
-            replaceString: "changed",
-          });
-          const B = yield* TestResource("B", { string: A.string });
-          return { A, B };
-        });
+          // A replacement fails (during create of new A) - B should not start
+          yield* program.pipe(stack.deploy, hook(failOn("A", "create")));
 
-        // A replacement fails (during create of new A) - B should not start
-        yield* stack.pipe(test.deploy, hook(failOn("A", "create")));
+          expect(
+            (yield* getState<ReplacingResourceState>("A"))?.status,
+          ).toEqual("replacing");
+          expect((yield* getState("B"))?.status).toEqual("created");
 
-        expect((yield* getState<ReplacingResourceState>("A"))?.status).toEqual(
-          "replacing",
-        );
-        expect((yield* getState("B"))?.status).toEqual("created");
+          // Recovery: re-apply should complete A replacement and update B
+          const output = yield* program.pipe(stack.deploy);
 
-        // Recovery: re-apply should complete A replacement and update B
-        const output = yield* stack.pipe(test.deploy);
-
-        expect((yield* getState("A"))?.status).toEqual("created");
-        expect((yield* getState("B"))?.status).toEqual("updated");
-        expect(output.A.string).toEqual("a-value-new");
-        expect(output.B.string).toEqual("a-value-new");
-      }).pipe(Effect.provide(MockLayers())),
+          expect((yield* getState("A"))?.status).toEqual("created");
+          expect((yield* getState("B"))?.status).toEqual("updated");
+          expect(output.A.string).toEqual("a-value-new");
+          expect(output.B.string).toEqual("a-value-new");
+        }),
     );
 
-    test(
+    test.provider(
       "A replaced, B update fails - recovery updates B then cleans up",
-      Effect.gen(function* () {
-        yield* Effect.gen(function* () {
-          const A = yield* TestResource("A", {
-            string: "a-value",
-            replaceString: "original",
+      (stack) =>
+        Effect.gen(function* () {
+          yield* Effect.gen(function* () {
+            const A = yield* TestResource("A", {
+              string: "a-value",
+              replaceString: "original",
+            });
+            yield* TestResource("B", { string: A.string });
+          }).pipe(stack.deploy);
+
+          const program = Effect.gen(function* () {
+            const A = yield* TestResource("A", {
+              string: "a-value-new",
+              replaceString: "changed",
+            });
+            const B = yield* TestResource("B", { string: A.string });
+            return { A, B };
           });
-          yield* TestResource("B", { string: A.string });
-        }).pipe(test.deploy);
 
-        const stack = Effect.gen(function* () {
-          const A = yield* TestResource("A", {
-            string: "a-value-new",
-            replaceString: "changed",
-          });
-          const B = yield* TestResource("B", { string: A.string });
-          return { A, B };
-        });
+          // A replacement succeeds, B fails to update
+          yield* program.pipe(stack.deploy, hook(failOn("B", "update")));
 
-        // A replacement succeeds, B fails to update
-        yield* stack.pipe(test.deploy, hook(failOn("B", "update")));
+          // A should be in replaced state (new A created, old A pending cleanup)
+          // B should be in updating state
+          const aState = yield* getState<ReplacedResourceState>("A");
+          expect(aState?.status).toEqual("replaced");
+          expect((yield* getState("B"))?.status).toEqual("updating");
 
-        // A should be in replaced state (new A created, old A pending cleanup)
-        // B should be in updating state
-        const aState = yield* getState<ReplacedResourceState>("A");
-        expect(aState?.status).toEqual("replaced");
-        expect((yield* getState("B"))?.status).toEqual("updating");
+          // Recovery: re-apply should update B and clean up old A
+          const output = yield* program.pipe(stack.deploy);
 
-        // Recovery: re-apply should update B and clean up old A
-        const output = yield* stack.pipe(test.deploy);
-
-        expect((yield* getState("A"))?.status).toEqual("created");
-        expect((yield* getState("B"))?.status).toEqual("updated");
-        expect(output.B.string).toEqual("a-value-new");
-      }).pipe(Effect.provide(MockLayers())),
+          expect((yield* getState("A"))?.status).toEqual("created");
+          expect((yield* getState("B"))?.status).toEqual("updated");
+          expect(output.B.string).toEqual("a-value-new");
+        }),
     );
   });
 
   describe("failures during collectGarbage", () => {
-    test(
+    test.provider(
       "A replaced, B updated, old A delete fails - recovery cleans up",
-      Effect.gen(function* () {
-        yield* Effect.gen(function* () {
-          const A = yield* TestResource("A", {
-            string: "a-value",
-            replaceString: "original",
+      (stack) =>
+        Effect.gen(function* () {
+          yield* Effect.gen(function* () {
+            const A = yield* TestResource("A", {
+              string: "a-value",
+              replaceString: "original",
+            });
+            yield* TestResource("B", { string: A.string });
+          }).pipe(stack.deploy);
+
+          const program = Effect.gen(function* () {
+            const A = yield* TestResource("A", {
+              string: "a-value-new",
+              replaceString: "changed",
+            });
+            const B = yield* TestResource("B", { string: A.string });
+            return { A, B };
           });
-          yield* TestResource("B", { string: A.string });
-        }).pipe(test.deploy);
 
-        const stack = Effect.gen(function* () {
-          const A = yield* TestResource("A", {
-            string: "a-value-new",
-            replaceString: "changed",
-          });
-          const B = yield* TestResource("B", { string: A.string });
-          return { A, B };
-        });
+          // A replacement and B update succeed, but old A delete fails
+          yield* program.pipe(stack.deploy, hook(failOn("A", "delete")));
 
-        // A replacement and B update succeed, but old A delete fails
-        yield* stack.pipe(test.deploy, hook(failOn("A", "delete")));
+          // A should be in replaced state (delete of old A failed)
+          // B should have been updated successfully
+          expect((yield* getState<ReplacedResourceState>("A"))?.status).toEqual(
+            "replaced",
+          );
+          expect((yield* getState("B"))?.status).toEqual("updated");
 
-        // A should be in replaced state (delete of old A failed)
-        // B should have been updated successfully
-        expect((yield* getState<ReplacedResourceState>("A"))?.status).toEqual(
-          "replaced",
-        );
-        expect((yield* getState("B"))?.status).toEqual("updated");
+          // Recovery: re-apply should clean up old A
+          const output = yield* program.pipe(stack.deploy);
 
-        // Recovery: re-apply should clean up old A
-        const output = yield* stack.pipe(test.deploy);
-
-        expect((yield* getState("A"))?.status).toEqual("created");
-        expect((yield* getState("B"))?.status).toEqual("updated");
-        expect(output.A.string).toEqual("a-value-new");
-      }).pipe(Effect.provide(MockLayers())),
+          expect((yield* getState("A"))?.status).toEqual("created");
+          expect((yield* getState("B"))?.status).toEqual("updated");
+          expect(output.A.string).toEqual("a-value-new");
+        }),
     );
 
-    test(
+    test.provider(
       "orphan B delete fails - recovery deletes B then A",
-      Effect.gen(function* () {
-        yield* Effect.gen(function* () {
-          const A = yield* TestResource("A", { string: "a-value" });
-          yield* TestResource("B", { string: A.string });
-        }).pipe(test.deploy);
-        expect((yield* getState("A"))?.status).toEqual("created");
-        expect((yield* getState("B"))?.status).toEqual("created");
+      (stack) =>
+        Effect.gen(function* () {
+          yield* Effect.gen(function* () {
+            const A = yield* TestResource("A", { string: "a-value" });
+            yield* TestResource("B", { string: A.string });
+          }).pipe(stack.deploy);
+          expect((yield* getState("A"))?.status).toEqual("created");
+          expect((yield* getState("B"))?.status).toEqual("created");
 
-        // Orphan deletion: B delete fails
-        yield* destroy().pipe(hook(failOn("B", "delete")));
+          // Orphan deletion: B delete fails
+          yield* stack.destroy().pipe(hook(failOn("B", "delete")));
 
-        // B should be in deleting state, A should still be created (waiting for B)
-        expect((yield* getState("B"))?.status).toEqual("deleting");
-        expect((yield* getState("A"))?.status).toEqual("created");
+          // B should be in deleting state, A should still be created (waiting for B)
+          expect((yield* getState("B"))?.status).toEqual("deleting");
+          expect((yield* getState("A"))?.status).toEqual("created");
 
-        // Recovery: re-apply destroy should delete B then A
-        yield* destroy();
+          // Recovery: re-apply destroy should delete B then A
+          yield* stack.destroy();
 
-        expect(yield* getState("A")).toBeUndefined();
-        expect(yield* getState("B")).toBeUndefined();
-      }).pipe(Effect.provide(MockLayers())),
+          expect(yield* getState("A")).toBeUndefined();
+          expect(yield* getState("B")).toBeUndefined();
+        }),
     );
 
-    test(
+    test.provider(
       "orphan A delete fails after B deleted - recovery deletes A",
-      Effect.gen(function* () {
-        yield* Effect.gen(function* () {
-          const A = yield* TestResource("A", { string: "a-value" });
-          yield* TestResource("B", { string: A.string });
-        }).pipe(test.deploy);
-        expect((yield* getState("A"))?.status).toEqual("created");
-        expect((yield* getState("B"))?.status).toEqual("created");
+      (stack) =>
+        Effect.gen(function* () {
+          yield* Effect.gen(function* () {
+            const A = yield* TestResource("A", { string: "a-value" });
+            yield* TestResource("B", { string: A.string });
+          }).pipe(stack.deploy);
+          expect((yield* getState("A"))?.status).toEqual("created");
+          expect((yield* getState("B"))?.status).toEqual("created");
 
-        // Orphan deletion: B succeeds, A fails
-        yield* destroy().pipe(hook(failOn("A", "delete")));
+          // Orphan deletion: B succeeds, A fails
+          yield* stack.destroy().pipe(hook(failOn("A", "delete")));
 
-        // B should be deleted, A should be in deleting state
-        expect(yield* getState("B")).toBeUndefined();
-        expect((yield* getState("A"))?.status).toEqual("deleting");
+          // B should be deleted, A should be in deleting state
+          expect(yield* getState("B")).toBeUndefined();
+          expect((yield* getState("A"))?.status).toEqual("deleting");
 
-        // Recovery: re-apply destroy should delete A
-        yield* destroy();
+          // Recovery: re-apply destroy should delete A
+          yield* stack.destroy();
 
-        expect(yield* getState("A")).toBeUndefined();
-      }).pipe(Effect.provide(MockLayers())),
+          expect(yield* getState("A")).toBeUndefined();
+        }),
     );
   });
 });
@@ -2090,15 +2096,14 @@ describe("dependent resources (A -> B)", () => {
 
 describe("three-level dependency chain (A -> B -> C)", () => {
   describe("happy path", () => {
-    test(
-      "create A then B then C",
+    test.provider("create A then B then C", (stack) =>
       Effect.gen(function* () {
         const output = yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: A.string });
           const C = yield* TestResource("C", { string: B.string });
           return { A, B, C };
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("created");
@@ -2106,34 +2111,32 @@ describe("three-level dependency chain (A -> B -> C)", () => {
         expect(output.A.string).toEqual("a-value");
         expect(output.B.string).toEqual("a-value");
         expect(output.C.string).toEqual("a-value");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "update A propagates through B to C",
+    test.provider("update A propagates through B to C", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: A.string });
           yield* TestResource("C", { string: B.string });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
         const output = yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value-updated" });
           const B = yield* TestResource("B", { string: A.string });
           const C = yield* TestResource("C", { string: B.string });
           return { A, B, C };
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
         expect((yield* getState("A"))?.status).toEqual("updated");
         expect((yield* getState("B"))?.status).toEqual("updated");
         expect((yield* getState("C"))?.status).toEqual("updated");
         expect(output.C.string).toEqual("a-value-updated");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "replace A propagates through B to C",
+    test.provider("replace A propagates through B to C", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", {
@@ -2142,7 +2145,7 @@ describe("three-level dependency chain (A -> B -> C)", () => {
           });
           const B = yield* TestResource("B", { string: A.string });
           yield* TestResource("C", { string: B.string });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
         const output = yield* Effect.gen(function* () {
           const A = yield* TestResource("A", {
@@ -2152,209 +2155,201 @@ describe("three-level dependency chain (A -> B -> C)", () => {
           const B = yield* TestResource("B", { string: A.string });
           const C = yield* TestResource("C", { string: B.string });
           return { A, B, C };
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("updated");
         expect((yield* getState("C"))?.status).toEqual("updated");
         expect(output.C.string).toEqual("a-value-new");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "delete all three (C first, then B, then A)",
+    test.provider("delete all three (C first, then B, then A)", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: A.string });
           yield* TestResource("C", { string: B.string });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
-        yield* destroy();
+        yield* stack.destroy();
 
         expect(yield* getState("A")).toBeUndefined();
         expect(yield* getState("B")).toBeUndefined();
         expect(yield* getState("C")).toBeUndefined();
         expect(yield* listState()).toEqual([]);
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
   });
 
   describe("creation failures", () => {
-    test(
-      "A create fails - B and C never start",
+    test.provider("A create fails - B and C never start", (stack) =>
       Effect.gen(function* () {
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: A.string });
           const C = yield* TestResource("C", { string: B.string });
           return { A, B, C };
         });
 
-        yield* stack.pipe(test.deploy, hook(failOn("A", "create")));
+        yield* program.pipe(stack.deploy, hook(failOn("A", "create")));
 
         expect((yield* getState("A"))?.status).toEqual("creating");
         expect(yield* getState("B")).toBeUndefined();
         expect(yield* getState("C")).toBeUndefined();
 
         // Recovery
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("created");
         expect((yield* getState("C"))?.status).toEqual("created");
         expect(output.C.string).toEqual("a-value");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "A creates, B create fails - C never starts",
+    test.provider("A creates, B create fails - C never starts", (stack) =>
       Effect.gen(function* () {
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: A.string });
           const C = yield* TestResource("C", { string: B.string });
           return { A, B, C };
         });
 
-        yield* stack.pipe(test.deploy, hook(failOn("B", "create")));
+        yield* program.pipe(stack.deploy, hook(failOn("B", "create")));
 
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("creating");
         expect(yield* getState("C")).toBeUndefined();
 
         // Recovery
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("created");
         expect((yield* getState("C"))?.status).toEqual("created");
         expect(output.C.string).toEqual("a-value");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "A and B create, C create fails",
+    test.provider("A and B create, C create fails", (stack) =>
       Effect.gen(function* () {
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: A.string });
           const C = yield* TestResource("C", { string: B.string });
           return { A, B, C };
         });
 
-        yield* stack.pipe(test.deploy, hook(failOn("C", "create")));
+        yield* program.pipe(stack.deploy, hook(failOn("C", "create")));
 
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("created");
         expect((yield* getState("C"))?.status).toEqual("creating");
 
         // Recovery
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("created");
         expect((yield* getState("C"))?.status).toEqual("created");
         expect(output.C.string).toEqual("a-value");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
   });
 
   describe("update failures", () => {
-    test(
-      "A update fails - B and C remain stable",
+    test.provider("A update fails - B and C remain stable", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: A.string });
           yield* TestResource("C", { string: B.string });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value-updated" });
           const B = yield* TestResource("B", { string: A.string });
           const C = yield* TestResource("C", { string: B.string });
           return { A, B, C };
         });
 
-        yield* stack.pipe(test.deploy, hook(failOn("A", "update")));
+        yield* program.pipe(stack.deploy, hook(failOn("A", "update")));
 
         expect((yield* getState("A"))?.status).toEqual("updating");
         expect((yield* getState("B"))?.status).toEqual("created");
         expect((yield* getState("C"))?.status).toEqual("created");
 
         // Recovery
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
         expect((yield* getState("A"))?.status).toEqual("updated");
         expect((yield* getState("B"))?.status).toEqual("updated");
         expect((yield* getState("C"))?.status).toEqual("updated");
         expect(output.C.string).toEqual("a-value-updated");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "A updates, B update fails - C remains stable",
+    test.provider("A updates, B update fails - C remains stable", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: A.string });
           yield* TestResource("C", { string: B.string });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value-updated" });
           const B = yield* TestResource("B", { string: A.string });
           const C = yield* TestResource("C", { string: B.string });
           return { A, B, C };
         });
 
-        yield* stack.pipe(test.deploy, hook(failOn("B", "update")));
+        yield* program.pipe(stack.deploy, hook(failOn("B", "update")));
 
         expect((yield* getState("A"))?.status).toEqual("updated");
         expect((yield* getState("B"))?.status).toEqual("updating");
         expect((yield* getState("C"))?.status).toEqual("created");
 
         // Recovery
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
         expect((yield* getState("A"))?.status).toEqual("updated");
         expect((yield* getState("B"))?.status).toEqual("updated");
         expect((yield* getState("C"))?.status).toEqual("updated");
         expect(output.C.string).toEqual("a-value-updated");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "A and B update, C update fails",
+    test.provider("A and B update, C update fails", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: A.string });
           yield* TestResource("C", { string: B.string });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value-updated" });
           const B = yield* TestResource("B", { string: A.string });
           const C = yield* TestResource("C", { string: B.string });
           return { A, B, C };
         });
 
-        yield* stack.pipe(test.deploy, hook(failOn("C", "update")));
+        yield* program.pipe(stack.deploy, hook(failOn("C", "update")));
 
         expect((yield* getState("A"))?.status).toEqual("updated");
         expect((yield* getState("B"))?.status).toEqual("updated");
         expect((yield* getState("C"))?.status).toEqual("updating");
 
         // Recovery
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
         expect((yield* getState("A"))?.status).toEqual("updated");
         expect((yield* getState("B"))?.status).toEqual("updated");
         expect((yield* getState("C"))?.status).toEqual("updated");
         expect(output.C.string).toEqual("a-value-updated");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
   });
 
   describe("replace cascade failures", () => {
-    test(
-      "A replace fails - B and C remain stable",
+    test.provider("A replace fails - B and C remain stable", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", {
@@ -2363,9 +2358,9 @@ describe("three-level dependency chain (A -> B -> C)", () => {
           });
           const B = yield* TestResource("B", { string: A.string });
           yield* TestResource("C", { string: B.string });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", {
             string: "a-value-new",
             replaceString: "changed",
@@ -2375,7 +2370,7 @@ describe("three-level dependency chain (A -> B -> C)", () => {
           return { A, B, C };
         });
 
-        yield* stack.pipe(test.deploy, hook(failOn("A", "create")));
+        yield* program.pipe(stack.deploy, hook(failOn("A", "create")));
 
         expect((yield* getState<ReplacingResourceState>("A"))?.status).toEqual(
           "replacing",
@@ -2384,16 +2379,15 @@ describe("three-level dependency chain (A -> B -> C)", () => {
         expect((yield* getState("C"))?.status).toEqual("created");
 
         // Recovery
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("updated");
         expect((yield* getState("C"))?.status).toEqual("updated");
         expect(output.C.string).toEqual("a-value-new");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "A replaced, B update fails - C remains stable",
+    test.provider("A replaced, B update fails - C remains stable", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", {
@@ -2402,9 +2396,9 @@ describe("three-level dependency chain (A -> B -> C)", () => {
           });
           const B = yield* TestResource("B", { string: A.string });
           yield* TestResource("C", { string: B.string });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", {
             string: "a-value-new",
             replaceString: "changed",
@@ -2414,7 +2408,7 @@ describe("three-level dependency chain (A -> B -> C)", () => {
           return { A, B, C };
         });
 
-        yield* stack.pipe(test.deploy, hook(failOn("B", "update")));
+        yield* program.pipe(stack.deploy, hook(failOn("B", "update")));
 
         expect((yield* getState<ReplacedResourceState>("A"))?.status).toEqual(
           "replaced",
@@ -2423,16 +2417,15 @@ describe("three-level dependency chain (A -> B -> C)", () => {
         expect((yield* getState("C"))?.status).toEqual("created");
 
         // Recovery
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("updated");
         expect((yield* getState("C"))?.status).toEqual("updated");
         expect(output.C.string).toEqual("a-value-new");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "A replaced, B updated, C update fails",
+    test.provider("A replaced, B updated, C update fails", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", {
@@ -2441,9 +2434,9 @@ describe("three-level dependency chain (A -> B -> C)", () => {
           });
           const B = yield* TestResource("B", { string: A.string });
           yield* TestResource("C", { string: B.string });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", {
             string: "a-value-new",
             replaceString: "changed",
@@ -2453,7 +2446,7 @@ describe("three-level dependency chain (A -> B -> C)", () => {
           return { A, B, C };
         });
 
-        yield* stack.pipe(test.deploy, hook(failOn("C", "update")));
+        yield* program.pipe(stack.deploy, hook(failOn("C", "update")));
 
         expect((yield* getState<ReplacedResourceState>("A"))?.status).toEqual(
           "replaced",
@@ -2462,119 +2455,117 @@ describe("three-level dependency chain (A -> B -> C)", () => {
         expect((yield* getState("C"))?.status).toEqual("updating");
 
         // Recovery
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("updated");
         expect((yield* getState("C"))?.status).toEqual("updated");
         expect(output.C.string).toEqual("a-value-new");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
+    test.provider(
       "A replaced, B and C updated, old A delete fails - recovery cleans up",
-      Effect.gen(function* () {
-        yield* Effect.gen(function* () {
-          const A = yield* TestResource("A", {
-            string: "a-value",
-            replaceString: "original",
+      (stack) =>
+        Effect.gen(function* () {
+          yield* Effect.gen(function* () {
+            const A = yield* TestResource("A", {
+              string: "a-value",
+              replaceString: "original",
+            });
+            const B = yield* TestResource("B", { string: A.string });
+            yield* TestResource("C", { string: B.string });
+          }).pipe(stack.deploy);
+
+          const program = Effect.gen(function* () {
+            const A = yield* TestResource("A", {
+              string: "a-value-new",
+              replaceString: "changed",
+            });
+            const B = yield* TestResource("B", { string: A.string });
+            const C = yield* TestResource("C", { string: B.string });
+            return { A, B, C };
           });
-          const B = yield* TestResource("B", { string: A.string });
-          yield* TestResource("C", { string: B.string });
-        }).pipe(test.deploy);
 
-        const stack = Effect.gen(function* () {
-          const A = yield* TestResource("A", {
-            string: "a-value-new",
-            replaceString: "changed",
-          });
-          const B = yield* TestResource("B", { string: A.string });
-          const C = yield* TestResource("C", { string: B.string });
-          return { A, B, C };
-        });
+          yield* program.pipe(stack.deploy, hook(failOn("A", "delete")));
 
-        yield* stack.pipe(test.deploy, hook(failOn("A", "delete")));
+          expect((yield* getState<ReplacedResourceState>("A"))?.status).toEqual(
+            "replaced",
+          );
+          expect((yield* getState("B"))?.status).toEqual("updated");
+          expect((yield* getState("C"))?.status).toEqual("updated");
 
-        expect((yield* getState<ReplacedResourceState>("A"))?.status).toEqual(
-          "replaced",
-        );
-        expect((yield* getState("B"))?.status).toEqual("updated");
-        expect((yield* getState("C"))?.status).toEqual("updated");
-
-        // Recovery
-        const output = yield* stack.pipe(test.deploy);
-        expect((yield* getState("A"))?.status).toEqual("created");
-        expect((yield* getState("B"))?.status).toEqual("updated");
-        expect((yield* getState("C"))?.status).toEqual("updated");
-        expect(output.C.string).toEqual("a-value-new");
-      }).pipe(Effect.provide(MockLayers())),
+          // Recovery
+          const output = yield* program.pipe(stack.deploy);
+          expect((yield* getState("A"))?.status).toEqual("created");
+          expect((yield* getState("B"))?.status).toEqual("updated");
+          expect((yield* getState("C"))?.status).toEqual("updated");
+          expect(output.C.string).toEqual("a-value-new");
+        }),
     );
   });
 
   describe("delete order failures", () => {
-    test(
-      "C delete fails - A and B waiting",
+    test.provider("C delete fails - A and B waiting", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: A.string });
           yield* TestResource("C", { string: B.string });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
-        yield* destroy().pipe(hook(failOn("C", "delete")));
+        yield* stack.destroy().pipe(hook(failOn("C", "delete")));
 
         expect((yield* getState("C"))?.status).toEqual("deleting");
         expect((yield* getState("B"))?.status).toEqual("created");
         expect((yield* getState("A"))?.status).toEqual("created");
 
         // Recovery
-        yield* destroy();
+        yield* stack.destroy();
         expect(yield* getState("A")).toBeUndefined();
         expect(yield* getState("B")).toBeUndefined();
         expect(yield* getState("C")).toBeUndefined();
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "C deleted, B delete fails - A waiting",
+    test.provider("C deleted, B delete fails - A waiting", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: A.string });
           yield* TestResource("C", { string: B.string });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
-        yield* destroy().pipe(hook(failOn("B", "delete")));
+        yield* stack.destroy().pipe(hook(failOn("B", "delete")));
 
         expect(yield* getState("C")).toBeUndefined();
         expect((yield* getState("B"))?.status).toEqual("deleting");
         expect((yield* getState("A"))?.status).toEqual("created");
 
         // Recovery
-        yield* destroy();
+        yield* stack.destroy();
         expect(yield* getState("A")).toBeUndefined();
         expect(yield* getState("B")).toBeUndefined();
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "C and B deleted, A delete fails",
+    test.provider("C and B deleted, A delete fails", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: A.string });
           yield* TestResource("C", { string: B.string });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
-        yield* destroy().pipe(hook(failOn("A", "delete")));
+        yield* stack.destroy().pipe(hook(failOn("A", "delete")));
 
         expect(yield* getState("C")).toBeUndefined();
         expect(yield* getState("B")).toBeUndefined();
         expect((yield* getState("A"))?.status).toEqual("deleting");
 
         // Recovery
-        yield* destroy();
+        yield* stack.destroy();
         expect(yield* getState("A")).toBeUndefined();
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
   });
 });
@@ -2590,8 +2581,7 @@ describe("three-level dependency chain (A -> B -> C)", () => {
 
 describe("diamond dependencies (A -> B,C -> D)", () => {
   describe("happy path", () => {
-    test(
-      "create all four resources",
+    test.provider("create all four resources", (stack) =>
       Effect.gen(function* () {
         const output = yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
@@ -2601,18 +2591,17 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
             string: Output.interpolate`${B.string}-${C.string}`,
           });
           return { A, B, C, D };
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("created");
         expect((yield* getState("C"))?.status).toEqual("created");
         expect((yield* getState("D"))?.status).toEqual("created");
         expect(output.D.string).toEqual("a-value-a-value");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "update A propagates to B, C, and D",
+    test.provider("update A propagates to B, C, and D", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
@@ -2621,7 +2610,7 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
           yield* TestResource("D", {
             string: Output.interpolate`${B.string}-${C.string}`,
           });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
         const output = yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "updated" });
@@ -2631,18 +2620,17 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
             string: Output.interpolate`${B.string}-${C.string}`,
           });
           return { A, B, C, D };
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
         expect((yield* getState("A"))?.status).toEqual("updated");
         expect((yield* getState("B"))?.status).toEqual("updated");
         expect((yield* getState("C"))?.status).toEqual("updated");
         expect((yield* getState("D"))?.status).toEqual("updated");
         expect(output.D.string).toEqual("updated-updated");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "add D while B replaces and C noops",
+    test.provider("add D while B replaces and C noops", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
@@ -2654,7 +2642,7 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
             string: Output.interpolate`${A.string}-c`,
             replaceString: "c-original",
           });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
         const output = yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
@@ -2670,7 +2658,7 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
             string: Output.interpolate`${B.string}-${C.string}`,
           });
           return { A, B, C, D };
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("created");
@@ -2679,11 +2667,10 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
         expect(output.B.replaceString).toEqual("b-changed");
         expect(output.C.replaceString).toEqual("c-original");
         expect(output.D.string).toEqual("a-value-b-replaced-a-value-c");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "add D while C replaces and B noops",
+    test.provider("add D while C replaces and B noops", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
@@ -2695,7 +2682,7 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
             string: Output.interpolate`${A.string}-c`,
             replaceString: "c-original",
           });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
         const output = yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
@@ -2711,7 +2698,7 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
             string: Output.interpolate`${B.string}-${C.string}`,
           });
           return { A, B, C, D };
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("created");
@@ -2720,11 +2707,10 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
         expect(output.B.replaceString).toEqual("b-original");
         expect(output.C.replaceString).toEqual("c-changed");
         expect(output.D.string).toEqual("a-value-b-a-value-c-replaced");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "add D while both B and C replace",
+    test.provider("add D while both B and C replace", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
@@ -2736,7 +2722,7 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
             string: Output.interpolate`${A.string}-c`,
             replaceString: "c-original",
           });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
         const output = yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
@@ -2752,7 +2738,7 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
             string: Output.interpolate`${B.string}-${C.string}`,
           });
           return { A, B, C, D };
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("created");
@@ -2763,11 +2749,10 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
         expect(output.D.string).toEqual(
           "a-value-b-replaced-a-value-c-replaced",
         );
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "delete all (D first, then B and C, then A)",
+    test.provider("delete all (D first, then B and C, then A)", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
@@ -2776,23 +2761,22 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
           yield* TestResource("D", {
             string: Output.interpolate`${B.string}-${C.string}`,
           });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
-        yield* destroy();
+        yield* stack.destroy();
 
         expect(yield* getState("A")).toBeUndefined();
         expect(yield* getState("B")).toBeUndefined();
         expect(yield* getState("C")).toBeUndefined();
         expect(yield* getState("D")).toBeUndefined();
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
   });
 
   describe("creation failures", () => {
-    test(
-      "A create fails - B, C, D never start",
+    test.provider("A create fails - B, C, D never start", (stack) =>
       Effect.gen(function* () {
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: A.string });
           const C = yield* TestResource("C", { string: A.string });
@@ -2802,7 +2786,7 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
           return { A, B, C, D };
         });
 
-        yield* stack.pipe(test.deploy, hook(failOn("A", "create")));
+        yield* program.pipe(stack.deploy, hook(failOn("A", "create")));
 
         expect((yield* getState("A"))?.status).toEqual("creating");
         expect(yield* getState("B")).toBeUndefined();
@@ -2810,83 +2794,88 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
         expect(yield* getState("D")).toBeUndefined();
 
         // Recovery
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("created");
         expect((yield* getState("C"))?.status).toEqual("created");
         expect((yield* getState("D"))?.status).toEqual("created");
         expect(output.D.string).toEqual("a-value-a-value");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
+    test.provider(
       "A creates, B create fails - C may create, D stuck",
-      Effect.gen(function* () {
-        const stack = Effect.gen(function* () {
-          const A = yield* TestResource("A", { string: "a-value" });
-          const B = yield* TestResource("B", { string: A.string });
-          const C = yield* TestResource("C", { string: A.string });
-          const D = yield* TestResource("D", {
-            string: Output.interpolate`${B.string}-${C.string}`,
+      (stack) =>
+        Effect.gen(function* () {
+          const program = Effect.gen(function* () {
+            const A = yield* TestResource("A", { string: "a-value" });
+            const B = yield* TestResource("B", { string: A.string });
+            const C = yield* TestResource("C", { string: A.string });
+            const D = yield* TestResource("D", {
+              string: Output.interpolate`${B.string}-${C.string}`,
+            });
+            return { A, B, C, D };
           });
-          return { A, B, C, D };
-        });
 
-        yield* stack.pipe(test.deploy, hook(failOn("B", "create")));
+          yield* program.pipe(stack.deploy, hook(failOn("B", "create")));
 
-        expect((yield* getState("A"))?.status).toEqual("created");
-        expect((yield* getState("B"))?.status).toEqual("creating");
-        // C might have been created since it doesn't depend on B
-        const cState = yield* getState("C");
-        expect(cState === undefined || cState?.status === "created").toBe(true);
-        expect(yield* getState("D")).toBeUndefined();
+          expect((yield* getState("A"))?.status).toEqual("created");
+          expect((yield* getState("B"))?.status).toEqual("creating");
+          // C might have been created since it doesn't depend on B
+          const cState = yield* getState("C");
+          expect(cState === undefined || cState?.status === "created").toBe(
+            true,
+          );
+          expect(yield* getState("D")).toBeUndefined();
 
-        // Recovery
-        const output = yield* stack.pipe(test.deploy);
-        expect((yield* getState("A"))?.status).toEqual("created");
-        expect((yield* getState("B"))?.status).toEqual("created");
-        expect((yield* getState("C"))?.status).toEqual("created");
-        expect((yield* getState("D"))?.status).toEqual("created");
-        expect(output.D.string).toEqual("a-value-a-value");
-      }).pipe(Effect.provide(MockLayers())),
+          // Recovery
+          const output = yield* program.pipe(stack.deploy);
+          expect((yield* getState("A"))?.status).toEqual("created");
+          expect((yield* getState("B"))?.status).toEqual("created");
+          expect((yield* getState("C"))?.status).toEqual("created");
+          expect((yield* getState("D"))?.status).toEqual("created");
+          expect(output.D.string).toEqual("a-value-a-value");
+        }),
     );
 
-    test(
+    test.provider(
       "A creates, C create fails - B may create, D stuck",
-      Effect.gen(function* () {
-        const stack = Effect.gen(function* () {
-          const A = yield* TestResource("A", { string: "a-value" });
-          const B = yield* TestResource("B", { string: A.string });
-          const C = yield* TestResource("C", { string: A.string });
-          const D = yield* TestResource("D", {
-            string: Output.interpolate`${B.string}-${C.string}`,
+      (stack) =>
+        Effect.gen(function* () {
+          const program = Effect.gen(function* () {
+            const A = yield* TestResource("A", { string: "a-value" });
+            const B = yield* TestResource("B", { string: A.string });
+            const C = yield* TestResource("C", { string: A.string });
+            const D = yield* TestResource("D", {
+              string: Output.interpolate`${B.string}-${C.string}`,
+            });
+            return { A, B, C, D };
           });
-          return { A, B, C, D };
-        });
 
-        yield* stack.pipe(test.deploy, hook(failOn("C", "create")));
+          yield* program.pipe(stack.deploy, hook(failOn("C", "create")));
 
-        expect((yield* getState("A"))?.status).toEqual("created");
-        expect((yield* getState("C"))?.status).toEqual("creating");
-        // B might have been created since it doesn't depend on C
-        const bState = yield* getState("B");
-        expect(bState === undefined || bState?.status === "created").toBe(true);
-        expect(yield* getState("D")).toBeUndefined();
+          expect((yield* getState("A"))?.status).toEqual("created");
+          expect((yield* getState("C"))?.status).toEqual("creating");
+          // B might have been created since it doesn't depend on C
+          const bState = yield* getState("B");
+          expect(bState === undefined || bState?.status === "created").toBe(
+            true,
+          );
+          expect(yield* getState("D")).toBeUndefined();
 
-        // Recovery
-        const output = yield* stack.pipe(test.deploy);
-        expect((yield* getState("A"))?.status).toEqual("created");
-        expect((yield* getState("B"))?.status).toEqual("created");
-        expect((yield* getState("C"))?.status).toEqual("created");
-        expect((yield* getState("D"))?.status).toEqual("created");
-        expect(output.D.string).toEqual("a-value-a-value");
-      }).pipe(Effect.provide(MockLayers())),
+          // Recovery
+          const output = yield* program.pipe(stack.deploy);
+          expect((yield* getState("A"))?.status).toEqual("created");
+          expect((yield* getState("B"))?.status).toEqual("created");
+          expect((yield* getState("C"))?.status).toEqual("created");
+          expect((yield* getState("D"))?.status).toEqual("created");
+          expect(output.D.string).toEqual("a-value-a-value");
+        }),
     );
 
-    test(
-      "A, B, C create - D create fails",
+    test.provider("A, B, C create - D create fails", (stack) =>
       Effect.gen(function* () {
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: A.string });
           const C = yield* TestResource("C", { string: A.string });
@@ -2896,7 +2885,7 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
           return { A, B, C, D };
         });
 
-        yield* stack.pipe(test.deploy, hook(failOn("D", "create")));
+        yield* program.pipe(stack.deploy, hook(failOn("D", "create")));
 
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("created");
@@ -2904,16 +2893,15 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
         expect((yield* getState("D"))?.status).toEqual("creating");
 
         // Recovery
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
         expect((yield* getState("D"))?.status).toEqual("created");
         expect(output.D.string).toEqual("a-value-a-value");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "both B and C fail to create - D stuck",
+    test.provider("both B and C fail to create - D stuck", (stack) =>
       Effect.gen(function* () {
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: A.string });
           const C = yield* TestResource("C", { string: A.string });
@@ -2923,8 +2911,8 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
           return { A, B, C, D };
         });
 
-        yield* stack.pipe(
-          test.deploy,
+        yield* program.pipe(
+          stack.deploy,
           hook(
             failOnMultiple([
               { id: "B", hook: "create" },
@@ -2945,18 +2933,17 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
         expect(yield* getState("D")).toBeUndefined();
 
         // Recovery
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
         expect((yield* getState("B"))?.status).toEqual("created");
         expect((yield* getState("C"))?.status).toEqual("created");
         expect((yield* getState("D"))?.status).toEqual("created");
         expect(output.D.string).toEqual("a-value-a-value");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
   });
 
   describe("update failures", () => {
-    test(
-      "A update fails - B, C, D remain stable",
+    test.provider("A update fails - B, C, D remain stable", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
@@ -2965,9 +2952,9 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
           yield* TestResource("D", {
             string: Output.interpolate`${B.string}-${C.string}`,
           });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "updated" });
           const B = yield* TestResource("B", { string: A.string });
           const C = yield* TestResource("C", { string: A.string });
@@ -2977,7 +2964,7 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
           return { A, B, C, D };
         });
 
-        yield* stack.pipe(test.deploy, hook(failOn("A", "update")));
+        yield* program.pipe(stack.deploy, hook(failOn("A", "update")));
 
         expect((yield* getState("A"))?.status).toEqual("updating");
         expect((yield* getState("B"))?.status).toEqual("created");
@@ -2985,59 +2972,59 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
         expect((yield* getState("D"))?.status).toEqual("created");
 
         // Recovery
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
         expect((yield* getState("A"))?.status).toEqual("updated");
         expect((yield* getState("B"))?.status).toEqual("updated");
         expect((yield* getState("C"))?.status).toEqual("updated");
         expect((yield* getState("D"))?.status).toEqual("updated");
         expect(output.D.string).toEqual("updated-updated");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
+    test.provider(
       "A updates, B update fails - C may update, D stuck",
-      Effect.gen(function* () {
-        yield* Effect.gen(function* () {
-          const A = yield* TestResource("A", { string: "a-value" });
-          const B = yield* TestResource("B", { string: A.string });
-          const C = yield* TestResource("C", { string: A.string });
-          yield* TestResource("D", {
-            string: Output.interpolate`${B.string}-${C.string}`,
+      (stack) =>
+        Effect.gen(function* () {
+          yield* Effect.gen(function* () {
+            const A = yield* TestResource("A", { string: "a-value" });
+            const B = yield* TestResource("B", { string: A.string });
+            const C = yield* TestResource("C", { string: A.string });
+            yield* TestResource("D", {
+              string: Output.interpolate`${B.string}-${C.string}`,
+            });
+          }).pipe(stack.deploy);
+
+          const program = Effect.gen(function* () {
+            const A = yield* TestResource("A", { string: "updated" });
+            const B = yield* TestResource("B", { string: A.string });
+            const C = yield* TestResource("C", { string: A.string });
+            const D = yield* TestResource("D", {
+              string: Output.interpolate`${B.string}-${C.string}`,
+            });
+            return { A, B, C, D };
           });
-        }).pipe(test.deploy);
 
-        const stack = Effect.gen(function* () {
-          const A = yield* TestResource("A", { string: "updated" });
-          const B = yield* TestResource("B", { string: A.string });
-          const C = yield* TestResource("C", { string: A.string });
-          const D = yield* TestResource("D", {
-            string: Output.interpolate`${B.string}-${C.string}`,
-          });
-          return { A, B, C, D };
-        });
+          yield* program.pipe(stack.deploy, hook(failOn("B", "update")));
 
-        yield* stack.pipe(test.deploy, hook(failOn("B", "update")));
+          expect((yield* getState("A"))?.status).toEqual("updated");
+          expect((yield* getState("B"))?.status).toEqual("updating");
+          // C might have been updated since it doesn't depend on B
+          const cState = yield* getState("C");
+          expect(
+            cState?.status === "created" || cState?.status === "updated",
+          ).toBe(true);
+          expect((yield* getState("D"))?.status).toEqual("created");
 
-        expect((yield* getState("A"))?.status).toEqual("updated");
-        expect((yield* getState("B"))?.status).toEqual("updating");
-        // C might have been updated since it doesn't depend on B
-        const cState = yield* getState("C");
-        expect(
-          cState?.status === "created" || cState?.status === "updated",
-        ).toBe(true);
-        expect((yield* getState("D"))?.status).toEqual("created");
-
-        // Recovery
-        const output = yield* stack.pipe(test.deploy);
-        expect((yield* getState("B"))?.status).toEqual("updated");
-        expect((yield* getState("C"))?.status).toEqual("updated");
-        expect((yield* getState("D"))?.status).toEqual("updated");
-        expect(output.D.string).toEqual("updated-updated");
-      }).pipe(Effect.provide(MockLayers())),
+          // Recovery
+          const output = yield* program.pipe(stack.deploy);
+          expect((yield* getState("B"))?.status).toEqual("updated");
+          expect((yield* getState("C"))?.status).toEqual("updated");
+          expect((yield* getState("D"))?.status).toEqual("updated");
+          expect(output.D.string).toEqual("updated-updated");
+        }),
     );
 
-    test(
-      "A, B, C update - D update fails",
+    test.provider("A, B, C update - D update fails", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
@@ -3046,9 +3033,9 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
           yield* TestResource("D", {
             string: Output.interpolate`${B.string}-${C.string}`,
           });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "updated" });
           const B = yield* TestResource("B", { string: A.string });
           const C = yield* TestResource("C", { string: A.string });
@@ -3058,7 +3045,7 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
           return { A, B, C, D };
         });
 
-        yield* stack.pipe(test.deploy, hook(failOn("D", "update")));
+        yield* program.pipe(stack.deploy, hook(failOn("D", "update")));
 
         expect((yield* getState("A"))?.status).toEqual("updated");
         expect((yield* getState("B"))?.status).toEqual("updated");
@@ -3066,16 +3053,15 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
         expect((yield* getState("D"))?.status).toEqual("updating");
 
         // Recovery
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
         expect((yield* getState("D"))?.status).toEqual("updated");
         expect(output.D.string).toEqual("updated-updated");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
   });
 
   describe("delete failures", () => {
-    test(
-      "D delete fails - B, C, A waiting",
+    test.provider("D delete fails - B, C, A waiting", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
@@ -3084,9 +3070,9 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
           yield* TestResource("D", {
             string: Output.interpolate`${B.string}-${C.string}`,
           });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
-        yield* destroy().pipe(hook(failOn("D", "delete")));
+        yield* stack.destroy().pipe(hook(failOn("D", "delete")));
 
         expect((yield* getState("D"))?.status).toEqual("deleting");
         expect((yield* getState("B"))?.status).toEqual("created");
@@ -3094,41 +3080,44 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
         expect((yield* getState("A"))?.status).toEqual("created");
 
         // Recovery
-        yield* destroy();
+        yield* stack.destroy();
         expect(yield* getState("A")).toBeUndefined();
         expect(yield* getState("B")).toBeUndefined();
         expect(yield* getState("C")).toBeUndefined();
         expect(yield* getState("D")).toBeUndefined();
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
+    test.provider(
       "D deleted, B delete fails - C may delete, A waiting",
-      Effect.gen(function* () {
-        yield* Effect.gen(function* () {
-          const A = yield* TestResource("A", { string: "a-value" });
-          const B = yield* TestResource("B", { string: A.string });
-          const C = yield* TestResource("C", { string: A.string });
-          yield* TestResource("D", {
-            string: Output.interpolate`${B.string}-${C.string}`,
-          });
-        }).pipe(test.deploy);
+      (stack) =>
+        Effect.gen(function* () {
+          yield* Effect.gen(function* () {
+            const A = yield* TestResource("A", { string: "a-value" });
+            const B = yield* TestResource("B", { string: A.string });
+            const C = yield* TestResource("C", { string: A.string });
+            yield* TestResource("D", {
+              string: Output.interpolate`${B.string}-${C.string}`,
+            });
+          }).pipe(stack.deploy);
 
-        yield* destroy().pipe(hook(failOn("B", "delete")));
+          yield* stack.destroy().pipe(hook(failOn("B", "delete")));
 
-        expect(yield* getState("D")).toBeUndefined();
-        expect((yield* getState("B"))?.status).toEqual("deleting");
-        // C may or may not be deleted depending on execution order
-        const cState = yield* getState("C");
-        expect(cState === undefined || cState?.status === "created").toBe(true);
-        expect((yield* getState("A"))?.status).toEqual("created");
+          expect(yield* getState("D")).toBeUndefined();
+          expect((yield* getState("B"))?.status).toEqual("deleting");
+          // C may or may not be deleted depending on execution order
+          const cState = yield* getState("C");
+          expect(cState === undefined || cState?.status === "created").toBe(
+            true,
+          );
+          expect((yield* getState("A"))?.status).toEqual("created");
 
-        // Recovery
-        yield* destroy();
-        expect(yield* getState("A")).toBeUndefined();
-        expect(yield* getState("B")).toBeUndefined();
-        expect(yield* getState("C")).toBeUndefined();
-      }).pipe(Effect.provide(MockLayers())),
+          // Recovery
+          yield* stack.destroy();
+          expect(yield* getState("A")).toBeUndefined();
+          expect(yield* getState("B")).toBeUndefined();
+          expect(yield* getState("C")).toBeUndefined();
+        }),
     );
   });
 });
@@ -3139,17 +3128,16 @@ describe("diamond dependencies (A -> B,C -> D)", () => {
 
 describe("independent resources (A, B with no dependencies)", () => {
   describe("parallel failures", () => {
-    test(
-      "both A and B fail to create",
+    test.provider("both A and B fail to create", (stack) =>
       Effect.gen(function* () {
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: "b-value" });
           return { A, B };
         });
 
-        yield* stack.pipe(
-          test.deploy,
+        yield* program.pipe(
+          stack.deploy,
           hook(
             failOnMultiple([
               { id: "A", hook: "create" },
@@ -3167,51 +3155,49 @@ describe("independent resources (A, B with no dependencies)", () => {
         expect(AState?.status ?? BState?.status).toEqual("creating");
 
         // Recovery
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("created");
         expect(output.A.string).toEqual("a-value");
         expect(output.B.string).toEqual("b-value");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "A creates, B fails - recovery creates B",
+    test.provider("A creates, B fails - recovery creates B", (stack) =>
       Effect.gen(function* () {
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-value" });
           const B = yield* TestResource("B", { string: "b-value" });
           return { A, B };
         });
 
-        yield* stack.pipe(test.deploy, hook(failOn("B", "create")));
+        yield* program.pipe(stack.deploy, hook(failOn("B", "create")));
 
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("creating");
 
         // Recovery
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
         expect((yield* getState("A"))?.status).toEqual("created");
         expect((yield* getState("B"))?.status).toEqual("created");
         expect(output.B.string).toEqual("b-value");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
 
-    test(
-      "A update fails, B update succeeds",
+    test.provider("A update fails, B update succeeds", (stack) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
           yield* TestResource("A", { string: "a-value" });
           yield* TestResource("B", { string: "b-value" });
-        }).pipe(test.deploy);
+        }).pipe(stack.deploy);
 
-        const stack = Effect.gen(function* () {
+        const program = Effect.gen(function* () {
           const A = yield* TestResource("A", { string: "a-updated" });
           const B = yield* TestResource("B", { string: "b-updated" });
           return { A, B };
         });
 
-        yield* stack.pipe(test.deploy, hook(failOn("A", "update")));
+        yield* program.pipe(stack.deploy, hook(failOn("A", "update")));
 
         expect((yield* getState("A"))?.status).toEqual("updating");
         // B might have been updated
@@ -3221,102 +3207,104 @@ describe("independent resources (A, B with no dependencies)", () => {
         ).toBe(true);
 
         // Recovery
-        const output = yield* stack.pipe(test.deploy);
+        const output = yield* program.pipe(stack.deploy);
         expect((yield* getState("A"))?.status).toEqual("updated");
         expect((yield* getState("B"))?.status).toEqual("updated");
         expect(output.A.string).toEqual("a-updated");
         expect(output.B.string).toEqual("b-updated");
-      }).pipe(Effect.provide(MockLayers())),
+      }),
     );
   });
 
   describe("mixed state recovery", () => {
-    test(
+    test.provider(
       "A in creating, B in updating state - recovery completes both",
-      Effect.gen(function* () {
-        // First create B successfully
-        yield* Effect.gen(function* () {
-          yield* TestResource("B", { string: "b-value" });
-        }).pipe(test.deploy);
-        expect((yield* getState("B"))?.status).toEqual("created");
+      (stack) =>
+        Effect.gen(function* () {
+          // First create B successfully
+          yield* Effect.gen(function* () {
+            yield* TestResource("B", { string: "b-value" });
+          }).pipe(stack.deploy);
+          expect((yield* getState("B"))?.status).toEqual("created");
 
-        // Now try to create A and update B - A fails
-        const stack = Effect.gen(function* () {
-          const A = yield* TestResource("A", { string: "a-value" });
-          const B = yield* TestResource("B", { string: "b-updated" });
-          return { A, B };
-        });
+          // Now try to create A and update B - A fails
+          const program = Effect.gen(function* () {
+            const A = yield* TestResource("A", { string: "a-value" });
+            const B = yield* TestResource("B", { string: "b-updated" });
+            return { A, B };
+          });
 
-        yield* stack.pipe(
-          test.deploy,
-          hook(
-            failOnMultiple([
-              { id: "A", hook: "create" },
-              { id: "B", hook: "update" },
-            ]),
-          ),
-        );
+          yield* program.pipe(
+            stack.deploy,
+            hook(
+              failOnMultiple([
+                { id: "A", hook: "create" },
+                { id: "B", hook: "update" },
+              ]),
+            ),
+          );
 
-        // effect terminates eagerly, so it's possible that A or B runs first and blocks the other from running
-        const AState = yield* getState("A");
-        const BState = yield* getState("B");
-        expect(AState?.status).toBeOneOf(["creating", undefined]);
-        expect(BState?.status).toBeOneOf(["created", "updating"]);
-        // at least one of A or B should have started their failing operation
-        expect(
-          AState?.status === "creating" || BState?.status === "updating",
-        ).toBe(true);
+          // effect terminates eagerly, so it's possible that A or B runs first and blocks the other from running
+          const AState = yield* getState("A");
+          const BState = yield* getState("B");
+          expect(AState?.status).toBeOneOf(["creating", undefined]);
+          expect(BState?.status).toBeOneOf(["created", "updating"]);
+          // at least one of A or B should have started their failing operation
+          expect(
+            AState?.status === "creating" || BState?.status === "updating",
+          ).toBe(true);
 
-        // Recovery
-        const output = yield* stack.pipe(test.deploy);
-        expect((yield* getState("A"))?.status).toEqual("created");
-        expect((yield* getState("B"))?.status).toEqual("updated");
-        expect(output.A.string).toEqual("a-value");
-        expect(output.B.string).toEqual("b-updated");
-      }).pipe(Effect.provide(MockLayers())),
+          // Recovery
+          const output = yield* program.pipe(stack.deploy);
+          expect((yield* getState("A"))?.status).toEqual("created");
+          expect((yield* getState("B"))?.status).toEqual("updated");
+          expect(output.A.string).toEqual("a-value");
+          expect(output.B.string).toEqual("b-updated");
+        }),
     );
 
-    test(
+    test.provider(
       "A in replacing, B in deleting state - complex recovery",
-      Effect.gen(function* () {
-        // Create both
-        yield* Effect.gen(function* () {
-          yield* TestResource("A", { replaceString: "original" });
-          yield* TestResource("B", { string: "b-value" });
-        }).pipe(test.deploy);
-        expect((yield* getState("A"))?.status).toEqual("created");
-        expect((yield* getState("B"))?.status).toEqual("created");
+      (stack) =>
+        Effect.gen(function* () {
+          // Create both
+          yield* Effect.gen(function* () {
+            yield* TestResource("A", { replaceString: "original" });
+            yield* TestResource("B", { string: "b-value" });
+          }).pipe(stack.deploy);
+          expect((yield* getState("A"))?.status).toEqual("created");
+          expect((yield* getState("B"))?.status).toEqual("created");
 
-        // Try to replace A and delete B (by not including B) - both fail
-        const stack = Effect.gen(function* () {
-          yield* TestResource("A", { replaceString: "changed" });
-        });
+          // Try to replace A and delete B (by not including B) - both fail
+          const program = Effect.gen(function* () {
+            yield* TestResource("A", { replaceString: "changed" });
+          });
 
-        yield* stack.pipe(
-          test.deploy,
-          hook(
-            failOnMultiple([
-              { id: "A", hook: "create" },
-              { id: "B", hook: "delete" },
-            ]),
-          ),
-        );
+          yield* program.pipe(
+            stack.deploy,
+            hook(
+              failOnMultiple([
+                { id: "A", hook: "create" },
+                { id: "B", hook: "delete" },
+              ]),
+            ),
+          );
 
-        // effect terminates eagerly, so it's possible that A or B runs first and blocks the other from running
-        const AState = yield* getState<ReplacingResourceState>("A");
-        const BState = yield* getState("B");
-        expect(AState?.status).toBeOneOf(["created", "replacing"]);
-        expect(BState?.status).toBeOneOf(["created", "deleting"]);
-        // at least one of A or B should have started their failing operation
-        expect(
-          AState?.status === "replacing" || BState?.status === "deleting",
-        ).toBe(true);
+          // effect terminates eagerly, so it's possible that A or B runs first and blocks the other from running
+          const AState = yield* getState<ReplacingResourceState>("A");
+          const BState = yield* getState("B");
+          expect(AState?.status).toBeOneOf(["created", "replacing"]);
+          expect(BState?.status).toBeOneOf(["created", "deleting"]);
+          // at least one of A or B should have started their failing operation
+          expect(
+            AState?.status === "replacing" || BState?.status === "deleting",
+          ).toBe(true);
 
-        // Recovery - complete the replace and delete
-        yield* stack.pipe(test.deploy);
-        expect((yield* getState("A"))?.status).toEqual("created");
-        expect(yield* getState("B")).toBeUndefined();
-      }).pipe(Effect.provide(MockLayers())),
+          // Recovery - complete the replace and delete
+          yield* program.pipe(stack.deploy);
+          expect((yield* getState("A"))?.status).toEqual("created");
+          expect(yield* getState("B")).toBeUndefined();
+        }),
     );
   });
 });
@@ -3326,207 +3314,211 @@ describe("independent resources (A, B with no dependencies)", () => {
 // =============================================================================
 
 describe("multiple resources replacing", () => {
-  test(
-    "two independent resources replace successfully",
+  test.provider("two independent resources replace successfully", (stack) =>
     Effect.gen(function* () {
       yield* Effect.gen(function* () {
         yield* TestResource("A", { replaceString: "a-original" });
         yield* TestResource("B", { replaceString: "b-original" });
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
 
       const output = yield* Effect.gen(function* () {
         const A = yield* TestResource("A", { replaceString: "a-new" });
         const B = yield* TestResource("B", { replaceString: "b-new" });
         return { A, B };
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
 
       expect((yield* getState("A"))?.status).toEqual("created");
       expect((yield* getState("B"))?.status).toEqual("created");
       expect(output.A.replaceString).toEqual("a-new");
       expect(output.B.replaceString).toEqual("b-new");
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 
-  test(
+  test.provider(
     "A replace fails, B replace succeeds - recovery completes A",
-    Effect.gen(function* () {
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", { replaceString: "a-original" });
-        yield* TestResource("B", { replaceString: "b-original" });
-      }).pipe(test.deploy);
+    (stack) =>
+      Effect.gen(function* () {
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", { replaceString: "a-original" });
+          yield* TestResource("B", { replaceString: "b-original" });
+        }).pipe(stack.deploy);
 
-      const stack = Effect.gen(function* () {
-        const A = yield* TestResource("A", { replaceString: "a-new" });
-        const B = yield* TestResource("B", { replaceString: "b-new" });
-        return { A, B };
-      });
+        const program = Effect.gen(function* () {
+          const A = yield* TestResource("A", { replaceString: "a-new" });
+          const B = yield* TestResource("B", { replaceString: "b-new" });
+          return { A, B };
+        });
 
-      yield* stack.pipe(test.deploy, hook(failOn("A", "create")));
+        yield* program.pipe(stack.deploy, hook(failOn("A", "create")));
 
-      expect((yield* getState<ReplacingResourceState>("A"))?.status).toEqual(
-        "replacing",
-      );
-      // B might have been replaced
-      const bState = yield* getState("B");
-      expect(
-        bState?.status === "created" ||
-          bState?.status === "replacing" ||
-          bState?.status === "replaced",
-      ).toBe(true);
+        expect((yield* getState<ReplacingResourceState>("A"))?.status).toEqual(
+          "replacing",
+        );
+        // B might have been replaced
+        const bState = yield* getState("B");
+        expect(
+          bState?.status === "created" ||
+            bState?.status === "replacing" ||
+            bState?.status === "replaced",
+        ).toBe(true);
 
-      // Recovery
-      const output = yield* stack.pipe(test.deploy);
-      expect((yield* getState("A"))?.status).toEqual("created");
-      expect((yield* getState("B"))?.status).toEqual("created");
-      expect(output.A.replaceString).toEqual("a-new");
-      expect(output.B.replaceString).toEqual("b-new");
-    }).pipe(Effect.provide(MockLayers())),
+        // Recovery
+        const output = yield* program.pipe(stack.deploy);
+        expect((yield* getState("A"))?.status).toEqual("created");
+        expect((yield* getState("B"))?.status).toEqual("created");
+        expect(output.A.replaceString).toEqual("a-new");
+        expect(output.B.replaceString).toEqual("b-new");
+      }),
   );
 
-  test(
+  test.provider(
     "both A and B replace fail - recovery completes both",
-    Effect.gen(function* () {
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", { replaceString: "a-original" });
-        yield* TestResource("B", { replaceString: "b-original" });
-      }).pipe(test.deploy);
+    (stack) =>
+      Effect.gen(function* () {
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", { replaceString: "a-original" });
+          yield* TestResource("B", { replaceString: "b-original" });
+        }).pipe(stack.deploy);
 
-      const stack = Effect.gen(function* () {
-        const A = yield* TestResource("A", { replaceString: "a-new" });
-        const B = yield* TestResource("B", { replaceString: "b-new" });
-        return { A, B };
-      });
+        const program = Effect.gen(function* () {
+          const A = yield* TestResource("A", { replaceString: "a-new" });
+          const B = yield* TestResource("B", { replaceString: "b-new" });
+          return { A, B };
+        });
 
-      yield* stack.pipe(
-        test.deploy,
-        hook(
-          failOnMultiple([
-            { id: "A", hook: "create" },
-            { id: "B", hook: "create" },
-          ]),
-        ),
-      );
+        yield* program.pipe(
+          stack.deploy,
+          hook(
+            failOnMultiple([
+              { id: "A", hook: "create" },
+              { id: "B", hook: "create" },
+            ]),
+          ),
+        );
 
-      // effect terminates eagerly, so it's possible that A or B runs first and blocks the other from running
-      const AState = yield* getState<ReplacingResourceState>("A");
-      const BState = yield* getState<ReplacingResourceState>("B");
-      expect(AState?.status).toBeOneOf(["created", "replacing"]);
-      expect(BState?.status).toBeOneOf(["created", "replacing"]);
-      // at least one of A or B should have started replacing
-      expect(
-        AState?.status === "replacing" || BState?.status === "replacing",
-      ).toBe(true);
+        // effect terminates eagerly, so it's possible that A or B runs first and blocks the other from running
+        const AState = yield* getState<ReplacingResourceState>("A");
+        const BState = yield* getState<ReplacingResourceState>("B");
+        expect(AState?.status).toBeOneOf(["created", "replacing"]);
+        expect(BState?.status).toBeOneOf(["created", "replacing"]);
+        // at least one of A or B should have started replacing
+        expect(
+          AState?.status === "replacing" || BState?.status === "replacing",
+        ).toBe(true);
 
-      // Recovery
-      const output = yield* stack.pipe(test.deploy);
-      expect((yield* getState("A"))?.status).toEqual("created");
-      expect((yield* getState("B"))?.status).toEqual("created");
-      expect(output.A.replaceString).toEqual("a-new");
-      expect(output.B.replaceString).toEqual("b-new");
-    }).pipe(Effect.provide(MockLayers())),
+        // Recovery
+        const output = yield* program.pipe(stack.deploy);
+        expect((yield* getState("A"))?.status).toEqual("created");
+        expect((yield* getState("B"))?.status).toEqual("created");
+        expect(output.A.replaceString).toEqual("a-new");
+        expect(output.B.replaceString).toEqual("b-new");
+      }),
   );
 
-  test(
+  test.provider(
     "A replaced, B replacing - old A delete fails, B create fails - recovery completes both",
-    Effect.gen(function* () {
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", { replaceString: "a-original" });
-        yield* TestResource("B", { replaceString: "b-original" });
-      }).pipe(test.deploy);
+    (stack) =>
+      Effect.gen(function* () {
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", { replaceString: "a-original" });
+          yield* TestResource("B", { replaceString: "b-original" });
+        }).pipe(stack.deploy);
 
-      const stack = Effect.gen(function* () {
-        const A = yield* TestResource("A", { replaceString: "a-new" });
-        const B = yield* TestResource("B", { replaceString: "b-new" });
-        return { A, B };
-      });
+        const program = Effect.gen(function* () {
+          const A = yield* TestResource("A", { replaceString: "a-new" });
+          const B = yield* TestResource("B", { replaceString: "b-new" });
+          return { A, B };
+        });
 
-      yield* stack.pipe(
-        test.deploy,
-        hook(
-          failOnMultiple([
-            { id: "A", hook: "delete" },
-            { id: "B", hook: "create" },
-          ]),
-        ),
-      );
+        yield* program.pipe(
+          stack.deploy,
+          hook(
+            failOnMultiple([
+              { id: "A", hook: "delete" },
+              { id: "B", hook: "create" },
+            ]),
+          ),
+        );
 
-      // effect terminates eagerly, so it's possible that A or B runs first and blocks the other from running
-      // A should be replaced (new created, old pending delete) or still replacing/created if B failed first
-      // B should be replacing (new not yet created) or already created if A failed first
-      const AState = yield* getState<ReplacedResourceState>("A");
-      const BState = yield* getState<ReplacingResourceState>("B");
-      expect(AState?.status).toBeOneOf(["created", "replacing", "replaced"]);
-      expect(BState?.status).toBeOneOf(["created", "replacing"]);
-      // at least one of A or B should have started their failing operation
-      expect(
-        AState?.status === "replaced" || BState?.status === "replacing",
-      ).toBe(true);
+        // effect terminates eagerly, so it's possible that A or B runs first and blocks the other from running
+        // A should be replaced (new created, old pending delete) or still replacing/created if B failed first
+        // B should be replacing (new not yet created) or already created if A failed first
+        const AState = yield* getState<ReplacedResourceState>("A");
+        const BState = yield* getState<ReplacingResourceState>("B");
+        expect(AState?.status).toBeOneOf(["created", "replacing", "replaced"]);
+        expect(BState?.status).toBeOneOf(["created", "replacing"]);
+        // at least one of A or B should have started their failing operation
+        expect(
+          AState?.status === "replaced" || BState?.status === "replacing",
+        ).toBe(true);
 
-      // Recovery
-      const output = yield* stack.pipe(test.deploy);
-      expect((yield* getState("A"))?.status).toEqual("created");
-      expect((yield* getState("B"))?.status).toEqual("created");
-      expect(output.A.replaceString).toEqual("a-new");
-      expect(output.B.replaceString).toEqual("b-new");
-    }).pipe(Effect.provide(MockLayers())),
+        // Recovery
+        const output = yield* program.pipe(stack.deploy);
+        expect((yield* getState("A"))?.status).toEqual("created");
+        expect((yield* getState("B"))?.status).toEqual("created");
+        expect(output.A.replaceString).toEqual("a-new");
+        expect(output.B.replaceString).toEqual("b-new");
+      }),
   );
 });
 
 describe("repeated replacements", () => {
-  test(
+  test.provider(
     "resource can be replaced again while still in replacing state",
-    Effect.gen(function* () {
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", { replaceString: "a-original" });
-      }).pipe(test.deploy);
+    (stack) =>
+      Effect.gen(function* () {
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", { replaceString: "a-original" });
+        }).pipe(stack.deploy);
 
-      const firstReplacement = Effect.gen(function* () {
-        yield* TestResource("A", { replaceString: "a-first" });
-      });
+        const firstReplacement = Effect.gen(function* () {
+          yield* TestResource("A", { replaceString: "a-first" });
+        });
 
-      yield* firstReplacement.pipe(test.deploy, hook(failOn("A", "create")));
+        yield* firstReplacement.pipe(stack.deploy, hook(failOn("A", "create")));
 
-      const replacingState = yield* getState<ReplacingResourceState>("A");
-      expect(replacingState?.status).toEqual("replacing");
+        const replacingState = yield* getState<ReplacingResourceState>("A");
+        expect(replacingState?.status).toEqual("replacing");
 
-      const secondReplacement = Effect.gen(function* () {
-        yield* TestResource("A", { replaceString: "a-second" });
-      });
+        const secondReplacement = Effect.gen(function* () {
+          yield* TestResource("A", { replaceString: "a-second" });
+        });
 
-      yield* secondReplacement.pipe(test.deploy);
+        yield* secondReplacement.pipe(stack.deploy);
 
-      const finalState = yield* getState("A");
-      expectConvergedStatus(finalState?.status);
-      expect(finalState?.props?.replaceString).toEqual("a-second");
-    }).pipe(Effect.provide(MockLayers())),
+        const finalState = yield* getState("A");
+        expectConvergedStatus(finalState?.status);
+        expect(finalState?.props?.replaceString).toEqual("a-second");
+      }),
   );
 
-  test(
+  test.provider(
     "resource can be replaced again while still in replaced state",
-    Effect.gen(function* () {
-      yield* Effect.gen(function* () {
-        yield* TestResource("A", { replaceString: "a-original" });
-      }).pipe(test.deploy);
+    (stack) =>
+      Effect.gen(function* () {
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", { replaceString: "a-original" });
+        }).pipe(stack.deploy);
 
-      const firstReplacement = Effect.gen(function* () {
-        yield* TestResource("A", { replaceString: "a-first" });
-      });
+        const firstReplacement = Effect.gen(function* () {
+          yield* TestResource("A", { replaceString: "a-first" });
+        });
 
-      yield* firstReplacement.pipe(test.deploy, hook(failOn("A", "delete")));
+        yield* firstReplacement.pipe(stack.deploy, hook(failOn("A", "delete")));
 
-      const replacedState = yield* getState<ReplacedResourceState>("A");
-      expect(replacedState?.status).toEqual("replaced");
+        const replacedState = yield* getState<ReplacedResourceState>("A");
+        expect(replacedState?.status).toEqual("replaced");
 
-      const secondReplacement = Effect.gen(function* () {
-        yield* TestResource("A", { replaceString: "a-second" });
-      });
+        const secondReplacement = Effect.gen(function* () {
+          yield* TestResource("A", { replaceString: "a-second" });
+        });
 
-      yield* secondReplacement.pipe(test.deploy);
+        yield* secondReplacement.pipe(stack.deploy);
 
-      const finalState = yield* getState("A");
-      expectConvergedStatus(finalState?.status);
-      expect(finalState?.props?.replaceString).toEqual("a-second");
-    }).pipe(Effect.provide(MockLayers())),
+        const finalState = yield* getState("A");
+        expectConvergedStatus(finalState?.status);
+        expect(finalState?.props?.replaceString).toEqual("a-second");
+      }),
   );
 });
 
@@ -3535,14 +3527,13 @@ describe("repeated replacements", () => {
 // =============================================================================
 
 describe("orphan chain deletion", () => {
-  test(
-    "three-level orphan chain deleted in correct order",
+  test.provider("three-level orphan chain deleted in correct order", (stack) =>
     Effect.gen(function* () {
       yield* Effect.gen(function* () {
         const A = yield* TestResource("A", { string: "a-value" });
         const B = yield* TestResource("B", { string: A.string });
         yield* TestResource("C", { string: B.string });
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
       expect((yield* getState("A"))?.status).toEqual("created");
       expect((yield* getState("B"))?.status).toEqual("created");
       expect((yield* getState("C"))?.status).toEqual("created");
@@ -3551,44 +3542,44 @@ describe("orphan chain deletion", () => {
       yield* Effect.gen(function* () {
         const A = yield* TestResource("A", { string: "a-value" });
         yield* TestResource("B", { string: A.string });
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
       expect((yield* getState("A"))?.status).toEqual("created");
       expect((yield* getState("B"))?.status).toEqual("created");
       expect(yield* getState("C")).toBeUndefined();
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 
-  test(
+  test.provider(
     "orphan with intermediate failure recovers correctly",
-    Effect.gen(function* () {
-      yield* Effect.gen(function* () {
-        const A = yield* TestResource("A", { string: "a-value" });
-        const B = yield* TestResource("B", { string: A.string });
-        yield* TestResource("C", { string: B.string });
-      }).pipe(test.deploy);
+    (stack) =>
+      Effect.gen(function* () {
+        yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", { string: "a-value" });
+          const B = yield* TestResource("B", { string: A.string });
+          yield* TestResource("C", { string: B.string });
+        }).pipe(stack.deploy);
 
-      // Remove all three - C fails to delete
-      yield* destroy().pipe(hook(failOn("C", "delete")));
+        // Remove all three - C fails to delete
+        yield* stack.destroy().pipe(hook(failOn("C", "delete")));
 
-      expect((yield* getState("C"))?.status).toEqual("deleting");
-      expect((yield* getState("B"))?.status).toEqual("created");
-      expect((yield* getState("A"))?.status).toEqual("created");
+        expect((yield* getState("C"))?.status).toEqual("deleting");
+        expect((yield* getState("B"))?.status).toEqual("created");
+        expect((yield* getState("A"))?.status).toEqual("created");
 
-      // Recovery
-      yield* destroy();
-      expect(yield* getState("A")).toBeUndefined();
-      expect(yield* getState("B")).toBeUndefined();
-      expect(yield* getState("C")).toBeUndefined();
-    }).pipe(Effect.provide(MockLayers())),
+        // Recovery
+        yield* stack.destroy();
+        expect(yield* getState("A")).toBeUndefined();
+        expect(yield* getState("B")).toBeUndefined();
+        expect(yield* getState("C")).toBeUndefined();
+      }),
   );
 
-  test(
-    "partial orphan - remove leaf, add new dependent",
+  test.provider("partial orphan - remove leaf, add new dependent", (stack) =>
     Effect.gen(function* () {
       yield* Effect.gen(function* () {
         const A = yield* TestResource("A", { string: "a-value" });
         yield* TestResource("B", { string: A.string });
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
       expect((yield* getState("A"))?.status).toEqual("created");
       expect((yield* getState("B"))?.status).toEqual("created");
 
@@ -3597,12 +3588,12 @@ describe("orphan chain deletion", () => {
         const A = yield* TestResource("A", { string: "a-value" });
         const C = yield* TestResource("C", { string: A.string });
         return { A, C };
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
       expect((yield* getState("A"))?.status).toEqual("created");
       expect(yield* getState("B")).toBeUndefined();
       expect((yield* getState("C"))?.status).toEqual("created");
       expect(output.C.string).toEqual("a-value");
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 });
 
@@ -3611,8 +3602,7 @@ describe("orphan chain deletion", () => {
 // =============================================================================
 
 describe("complex mixed state scenarios", () => {
-  test(
-    "replace upstream while creating downstream",
+  test.provider("replace upstream while creating downstream", (stack) =>
     Effect.gen(function* () {
       // Create A
       yield* Effect.gen(function* () {
@@ -3620,7 +3610,7 @@ describe("complex mixed state scenarios", () => {
           string: "a-value",
           replaceString: "original",
         });
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
       expect((yield* getState("A"))?.status).toEqual("created");
 
       // Now add B dependent on A, and also replace A
@@ -3631,70 +3621,69 @@ describe("complex mixed state scenarios", () => {
         });
         const B = yield* TestResource("B", { string: A.string });
         return { A, B };
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
 
       expect((yield* getState("A"))?.status).toEqual("created");
       expect((yield* getState("B"))?.status).toEqual("created");
       expect(output.A.string).toEqual("a-value-new");
       expect(output.B.string).toEqual("a-value-new");
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 
-  test(
-    "update upstream, create and delete in same apply",
+  test.provider("update upstream, create and delete in same apply", (stack) =>
     Effect.gen(function* () {
       // Create A and B
       yield* Effect.gen(function* () {
         yield* TestResource("A", { string: "a-value" });
         yield* TestResource("B", { string: "b-value" });
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
 
       // Update A, delete B (by not including), create C
       const output = yield* Effect.gen(function* () {
         const A = yield* TestResource("A", { string: "a-updated" });
         const C = yield* TestResource("C", { string: A.string });
         return { A, C };
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
 
       expect((yield* getState("A"))?.status).toEqual("updated");
       expect(yield* getState("B")).toBeUndefined();
       expect((yield* getState("C"))?.status).toEqual("created");
       expect(output.C.string).toEqual("a-updated");
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 
-  test(
+  test.provider(
     "chain reaction: A replace triggers B update triggers C update",
-    Effect.gen(function* () {
-      yield* Effect.gen(function* () {
-        const A = yield* TestResource("A", {
-          string: "a-value",
-          replaceString: "original",
-        });
-        const B = yield* TestResource("B", { string: A.string });
-        yield* TestResource("C", { string: B.string });
-      }).pipe(test.deploy);
+    (stack) =>
+      Effect.gen(function* () {
+        yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", {
+            string: "a-value",
+            replaceString: "original",
+          });
+          const B = yield* TestResource("B", { string: A.string });
+          yield* TestResource("C", { string: B.string });
+        }).pipe(stack.deploy);
 
-      // Replace A - should cascade updates to B and C
-      const output = yield* Effect.gen(function* () {
-        const A = yield* TestResource("A", {
-          string: "a-replaced",
-          replaceString: "changed",
-        });
-        const B = yield* TestResource("B", { string: A.string });
-        const C = yield* TestResource("C", { string: B.string });
-        return { A, B, C };
-      }).pipe(test.deploy);
+        // Replace A - should cascade updates to B and C
+        const output = yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", {
+            string: "a-replaced",
+            replaceString: "changed",
+          });
+          const B = yield* TestResource("B", { string: A.string });
+          const C = yield* TestResource("C", { string: B.string });
+          return { A, B, C };
+        }).pipe(stack.deploy);
 
-      expect((yield* getState("A"))?.status).toEqual("created");
-      expect((yield* getState("B"))?.status).toEqual("updated");
-      expect((yield* getState("C"))?.status).toEqual("updated");
-      expect(output.C.string).toEqual("a-replaced");
-    }).pipe(Effect.provide(MockLayers())),
+        expect((yield* getState("A"))?.status).toEqual("created");
+        expect((yield* getState("B"))?.status).toEqual("updated");
+        expect((yield* getState("C"))?.status).toEqual("updated");
+        expect(output.C.string).toEqual("a-replaced");
+      }),
   );
 
-  test(
-    "multiple failures across all operation types",
+  test.provider("multiple failures across all operation types", (stack) =>
     Effect.gen(function* () {
       // Setup: A, B created; C, D will be added
       yield* Effect.gen(function* () {
@@ -3703,10 +3692,10 @@ describe("complex mixed state scenarios", () => {
           replaceString: "original",
         });
         yield* TestResource("B", { string: "b-value" });
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
 
       // Complex operation: A replace, B update, C create, D not included (nothing to delete)
-      const stack = Effect.gen(function* () {
+      const program = Effect.gen(function* () {
         const A = yield* TestResource("A", {
           string: "a-replaced",
           replaceString: "changed",
@@ -3717,8 +3706,8 @@ describe("complex mixed state scenarios", () => {
       });
 
       // Fail on A replace (create phase) and C create
-      yield* stack.pipe(
-        test.deploy,
+      yield* program.pipe(
+        stack.deploy,
         hook(
           failOnMultiple([
             { id: "A", hook: "create" },
@@ -3743,62 +3732,62 @@ describe("complex mixed state scenarios", () => {
       ).toBe(true);
 
       // Recovery
-      const output = yield* stack.pipe(test.deploy);
+      const output = yield* program.pipe(stack.deploy);
       expect((yield* getState("A"))?.status).toEqual("created");
       expect((yield* getState("B"))?.status).toEqual("updated");
       expect((yield* getState("C"))?.status).toEqual("created");
       expect(output.A.replaceString).toEqual("changed");
       expect(output.B.string).toEqual("b-updated");
       expect(output.C.string).toEqual("c-value");
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 });
 
 describe("artifacts", () => {
-  test(
-    "shares artifacts from plan diff into apply update",
+  test.provider("shares artifacts from plan diff into apply update", (stack) =>
     Effect.gen(function* () {
       yield* Effect.gen(function* () {
         yield* ArtifactProbe("A", { value: "v1" });
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
 
       const updated = yield* Effect.gen(function* () {
         const A = yield* ArtifactProbe("A", { value: "v2" });
         return { A };
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
 
       expect(updated.A.value).toEqual("v2");
       expect(updated.A.artifactValue).toEqual("v2");
       expect((yield* getState("A"))?.status).toEqual("updated");
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 
-  test(
+  test.provider(
     "isolates artifact bags by FQN for namespaced resources with the same leaf logical ID",
-    Effect.gen(function* () {
-      const Site = Construct.fn(function* (
-        _id: string,
-        props: { value: string },
-      ) {
-        return yield* ArtifactProbe("Shared", { value: props.value });
-      });
+    (stack) =>
+      Effect.gen(function* () {
+        const Site = Construct.fn(function* (
+          _id: string,
+          props: { value: string },
+        ) {
+          return yield* ArtifactProbe("Shared", { value: props.value });
+        });
 
-      yield* Effect.gen(function* () {
-        yield* Site("Left", { value: "left-v1" });
-        yield* Site("Right", { value: "right-v1" });
-      }).pipe(test.deploy);
+        yield* Effect.gen(function* () {
+          yield* Site("Left", { value: "left-v1" });
+          yield* Site("Right", { value: "right-v1" });
+        }).pipe(stack.deploy);
 
-      const updated = yield* Effect.gen(function* () {
-        const left = yield* Site("Left", { value: "left-v2" });
-        const right = yield* Site("Right", { value: "right-v2" });
-        return { left, right };
-      }).pipe(test.deploy);
+        const updated = yield* Effect.gen(function* () {
+          const left = yield* Site("Left", { value: "left-v2" });
+          const right = yield* Site("Right", { value: "right-v2" });
+          return { left, right };
+        }).pipe(stack.deploy);
 
-      expect(updated.left.artifactValue).toEqual("left-v2");
-      expect(updated.right.artifactValue).toEqual("right-v2");
-      expect((yield* getState("Left/Shared"))?.status).toEqual("updated");
-      expect((yield* getState("Right/Shared"))?.status).toEqual("updated");
-    }).pipe(Effect.provide(MockLayers())),
+        expect(updated.left.artifactValue).toEqual("left-v2");
+        expect(updated.right.artifactValue).toEqual("right-v2");
+        expect((yield* getState("Left/Shared"))?.status).toEqual("updated");
+        expect((yield* getState("Right/Shared"))?.status).toEqual("updated");
+      }),
   );
 });
 
@@ -3810,348 +3799,369 @@ describe("artifacts", () => {
 
 describe("static stable properties (provider.stables)", () => {
   describe("diff returns undefined with tag-only changes", () => {
-    test(
+    test.provider(
       "upstream has static stables, diff returns undefined, downstream depends on stableId",
-      Effect.gen(function* () {
-        // Stage 1: Create A with no tags, B depends on A.stableId
-        {
-          const output = yield* Effect.gen(function* () {
-            const A = yield* StaticStablesResource("A", { string: "value" });
-            const B = yield* TestResource("B", { string: A.stableId });
-            return { A, B };
-          }).pipe(test.deploy);
-          expect(output.A.stableId).toEqual("stable-A");
-          expect(output.B.string).toEqual("stable-A");
-          expect((yield* getState("A"))?.status).toEqual("created");
-          expect((yield* getState("B"))?.status).toEqual("created");
-        }
+      (stack) =>
+        Effect.gen(function* () {
+          // Stage 1: Create A with no tags, B depends on A.stableId
+          {
+            const output = yield* Effect.gen(function* () {
+              const A = yield* StaticStablesResource("A", { string: "value" });
+              const B = yield* TestResource("B", { string: A.stableId });
+              return { A, B };
+            }).pipe(stack.deploy);
+            expect(output.A.stableId).toEqual("stable-A");
+            expect(output.B.string).toEqual("stable-A");
+            expect((yield* getState("A"))?.status).toEqual("created");
+            expect((yield* getState("B"))?.status).toEqual("created");
+          }
 
-        // Stage 2: Add tags to A - diff returns undefined, but arePropsChanged is true
-        // B depends on A.stableId which should remain stable
-        {
-          const output = yield* Effect.gen(function* () {
-            const A = yield* StaticStablesResource("A", {
-              string: "value",
-              tags: { Name: "tagged-resource" },
-            });
-            const B = yield* TestResource("B", { string: A.stableId });
-            return { A, B };
-          }).pipe(test.deploy);
-          // A should be updated (tags changed)
-          expect(output.A.tags).toEqual({ Name: "tagged-resource" });
-          // B should NOT be updated because stableId didn't change
-          expect(output.B.string).toEqual("stable-A");
-          expect((yield* getState("A"))?.status).toEqual("updated");
-          // B should remain "created" (noop) since its input (stableId) didn't change
-          expect((yield* getState("B"))?.status).toEqual("created");
-        }
-      }).pipe(Effect.provide(MockLayers())),
+          // Stage 2: Add tags to A - diff returns undefined, but arePropsChanged is true
+          // B depends on A.stableId which should remain stable
+          {
+            const output = yield* Effect.gen(function* () {
+              const A = yield* StaticStablesResource("A", {
+                string: "value",
+                tags: { Name: "tagged-resource" },
+              });
+              const B = yield* TestResource("B", { string: A.stableId });
+              return { A, B };
+            }).pipe(stack.deploy);
+            // A should be updated (tags changed)
+            expect(output.A.tags).toEqual({ Name: "tagged-resource" });
+            // B should NOT be updated because stableId didn't change
+            expect(output.B.string).toEqual("stable-A");
+            expect((yield* getState("A"))?.status).toEqual("updated");
+            // B should remain "created" (noop) since its input (stableId) didn't change
+            expect((yield* getState("B"))?.status).toEqual("created");
+          }
+        }),
     );
 
-    test(
+    test.provider(
       "chain: A -> B -> C where B depends on A.stableId and C depends on B.stableString",
-      Effect.gen(function* () {
-        // Stage 1: Create chain
-        {
-          const output = yield* Effect.gen(function* () {
-            const A = yield* StaticStablesResource("A", { string: "initial" });
-            const B = yield* TestResource("B", { string: A.stableId });
-            const C = yield* TestResource("C", { string: B.stableString });
-            return { A, B, C };
-          }).pipe(test.deploy);
-          expect(output.A.stableId).toEqual("stable-A");
-          expect(output.B.string).toEqual("stable-A");
-          expect(output.C.string).toEqual("B");
-        }
+      (stack) =>
+        Effect.gen(function* () {
+          // Stage 1: Create chain
+          {
+            const output = yield* Effect.gen(function* () {
+              const A = yield* StaticStablesResource("A", {
+                string: "initial",
+              });
+              const B = yield* TestResource("B", { string: A.stableId });
+              const C = yield* TestResource("C", { string: B.stableString });
+              return { A, B, C };
+            }).pipe(stack.deploy);
+            expect(output.A.stableId).toEqual("stable-A");
+            expect(output.B.string).toEqual("stable-A");
+            expect(output.C.string).toEqual("B");
+          }
 
-        // Stage 2: Change A's tags only - diff returns undefined
-        // Neither B nor C should update since their inputs are stable
-        {
-          const output = yield* Effect.gen(function* () {
-            const A = yield* StaticStablesResource("A", {
-              string: "initial",
-              tags: { Env: "production" },
-            });
-            const B = yield* TestResource("B", { string: A.stableId });
-            const C = yield* TestResource("C", { string: B.stableString });
-            return { A, B, C };
-          }).pipe(test.deploy);
-          expect(output.A.tags).toEqual({ Env: "production" });
-          expect((yield* getState("A"))?.status).toEqual("updated");
-          // B and C should not change
-          expect((yield* getState("B"))?.status).toEqual("created");
-          expect((yield* getState("C"))?.status).toEqual("created");
-        }
-      }).pipe(Effect.provide(MockLayers())),
+          // Stage 2: Change A's tags only - diff returns undefined
+          // Neither B nor C should update since their inputs are stable
+          {
+            const output = yield* Effect.gen(function* () {
+              const A = yield* StaticStablesResource("A", {
+                string: "initial",
+                tags: { Env: "production" },
+              });
+              const B = yield* TestResource("B", { string: A.stableId });
+              const C = yield* TestResource("C", { string: B.stableString });
+              return { A, B, C };
+            }).pipe(stack.deploy);
+            expect(output.A.tags).toEqual({ Env: "production" });
+            expect((yield* getState("A"))?.status).toEqual("updated");
+            // B and C should not change
+            expect((yield* getState("B"))?.status).toEqual("created");
+            expect((yield* getState("C"))?.status).toEqual("created");
+          }
+        }),
     );
 
-    test(
+    test.provider(
       "diamond: A -> B,C -> D where all depend on stable properties",
-      Effect.gen(function* () {
-        // Stage 1: Create diamond
-        {
-          const output = yield* Effect.gen(function* () {
-            const A = yield* StaticStablesResource("A", { string: "initial" });
-            const B = yield* TestResource("B", { string: A.stableId });
-            const C = yield* TestResource("C", { string: A.stableArn });
-            const D = yield* TestResource("D", {
-              string: Output.interpolate`${B.stableString}-${C.stableString}`,
-            });
-            return { A, B, C, D };
-          }).pipe(test.deploy);
-          expect(output.A.stableId).toEqual("stable-A");
-          expect(output.A.stableArn).toEqual(
-            "arn:test:resource:us-east-1:123456789:A",
-          );
-          expect(output.B.string).toEqual("stable-A");
-          expect(output.C.string).toEqual(
-            "arn:test:resource:us-east-1:123456789:A",
-          );
-          expect(output.D.string).toEqual("B-C");
-        }
+      (stack) =>
+        Effect.gen(function* () {
+          // Stage 1: Create diamond
+          {
+            const output = yield* Effect.gen(function* () {
+              const A = yield* StaticStablesResource("A", {
+                string: "initial",
+              });
+              const B = yield* TestResource("B", { string: A.stableId });
+              const C = yield* TestResource("C", { string: A.stableArn });
+              const D = yield* TestResource("D", {
+                string: Output.interpolate`${B.stableString}-${C.stableString}`,
+              });
+              return { A, B, C, D };
+            }).pipe(stack.deploy);
+            expect(output.A.stableId).toEqual("stable-A");
+            expect(output.A.stableArn).toEqual(
+              "arn:test:resource:us-east-1:123456789:A",
+            );
+            expect(output.B.string).toEqual("stable-A");
+            expect(output.C.string).toEqual(
+              "arn:test:resource:us-east-1:123456789:A",
+            );
+            expect(output.D.string).toEqual("B-C");
+          }
 
-        // Stage 2: Change A's tags - should not affect B, C, or D
-        {
-          yield* Effect.gen(function* () {
-            const A = yield* StaticStablesResource("A", {
-              string: "initial",
-              tags: { Team: "platform" },
-            });
-            const B = yield* TestResource("B", { string: A.stableId });
-            const C = yield* TestResource("C", { string: A.stableArn });
-            yield* TestResource("D", {
-              string: Output.interpolate`${B.stableString}-${C.stableString}`,
-            });
-          }).pipe(test.deploy);
-          expect((yield* getState("A"))?.status).toEqual("updated");
-          expect((yield* getState("B"))?.status).toEqual("created");
-          expect((yield* getState("C"))?.status).toEqual("created");
-          expect((yield* getState("D"))?.status).toEqual("created");
-        }
-      }).pipe(Effect.provide(MockLayers())),
+          // Stage 2: Change A's tags - should not affect B, C, or D
+          {
+            yield* Effect.gen(function* () {
+              const A = yield* StaticStablesResource("A", {
+                string: "initial",
+                tags: { Team: "platform" },
+              });
+              const B = yield* TestResource("B", { string: A.stableId });
+              const C = yield* TestResource("C", { string: A.stableArn });
+              yield* TestResource("D", {
+                string: Output.interpolate`${B.stableString}-${C.stableString}`,
+              });
+            }).pipe(stack.deploy);
+            expect((yield* getState("A"))?.status).toEqual("updated");
+            expect((yield* getState("B"))?.status).toEqual("created");
+            expect((yield* getState("C"))?.status).toEqual("created");
+            expect((yield* getState("D"))?.status).toEqual("created");
+          }
+        }),
     );
   });
 
   describe("diff returns update action with static stables", () => {
-    test(
+    test.provider(
       "upstream has static stables and diff returns update, downstream depends on stableId",
-      Effect.gen(function* () {
-        // Stage 1: Create A and B
-        {
-          const output = yield* Effect.gen(function* () {
-            const A = yield* StaticStablesResource("A", { string: "value-1" });
-            const B = yield* TestResource("B", { string: A.stableId });
-            return { A, B };
-          }).pipe(test.deploy);
-          expect(output.A.stableId).toEqual("stable-A");
-          expect(output.B.string).toEqual("stable-A");
-        }
+      (stack) =>
+        Effect.gen(function* () {
+          // Stage 1: Create A and B
+          {
+            const output = yield* Effect.gen(function* () {
+              const A = yield* StaticStablesResource("A", {
+                string: "value-1",
+              });
+              const B = yield* TestResource("B", { string: A.stableId });
+              return { A, B };
+            }).pipe(stack.deploy);
+            expect(output.A.stableId).toEqual("stable-A");
+            expect(output.B.string).toEqual("stable-A");
+          }
 
-        // Stage 2: Change A's string - diff returns "update", stableId still stable
-        {
-          const output = yield* Effect.gen(function* () {
-            const A = yield* StaticStablesResource("A", { string: "value-2" });
-            const B = yield* TestResource("B", { string: A.stableId });
-            return { A, B };
-          }).pipe(test.deploy);
-          expect(output.A.string).toEqual("value-2");
-          expect(output.A.stableId).toEqual("stable-A");
-          expect((yield* getState("A"))?.status).toEqual("updated");
-          // B should not change since stableId is stable
-          expect((yield* getState("B"))?.status).toEqual("created");
-        }
-      }).pipe(Effect.provide(MockLayers())),
+          // Stage 2: Change A's string - diff returns "update", stableId still stable
+          {
+            const output = yield* Effect.gen(function* () {
+              const A = yield* StaticStablesResource("A", {
+                string: "value-2",
+              });
+              const B = yield* TestResource("B", { string: A.stableId });
+              return { A, B };
+            }).pipe(stack.deploy);
+            expect(output.A.string).toEqual("value-2");
+            expect(output.A.stableId).toEqual("stable-A");
+            expect((yield* getState("A"))?.status).toEqual("updated");
+            // B should not change since stableId is stable
+            expect((yield* getState("B"))?.status).toEqual("created");
+          }
+        }),
     );
 
-    test(
+    test.provider(
       "downstream depends on non-stable property, should update",
-      Effect.gen(function* () {
-        // Stage 1: Create A and B where B depends on A.string (non-stable)
-        {
-          const output = yield* Effect.gen(function* () {
-            const A = yield* StaticStablesResource("A", { string: "value-1" });
-            const B = yield* TestResource("B", { string: A.string });
-            return { A, B };
-          }).pipe(test.deploy);
-          expect(output.A.string).toEqual("value-1");
-          expect(output.B.string).toEqual("value-1");
-        }
+      (stack) =>
+        Effect.gen(function* () {
+          // Stage 1: Create A and B where B depends on A.string (non-stable)
+          {
+            const output = yield* Effect.gen(function* () {
+              const A = yield* StaticStablesResource("A", {
+                string: "value-1",
+              });
+              const B = yield* TestResource("B", { string: A.string });
+              return { A, B };
+            }).pipe(stack.deploy);
+            expect(output.A.string).toEqual("value-1");
+            expect(output.B.string).toEqual("value-1");
+          }
 
-        // Stage 2: Change A's string - B should update
-        {
-          const output = yield* Effect.gen(function* () {
-            const A = yield* StaticStablesResource("A", { string: "value-2" });
-            const B = yield* TestResource("B", { string: A.string });
-            return { A, B };
-          }).pipe(test.deploy);
-          expect(output.A.string).toEqual("value-2");
-          expect(output.B.string).toEqual("value-2");
-          expect((yield* getState("A"))?.status).toEqual("updated");
-          expect((yield* getState("B"))?.status).toEqual("updated");
-        }
-      }).pipe(Effect.provide(MockLayers())),
+          // Stage 2: Change A's string - B should update
+          {
+            const output = yield* Effect.gen(function* () {
+              const A = yield* StaticStablesResource("A", {
+                string: "value-2",
+              });
+              const B = yield* TestResource("B", { string: A.string });
+              return { A, B };
+            }).pipe(stack.deploy);
+            expect(output.A.string).toEqual("value-2");
+            expect(output.B.string).toEqual("value-2");
+            expect((yield* getState("A"))?.status).toEqual("updated");
+            expect((yield* getState("B"))?.status).toEqual("updated");
+          }
+        }),
     );
   });
 
   describe("replace action with static stables", () => {
-    test(
+    test.provider(
       "upstream replaces, downstream depends on stableId - should update with new value",
-      Effect.gen(function* () {
-        // Stage 1: Create A and B
-        {
-          const output = yield* Effect.gen(function* () {
-            const A = yield* StaticStablesResource("A", {
-              string: "value",
-              replaceString: "original",
-            });
-            const B = yield* TestResource("B", { string: A.stableId });
-            return { A, B };
-          }).pipe(test.deploy);
-          expect(output.A.stableId).toEqual("stable-A");
-          expect(output.B.string).toEqual("stable-A");
-        }
+      (stack) =>
+        Effect.gen(function* () {
+          // Stage 1: Create A and B
+          {
+            const output = yield* Effect.gen(function* () {
+              const A = yield* StaticStablesResource("A", {
+                string: "value",
+                replaceString: "original",
+              });
+              const B = yield* TestResource("B", { string: A.stableId });
+              return { A, B };
+            }).pipe(stack.deploy);
+            expect(output.A.stableId).toEqual("stable-A");
+            expect(output.B.string).toEqual("stable-A");
+          }
 
-        // Stage 2: Replace A - stableId will change (new resource)
-        {
-          const output = yield* Effect.gen(function* () {
-            const A = yield* StaticStablesResource("A", {
-              string: "value",
-              replaceString: "changed",
-            });
-            const B = yield* TestResource("B", { string: A.stableId });
-            return { A, B };
-          }).pipe(test.deploy);
-          // A was replaced, stableId is regenerated
-          expect(output.A.stableId).toEqual("stable-A");
-          expect(output.B.string).toEqual("stable-A");
-          expect((yield* getState("A"))?.status).toEqual("created");
-          expect((yield* getState("B"))?.status).toEqual("updated");
-        }
-      }).pipe(Effect.provide(MockLayers())),
+          // Stage 2: Replace A - stableId will change (new resource)
+          {
+            const output = yield* Effect.gen(function* () {
+              const A = yield* StaticStablesResource("A", {
+                string: "value",
+                replaceString: "changed",
+              });
+              const B = yield* TestResource("B", { string: A.stableId });
+              return { A, B };
+            }).pipe(stack.deploy);
+            // A was replaced, stableId is regenerated
+            expect(output.A.stableId).toEqual("stable-A");
+            expect(output.B.string).toEqual("stable-A");
+            expect((yield* getState("A"))?.status).toEqual("created");
+            expect((yield* getState("B"))?.status).toEqual("updated");
+          }
+        }),
     );
   });
 });
 
 describe("Redacted props/outputs survive deploy", () => {
-  test(
+  test.provider(
     "preserves a Redacted prop end-to-end through create",
-    Effect.gen(function* () {
-      const secret = Redacted.make("hunter2");
-      const created = yield* Effect.gen(function* () {
-        return yield* TestResource("A", {
-          string: "x",
-          redacted: secret,
-        });
-      }).pipe(test.deploy);
+    (stack) =>
+      Effect.gen(function* () {
+        const secret = Redacted.make("hunter2");
+        const created = yield* Effect.gen(function* () {
+          return yield* TestResource("A", {
+            string: "x",
+            redacted: secret,
+          });
+        }).pipe(stack.deploy);
 
-      expect(Redacted.isRedacted(created.redacted)).toBe(true);
-      expect(Redacted.value(created.redacted!)).toBe("hunter2");
+        expect(Redacted.isRedacted(created.redacted)).toBe(true);
+        expect(Redacted.value(created.redacted!)).toBe("hunter2");
 
-      const state = yield* getState("A");
-      expect(state).toBeDefined();
-      expect(Redacted.isRedacted((state!.props as any).redacted)).toBe(true);
-      expect(Redacted.value((state!.props as any).redacted)).toBe("hunter2");
-      expect(Redacted.isRedacted((state!.attr as any).redacted)).toBe(true);
-      expect(Redacted.value((state!.attr as any).redacted)).toBe("hunter2");
-    }).pipe(Effect.provide(MockLayers())),
+        const state = yield* getState("A");
+        expect(state).toBeDefined();
+        expect(Redacted.isRedacted((state!.props as any).redacted)).toBe(true);
+        expect(Redacted.value((state!.props as any).redacted)).toBe("hunter2");
+        expect(Redacted.isRedacted((state!.attr as any).redacted)).toBe(true);
+        expect(Redacted.value((state!.attr as any).redacted)).toBe("hunter2");
+      }),
   );
 
-  test(
+  test.provider(
     "preserves Redacted values nested inside an array end-to-end",
-    Effect.gen(function* () {
-      const created = yield* Effect.gen(function* () {
-        return yield* TestResource("A", {
-          string: "x",
-          redactedArray: [Redacted.make("a"), Redacted.make("b")],
-        });
-      }).pipe(test.deploy);
+    (stack) =>
+      Effect.gen(function* () {
+        const created = yield* Effect.gen(function* () {
+          return yield* TestResource("A", {
+            string: "x",
+            redactedArray: [Redacted.make("a"), Redacted.make("b")],
+          });
+        }).pipe(stack.deploy);
 
-      expect(created.redactedArray).toBeDefined();
-      expect(created.redactedArray!.length).toBe(2);
-      expect(Redacted.isRedacted(created.redactedArray![0]!)).toBe(true);
-      expect(Redacted.value(created.redactedArray![0]!)).toBe("a");
-      expect(Redacted.isRedacted(created.redactedArray![1]!)).toBe(true);
-      expect(Redacted.value(created.redactedArray![1]!)).toBe("b");
-    }).pipe(Effect.provide(MockLayers())),
+        expect(created.redactedArray).toBeDefined();
+        expect(created.redactedArray!.length).toBe(2);
+        expect(Redacted.isRedacted(created.redactedArray![0]!)).toBe(true);
+        expect(Redacted.value(created.redactedArray![0]!)).toBe("a");
+        expect(Redacted.isRedacted(created.redactedArray![1]!)).toBe(true);
+        expect(Redacted.value(created.redactedArray![1]!)).toBe("b");
+      }),
   );
 
-  test(
+  test.provider(
     "preserves a Redacted output flowing into a downstream resource prop",
-    Effect.gen(function* () {
-      const output = yield* Effect.gen(function* () {
-        const A = yield* TestResource("A", {
-          string: "x",
-          redacted: Redacted.make("hunter2"),
-        });
-        const B = yield* TestResource("B", {
-          string: "y",
-          redacted: A.redacted as any,
-        });
-        return { A, B };
-      }).pipe(test.deploy);
+    (stack) =>
+      Effect.gen(function* () {
+        const output = yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", {
+            string: "x",
+            redacted: Redacted.make("hunter2"),
+          });
+          const B = yield* TestResource("B", {
+            string: "y",
+            redacted: A.redacted as any,
+          });
+          return { A, B };
+        }).pipe(stack.deploy);
 
-      expect(Redacted.isRedacted(output.B.redacted)).toBe(true);
-      expect(Redacted.value(output.B.redacted!)).toBe("hunter2");
+        expect(Redacted.isRedacted(output.B.redacted)).toBe(true);
+        expect(Redacted.value(output.B.redacted!)).toBe("hunter2");
 
-      const bState = yield* getState("B");
-      expect(Redacted.isRedacted((bState!.props as any).redacted)).toBe(true);
-      expect(Redacted.value((bState!.props as any).redacted)).toBe("hunter2");
-      expect(Redacted.isRedacted((bState!.attr as any).redacted)).toBe(true);
-      expect(Redacted.value((bState!.attr as any).redacted)).toBe("hunter2");
-    }).pipe(Effect.provide(MockLayers())),
+        const bState = yield* getState("B");
+        expect(Redacted.isRedacted((bState!.props as any).redacted)).toBe(true);
+        expect(Redacted.value((bState!.props as any).redacted)).toBe("hunter2");
+        expect(Redacted.isRedacted((bState!.attr as any).redacted)).toBe(true);
+        expect(Redacted.value((bState!.attr as any).redacted)).toBe("hunter2");
+      }),
   );
 
-  test(
+  test.provider(
     "no-op redeploy when only Redacted prop is present and value unchanged",
-    Effect.gen(function* () {
-      const first = yield* Effect.gen(function* () {
-        return yield* TestResource("A", {
-          string: "x",
-          redacted: Redacted.make("hunter2"),
-        });
-      }).pipe(test.deploy);
-      expect(Redacted.value(first.redacted!)).toBe("hunter2");
+    (stack) =>
+      Effect.gen(function* () {
+        const first = yield* Effect.gen(function* () {
+          return yield* TestResource("A", {
+            string: "x",
+            redacted: Redacted.make("hunter2"),
+          });
+        }).pipe(stack.deploy);
+        expect(Redacted.value(first.redacted!)).toBe("hunter2");
 
-      const before = yield* getState("A");
+        const before = yield* getState("A");
 
-      yield* Effect.gen(function* () {
-        return yield* TestResource("A", {
-          string: "x",
-          redacted: Redacted.make("hunter2"),
-        });
-      }).pipe(test.deploy);
+        yield* Effect.gen(function* () {
+          return yield* TestResource("A", {
+            string: "x",
+            redacted: Redacted.make("hunter2"),
+          });
+        }).pipe(stack.deploy);
 
-      const after = yield* getState("A");
-      expect(after?.status).toBe("created");
-      expect((before as any).updatedAt ?? null).toEqual(
-        (after as any).updatedAt ?? null,
-      );
-      expect(Redacted.value((after!.attr as any).redacted)).toBe("hunter2");
-    }).pipe(Effect.provide(MockLayers())),
+        const after = yield* getState("A");
+        expect(after?.status).toBe("created");
+        expect((before as any).updatedAt ?? null).toEqual(
+          (after as any).updatedAt ?? null,
+        );
+        expect(Redacted.value((after!.attr as any).redacted)).toBe("hunter2");
+      }),
   );
 
-  test(
-    "update redeploy when Redacted prop value changes",
+  test.provider("update redeploy when Redacted prop value changes", (stack) =>
     Effect.gen(function* () {
       yield* Effect.gen(function* () {
         return yield* TestResource("A", {
           string: "x",
           redacted: Redacted.make("old"),
         });
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
 
       const updated = yield* Effect.gen(function* () {
         return yield* TestResource("A", {
           string: "x",
           redacted: Redacted.make("new"),
         });
-      }).pipe(test.deploy);
+      }).pipe(stack.deploy);
 
       expect(Redacted.isRedacted(updated.redacted)).toBe(true);
       expect(Redacted.value(updated.redacted!)).toBe("new");
       const state = yield* getState("A");
       expect(state?.status).toBe("updated");
       expect(Redacted.value((state!.attr as any).redacted)).toBe("new");
-    }).pipe(Effect.provide(MockLayers())),
+    }),
   );
 });

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -7,20 +7,18 @@ import * as Stack from "@/Stack";
 import { Stage } from "@/Stage";
 import {
   inMemoryState,
+  InMemoryService,
   State,
   type ResourceState,
   type ResourceStatus,
 } from "@/State";
-import {
-  test as baseTest,
-  expectEmptyObject,
-  expectPropExpr,
-} from "@/Test/Vitest";
+import * as Test from "@/Test/Vitest";
 import { describe, expect } from "@effect/vitest";
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import {
   ArtifactProbe,
@@ -34,52 +32,59 @@ import {
   type TestResourceProps,
 } from "./test.resources";
 
-const test = Object.assign(
-  ((name: string, ...args: any[]) => {
-    if (args.length === 1) {
-      return (baseTest as any)(
-        name,
-        {
-          providers: false,
-        },
-        args[0],
-      );
-    }
+const TEST_STACK = "test";
+const TEST_STAGE = "test";
 
-    const [options, effect] = args;
-    return (baseTest as any)(
-      name,
-      {
-        ...options,
-        providers: false,
-      },
-      effect,
-    );
-  }) as typeof baseTest,
-  baseTest,
+// Fresh in-memory state per test run so seeded resources from one test
+// don't leak into another in the same file.
+const freshState = Layer.effect(
+  State,
+  Effect.sync(() => InMemoryService({})),
 );
 
-const _test = test;
+const { test } = Test.make({
+  providers: TestLayers(),
+  state: freshState,
+});
+
+// Resolve stack name/stage from ambient Stack if present (for test.provider)
+// otherwise fall back to the file-level defaults (for plain test()).
+const resolveStackId = Effect.gen(function* () {
+  const ambient = yield* Effect.serviceOption(Stack.Stack);
+  return Option.match(ambient, {
+    onNone: () => ({ name: TEST_STACK, stage: TEST_STAGE }),
+    onSome: (s) => ({ name: s.name, stage: s.stage }),
+  });
+});
+
+const seed = (resources: Record<string, ResourceState>) =>
+  Effect.gen(function* () {
+    const { name, stage } = yield* resolveStackId;
+    const state = yield* State;
+    for (const [fqn, value] of Object.entries(resources)) {
+      yield* state.set({ stack: name, stage, fqn, value });
+    }
+  });
 
 const instanceId = "852f6ec2e19b66589825efe14dca2971";
 
 const makePlan = <A, Err = never, Req = never>(
   effect: Effect.Effect<A, Err, Req>,
   options?: Plan.MakePlanOptions,
-): Effect.Effect<Plan.Plan<A>, Err, never> =>
-  // @ts-expect-error
+): Effect.Effect<Plan.Plan<A>, Err, State> =>
+  // @ts-expect-error - Stack.make's typing erases R unsoundly here
   Effect.gen(function* () {
-    const stack = yield* Stack.Stack;
+    const { name, stage } = yield* resolveStackId;
     // @ts-expect-error
     return yield* effect.pipe(
       // @ts-expect-error
       Stack.make({
-        name: stack.name,
+        name,
         providers: Layer.empty,
         state: inMemoryState(),
       }),
-      Effect.provideService(Stage, stack.stage),
-      Effect.flatMap((stackSpec) => Plan.make(stackSpec, options)),
+      Effect.provideService(Stage, stage),
+      Effect.flatMap((stackSpec: any) => Plan.make(stackSpec, options)),
       Effect.provide(TestLayers()),
     );
   });
@@ -88,20 +93,20 @@ const makePlanWithCustomStack =
   (stackSpec: any) =>
   <A, Err = never, Req = never>(
     effect: Effect.Effect<A, Err, Req>,
-  ): Effect.Effect<Plan.Plan<A>, Err, never> =>
+  ): Effect.Effect<Plan.Plan<A>, Err, State> =>
     // @ts-expect-error
     Effect.gen(function* () {
-      const stack = yield* Stack.Stack;
+      const { name, stage } = yield* resolveStackId;
       // @ts-expect-error
       return yield* effect.pipe(
         // @ts-expect-error
         Stack.make({
-          name: stack.name,
+          name,
           providers: Layer.empty,
           state: inMemoryState(),
           stack: stackSpec,
         }),
-        Effect.provideService(Stage, stack.stage),
+        Effect.provideService(Stage, stage),
         Effect.flatMap(Plan.make),
         Effect.provide(TestLayers()),
       );
@@ -109,8 +114,8 @@ const makePlanWithCustomStack =
 
 test(
   "artifacts are isolated by FQN during plan diff for namespaced resources",
-  {
-    state: test.state({
+  Effect.gen(function* () {
+    yield* seed({
       "Left/Shared": {
         instanceId: "left-instance",
         providerVersion: 0,
@@ -147,9 +152,7 @@ test(
         bindings: [],
         downstream: [],
       },
-    }),
-  },
-  Effect.gen(function* () {
+    });
     const Site = Construct.fn(function* (
       _id: string,
       props: { value: string },
@@ -170,9 +173,6 @@ test(
 
 test(
   "create all resources when plan is empty",
-  {
-    state: test.state(),
-  },
   Effect.gen(function* () {
     expect(
       yield* Effect.gen(function* () {
@@ -207,15 +207,18 @@ test(
           state: undefined,
         },
       },
-      deletions: expectEmptyObject(),
+      deletions: expect.toSatisfy(
+        (d: any) => Object.keys(d).length === 0,
+        "empty object",
+      ),
     });
   }),
 );
 
 test(
   "update the changed resources and no-op un-changed resources",
-  {
-    state: test.state({
+  Effect.gen(function* () {
+    yield* seed({
       MyBucket: {
         instanceId,
         providerVersion: 0,
@@ -233,9 +236,7 @@ test(
         bindings: [],
         downstream: [],
       },
-    }),
-  },
-  Effect.gen(function* () {
+    });
     expect(
       yield* makePlan(
         Effect.gen(function* () {
@@ -265,15 +266,18 @@ test(
           state: undefined,
         },
       },
-      deletions: expectEmptyObject(),
+      deletions: expect.toSatisfy(
+        (d: any) => Object.keys(d).length === 0,
+        "empty object",
+      ),
     });
   }),
 );
 
 test(
   "force changes noop resources into updates",
-  {
-    state: test.state({
+  Effect.gen(function* () {
+    yield* seed({
       MyBucket: {
         instanceId,
         providerVersion: 0,
@@ -291,9 +295,7 @@ test(
         bindings: [],
         downstream: [],
       },
-    }),
-  },
-  Effect.gen(function* () {
+    });
     expect(
       yield* makePlan(
         Effect.gen(function* () {
@@ -316,15 +318,18 @@ test(
           },
         },
       },
-      deletions: expectEmptyObject(),
+      deletions: expect.toSatisfy(
+        (d: any) => Object.keys(d).length === 0,
+        "empty object",
+      ),
     });
   }),
 );
 
 test(
   "no-op resources with undefined props",
-  {
-    state: test.state({
+  Effect.gen(function* () {
+    yield* seed({
       MyQueue: {
         instanceId,
         providerVersion: 0,
@@ -341,9 +346,7 @@ test(
         bindings: [],
         downstream: [],
       },
-    }),
-  },
-  Effect.gen(function* () {
+    });
     expect(
       yield* makePlan(
         Effect.gen(function* () {
@@ -360,15 +363,18 @@ test(
           },
         },
       },
-      deletions: expectEmptyObject(),
+      deletions: expect.toSatisfy(
+        (d: any) => Object.keys(d).length === 0,
+        "empty object",
+      ),
     });
   }),
 );
 
 test(
   "no-op resources when object prop key order changes",
-  {
-    state: test.state({
+  Effect.gen(function* () {
+    yield* seed({
       MyFunction: {
         instanceId,
         providerVersion: 0,
@@ -395,9 +401,7 @@ test(
         bindings: [],
         downstream: [],
       },
-    }),
-  },
-  Effect.gen(function* () {
+    });
     expect(
       yield* makePlan(
         Effect.gen(function* () {
@@ -420,15 +424,18 @@ test(
           },
         },
       },
-      deletions: expectEmptyObject(),
+      deletions: expect.toSatisfy(
+        (d: any) => Object.keys(d).length === 0,
+        "empty object",
+      ),
     });
   }),
 );
 
 test(
   "delete orphaned resources",
-  {
-    state: test.state({
+  Effect.gen(function* () {
+    yield* seed({
       MyBucket: {
         instanceId,
         providerVersion: 0,
@@ -463,9 +470,7 @@ test(
         bindings: [],
         downstream: [],
       },
-    }),
-  },
-  Effect.gen(function* () {
+    });
     expect(
       yield* makePlan(
         Effect.gen(function* () {
@@ -509,8 +514,8 @@ test(
 
 test(
   "allow deleting a resource after a surviving consumer removes the dependency",
-  {
-    state: test.state({
+  Effect.gen(function* () {
+    yield* seed({
       Secret: {
         instanceId,
         providerVersion: 0,
@@ -556,9 +561,7 @@ test(
         bindings: [],
         downstream: [],
       },
-    }),
-  },
-  Effect.gen(function* () {
+    });
     expect(
       yield* makePlan(
         Effect.gen(function* () {
@@ -592,8 +595,8 @@ test(
 
 test(
   "reject deleting a resource when a surviving consumer still references it",
-  {
-    state: test.state({
+  Effect.gen(function* () {
+    yield* seed({
       Secret: {
         instanceId,
         providerVersion: 0,
@@ -639,13 +642,10 @@ test(
         bindings: [],
         downstream: [],
       },
-    }),
-  },
-  Effect.gen(function* () {
-    const currentStack = yield* Stack.Stack;
+    });
     const malformedStack = {
-      name: currentStack.name,
-      stage: currentStack.stage,
+      name: TEST_STACK,
+      stage: TEST_STAGE,
       resources: {},
       bindings: {},
       output: undefined,
@@ -683,7 +683,7 @@ test(
 );
 
 describe("replace resource when replaceString changes", () => {
-  const state = test.state({
+  const stateResources: Record<string, ResourceState> = {
     A: {
       instanceId,
       providerVersion: 0,
@@ -699,12 +699,12 @@ describe("replace resource when replaceString changes", () => {
       downstream: [],
       bindings: [],
     },
-  });
+  };
 
   test(
     "noop and replace when replaceString is fully resolved at plan time",
-    { state },
     Effect.gen(function* () {
+      yield* seed(stateResources);
       expect(
         yield* Effect.gen(function* () {
           yield* TestResource("A", {
@@ -717,7 +717,10 @@ describe("replace resource when replaceString changes", () => {
             action: "noop",
           },
         },
-        deletions: expectEmptyObject(),
+        deletions: expect.toSatisfy(
+          (d: any) => Object.keys(d).length === 0,
+          "empty object",
+        ),
       });
 
       expect(
@@ -735,15 +738,18 @@ describe("replace resource when replaceString changes", () => {
             },
           },
         },
-        deletions: expectEmptyObject(),
+        deletions: expect.toSatisfy(
+          (d: any) => Object.keys(d).length === 0,
+          "empty object",
+        ),
       });
     }),
   );
 
   test(
     "force preserves replaces",
-    { state },
     Effect.gen(function* () {
+      yield* seed(stateResources);
       expect(
         yield* Effect.gen(function* () {
           yield* TestResource("A", {
@@ -759,15 +765,18 @@ describe("replace resource when replaceString changes", () => {
             },
           },
         },
-        deletions: expectEmptyObject(),
+        deletions: expect.toSatisfy(
+          (d: any) => Object.keys(d).length === 0,
+          "empty object",
+        ),
       });
     }),
   );
 
   test(
     "update when replaceString depends on unresolved output (diff short-circuits)",
-    { state },
     Effect.gen(function* () {
+      yield* seed(stateResources);
       let B: TestResource;
       expect(
         yield* Effect.gen(function* () {
@@ -783,11 +792,21 @@ describe("replace resource when replaceString changes", () => {
           A: {
             action: "update",
             props: {
-              replaceString: expectPropExpr("string", B!),
+              replaceString: expect.objectContaining({
+                kind: "PropExpr",
+                identifier: "string",
+                expr: expect.objectContaining({
+                  kind: "ResourceExpr",
+                  src: B!,
+                }),
+              }),
             },
           },
         },
-        deletions: expectEmptyObject(),
+        deletions: expect.toSatisfy(
+          (d: any) => Object.keys(d).length === 0,
+          "empty object",
+        ),
       });
     }),
   );
@@ -795,8 +814,8 @@ describe("replace resource when replaceString changes", () => {
 
 test(
   "update resource when a binding is added without prop changes",
-  {
-    state: test.state({
+  Effect.gen(function* () {
+    yield* seed({
       A: {
         instanceId,
         providerVersion: 0,
@@ -815,9 +834,7 @@ test(
         bindings: [],
         downstream: [],
       },
-    }),
-  },
-  Effect.gen(function* () {
+    });
     expect(
       yield* Effect.gen(function* () {
         const target = yield* BindingTarget("A", {
@@ -849,15 +866,18 @@ test(
           },
         },
       },
-      deletions: expectEmptyObject(),
+      deletions: expect.toSatisfy(
+        (d: any) => Object.keys(d).length === 0,
+        "empty object",
+      ),
     });
   }),
 );
 
 test(
   "update resource when a binding is removed without prop changes",
-  {
-    state: test.state({
+  Effect.gen(function* () {
+    yield* seed({
       A: {
         instanceId,
         providerVersion: 0,
@@ -887,9 +907,7 @@ test(
         ],
         downstream: [],
       },
-    }),
-  },
-  Effect.gen(function* () {
+    });
     expect(
       yield* Effect.gen(function* () {
         yield* BindingTarget("A", {
@@ -916,86 +934,91 @@ test(
           },
         },
       },
-      deletions: expectEmptyObject(),
+      deletions: expect.toSatisfy(
+        (d: any) => Object.keys(d).length === 0,
+        "empty object",
+      ),
     });
   }),
 );
 
-test(
+test.provider(
   "binding removals do not keep reappearing after apply",
-  {
-    state: test.state({
-      A: {
-        instanceId,
-        providerVersion: 0,
-        logicalId: "A",
+  (scratch) =>
+    Effect.gen(function* () {
+      const state = yield* State;
+      yield* state.set({
+        stack: scratch.name,
+        stage: TEST_STAGE,
         fqn: "A",
-        namespace: undefined,
-        resourceType: "Test.BindingTarget",
-        status: "created",
-        props: {
-          name: "target",
-        },
-        attr: {
-          name: "target",
-          env: {
-            FEATURE_FLAG: "on",
+        value: {
+          instanceId,
+          providerVersion: 0,
+          logicalId: "A",
+          fqn: "A",
+          namespace: undefined,
+          resourceType: "Test.BindingTarget",
+          status: "created",
+          props: {
+            name: "target",
           },
-        },
-        bindings: [
-          {
-            sid: "TestBinding",
-            data: {
-              env: {
-                FEATURE_FLAG: "on",
-              },
+          attr: {
+            name: "target",
+            env: {
+              FEATURE_FLAG: "on",
             },
           },
-        ],
-        downstream: [],
-      },
-    }),
-  },
-  Effect.gen(function* () {
-    const stack = yield* Stack.Stack;
-    const state = yield* State;
+          bindings: [
+            {
+              sid: "TestBinding",
+              data: {
+                env: {
+                  FEATURE_FLAG: "on",
+                },
+              },
+            },
+          ],
+          downstream: [],
+        },
+      });
 
-    yield* test
-      .deploy(
+      yield* scratch.deploy(
         Effect.gen(function* () {
           yield* BindingTarget("A", {
             name: "target",
           });
         }),
-      )
-      .pipe(Effect.provide(TestLayers()));
+      );
 
-    expect(
-      yield* state.get({
-        stack: stack.name,
-        stage: stack.stage,
-        fqn: "A",
-      }),
-    ).toMatchObject({
-      bindings: [],
-    });
+      expect(
+        yield* state.get({
+          stack: scratch.name,
+          stage: TEST_STAGE,
+          fqn: "A",
+        }),
+      ).toMatchObject({
+        bindings: [],
+      });
 
-    expect(
-      yield* Effect.gen(function* () {
-        yield* BindingTarget("A", {
-          name: "target",
-        });
-      }).pipe(makePlan),
-    ).toMatchObject({
-      resources: {
-        A: {
-          action: "noop",
-          bindings: [],
+      expect(
+        yield* Effect.gen(function* () {
+          yield* BindingTarget("A", {
+            name: "target",
+          });
+        }).pipe(makePlan),
+      ).toMatchObject({
+        resources: {
+          A: {
+            action: "noop",
+            bindings: [],
+          },
         },
-      },
-      deletions: expectEmptyObject(),
-    });
-  }),
+        deletions: expect.toSatisfy(
+          (d: any) => Object.keys(d).length === 0,
+          "empty object",
+        ),
+      });
+    }),
 );
 
 describe("construct namespaces", () => {
@@ -1032,14 +1055,23 @@ describe("construct namespaces", () => {
                 sid: "Policy",
                 data: {
                   env: {
-                    BUCKET: expectPropExpr(
-                      "string",
-                      plan.resources["MarketingSite/Bucket"]!.resource,
-                    ),
-                    DISTRIBUTION: expectPropExpr(
-                      "string",
-                      plan.resources["MarketingSite/Distribution"]!.resource,
-                    ),
+                    BUCKET: expect.objectContaining({
+                      kind: "PropExpr",
+                      identifier: "string",
+                      expr: expect.objectContaining({
+                        kind: "ResourceExpr",
+                        src: plan.resources["MarketingSite/Bucket"]!.resource,
+                      }),
+                    }),
+                    DISTRIBUTION: expect.objectContaining({
+                      kind: "PropExpr",
+                      identifier: "string",
+                      expr: expect.objectContaining({
+                        kind: "ResourceExpr",
+                        src: plan.resources["MarketingSite/Distribution"]!
+                          .resource,
+                      }),
+                    }),
                   },
                 },
               },
@@ -1050,7 +1082,10 @@ describe("construct namespaces", () => {
             bindings: [],
           },
         },
-        deletions: expectEmptyObject(),
+        deletions: expect.toSatisfy(
+          (d: any) => Object.keys(d).length === 0,
+          "empty object",
+        ),
       });
     }),
   );
@@ -1091,7 +1126,10 @@ describe("construct namespaces", () => {
             },
           },
         },
-        deletions: expectEmptyObject(),
+        deletions: expect.toSatisfy(
+          (d: any) => Object.keys(d).length === 0,
+          "empty object",
+        ),
       });
     }),
   );
@@ -1200,15 +1238,13 @@ const testSimple = (
 ) =>
   test(
     title,
-    {
-      state: test.state({
+    Effect.gen(function* () {
+      yield* seed({
         A: createTestResourceState({
           ...testCase.state,
           logicalId: "A",
         }),
-      }),
-    },
-    Effect.gen(function* () {
+      });
       {
         const plan = Effect.gen(function* () {
           yield* TestResource("A", testCase.props);
@@ -1229,7 +1265,10 @@ const testSimple = (
             resources: {
               A: testCase.plan,
             },
-            deletions: expectEmptyObject(),
+            deletions: expect.toSatisfy(
+              (d: any) => Object.keys(d).length === 0,
+              "empty object",
+            ),
           });
         }
       }
@@ -1665,21 +1704,31 @@ test(
           props: {
             name: "test-function",
             env: {
-              QUEUE_URL: expectPropExpr("queueUrl", MyQueue!),
+              QUEUE_URL: expect.objectContaining({
+                kind: "PropExpr",
+                identifier: "queueUrl",
+                expr: expect.objectContaining({
+                  kind: "ResourceExpr",
+                  src: MyQueue!,
+                }),
+              }),
             },
           },
           state: undefined,
         },
       },
-      deletions: expectEmptyObject(),
+      deletions: expect.toSatisfy(
+        (d: any) => Object.keys(d).length === 0,
+        "empty object",
+      ),
     });
   }),
 );
 
 test(
   "detect that queueUrl will change and pass through the PropExpr instead of old output",
-  {
-    state: test.state({
+  Effect.gen(function* () {
+    yield* seed({
       MyQueue: {
         instanceId,
         providerVersion: 0,
@@ -1697,9 +1746,7 @@ test(
         downstream: [],
         bindings: [],
       },
-    }),
-  },
-  Effect.gen(function* () {
+    });
     let MyQueue: Queue;
     let MyFunction: Function;
     const plan = yield* Effect.gen(function* () {
@@ -1720,19 +1767,29 @@ test(
           props: {
             name: "test-function",
             env: {
-              QUEUE_URL: expectPropExpr("queueUrl", MyQueue!),
+              QUEUE_URL: expect.objectContaining({
+                kind: "PropExpr",
+                identifier: "queueUrl",
+                expr: expect.objectContaining({
+                  kind: "ResourceExpr",
+                  src: MyQueue!,
+                }),
+              }),
             },
           },
           state: undefined,
         },
       },
-      deletions: expectEmptyObject(),
+      deletions: expect.toSatisfy(
+        (d: any) => Object.keys(d).length === 0,
+        "empty object",
+      ),
     });
   }),
 );
 
 describe("Outputs should resolve to old values", () => {
-  const state = _test.state({
+  const stateResources: Record<string, ResourceState> = {
     A: {
       instanceId,
       providerVersion: 0,
@@ -1752,7 +1809,7 @@ describe("Outputs should resolve to old values", () => {
       downstream: [],
       bindings: [],
     },
-  });
+  };
 
   const expected = (props: Input.Resolve<InputProps<TestResourceProps>>) => ({
     resources: {
@@ -1766,20 +1823,21 @@ describe("Outputs should resolve to old values", () => {
         props: props,
       },
     },
-    deletions: expectEmptyObject(),
+    deletions: expect.toSatisfy(
+      (d: any) => Object.keys(d).length === 0,
+      "empty object",
+    ),
   });
 
-  const test = <const I extends InputProps<TestResourceProps>>(
+  const subtest = <const I extends InputProps<TestResourceProps>>(
     description: string,
     input: (resource: TestResource) => I,
     attr: Input.Resolve<I>,
   ) =>
-    _test(
+    test(
       description,
-      {
-        state,
-      },
       Effect.gen(function* () {
+        yield* seed(stateResources);
         expect(
           yield* Effect.gen(function* () {
             const A = yield* TestResource("A", {
@@ -1792,7 +1850,7 @@ describe("Outputs should resolve to old values", () => {
       }),
     );
 
-  test(
+  subtest(
     "string",
     (A) => ({
       string: A.string,
@@ -1802,7 +1860,7 @@ describe("Outputs should resolve to old values", () => {
     },
   );
 
-  test(
+  subtest(
     "string.apply(string => undefined)",
     (A) => ({
       string: A.string.pipe(Output.map(() => undefined)),
@@ -1812,7 +1870,7 @@ describe("Outputs should resolve to old values", () => {
     },
   );
 
-  test(
+  subtest(
     "string.effect(string => Effect.succeed(undefined))",
     (A) => ({
       string: A.string.pipe(Output.mapEffect(() => Effect.succeed(undefined))),
@@ -1822,7 +1880,7 @@ describe("Outputs should resolve to old values", () => {
     },
   );
 
-  test(
+  subtest(
     "stringArray[0].toUpperCase()",
     (A) => ({
       string: A.stringArray.pipe(
@@ -1834,7 +1892,7 @@ describe("Outputs should resolve to old values", () => {
     },
   );
 
-  test(
+  subtest(
     "resource object",
     (A) => ({
       object: A as any,
@@ -1848,16 +1906,16 @@ describe("Outputs should resolve to old values", () => {
 });
 
 describe("stable properties should not cause downstream changes", () => {
-  const test = (
+  const subtest = (
     description: string,
     input: (A: TestResource) => InputProps<TestResourceProps>,
   ) => {
     // @ts-expect-error - get the keys
     const props = input(Output.of({}));
-    _test(
+    test(
       description,
-      {
-        state: _test.state({
+      Effect.gen(function* () {
+        yield* seed({
           A: {
             instanceId,
             providerVersion: 0,
@@ -1897,9 +1955,7 @@ describe("stable properties should not cause downstream changes", () => {
             downstream: [],
             bindings: [],
           },
-        }),
-      },
-      Effect.gen(function* () {
+        });
         expect(
           yield* Effect.gen(function* () {
             const A = yield* TestResource("A", {
@@ -1919,47 +1975,56 @@ describe("stable properties should not cause downstream changes", () => {
               action: "noop",
             },
           },
-          deletions: expectEmptyObject(),
+          deletions: expect.toSatisfy(
+            (d: any) => Object.keys(d).length === 0,
+            "empty object",
+          ),
         });
       }),
     );
   };
 
-  test("A.stableString", (A) => ({
+  subtest("A.stableString", (A) => ({
     string: A.stableString,
   }));
 
-  test("A.stableString.apply((string) => string.toUpperCase())", (A) => ({
+  subtest("A.stableString.apply((string) => string.toUpperCase())", (A) => ({
     string: A.stableString.pipe(Output.map((string) => string.toUpperCase())),
   }));
 
-  test("A.stableString.effect((string) => Effect.succeed(string.toUpperCase()))", (A) => ({
-    string: A.stableString.pipe(
-      Output.mapEffect((string) => Effect.succeed(string.toUpperCase())),
-    ),
-  }));
+  subtest(
+    "A.stableString.effect((string) => Effect.succeed(string.toUpperCase()))",
+    (A) => ({
+      string: A.stableString.pipe(
+        Output.mapEffect((string) => Effect.succeed(string.toUpperCase())),
+      ),
+    }),
+  );
 
-  test("A.stableArray", (A) => ({
+  subtest("A.stableArray", (A) => ({
     stringArray: A.stableArray,
   }));
 
-  test("A.stableArray[0]", (A) => ({
+  subtest("A.stableArray[0]", (A) => ({
     string: A.stableArray.pipe(Output.map((stableArray) => stableArray[0]!)),
   }));
 
-  test("A.stableArray[0].apply((string) => string.toUpperCase())", (A) => ({
+  subtest("A.stableArray[0].apply((string) => string.toUpperCase())", (A) => ({
     string: A.stableArray.pipe(
       Output.map((stableArray) => stableArray[0]!.toUpperCase()),
     ),
   }));
 
-  test("A.stableArray[0].effect((string) => Effect.succeed(string.toUpperCase()))", (A) => ({
-    string: A.stableArray.pipe(
-      Output.mapEffect((stableArray) =>
-        Effect.succeed(stableArray[0]!.toUpperCase()),
+  subtest(
+    "A.stableArray[0].effect((string) => Effect.succeed(string.toUpperCase()))",
+    (A) => ({
+      string: A.stableArray.pipe(
+        Output.mapEffect((stableArray) =>
+          Effect.succeed(stableArray[0]!.toUpperCase()),
+        ),
       ),
-    ),
-  }));
+    }),
+  );
 });
 
 describe("unsatisfied cycle detection", () => {
@@ -1973,9 +2038,6 @@ describe("unsatisfied cycle detection", () => {
 
   test(
     "binding cycle between resources without precreate dies",
-    {
-      state: test.state(),
-    },
     Effect.gen(function* () {
       const exit = yield* makePlan(
         Effect.gen(function* () {
@@ -2003,9 +2065,6 @@ describe("unsatisfied cycle detection", () => {
 
   test(
     "binding cycle with all precreate resources succeeds",
-    {
-      state: test.state(),
-    },
     Effect.gen(function* () {
       const exit = yield* makePlan(
         Effect.gen(function* () {
@@ -2029,9 +2088,6 @@ describe("unsatisfied cycle detection", () => {
 
   test(
     "mixed cycle succeeds when precreate resource breaks it",
-    {
-      state: test.state(),
-    },
     Effect.gen(function* () {
       const exit = yield* makePlan(
         Effect.gen(function* () {
@@ -2054,9 +2110,6 @@ describe("unsatisfied cycle detection", () => {
 
   test(
     "three-node binding cycle dies when none have precreate",
-    {
-      state: test.state(),
-    },
     Effect.gen(function* () {
       const exit = yield* makePlan(
         Effect.gen(function* () {
@@ -2082,9 +2135,6 @@ describe("unsatisfied cycle detection", () => {
 
   test(
     "acyclic binding graph succeeds even without precreate",
-    {
-      state: test.state(),
-    },
     Effect.gen(function* () {
       const exit = yield* makePlan(
         Effect.gen(function* () {
@@ -2109,8 +2159,8 @@ describe("unsatisfied cycle detection", () => {
 describe("unresolved plan inputs in diff should conservatively update", () => {
   test(
     "update when upstream resource is new and downstream news contains exprs",
-    {
-      state: _test.state({
+    Effect.gen(function* () {
+      yield* seed({
         B: {
           instanceId,
           providerVersion: 0,
@@ -2130,9 +2180,7 @@ describe("unresolved plan inputs in diff should conservatively update", () => {
           downstream: [],
           bindings: [],
         },
-      }),
-    },
-    Effect.gen(function* () {
+      });
       const plan = yield* Effect.gen(function* () {
         const A = yield* TestResource("A", {
           string: "hello",
@@ -2151,9 +2199,6 @@ describe("unresolved plan inputs in diff should conservatively update", () => {
 describe("Redacted props/outputs are preserved through plan", () => {
   test(
     "Redacted prop on a new resource is preserved as a Redacted in the plan",
-    {
-      state: test.state(),
-    },
     Effect.gen(function* () {
       const plan = yield* Effect.gen(function* () {
         yield* TestResource("A", {
@@ -2172,9 +2217,6 @@ describe("Redacted props/outputs are preserved through plan", () => {
 
   test(
     "Redacted prop nested inside an array is preserved through the plan",
-    {
-      state: test.state(),
-    },
     Effect.gen(function* () {
       const plan = yield* Effect.gen(function* () {
         yield* TestResource("A", {
@@ -2197,8 +2239,8 @@ describe("Redacted props/outputs are preserved through plan", () => {
 
   test(
     "no-op when prior state has the same Redacted value",
-    {
-      state: test.state({
+    Effect.gen(function* () {
+      yield* seed({
         A: {
           instanceId,
           providerVersion: 0,
@@ -2223,9 +2265,7 @@ describe("Redacted props/outputs are preserved through plan", () => {
           downstream: [],
           bindings: [],
         },
-      }),
-    },
-    Effect.gen(function* () {
+      });
       const plan = yield* Effect.gen(function* () {
         yield* TestResource("A", {
           string: "x",
@@ -2239,8 +2279,8 @@ describe("Redacted props/outputs are preserved through plan", () => {
 
   test(
     "update when Redacted prop value changes",
-    {
-      state: test.state({
+    Effect.gen(function* () {
+      yield* seed({
         A: {
           instanceId,
           providerVersion: 0,
@@ -2265,9 +2305,7 @@ describe("Redacted props/outputs are preserved through plan", () => {
           downstream: [],
           bindings: [],
         },
-      }),
-    },
-    Effect.gen(function* () {
+      });
       const plan = yield* Effect.gen(function* () {
         yield* TestResource("A", {
           string: "x",
@@ -2285,8 +2323,8 @@ describe("Redacted props/outputs are preserved through plan", () => {
 
   test(
     "Redacted output flowing into a downstream resource preserves its redaction",
-    {
-      state: test.state({
+    Effect.gen(function* () {
+      yield* seed({
         A: {
           instanceId,
           providerVersion: 0,
@@ -2311,9 +2349,7 @@ describe("Redacted props/outputs are preserved through plan", () => {
           downstream: [],
           bindings: [],
         },
-      }),
-    },
-    Effect.gen(function* () {
+      });
       const plan = yield* Effect.gen(function* () {
         const A = yield* TestResource("A", {
           string: "x",

--- a/packages/better-auth/tsconfig.json
+++ b/packages/better-auth/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": [
-    "src/**/*.ts"
-  ],
+  "include": ["src/**/*.ts"],
   "compilerOptions": {
     "composite": true,
     "noEmit": false,

--- a/packages/pr-package/tsconfig.json
+++ b/packages/pr-package/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": [
-    "src/**/*.ts"
-  ],
+  "include": ["src/**/*.ts"],
   "compilerOptions": {
     "composite": true,
     "noEmit": false,

--- a/website/src/content/docs/concepts/testing.mdx
+++ b/website/src/content/docs/concepts/testing.mdx
@@ -5,47 +5,54 @@ sidebar:
   order: 10
 ---
 
-Alchemy provides test utilities that integrate with Bun and Vitest,
-wrapping their test APIs with Effect support and stack lifecycle
-management.
+Alchemy provides Effect-aware test utilities for both Bun and
+Vitest. Both runners expose the **same** `Test.make({ providers,
+state })` factory — pick whichever runner your project uses.
 
-## Test harness
+## Configure once per file
 
-The test harness provides Effect-aware versions of `test`,
-`beforeAll`, `afterAll`, and `expect`:
+Configure providers (and optionally state) once at the top of every
+test file:
 
 ```typescript
-import { beforeAll, deploy, expect, test } from "alchemy/Test/Bun";
+import * as Test from "alchemy/Test/Bun"; // or "alchemy/Test/Vitest"
+import * as Cloudflare from "alchemy/Cloudflare";
+
+const { test, deploy, destroy, beforeAll, afterAll } = Test.make({
+  providers: Cloudflare.providers(),
+  state: Cloudflare.state(),       // optional, defaults to localState()
+  // profile?: string              // optional ALCHEMY_PROFILE override
+});
 ```
 
-Each `test(name, effect)` runs an Effect generator instead of an
-async function. The harness provides platform layers (`HttpClient`,
-etc.) automatically.
-
-## Deploy and destroy
-
-`deploy(Stack)` returns an Effect that plans and applies a stack,
-resolving to its outputs. `destroy(Stack)` tears it down:
+`expect` and `describe` come from the underlying runner directly:
 
 ```typescript
-import { afterAll, beforeAll, deploy, destroy } from "alchemy/Test/Bun";
+import { expect, describe } from "bun:test";   // Bun
+// or:
+import { expect, describe } from "@effect/vitest"; // Vitest
+```
+
+Credentials resolve through the same `AuthProviders` registry as
+`alchemy deploy`. The harness honors `ALCHEMY_PROFILE` (and the
+`profile` factory option) so tests pick up the same `alchemy login`
+profile your CLI uses.
+
+## Two test shapes
+
+### `test(name, effect)` — stack tests
+
+For end-to-end tests against a deployed stack: deploy your
+`Alchemy.Stack` once in `beforeAll`, then assert against its
+outputs.
+
+```typescript
 import Stack from "../alchemy.run.ts";
 
 const stack = beforeAll(deploy(Stack));
+
 afterAll.skipIf(!process.env.CI)(destroy(Stack));
-```
 
-- `beforeAll(effect)` runs the Effect once before all tests and
-  returns a lazy accessor
-- `afterAll.skipIf(!process.env.CI)` skips destroy locally for fast
-  iteration
-- On CI (`CI=true`), the stack is torn down after tests complete
-
-## Accessing outputs
-
-Use `yield* stack` inside a test to get the deployed stack's outputs:
-
-```typescript
 test(
   "worker is reachable",
   Effect.gen(function* () {
@@ -55,9 +62,53 @@ test(
 );
 ```
 
+- `beforeAll(effect)` runs once before all tests and returns a lazy
+  accessor. `yield* stack` inside a test resolves to the deployed
+  outputs.
+- `afterAll.skipIf(predicate)` skips destroy locally for fast
+  iteration. On CI the stack is torn down after tests complete.
+
+### `test.provider(name, (stack) => effect)` — provider tests
+
+For unit-testing a custom provider's CRUD lifecycle. Each
+`test.provider` invocation gets its own scratch stack with a private
+in-memory state store; `stack.deploy(...)` and `stack.destroy()`
+exercise create / update / replace / delete paths without polluting
+`.alchemy/`.
+
+```typescript
+import { Table } from "alchemy/AWS/DynamoDB";
+import * as DynamoDB from "@distilled.cloud/aws/dynamodb";
+
+test.provider(
+  "create, update, delete table",
+  (stack) => Effect.gen(function* () {
+    const table = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Table("TestTable", {
+          partitionKey: "id",
+          attributes: { id: "S" },
+        });
+      }),
+    );
+
+    const actual = yield* DynamoDB.describeTable({
+      TableName: table.tableName,
+    });
+    expect(actual.Table?.TableArn).toEqual(table.tableArn);
+
+    yield* stack.destroy();
+  }),
+);
+```
+
+Inside a `test.provider` body the configured `providers` layer is
+already in scope, so you can call provider SDKs (here
+`DynamoDB.describeTable`) directly.
+
 ## HTTP assertions
 
-`HttpClient` is provided automatically by the test harness:
+`HttpClient` is provided automatically by both runners:
 
 ```typescript
 import * as HttpClient from "effect/unstable/http/HttpClient";
@@ -79,53 +130,34 @@ test(
 );
 ```
 
+## Test variants
+
+Both runners expose the same skip / only / todo modifiers:
+
+- `test.skip(name, effect)` / `test.skipIf(condition)(name, effect)`
+- `test.only(name, effect)` (Bun only)
+- `test.todo(name, effect)` (Bun only)
+- `test.provider.skip(name, fn)` /
+  `test.provider.skipIf(condition)(name, fn)`
+- `afterAll.skipIf(predicate)(effect)` — skip teardown locally,
+  run on CI
+
 ## State in tests
 
-Tests use the same state management as production deploys. By
-default, `LocalState` persists to `.alchemy/` so subsequent test
-runs reuse existing resources (making re-runs fast).
+`Test.make({ state })` controls the state store used by top-level
+`deploy(Stack)` / `destroy(Stack)`. Defaults to `localState()` which
+persists to `.alchemy/`, so re-runs reuse existing resources.
 
-For unit testing providers, Alchemy provides an in-memory state
-store:
-
-```typescript
-import * as TestState from "alchemy/Test/TestState";
-
-// Start with empty state
-const state = TestState.defaultState;
-
-// Or seed with existing resources
-const state = TestState.state({
-  MyResource: {
-    /* ResourceState */
-  },
-});
-```
-
-## Test CLI
-
-The test harness includes a `TestCli` that auto-approves plans and
-suppresses interactive prompts. This is provided automatically —
-you don't need to configure it.
-
-## Vitest support
-
-Alchemy also supports Vitest with the same API:
-
-```typescript
-import { beforeAll, deploy, expect, test } from "alchemy/Test/Vitest";
-```
-
-The Vitest harness provides identical functionality with Vitest's
-test runner instead of Bun's.
+`test.provider` always uses a fresh in-memory store per test —
+seed pre-existing resources by calling `state.set(...)` at the top
+of the test body if needed.
 
 ## Async and streaming pipelines
 
-The same harness works for offline jobs and streaming pipelines —
-write to the source, await the sink, no mocks:
+The same harness works for streaming pipelines — write to the
+source, await the sink, no mocks:
 
 ```typescript
-// Async / streaming jobs — same pattern.
 test(
   "DynamoDB stream → SQS pipeline",
   Effect.gen(function* () {
@@ -136,17 +168,16 @@ test(
       Item: { id: { S: "1" } },
     });
 
-    // wait for the Lambda to fan out into the queue
     const msg = yield* SQS.receive(queueUrl).pipe(Effect.timeout("10 seconds"));
     expect(msg.Body).toContain('"id":"1"');
   }),
 );
 ```
 
-- **No mocks** — Your tests run against real R2, real DynamoDB, real
+- **No mocks** — Tests run against real R2, real DynamoDB, real
   Workers. What passes locally passes in prod.
-- **Per-suite isolation** — Stage names from PR or test ID. Two suites
-  run the same tests in parallel without collision.
-- **Effect-aware test runner** — Vitest and Bun test wrapped with
-  Effect support. Yield from any test, get typed errors at the
-  assertion line.
+- **Per-suite isolation** — Stage names from PR or test ID. Two
+  suites run the same tests in parallel without collision.
+- **Effect-aware test runner** — Vitest and Bun wrapped with Effect
+  support. Yield from any test, get typed errors at the assertion
+  line.

--- a/website/src/content/docs/guides/custom-provider.mdx
+++ b/website/src/content/docs/guides/custom-provider.mdx
@@ -776,42 +776,44 @@ providers: Layer.mergeAll(Cloudflare.providers(), Stripe.providers()),
 ## Test the lifecycle
 
 Alchemy's test harness (`alchemy/Test/Vitest` or `alchemy/Test/Bun`)
-runs an in-memory state store and lets you `deploy` a sub-stack,
-make assertions against the live resource, then `destroy` it.
+configures providers + state once at the top of the file, then
+exposes `test.provider(name, (stack) => ...)` for provider-level
+tests. Each `test.provider` body receives a fresh in-memory scratch
+stack with `.deploy(effect)` and `.destroy()` helpers.
 
 :::note[Three things the harness gives you]
-- **`yield* destroy()`** — clears any leftover state from a
-  previous run. Call it at the start (and end) of each test.
-- **`test.deploy(effect)`** — runs a sub-stack with the in-memory
-  state store. The same logical ID across two `test.deploy` calls
+- **`Test.make({ providers })`** — wires your provider Layer into
+  every test in the file so the resource type resolves.
+- **`stack.deploy(effect)`** — runs a sub-stack with an in-memory
+  state store. The same logical ID across two `stack.deploy` calls
   triggers an `update` (or `replace`, depending on `diff`).
-- **`Effect.provide(providers(...))`** — wires your provider Layer
-  into the test so the resource type resolves.
+- **`stack.destroy()`** — replans against an empty desired state to
+  tear everything down. Call at the end of the test.
 :::
 
 Create `test/Product.test.ts`:
 
 ```typescript
 // test/Product.test.ts
-import * as Alchemy from "alchemy";
-import { destroy, test } from "alchemy/Test/Vitest";
+import * as Test from "alchemy/Test/Vitest";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import Stripe from "stripe";
 import * as StripeProvider from "../src/stripe";
 
-// Tests resolve credentials through the same AuthProvider as deploys
-// — set STRIPE_API_KEY (with `method: "env"`) or run `alchemy login`
-// against a test profile beforehand.
+// Configure providers once per file. Credentials resolve through the
+// same AuthProvider system as `alchemy deploy` — set STRIPE_API_KEY
+// (with `method: "env"`) or run `alchemy login` against a test
+// profile beforehand.
+const { test } = Test.make({ providers: StripeProvider.providers() });
+
 const stripe = new Stripe(process.env.STRIPE_API_KEY!);
 
-test(
+test.provider(
   "create, update, delete a product",
-  Effect.gen(function* () {
-    yield* destroy();
-
+  (stack) => Effect.gen(function* () {
     // Create
-    const created = yield* test.deploy(
+    const created = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* StripeProvider.Product("TestProduct", {
           name: "v1",
@@ -827,7 +829,7 @@ test(
     expect(live1.name).toBe("v1");
 
     // Update (in place)
-    const updated = yield* test.deploy(
+    const updated = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* StripeProvider.Product("TestProduct", {
           name: "v2",
@@ -843,8 +845,8 @@ test(
     expect(live2.name).toBe("v2");
 
     // Destroy
-    yield* destroy();
-  }).pipe(Effect.provide(StripeProvider.providers())),
+    yield* stack.destroy();
+  }),
 );
 ```
 


### PR DESCRIPTION
Aligned the bun and vitest harnesses with a new design that works with your profiles and supports testing stacks and providers

### Configure once per file

```ts
import * as Test from "alchemy/Test/Bun"; // or "alchemy/Test/Vitest"
import * as Cloudflare from "alchemy/Cloudflare";

const { test, deploy, destroy, beforeAll, afterAll } = Test.make({
  providers: Cloudflare.providers(),
  state: Cloudflare.state(),
  // profile?: string  // ALCHEMY_PROFILE override; routes through the same
  //                    // AuthProvider system as `alchemy deploy`
});
```

### Stack tests — `test(name, effect)`

```ts
import Stack from "../alchemy.run.ts";

const stack = beforeAll(deploy(Stack));
afterAll.skipIf(!process.env.CI)(destroy(Stack));

test("worker is reachable", Effect.gen(function* () {
  const { url } = yield* stack;
  expect(url).toBeString();
}));
```

### Provider tests — `test.provider(name, (stack) => effect)`

Each call gets a private in-memory scratch stack with `.deploy(...)` / `.destroy()`. The configured `providers` layer is ambient inside the body, so SDK calls work directly.

```ts
test.provider(
  "create, update, delete table",
  (stack) => Effect.gen(function* () {
    const table = yield* stack.deploy(
      Effect.gen(function* () {
        return yield* Table("TestTable", {
          partitionKey: "id",
          attributes: { id: "S" },
        });
      }),
    );

    const actual = yield* DynamoDB.describeTable({
      TableName: table.tableName,
    });
    expect(actual.Table?.TableArn).toEqual(table.tableArn);

    yield* stack.destroy();
  }),
);
```

### Before / after

```diff
- import { destroy, test } from "alchemy/Test/Vitest";
+ import * as Test from "alchemy/Test/Vitest";
+ import * as AWS from "alchemy/AWS";
+
+ const { test } = Test.make({ providers: AWS.providers() });

- test(
-   "create, update, delete table",
-   Effect.gen(function* () {
-     yield* destroy();
-     const table = yield* test.deploy(
-       Effect.gen(function* () {
-         return yield* Table("TestTable", { ... });
-       }),
-     );
-     // ...
-     yield* destroy();
-   }).pipe(Effect.provide(AWS.providers())),
- );
+ test.provider(
+   "create, update, delete table",
+   (stack) => Effect.gen(function* () {
+     const table = yield* stack.deploy(
+       Effect.gen(function* () {
+         return yield* Table("TestTable", { ... });
+       }),
+     );
+     // ...
+     yield* stack.destroy();
+   }),
+ );
```

`expect` / `describe` come from the runner directly (`bun:test` or `@effect/vitest`).