### PR TITLE
fix(cloudflare): guard StateStore Api source-path resolution from worker runtime

### DIFF
--- a/packages/alchemy/src/Cloudflare/StateStore/Api.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Api.ts
@@ -33,13 +33,23 @@ export const STATE_STORE_SCRIPT_NAME = "alchemy-state-store" as const;
  *
  * In the bundled case, fall back to the published source file shipped
  * alongside the CLI under `../src/Cloudflare/StateStore/Api.ts`.
+ *
+ * Guarded with try/catch because this same module is also evaluated by
+ * the Cloudflare Workers runtime once the bundle is deployed, where
+ * `import.meta.url` may be missing or use a non-`file:` scheme. The
+ * resolved path is only consumed at bundle-time by the alchemy CLI; the
+ * worker runtime never reads it, so an empty fallback is safe.
  */
 const API_SOURCE_PATH = (() => {
-  const here = fileURLToPath(import.meta.url);
-  if (here.endsWith(".ts")) return here;
-  return fileURLToPath(
-    new URL("../src/Cloudflare/StateStore/Api.ts", import.meta.url),
-  );
+  try {
+    const here = fileURLToPath(import.meta.url);
+    if (here.endsWith(".ts")) return here;
+    return fileURLToPath(
+      new URL("../src/Cloudflare/StateStore/Api.ts", import.meta.url),
+    );
+  } catch {
+    return "";
+  }
 })();
 
 export default Worker(


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by #131. The state-store worker now boots successfully end-to-end.

## What broke

In #131 I added a top-level IIFE in `Cloudflare/StateStore/Api.ts` that resolves the file's own on-disk path so the alchemy CLI's worker bundler can use it as the entry point — fixing the \`[MISSING_EXPORT] \"default\" is not exported by \"bin/alchemy.js\"\` failure when the CLI runs from its bundled \`bin/alchemy.js\`.

The catch I missed: `Api.ts` is also evaluated by the Cloudflare Workers runtime once the bundle is deployed. In that environment `import.meta.url` is undefined, so `fileURLToPath(import.meta.url)` throws on worker startup:

```
ScriptStartupError: Uncaught TypeError: The \"path\" argument must be of type string or an instance of URL. Received undefined
  at node-internal:internal_url:155:15 in fileURLToPath
  at virtual_alchemy-entry.js:6:34907
```

The worker never starts, so `bun alchemy bootstrap cloudflare` fails right after creating the Secrets Store / secrets / random values, when it tries to actually deploy the state-store worker.

## Fix

Wrap the path resolution in `try/catch` with an empty-string fallback. The resolved path is only consumed at bundle-time by the alchemy CLI as the rolldown entry point; the worker runtime never reads it.

## Verification

End-to-end run from `examples/cloudflare-worker`:

```
$ bun alchemy bootstrap cloudflare --force
✓ AlchemyStateStoreToken (Cloudflare.SecretsStore.Secret) no change
✓ Api (Cloudflare.Worker) created
  • Enabling workers.dev subdomain...
✓ StateStoreAuthTokenValue (Alchemy.Random) no change
✓ StateStoreEncryptionKey (Cloudflare.SecretsStore.Secret) no change
✓ StateStoreEncryptionKeyValue (Alchemy.Random) no change
✓ StateStoreSecrets (Cloudflare.SecretsStore) no change
◆  HTTP state store credentials saved for 'default'.
●    url:     https://alchemy-state-store.testing-2b2.workers.dev
◆  Cloudflare State Store 'alchemy-state-store' is ready.
```

## Test plan

- [x] `bun x tsc -b` clean
- [x] `bun alchemy bootstrap cloudflare --force` succeeds against a real Cloudflare account

Made with [Cursor](https://cursor.com)