### PR TITLE
fix(pr-package): use `bun add <name>@<url>` to dodge bun DependencyLoop bug

### DIFF
--- a/.github/workflows/pr-package.yaml
+++ b/.github/workflows/pr-package.yaml
@@ -149,7 +149,13 @@ jobs:
         run: |
           set -euo pipefail
           MARKER="<!-- pr-package-comment -->"
-          BODY=$(printf '%s\n\nInstall the packages built from this commit:\n\n**alchemy**\n```sh\nbun add https://pkg.ing/alchemy/%s\n```\n\n**@alchemy.run/better-auth**\n```sh\nbun add https://pkg.ing/@alchemy.run/better-auth/%s\n```\n\n**@alchemy.run/pr-package**\n```sh\nbun add https://pkg.ing/@alchemy.run/pr-package/%s\n```\n' "$MARKER" "$SHORT_SHA" "$SHORT_SHA" "$SHORT_SHA")
+          # Use `bun add <name>@<url>` instead of `bun add <url>`. Without an
+          # explicit name, bun's resolver hits a DependencyLoop bug when the
+          # consumer already has the same package name resolved from npm
+          # (oven-sh/bun#5789, oven-sh/bun#17946). The aliased form bypasses
+          # the buggy reconciliation path and works on fresh and existing
+          # projects alike.
+          BODY=$(printf '%s\n\nInstall the packages built from this commit:\n\n**alchemy**\n```sh\nbun add alchemy@https://pkg.ing/alchemy/%s\n```\n\n**@alchemy.run/better-auth**\n```sh\nbun add @alchemy.run/better-auth@https://pkg.ing/@alchemy.run/better-auth/%s\n```\n\n**@alchemy.run/pr-package**\n```sh\nbun add @alchemy.run/pr-package@https://pkg.ing/@alchemy.run/pr-package/%s\n```\n' "$MARKER" "$SHORT_SHA" "$SHORT_SHA" "$SHORT_SHA")
 
           existing=$(gh api --paginate \
             "repos/${REPO}/issues/${PR_NUMBER}/comments" \


### PR DESCRIPTION
## Summary

The PR-package sticky comment currently tells users to install with `bun add https://pkg.ing/<pkg>/<sha>`. That command crashes whenever the consumer's project already has the same package resolved from npm:

```
$ bun add https://pkg.ing/alchemy/9bee6d8
error: Package "alchemy@https://pkg.ing/alchemy/9bee6d8" has a dependency loop
  Resolution: "alchemy@2.0.0-beta.22"
  Dependency: "alchemy@https://pkg.ing/alchemy/9bee6d8"
error: An internal error occurred (DependencyLoop)
```

This is a known long-standing bun bug ([oven-sh/bun#5789](https://github.com/oven-sh/bun/issues/5789), [oven-sh/bun#17946](https://github.com/oven-sh/bun/issues/17946)) in the name-inference / lockfile-reconciliation path of `bun add <bare-url>`.

## What I tried

I stood up a local Bun.serve mimicking `pkg.ing`'s redirect chain (alias → 301 → tag → 302 → tarball) serving a real `bun pm pack`'d alchemy tarball, reproduced the error byte-for-byte, then tried each plausible mitigation:

| Approach | Result |
|---|---|
| `bun add <url>` (current) | fails with DependencyLoop |
| `bun add --force <url>` | fails |
| Manually edit `package.json` then `bun install` | works |
| `bun remove alchemy && bun add <url>` | works |
| `bun add` when no prior alchemy entry | works |
| **`bun add alchemy@<url>` (aliased)** | **works** |

The tarball, redirect chain, and published versions are all fine — anything other than `bun add <bare-url>` installs the same tarball cleanly. Passing the package name explicitly bypasses the buggy reconciliation entirely.

## Change

One line in `.github/workflows/pr-package.yaml`: switch the sticky-comment template from `bun add https://pkg.ing/<pkg>/<sha>` to `bun add <pkg>@https://pkg.ing/<pkg>/<sha>` for all three packages (`alchemy`, `@alchemy.run/better-auth`, `@alchemy.run/pr-package`). The publish steps and the worker are untouched.

## Test plan

- [ ] CI runs `pr-package` workflow on this PR
- [ ] Sticky comment lands with the new aliased install commands
- [ ] In a fresh consumer project (no prior `alchemy` dep): copy the `bun add alchemy@https://pkg.ing/alchemy/<sha>` command from the comment and confirm it installs
- [ ] In a consumer project that already has `alchemy@2.0.0-beta.22` from npm: run the same command and confirm it installs without DependencyLoop
- [ ] Confirm `import "alchemy"` resolves to the URL-installed copy in both cases


Made with [Cursor](https://cursor.com)