### PR TITLE
feat(aws): add AWS API Gateway REST resources

### DIFF
--- a/examples/aws-rest-api/alchemy.run.ts
+++ b/examples/aws-rest-api/alchemy.run.ts
@@ -1,0 +1,84 @@
+import * as Alchemy from "alchemy";
+import * as AWS from "alchemy/AWS";
+import * as Output from "alchemy/Output";
+import * as Effect from "effect/Effect";
+import JobFunction from "./src/JobFunction.ts";
+
+const aws = AWS.providers();
+
+export default Alchemy.Stack(
+  "AwsRestApiProxy",
+  {
+    providers: aws,
+    state: Alchemy.localState(),
+  },
+  Effect.gen(function* () {
+    const { region, accountId } = yield* AWS.AWSEnvironment;
+
+    const fn = yield* JobFunction;
+
+    const api = yield* AWS.ApiGateway.RestApi("PublicApi", {
+      name: "alchemy-example-rest-api",
+      endpointConfiguration: { types: ["REGIONAL"] },
+    });
+
+    const proxyResource = yield* AWS.ApiGateway.Resource("Proxy", {
+      restApiId: api.restApiId,
+      parentId: api.rootResourceId,
+      pathPart: "{proxy+}",
+    });
+
+    const invokeUri = Output.interpolate`arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/${fn.functionArn}/invocations`;
+
+    yield* AWS.ApiGateway.Method("RootAny", {
+      restApiId: api.restApiId,
+      resourceId: api.rootResourceId,
+      httpMethod: "ANY",
+      authorizationType: "NONE",
+      integration: {
+        type: "AWS_PROXY",
+        integrationHttpMethod: "POST",
+        uri: invokeUri,
+      },
+    });
+
+    yield* AWS.ApiGateway.Method("ProxyAny", {
+      restApiId: api.restApiId,
+      resourceId: proxyResource.resourceId,
+      httpMethod: "ANY",
+      authorizationType: "NONE",
+      integration: {
+        type: "AWS_PROXY",
+        integrationHttpMethod: "POST",
+        uri: invokeUri,
+      },
+    });
+
+    const deployment = yield* AWS.ApiGateway.Deployment("Release", {
+      restApiId: api.restApiId,
+      description: "initial",
+      triggers: {
+        rootMethod: "ANY",
+        proxyMethod: "ANY",
+      },
+    });
+
+    const stage = yield* AWS.ApiGateway.Stage("ProdStage", {
+      restApiId: api.restApiId,
+      stageName: "prod",
+      deploymentId: deployment.deploymentId,
+    });
+
+    yield* AWS.Lambda.Permission("ApiGatewayInvoke", {
+      action: "lambda:InvokeFunction",
+      functionName: fn.functionName,
+      principal: "apigateway.amazonaws.com",
+      sourceArn: Output.interpolate`arn:aws:execute-api:${region}:${accountId}:${api.restApiId}/*/*/*`,
+    });
+
+    return {
+      invokeUrl: Output.interpolate`https://${api.restApiId}.execute-api.${region}.amazonaws.com/${stage.stageName}/`,
+      restApiId: api.restApiId,
+    };
+  }),
+);

--- a/examples/aws-rest-api/package.json
+++ b/examples/aws-rest-api/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "aws-rest-api",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alchemy-run/alchemy-effect"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "deploy": "alchemy deploy",
+    "dev": "alchemy dev",
+    "destroy": "alchemy destroy"
+  },
+  "dependencies": {
+    "@distilled.cloud/aws": "catalog:",
+    "alchemy": "workspace:*",
+    "effect": "catalog:"
+  }
+}

--- a/examples/aws-rest-api/src/JobFunction.ts
+++ b/examples/aws-rest-api/src/JobFunction.ts
@@ -1,0 +1,22 @@
+import * as AWS from "alchemy/AWS";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+const main = import.meta.filename;
+
+/**
+ * Minimal Lambda for API Gateway `AWS_PROXY` — returns plain text.
+ */
+export default class JobFunction extends AWS.Lambda.Function<AWS.Lambda.Function>()(
+  "JobFunction",
+  {
+    main,
+  },
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.gen(function* () {
+        return HttpServerResponse.text("Hello from REST API + Lambda");
+      }),
+    };
+  }),
+) {}

--- a/examples/aws-rest-api/tsconfig.json
+++ b/examples/aws-rest-api/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["alchemy.run.ts", "src/**/*.ts"],
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "target": "ESNext"
+  },
+  "references": [
+    {
+      "path": "../../packages/alchemy/tsconfig.json"
+    }
+  ]
+}

--- a/packages/alchemy/src/AWS/ApiGateway/Account.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/Account.ts
@@ -1,0 +1,147 @@
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import * as Effect from "effect/Effect";
+import { isResolved } from "../../Diff.ts";
+import type { Input } from "../../Input.ts";
+import * as Provider from "../../Provider.ts";
+import { Resource } from "../../Resource.ts";
+import type { Providers } from "../Providers.ts";
+
+export interface AccountProps {
+  /**
+   * IAM role ARN for API Gateway to push logs to CloudWatch.
+   */
+  cloudwatchRoleArn?: string;
+}
+
+export interface Account extends Resource<
+  "AWS.ApiGateway.Account",
+  AccountProps,
+  {
+    cloudwatchRoleArn: string | undefined;
+    /**
+     * True when this stack last applied a desired `cloudwatchRoleArn` (including clearing it).
+     * Used so destroy does not remove a role the stack never configured.
+     */
+    managesCloudwatchRoleArn: boolean;
+  },
+  never,
+  Providers
+> {}
+
+/**
+ * Account-level settings for Amazon API Gateway in the current region
+ * (CloudWatch logging role, etc.).
+ *
+ * @section Account settings
+ * @example Set logging role
+ * ```typescript
+ * yield* ApiGateway.Account("Account", {
+ *   cloudwatchRoleArn: role.roleArn,
+ * });
+ * ```
+ */
+const AccountResource = Resource<Account>("AWS.ApiGateway.Account");
+
+export { AccountResource as Account };
+
+export const AccountProvider = () =>
+  Provider.effect(
+    AccountResource,
+    Effect.gen(function* () {
+      return {
+        diff: Effect.fn(function* ({ news: newsIn, olds, output }) {
+          if (!isResolved(newsIn)) return;
+          const news = newsIn as AccountProps;
+          const prevManages = output?.managesCloudwatchRoleArn ?? false;
+          const nextManages = news.cloudwatchRoleArn !== undefined;
+          if (nextManages) {
+            if (news.cloudwatchRoleArn !== olds.cloudwatchRoleArn) {
+              return { action: "update" } as const;
+            }
+          } else if (prevManages) {
+            return { action: "update" } as const;
+          }
+        }),
+        read: Effect.fn(function* ({ output }) {
+          const a = yield* ag
+            .getAccount({})
+            .pipe(
+              Effect.catchTag("NotFoundException", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+          return {
+            cloudwatchRoleArn: a?.cloudwatchRoleArn,
+            managesCloudwatchRoleArn: output?.managesCloudwatchRoleArn ?? false,
+          };
+        }),
+        create: Effect.fn(function* ({ news: newsIn, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("Account props were not resolved");
+          }
+          const news = newsIn as AccountProps;
+          const manages = news.cloudwatchRoleArn !== undefined;
+          const patches: ag.PatchOperation[] = [];
+          if (manages) {
+            if (news.cloudwatchRoleArn) {
+              patches.push({
+                op: "replace",
+                path: "/cloudwatchRoleArn",
+                value: news.cloudwatchRoleArn,
+              });
+            } else {
+              patches.push({ op: "remove", path: "/cloudwatchRoleArn" });
+            }
+          }
+          if (patches.length > 0) {
+            yield* ag.updateAccount({ patchOperations: patches });
+          }
+          yield* session.note("Updated API Gateway account settings");
+          const a = yield* ag.getAccount({});
+          return {
+            cloudwatchRoleArn: a.cloudwatchRoleArn,
+            managesCloudwatchRoleArn: manages,
+          };
+        }),
+        update: Effect.fn(function* ({ news: newsIn, output, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("Account props were not resolved");
+          }
+          const news = newsIn as AccountProps;
+          let manages = output.managesCloudwatchRoleArn;
+          if (news.cloudwatchRoleArn !== undefined) {
+            manages = true;
+            yield* ag.updateAccount({
+              patchOperations: news.cloudwatchRoleArn
+                ? [
+                    {
+                      op: "replace",
+                      path: "/cloudwatchRoleArn",
+                      value: news.cloudwatchRoleArn,
+                    },
+                  ]
+                : [{ op: "remove", path: "/cloudwatchRoleArn" }],
+            });
+          } else {
+            manages = false;
+          }
+          yield* session.note("Updated API Gateway account settings");
+          const a = yield* ag.getAccount({});
+          return {
+            cloudwatchRoleArn: a.cloudwatchRoleArn,
+            managesCloudwatchRoleArn: manages,
+          };
+        }),
+        delete: Effect.fn(function* ({ output, session }) {
+          if (output.managesCloudwatchRoleArn) {
+            yield* ag
+              .updateAccount({
+                patchOperations: [{ op: "remove", path: "/cloudwatchRoleArn" }],
+              })
+              .pipe(Effect.catchTag("BadRequestException", () => Effect.void));
+            yield* session.note("Cleared API Gateway account CloudWatch role");
+          }
+        }),
+      };
+    }),
+  );

--- a/packages/alchemy/src/AWS/ApiGateway/ApiKey.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/ApiKey.ts
@@ -1,0 +1,193 @@
+import { Region } from "@distilled.cloud/aws/Region";
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import * as Effect from "effect/Effect";
+import { deepEqual, isResolved } from "../../Diff.ts";
+import * as Provider from "../../Provider.ts";
+import { Resource } from "../../Resource.ts";
+import type { Providers } from "../Providers.ts";
+import { createInternalTags } from "../../Tags.ts";
+
+import { apiKeyArn, syncTags } from "./common.ts";
+
+export interface ApiKeyProps {
+  name?: string;
+  description?: string;
+  enabled?: boolean;
+  generateDistinctId?: boolean;
+  /**
+   * Write-only value when creating; never stored in resource state or outputs.
+   */
+  value?: string;
+  stageKeys?: ag.StageKey[];
+  customerId?: string;
+  tags?: Record<string, string>;
+}
+
+export interface ApiKey extends Resource<
+  "AWS.ApiGateway.ApiKey",
+  ApiKeyProps,
+  {
+    id: string;
+    name: string | undefined;
+    enabled: boolean | undefined;
+    tags: Record<string, string>;
+  },
+  never,
+  Providers
+> {}
+
+/**
+ * API Gateway API key for usage plans and `apiKeyRequired` methods.
+ *
+ * @section API keys
+ * @example Generated key
+ * ```typescript
+ * const key = yield* ApiGateway.ApiKey("PartnerKey", {
+ *   name: "partner",
+ *   generateDistinctId: true,
+ * });
+ * ```
+ */
+const ApiKeyResource = Resource<ApiKey>("AWS.ApiGateway.ApiKey");
+
+export { ApiKeyResource as ApiKey };
+
+const toTags = (tags: ag.ApiKey["tags"]) =>
+  Object.fromEntries(
+    Object.entries(tags ?? {}).filter(
+      (e): e is [string, string] => e[1] !== undefined,
+    ),
+  );
+
+export const ApiKeyProvider = () =>
+  Provider.effect(
+    ApiKeyResource,
+    Effect.gen(function* () {
+      const awsRegion = yield* Region;
+
+      return {
+        stables: ["id"] as const,
+        diff: Effect.fn(function* ({ news: newsIn, olds }) {
+          if (!isResolved(newsIn)) return;
+          const news = newsIn as ApiKeyProps;
+          if (
+            news.value !== olds.value ||
+            news.customerId !== olds.customerId
+          ) {
+            return { action: "replace" } as const;
+          }
+        }),
+        read: Effect.fn(function* ({ output }) {
+          if (!output?.id) return undefined;
+          const k = yield* ag
+            .getApiKey({ apiKey: output.id, includeValue: false })
+            .pipe(
+              Effect.catchTag("NotFoundException", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+          if (!k?.id) return undefined;
+          return {
+            id: k.id,
+            name: k.name,
+            enabled: k.enabled,
+            tags: toTags(k.tags),
+          };
+        }),
+        create: Effect.fn(function* ({ id, news: newsIn, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("ApiKey props were not resolved");
+          }
+          const news = newsIn as ApiKeyProps;
+          const internalTags = yield* createInternalTags(id);
+          const allTags = { ...news.tags, ...internalTags };
+
+          const k = yield* ag.createApiKey({
+            name: news.name,
+            description: news.description,
+            enabled: news.enabled,
+            generateDistinctId: news.generateDistinctId,
+            value: news.value,
+            stageKeys: news.stageKeys,
+            customerId: news.customerId,
+            tags: allTags,
+          });
+          if (!k.id) return yield* Effect.die("createApiKey missing id");
+          yield* session.note(`Created API key ${k.id}`);
+          const full = yield* ag.getApiKey({
+            apiKey: k.id,
+            includeValue: false,
+          });
+          if (!full.id) return yield* Effect.die("getApiKey missing id");
+          return {
+            id: full.id,
+            name: full.name,
+            enabled: full.enabled,
+            tags: toTags(full.tags),
+          };
+        }),
+        update: Effect.fn(function* ({ id, news: newsIn, output, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("ApiKey props were not resolved");
+          }
+          const news = newsIn as ApiKeyProps;
+          const patches: ag.PatchOperation[] = [];
+          if (news.name !== output.name) {
+            patches.push({
+              op: "replace",
+              path: "/name",
+              value: news.name ?? "",
+            });
+          }
+          if (news.description !== undefined) {
+            patches.push({
+              op: "replace",
+              path: "/description",
+              value: news.description ?? "",
+            });
+          }
+          if (news.enabled !== undefined && news.enabled !== output.enabled) {
+            patches.push({
+              op: "replace",
+              path: "/enabled",
+              value: String(news.enabled),
+            });
+          }
+          if (patches.length > 0) {
+            yield* ag.updateApiKey({
+              apiKey: output.id,
+              patchOperations: patches,
+            });
+          }
+
+          const internalTags = yield* createInternalTags(id);
+          const newTags = { ...news.tags, ...internalTags };
+          if (!deepEqual(output.tags, newTags)) {
+            yield* syncTags({
+              resourceArn: apiKeyArn(awsRegion, output.id),
+              oldTags: output.tags,
+              newTags,
+            });
+          }
+
+          yield* session.note(`Updated API key ${output.id}`);
+          const full = yield* ag.getApiKey({
+            apiKey: output.id,
+            includeValue: false,
+          });
+          return {
+            id: output.id,
+            name: full.name,
+            enabled: full.enabled,
+            tags: toTags(full.tags),
+          };
+        }),
+        delete: Effect.fn(function* ({ output, session }) {
+          yield* ag
+            .deleteApiKey({ apiKey: output.id })
+            .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
+          yield* session.note(`Deleted API key ${output.id}`);
+        }),
+      };
+    }),
+  );

--- a/packages/alchemy/src/AWS/ApiGateway/ApiKey.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/ApiKey.ts
@@ -1,25 +1,55 @@
 import { Region } from "@distilled.cloud/aws/Region";
 import * as ag from "@distilled.cloud/aws/api-gateway";
 import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import * as Stream from "effect/Stream";
 import { deepEqual, isResolved } from "../../Diff.ts";
+import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
-import { createInternalTags } from "../../Tags.ts";
+import { createInternalTags, hasAlchemyTags, tagRecord } from "../../Tags.ts";
 
 import { apiKeyArn, syncTags } from "./common.ts";
 
 export interface ApiKeyProps {
+  /**
+   * Friendly name for the API key.
+   *
+   * If omitted, Alchemy generates a deterministic physical name from the
+   * stack, stage, logical ID, and instance ID.
+   */
   name?: string;
+  /**
+   * Human-readable description shown in API Gateway.
+   */
   description?: string;
+  /**
+   * Whether clients can use the key.
+   *
+   * @default true
+   */
   enabled?: boolean;
+  /**
+   * Appends a distinct suffix to the generated key value when AWS generates it.
+   */
   generateDistinctId?: boolean;
   /**
    * Write-only value when creating; never stored in resource state or outputs.
+   * Wrap with `Redacted.make` so state encoding preserves redaction.
    */
-  value?: string;
+  value?: Redacted.Redacted<string>;
+  /**
+   * Stage associations to attach directly to this API key.
+   */
   stageKeys?: ag.StageKey[];
+  /**
+   * External customer identifier associated with the key.
+   */
   customerId?: string;
+  /**
+   * User-defined tags. Alchemy internal tags are merged automatically.
+   */
   tags?: Record<string, string>;
 }
 
@@ -43,7 +73,6 @@ export interface ApiKey extends Resource<
  * @example Generated key
  * ```typescript
  * const key = yield* ApiGateway.ApiKey("PartnerKey", {
- *   name: "partner",
  *   generateDistinctId: true,
  * });
  * ```
@@ -52,12 +81,30 @@ const ApiKeyResource = Resource<ApiKey>("AWS.ApiGateway.ApiKey");
 
 export { ApiKeyResource as ApiKey };
 
-const toTags = (tags: ag.ApiKey["tags"]) =>
-  Object.fromEntries(
-    Object.entries(tags ?? {}).filter(
-      (e): e is [string, string] => e[1] !== undefined,
-    ),
-  );
+const resolvedValue = (value: Redacted.Redacted<string> | undefined) =>
+  value ? Redacted.value(value) : undefined;
+
+const generatedName = (id: string, props: ApiKeyProps) =>
+  props.name
+    ? Effect.succeed(props.name)
+    : createPhysicalName({
+        id,
+        maxLength: 128,
+      });
+
+const readByName = Effect.fn(function* (id: string, name: string) {
+  const keys = yield* ag.getApiKeys
+    .items({ nameQuery: name, limit: 500, includeValues: false })
+    .pipe(Stream.runCollect);
+
+  for (const key of keys) {
+    if (key.name !== name || !key.id) continue;
+    if (yield* hasAlchemyTags(id, key.tags)) {
+      return key;
+    }
+  }
+  return undefined;
+});
 
 export const ApiKeyProvider = () =>
   Provider.effect(
@@ -71,7 +118,7 @@ export const ApiKeyProvider = () =>
           if (!isResolved(newsIn)) return;
           const news = newsIn as ApiKeyProps;
           if (
-            news.value !== olds.value ||
+            resolvedValue(news.value) !== resolvedValue(olds.value) ||
             news.customerId !== olds.customerId
           ) {
             return { action: "replace" } as const;
@@ -91,7 +138,7 @@ export const ApiKeyProvider = () =>
             id: k.id,
             name: k.name,
             enabled: k.enabled,
-            tags: toTags(k.tags),
+            tags: tagRecord(k.tags),
           };
         }),
         create: Effect.fn(function* ({ id, news: newsIn, session }) {
@@ -99,19 +146,34 @@ export const ApiKeyProvider = () =>
             return yield* Effect.die("ApiKey props were not resolved");
           }
           const news = newsIn as ApiKeyProps;
+          const name = yield* generatedName(id, news);
           const internalTags = yield* createInternalTags(id);
           const allTags = { ...news.tags, ...internalTags };
 
-          const k = yield* ag.createApiKey({
-            name: news.name,
-            description: news.description,
-            enabled: news.enabled,
-            generateDistinctId: news.generateDistinctId,
-            value: news.value,
-            stageKeys: news.stageKeys,
-            customerId: news.customerId,
-            tags: allTags,
-          });
+          const k = yield* ag
+            .createApiKey({
+              name,
+              description: news.description,
+              enabled: news.enabled,
+              generateDistinctId: news.generateDistinctId,
+              value: resolvedValue(news.value),
+              stageKeys: news.stageKeys,
+              customerId: news.customerId,
+              tags: allTags,
+            })
+            .pipe(
+              Effect.catchTag("ConflictException", () =>
+                Effect.gen(function* () {
+                  const existing = yield* readByName(id, name);
+                  if (existing) return existing;
+                  return yield* Effect.fail(
+                    new ag.ConflictException({
+                      message: `API key '${name}' already exists and is not managed by alchemy`,
+                    }),
+                  );
+                }),
+              ),
+            );
           if (!k.id) return yield* Effect.die("createApiKey missing id");
           yield* session.note(`Created API key ${k.id}`);
           const full = yield* ag.getApiKey({
@@ -123,7 +185,7 @@ export const ApiKeyProvider = () =>
             id: full.id,
             name: full.name,
             enabled: full.enabled,
-            tags: toTags(full.tags),
+            tags: tagRecord(full.tags),
           };
         }),
         update: Effect.fn(function* ({ id, news: newsIn, output, session }) {
@@ -132,7 +194,9 @@ export const ApiKeyProvider = () =>
           }
           const news = newsIn as ApiKeyProps;
           const patches: ag.PatchOperation[] = [];
-          if (news.name !== output.name) {
+          // Generated names are stable physical names; only patch when the user
+          // explicitly supplies a new name.
+          if (news.name !== undefined && news.name !== output.name) {
             patches.push({
               op: "replace",
               path: "/name",
@@ -179,7 +243,7 @@ export const ApiKeyProvider = () =>
             id: output.id,
             name: full.name,
             enabled: full.enabled,
-            tags: toTags(full.tags),
+            tags: tagRecord(full.tags),
           };
         }),
         delete: Effect.fn(function* ({ output, session }) {

--- a/packages/alchemy/src/AWS/ApiGateway/ApiKey.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/ApiKey.ts
@@ -118,6 +118,8 @@ export const ApiKeyProvider = () =>
           if (!isResolved(newsIn)) return;
           const news = newsIn as ApiKeyProps;
           if (
+            // API Gateway never returns the key value after create, so rotating
+            // a user-supplied value is modeled as replacement instead of patch.
             resolvedValue(news.value) !== resolvedValue(olds.value) ||
             news.customerId !== olds.customerId
           ) {

--- a/packages/alchemy/src/AWS/ApiGateway/Authorizer.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/Authorizer.ts
@@ -1,0 +1,210 @@
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import * as Effect from "effect/Effect";
+import { deepEqual, isResolved } from "../../Diff.ts";
+import type { Input } from "../../Input.ts";
+import * as Provider from "../../Provider.ts";
+import { Resource } from "../../Resource.ts";
+import type { Providers } from "../Providers.ts";
+
+export interface AuthorizerProps {
+  restApiId: Input<string>;
+  name: string;
+  type: ag.AuthorizerType;
+  providerARNs?: string[];
+  authType?: string;
+  authorizerUri?: string;
+  authorizerCredentials?: string;
+  identitySource?: string;
+  identityValidationExpression?: string;
+  authorizerResultTtlInSeconds?: number;
+}
+
+export interface Authorizer extends Resource<
+  "AWS.ApiGateway.Authorizer",
+  AuthorizerProps,
+  {
+    authorizerId: string;
+    restApiId: string;
+    name: string;
+    type: ag.AuthorizerType;
+  },
+  never,
+  Providers
+> {}
+
+/**
+ * REST API Lambda, Cognito, or gateway authorizer.
+ *
+ * @section Authorizers
+ * @example Lambda TOKEN authorizer
+ * ```typescript
+ * const authorizer = yield* ApiGateway.Authorizer("Auth", {
+ *   restApiId: api.restApiId,
+ *   name: "lambda-auth",
+ *   type: "TOKEN",
+ *   authorizerUri: authorizerInvokeArn,
+ *   identitySource: "method.request.header.Authorization",
+ * });
+ * ```
+ */
+const AuthorizerResource = Resource<Authorizer>("AWS.ApiGateway.Authorizer");
+
+export { AuthorizerResource as Authorizer };
+
+export const AuthorizerProvider = () =>
+  Provider.effect(
+    AuthorizerResource,
+    Effect.gen(function* () {
+      return {
+        stables: ["authorizerId", "restApiId"] as const,
+        diff: Effect.fn(function* ({ news: newsIn, olds }) {
+          if (!isResolved(newsIn)) return;
+          const news = newsIn as AuthorizerProps;
+          if (
+            news.restApiId !== olds.restApiId ||
+            news.name !== olds.name ||
+            news.type !== olds.type
+          ) {
+            return { action: "replace" } as const;
+          }
+          if (!deepEqual(news.providerARNs, olds.providerARNs)) {
+            return { action: "replace" } as const;
+          }
+          if (news.authType !== olds.authType) {
+            return { action: "replace" } as const;
+          }
+        }),
+        read: Effect.fn(function* ({ output }) {
+          if (!output?.authorizerId) return undefined;
+          const a = yield* ag
+            .getAuthorizer({
+              restApiId: output.restApiId,
+              authorizerId: output.authorizerId,
+            })
+            .pipe(
+              Effect.catchTag("NotFoundException", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+          if (!a?.id) return undefined;
+          return {
+            authorizerId: a.id,
+            restApiId: output.restApiId,
+            name: a.name!,
+            type: a.type!,
+          };
+        }),
+        create: Effect.fn(function* ({ news: newsIn, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("Authorizer props were not resolved");
+          }
+          const news = newsIn as Input.ResolveProps<AuthorizerProps>;
+          const a = yield* ag.createAuthorizer({
+            restApiId: news.restApiId as string,
+            name: news.name,
+            type: news.type,
+            providerARNs: news.providerARNs,
+            authType: news.authType,
+            authorizerUri: news.authorizerUri,
+            authorizerCredentials: news.authorizerCredentials,
+            identitySource: news.identitySource,
+            identityValidationExpression: news.identityValidationExpression,
+            authorizerResultTtlInSeconds: news.authorizerResultTtlInSeconds,
+          });
+          if (!a.id) return yield* Effect.die("createAuthorizer missing id");
+          yield* session.note(`Created authorizer ${a.id}`);
+          return {
+            authorizerId: a.id,
+            restApiId: news.restApiId as string,
+            name: news.name,
+            type: news.type,
+          };
+        }),
+        update: Effect.fn(function* ({ news: newsIn, olds, output, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("Authorizer props were not resolved");
+          }
+          const news = newsIn as Input.ResolveProps<AuthorizerProps>;
+          const patches: ag.PatchOperation[] = [];
+          if (news.authorizerUri !== olds.authorizerUri) {
+            patches.push({
+              op: news.authorizerUri === undefined ? "remove" : "replace",
+              path: "/authorizerUri",
+              value: news.authorizerUri,
+            });
+          }
+          if (news.identitySource !== olds.identitySource) {
+            patches.push({
+              op: news.identitySource === undefined ? "remove" : "replace",
+              path: "/identitySource",
+              value: news.identitySource,
+            });
+          }
+          if (news.authorizerCredentials !== olds.authorizerCredentials) {
+            patches.push({
+              op:
+                news.authorizerCredentials === undefined ? "remove" : "replace",
+              path: "/authorizerCredentials",
+              value: news.authorizerCredentials,
+            });
+          }
+          if (
+            news.identityValidationExpression !==
+            olds.identityValidationExpression
+          ) {
+            patches.push({
+              op:
+                news.identityValidationExpression === undefined
+                  ? "remove"
+                  : "replace",
+              path: "/identityValidationExpression",
+              value: news.identityValidationExpression,
+            });
+          }
+          if (
+            news.authorizerResultTtlInSeconds !==
+            olds.authorizerResultTtlInSeconds
+          ) {
+            patches.push({
+              op:
+                news.authorizerResultTtlInSeconds === undefined
+                  ? "remove"
+                  : "replace",
+              path: "/authorizerResultTtlInSeconds",
+              value:
+                news.authorizerResultTtlInSeconds === undefined
+                  ? undefined
+                  : String(news.authorizerResultTtlInSeconds),
+            });
+          }
+          if (patches.length > 0) {
+            yield* ag.updateAuthorizer({
+              restApiId: output.restApiId,
+              authorizerId: output.authorizerId,
+              patchOperations: patches,
+            });
+          }
+          yield* session.note(`Updated authorizer ${output.authorizerId}`);
+          const a = yield* ag.getAuthorizer({
+            restApiId: output.restApiId,
+            authorizerId: output.authorizerId,
+          });
+          return {
+            authorizerId: output.authorizerId,
+            restApiId: output.restApiId,
+            name: a.name!,
+            type: a.type!,
+          };
+        }),
+        delete: Effect.fn(function* ({ output, session }) {
+          yield* ag
+            .deleteAuthorizer({
+              restApiId: output.restApiId,
+              authorizerId: output.authorizerId,
+            })
+            .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
+          yield* session.note(`Deleted authorizer ${output.authorizerId}`);
+        }),
+      };
+    }),
+  );

--- a/packages/alchemy/src/AWS/ApiGateway/Authorizer.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/Authorizer.ts
@@ -2,20 +2,55 @@ import * as ag from "@distilled.cloud/aws/api-gateway";
 import * as Effect from "effect/Effect";
 import { deepEqual, isResolved } from "../../Diff.ts";
 import type { Input } from "../../Input.ts";
+import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
 
 export interface AuthorizerProps {
+  /**
+   * REST API identifier that owns the authorizer.
+   */
   restApiId: Input<string>;
-  name: string;
+  /**
+   * Authorizer name.
+   *
+   * If omitted, Alchemy generates a deterministic physical name.
+   */
+  name?: string;
+  /**
+   * Authorizer type.
+   */
   type: ag.AuthorizerType;
+  /**
+   * Cognito user pool ARNs for `COGNITO_USER_POOLS` authorizers.
+   */
   providerARNs?: string[];
+  /**
+   * Custom authorization type label.
+   */
   authType?: string;
+  /**
+   * Lambda invocation URI for `TOKEN` or `REQUEST` authorizers.
+   */
   authorizerUri?: string;
+  /**
+   * IAM role ARN used by API Gateway to invoke the authorizer.
+   *
+   * This is not secret key material; API Gateway stores the role ARN.
+   */
   authorizerCredentials?: string;
+  /**
+   * Identity source expression, e.g. `method.request.header.Authorization`.
+   */
   identitySource?: string;
+  /**
+   * Validation regex for token authorizers.
+   */
   identityValidationExpression?: string;
+  /**
+   * Cache TTL for authorizer results, in seconds.
+   */
   authorizerResultTtlInSeconds?: number;
 }
 
@@ -40,7 +75,6 @@ export interface Authorizer extends Resource<
  * ```typescript
  * const authorizer = yield* ApiGateway.Authorizer("Auth", {
  *   restApiId: api.restApiId,
- *   name: "lambda-auth",
  *   type: "TOKEN",
  *   authorizerUri: authorizerInvokeArn,
  *   identitySource: "method.request.header.Authorization",
@@ -50,6 +84,14 @@ export interface Authorizer extends Resource<
 const AuthorizerResource = Resource<Authorizer>("AWS.ApiGateway.Authorizer");
 
 export { AuthorizerResource as Authorizer };
+
+const generatedName = (id: string, props: AuthorizerProps) =>
+  props.name
+    ? Effect.succeed(props.name)
+    : createPhysicalName({
+        id,
+        maxLength: 128,
+      });
 
 export const AuthorizerProvider = () =>
   Provider.effect(
@@ -61,8 +103,10 @@ export const AuthorizerProvider = () =>
           if (!isResolved(newsIn)) return;
           const news = newsIn as AuthorizerProps;
           if (
+            // These fields define the authorizer identity and kind; replacement
+            // avoids patching a different authorizer shape in place.
             news.restApiId !== olds.restApiId ||
-            news.name !== olds.name ||
+            (news.name !== undefined && news.name !== olds.name) ||
             news.type !== olds.type
           ) {
             return { action: "replace" } as const;
@@ -94,14 +138,15 @@ export const AuthorizerProvider = () =>
             type: a.type!,
           };
         }),
-        create: Effect.fn(function* ({ news: newsIn, session }) {
+        create: Effect.fn(function* ({ id, news: newsIn, session }) {
           if (!isResolved(newsIn)) {
             return yield* Effect.die("Authorizer props were not resolved");
           }
           const news = newsIn as Input.ResolveProps<AuthorizerProps>;
+          const name = yield* generatedName(id, news);
           const a = yield* ag.createAuthorizer({
             restApiId: news.restApiId as string,
-            name: news.name,
+            name,
             type: news.type,
             providerARNs: news.providerARNs,
             authType: news.authType,
@@ -116,7 +161,7 @@ export const AuthorizerProvider = () =>
           return {
             authorizerId: a.id,
             restApiId: news.restApiId as string,
-            name: news.name,
+            name,
             type: news.type,
           };
         }),

--- a/packages/alchemy/src/AWS/ApiGateway/BasePathMapping.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/BasePathMapping.ts
@@ -1,0 +1,183 @@
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import * as Effect from "effect/Effect";
+import { isResolved } from "../../Diff.ts";
+import type { Input } from "../../Input.ts";
+import * as Provider from "../../Provider.ts";
+import { Resource } from "../../Resource.ts";
+import type { Providers } from "../Providers.ts";
+
+const normalizeBasePath = (basePath: string | undefined) =>
+  basePath === undefined || basePath === "" ? "(none)" : basePath;
+
+export interface BasePathMappingProps {
+  domainName: string;
+  domainNameId?: string;
+  /**
+   * Base path segment; omit or empty string for root mapping (`(none)` in API Gateway).
+   */
+  basePath?: string;
+  restApiId: Input<string>;
+  stage?: string;
+}
+
+export interface BasePathMapping extends Resource<
+  "AWS.ApiGateway.BasePathMapping",
+  BasePathMappingProps,
+  {
+    domainName: string;
+    domainNameId: string | undefined;
+    basePath: string;
+    restApiId: string;
+    stage: string | undefined;
+  },
+  never,
+  Providers
+> {}
+
+/**
+ * Maps a custom domain name path to a REST API stage.
+ *
+ * @section Custom domain
+ * @example Root mapping
+ * ```typescript
+ * yield* ApiGateway.BasePathMapping("Root", {
+ *   domainName: domain.domainName,
+ *   restApiId: api.restApiId,
+ *   stage: stage.stageName,
+ * });
+ * ```
+ */
+const BasePathMappingResource = Resource<BasePathMapping>(
+  "AWS.ApiGateway.BasePathMapping",
+);
+
+export { BasePathMappingResource as BasePathMapping };
+
+export const BasePathMappingProvider = () =>
+  Provider.effect(
+    BasePathMappingResource,
+    Effect.gen(function* () {
+      return {
+        stables: ["domainName", "domainNameId", "basePath"] as const,
+        diff: Effect.fn(function* ({ news: newsIn, olds }) {
+          if (!isResolved(newsIn)) return;
+          const news = newsIn as Input.ResolveProps<BasePathMappingProps>;
+          if (
+            news.domainName !== olds.domainName ||
+            normalizeBasePath(news.basePath) !==
+              normalizeBasePath(olds.basePath)
+          ) {
+            return { action: "replace" } as const;
+          }
+        }),
+        read: Effect.fn(function* ({ output }) {
+          if (!output) return undefined;
+          const b = yield* ag
+            .getBasePathMapping({
+              domainName: output.domainName,
+              basePath: output.basePath,
+              domainNameId: output.domainNameId,
+            })
+            .pipe(
+              Effect.catchTag("NotFoundException", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+          if (!b?.restApiId) return undefined;
+          return {
+            domainName: output.domainName,
+            basePath: output.basePath,
+            domainNameId: output.domainNameId,
+            restApiId: b.restApiId,
+            stage: b.stage,
+          };
+        }),
+        create: Effect.fn(function* ({ news: newsIn, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("BasePathMapping props were not resolved");
+          }
+          const news = newsIn as Input.ResolveProps<BasePathMappingProps>;
+          const basePath = normalizeBasePath(news.basePath);
+          yield* ag.createBasePathMapping({
+            domainName: news.domainName,
+            domainNameId: news.domainNameId,
+            basePath: basePath === "(none)" ? undefined : news.basePath,
+            restApiId: news.restApiId as string,
+            stage: news.stage,
+          });
+          yield* session.note(
+            `Created base path mapping ${news.domainName} / ${basePath}`,
+          );
+          const b = yield* ag.getBasePathMapping({
+            domainName: news.domainName,
+            basePath,
+            domainNameId: news.domainNameId,
+          });
+          return {
+            domainName: news.domainName,
+            domainNameId: news.domainNameId,
+            basePath,
+            restApiId: b.restApiId!,
+            stage: b.stage,
+          };
+        }),
+        update: Effect.fn(function* ({ news: newsIn, output, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("BasePathMapping props were not resolved");
+          }
+          const news = newsIn as Input.ResolveProps<BasePathMappingProps>;
+          const patches: ag.PatchOperation[] = [
+            ...(news.restApiId !== output.restApiId
+              ? [
+                  {
+                    op: "replace" as const,
+                    path: "/restApiId",
+                    value: news.restApiId as string,
+                  },
+                ]
+              : []),
+            ...(news.stage !== output.stage
+              ? [
+                  {
+                    op: "replace" as const,
+                    path: "/stage",
+                    value: news.stage ?? "",
+                  },
+                ]
+              : []),
+          ];
+          if (patches.length > 0) {
+            yield* ag.updateBasePathMapping({
+              domainName: output.domainName,
+              basePath: output.basePath,
+              domainNameId: output.domainNameId,
+              patchOperations: patches,
+            });
+          }
+          yield* session.note(`Updated base path mapping`);
+          const b = yield* ag.getBasePathMapping({
+            domainName: output.domainName,
+            basePath: output.basePath,
+            domainNameId: output.domainNameId,
+          });
+          return {
+            domainName: output.domainName,
+            domainNameId: output.domainNameId,
+            basePath: output.basePath,
+            restApiId: b.restApiId!,
+            stage: b.stage,
+          };
+        }),
+        delete: Effect.fn(function* ({ output, session }) {
+          yield* ag
+            .deleteBasePathMapping({
+              domainName: output.domainName,
+              basePath: output.basePath,
+              domainNameId: output.domainNameId,
+            })
+            .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
+          yield* session.note(`Deleted base path mapping`);
+        }),
+      };
+    }),
+  );

--- a/packages/alchemy/src/AWS/ApiGateway/Deployment.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/Deployment.ts
@@ -1,0 +1,190 @@
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import * as Effect from "effect/Effect";
+import { createHash } from "node:crypto";
+import { deepEqual, isResolved } from "../../Diff.ts";
+import type { Input } from "../../Input.ts";
+import * as Provider from "../../Provider.ts";
+import { Resource } from "../../Resource.ts";
+import type { Providers } from "../Providers.ts";
+
+export interface DeploymentProps {
+  restApiId: Input<string>;
+  description?: string;
+  stageName?: string;
+  stageDescription?: string;
+  cacheClusterEnabled?: boolean;
+  cacheClusterSize?: ag.CacheClusterSize;
+  variables?: { [key: string]: string | undefined };
+  canarySettings?: ag.DeploymentCanarySettings;
+  tracingEnabled?: boolean;
+  /**
+   * Opaque key/value map; when any value changes, a replacement deployment is planned.
+   */
+  triggers?: Record<string, string>;
+}
+
+export interface Deployment extends Resource<
+  "AWS.ApiGateway.Deployment",
+  DeploymentProps,
+  {
+    deploymentId: string;
+    restApiId: string;
+    description: string | undefined;
+  },
+  never,
+  Providers
+> {}
+
+/**
+ * An API Gateway deployment snapshot for a REST API.
+ *
+ * @section Deployments
+ * @example Create deployment
+ * ```typescript
+ * const deployment = yield* ApiGateway.Deployment("Release", {
+ *   restApiId: api.restApiId,
+ *   description: "v1",
+ * });
+ * ```
+ */
+const DeploymentResource = Resource<Deployment>("AWS.ApiGateway.Deployment");
+
+export { DeploymentResource as Deployment };
+
+const embedTriggers = (
+  description: string | undefined,
+  triggers?: Record<string, string>,
+) =>
+  Effect.gen(function* () {
+    if (!triggers || Object.keys(triggers).length === 0) {
+      return description;
+    }
+    const fp = yield* Effect.sync(() =>
+      createHash("sha256")
+        .update(JSON.stringify(triggers))
+        .digest("hex")
+        .slice(0, 24),
+    );
+    const suffix = `@alchemy:triggers:${fp}`;
+    return description ? `${description}\n${suffix}` : suffix;
+  });
+
+export const DeploymentProvider = () =>
+  Provider.effect(
+    DeploymentResource,
+    Effect.gen(function* () {
+      return {
+        stables: ["deploymentId", "restApiId"] as const,
+        diff: Effect.fn(function* ({ news: newsIn, olds }) {
+          if (!isResolved(newsIn)) return;
+          const news = newsIn as Input.ResolveProps<DeploymentProps>;
+          const oldsP = olds as Input.ResolveProps<DeploymentProps>;
+          if (news.restApiId !== oldsP.restApiId) {
+            return { action: "replace" } as const;
+          }
+          if (!deepEqual(news.triggers, oldsP.triggers)) {
+            return { action: "replace" } as const;
+          }
+          if (
+            news.stageName !== oldsP.stageName ||
+            news.stageDescription !== oldsP.stageDescription ||
+            news.cacheClusterEnabled !== oldsP.cacheClusterEnabled ||
+            news.cacheClusterSize !== oldsP.cacheClusterSize ||
+            !deepEqual(news.variables, oldsP.variables) ||
+            !deepEqual(news.canarySettings, oldsP.canarySettings) ||
+            news.tracingEnabled !== oldsP.tracingEnabled
+          ) {
+            return { action: "replace" } as const;
+          }
+          if (news.description !== oldsP.description) {
+            return { action: "update" } as const;
+          }
+        }),
+        read: Effect.fn(function* ({ output }) {
+          if (!output?.deploymentId) return undefined;
+          const d = yield* ag
+            .getDeployment({
+              restApiId: output.restApiId,
+              deploymentId: output.deploymentId,
+            })
+            .pipe(
+              Effect.catchTag("NotFoundException", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+          if (!d?.id) return undefined;
+          return {
+            deploymentId: d.id,
+            restApiId: output.restApiId,
+            description: d.description,
+          };
+        }),
+        create: Effect.fn(function* ({ news: newsIn, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("Deployment props were not resolved");
+          }
+          const news = newsIn as Input.ResolveProps<DeploymentProps>;
+          const description = yield* embedTriggers(
+            news.description,
+            news.triggers,
+          );
+          const d = yield* ag.createDeployment({
+            restApiId: news.restApiId as string,
+            stageName: news.stageName,
+            stageDescription: news.stageDescription,
+            description,
+            cacheClusterEnabled: news.cacheClusterEnabled,
+            cacheClusterSize: news.cacheClusterSize,
+            variables: news.variables,
+            canarySettings: news.canarySettings,
+            tracingEnabled: news.tracingEnabled,
+          });
+          if (!d.id) return yield* Effect.die("createDeployment missing id");
+          yield* session.note(`Created deployment ${d.id}`);
+          return {
+            deploymentId: d.id,
+            restApiId: news.restApiId as string,
+            description: d.description,
+          };
+        }),
+        update: Effect.fn(function* ({ news: newsIn, output, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("Deployment props were not resolved");
+          }
+          const news = newsIn as Input.ResolveProps<DeploymentProps>;
+          const description = yield* embedTriggers(
+            news.description,
+            news.triggers,
+          );
+          if (description !== output.description) {
+            yield* ag.updateDeployment({
+              restApiId: output.restApiId,
+              deploymentId: output.deploymentId,
+              patchOperations: description
+                ? [{ op: "replace", path: "/description", value: description }]
+                : [{ op: "remove", path: "/description" }],
+            });
+          }
+          yield* session.note(`Updated deployment ${output.deploymentId}`);
+          const d = yield* ag.getDeployment({
+            restApiId: output.restApiId,
+            deploymentId: output.deploymentId,
+          });
+          return {
+            deploymentId: output.deploymentId,
+            restApiId: output.restApiId,
+            description: d?.description,
+          };
+        }),
+        delete: Effect.fn(function* ({ output, session }) {
+          yield* ag
+            .deleteDeployment({
+              restApiId: output.restApiId,
+              deploymentId: output.deploymentId,
+            })
+            .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
+          yield* session.note(`Deleted deployment ${output.deploymentId}`);
+        }),
+      };
+    }),
+  );

--- a/packages/alchemy/src/AWS/ApiGateway/DomainName.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/DomainName.ts
@@ -1,0 +1,260 @@
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import * as Effect from "effect/Effect";
+import { deepEqual, isResolved } from "../../Diff.ts";
+import * as Provider from "../../Provider.ts";
+import { Resource } from "../../Resource.ts";
+import type { Providers } from "../Providers.ts";
+import { createInternalTags } from "../../Tags.ts";
+
+import { syncTags } from "./common.ts";
+
+export interface DomainNameProps {
+  domainName: string;
+  certificateName?: string;
+  certificateBody?: string;
+  certificatePrivateKey?: string;
+  certificateChain?: string;
+  certificateArn?: string;
+  regionalCertificateName?: string;
+  regionalCertificateArn?: string;
+  endpointConfiguration?: ag.EndpointConfiguration;
+  securityPolicy?: ag.SecurityPolicy;
+  endpointAccessMode?: ag.EndpointAccessMode;
+  mutualTlsAuthentication?: ag.MutualTlsAuthenticationInput;
+  ownershipVerificationCertificateArn?: string;
+  policy?: string;
+  routingMode?: ag.RoutingMode;
+  tags?: Record<string, string>;
+}
+
+export interface DomainName extends Resource<
+  "AWS.ApiGateway.DomainName",
+  DomainNameProps,
+  {
+    domainName: string;
+    regionalDomainName: string | undefined;
+    regionalHostedZoneId: string | undefined;
+    distributionDomainName: string | undefined;
+    distributionHostedZoneId: string | undefined;
+    domainNameArn: string | undefined;
+    tags: Record<string, string>;
+  },
+  never,
+  Providers
+> {}
+
+/**
+ * Custom domain name for an Amazon API Gateway REST API.
+ *
+ * @section Custom domain
+ * @example Regional custom domain
+ * ```typescript
+ * const domain = yield* ApiGateway.DomainName("ApiDomain", {
+ *   domainName: "api.example.com",
+ *   regionalCertificateArn: cert.certificateArn,
+ *   endpointConfiguration: { types: ["REGIONAL"] },
+ *   securityPolicy: "TLS_1_2",
+ * });
+ * ```
+ */
+const DomainNameResource = Resource<DomainName>("AWS.ApiGateway.DomainName");
+
+export { DomainNameResource as DomainName };
+
+const toTags = (tags: ag.DomainName["tags"]) =>
+  Object.fromEntries(
+    Object.entries(tags ?? {}).filter(
+      (e): e is [string, string] => e[1] !== undefined,
+    ),
+  );
+
+export const DomainNameProvider = () =>
+  Provider.effect(
+    DomainNameResource,
+    Effect.gen(function* () {
+      return {
+        stables: ["domainName"] as const,
+        diff: Effect.fn(function* ({ news: newsIn, olds }) {
+          if (!isResolved(newsIn)) return;
+          const news = newsIn as DomainNameProps;
+          if (news.domainName !== olds.domainName) {
+            return { action: "replace" } as const;
+          }
+          if (
+            !deepEqual(news.endpointConfiguration, olds.endpointConfiguration)
+          ) {
+            return { action: "replace" } as const;
+          }
+          if (news.endpointAccessMode !== olds.endpointAccessMode) {
+            return { action: "replace" } as const;
+          }
+          if (news.certificateBody !== olds.certificateBody) {
+            return { action: "replace" } as const;
+          }
+          if (news.certificatePrivateKey !== olds.certificatePrivateKey) {
+            return { action: "replace" } as const;
+          }
+          if (news.certificateChain !== olds.certificateChain) {
+            return { action: "replace" } as const;
+          }
+          if (news.certificateName !== olds.certificateName) {
+            return { action: "replace" } as const;
+          }
+          if (news.regionalCertificateName !== olds.regionalCertificateName) {
+            return { action: "replace" } as const;
+          }
+          if (
+            !deepEqual(
+              news.mutualTlsAuthentication,
+              olds.mutualTlsAuthentication,
+            )
+          ) {
+            return { action: "replace" } as const;
+          }
+          if (news.policy !== olds.policy) {
+            return { action: "replace" } as const;
+          }
+          if (news.routingMode !== olds.routingMode) {
+            return { action: "replace" } as const;
+          }
+          if (
+            news.ownershipVerificationCertificateArn !==
+            olds.ownershipVerificationCertificateArn
+          ) {
+            return { action: "replace" } as const;
+          }
+        }),
+        read: Effect.fn(function* ({ output }) {
+          if (!output?.domainName) return undefined;
+          const d = yield* ag
+            .getDomainName({ domainName: output.domainName })
+            .pipe(
+              Effect.catchTag("NotFoundException", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+          if (!d?.domainName) return undefined;
+          return {
+            domainName: d.domainName,
+            regionalDomainName: d.regionalDomainName,
+            regionalHostedZoneId: d.regionalHostedZoneId,
+            distributionDomainName: d.distributionDomainName,
+            distributionHostedZoneId: d.distributionHostedZoneId,
+            domainNameArn: d.domainNameArn,
+            tags: toTags(d.tags),
+          };
+        }),
+        create: Effect.fn(function* ({ id, news: newsIn, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("DomainName props were not resolved");
+          }
+          const news = newsIn as DomainNameProps;
+          const internalTags = yield* createInternalTags(id);
+          const allTags = { ...news.tags, ...internalTags };
+
+          yield* ag.createDomainName({
+            domainName: news.domainName,
+            certificateName: news.certificateName,
+            certificateBody: news.certificateBody,
+            certificatePrivateKey: news.certificatePrivateKey,
+            certificateChain: news.certificateChain,
+            certificateArn: news.certificateArn,
+            regionalCertificateName: news.regionalCertificateName,
+            regionalCertificateArn: news.regionalCertificateArn,
+            endpointConfiguration: news.endpointConfiguration,
+            tags: allTags,
+            securityPolicy: news.securityPolicy,
+            endpointAccessMode: news.endpointAccessMode,
+            mutualTlsAuthentication: news.mutualTlsAuthentication,
+            ownershipVerificationCertificateArn:
+              news.ownershipVerificationCertificateArn,
+            policy: news.policy,
+            routingMode: news.routingMode,
+          });
+
+          yield* session.note(`Created domain name ${news.domainName}`);
+          const d = yield* ag.getDomainName({ domainName: news.domainName });
+          return {
+            domainName: d.domainName!,
+            regionalDomainName: d.regionalDomainName,
+            regionalHostedZoneId: d.regionalHostedZoneId,
+            distributionDomainName: d.distributionDomainName,
+            distributionHostedZoneId: d.distributionHostedZoneId,
+            domainNameArn: d.domainNameArn,
+            tags: toTags(d.tags),
+          };
+        }),
+        update: Effect.fn(function* ({
+          id,
+          news: newsIn,
+          olds,
+          output,
+          session,
+        }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("DomainName props were not resolved");
+          }
+          const news = newsIn as DomainNameProps;
+          const patches: ag.PatchOperation[] = [];
+          if (news.securityPolicy !== olds.securityPolicy) {
+            patches.push({
+              op: news.securityPolicy === undefined ? "remove" : "replace",
+              path: "/securityPolicy",
+              value: news.securityPolicy,
+            });
+          }
+          if (news.regionalCertificateArn !== olds.regionalCertificateArn) {
+            patches.push({
+              op:
+                news.regionalCertificateArn === undefined
+                  ? "remove"
+                  : "replace",
+              path: "/regionalCertificateArn",
+              value: news.regionalCertificateArn,
+            });
+          }
+          if (news.certificateArn !== olds.certificateArn) {
+            patches.push({
+              op: news.certificateArn === undefined ? "remove" : "replace",
+              path: "/certificateArn",
+              value: news.certificateArn,
+            });
+          }
+          if (patches.length > 0) {
+            yield* ag.updateDomainName({
+              domainName: output.domainName,
+              patchOperations: patches,
+            });
+          }
+
+          const internalTags = yield* createInternalTags(id);
+          const newTags = { ...news.tags, ...internalTags };
+          if (!deepEqual(output.tags, newTags) && output.domainNameArn) {
+            yield* syncTags({
+              resourceArn: output.domainNameArn,
+              oldTags: output.tags,
+              newTags,
+            });
+          }
+
+          yield* session.note(`Updated domain name ${output.domainName}`);
+          const d = yield* ag.getDomainName({ domainName: output.domainName });
+          return {
+            domainName: d.domainName!,
+            regionalDomainName: d.regionalDomainName,
+            regionalHostedZoneId: d.regionalHostedZoneId,
+            distributionDomainName: d.distributionDomainName,
+            distributionHostedZoneId: d.distributionHostedZoneId,
+            domainNameArn: d.domainNameArn,
+            tags: toTags(d.tags),
+          };
+        }),
+        delete: Effect.fn(function* ({ output, session }) {
+          yield* ag
+            .deleteDomainName({ domainName: output.domainName })
+            .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
+          yield* session.note(`Deleted domain name ${output.domainName}`);
+        }),
+      };
+    }),
+  );

--- a/packages/alchemy/src/AWS/ApiGateway/DomainName.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/DomainName.ts
@@ -1,10 +1,11 @@
 import * as ag from "@distilled.cloud/aws/api-gateway";
 import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
 import { deepEqual, isResolved } from "../../Diff.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
-import { createInternalTags } from "../../Tags.ts";
+import { createInternalTags, tagRecord } from "../../Tags.ts";
 
 import { syncTags } from "./common.ts";
 
@@ -61,12 +62,12 @@ const DomainNameResource = Resource<DomainName>("AWS.ApiGateway.DomainName");
 
 export { DomainNameResource as DomainName };
 
-const toTags = (tags: ag.DomainName["tags"]) =>
-  Object.fromEntries(
-    Object.entries(tags ?? {}).filter(
-      (e): e is [string, string] => e[1] !== undefined,
-    ),
-  );
+const retryDomainNameMutation = Effect.retry({
+  while: (e: any) =>
+    e._tag === "ConflictException" || e._tag === "TooManyRequestsException",
+  schedule: Schedule.spaced("1 second"),
+  times: 8,
+});
 
 export const DomainNameProvider = () =>
   Provider.effect(
@@ -141,7 +142,7 @@ export const DomainNameProvider = () =>
             distributionDomainName: d.distributionDomainName,
             distributionHostedZoneId: d.distributionHostedZoneId,
             domainNameArn: d.domainNameArn,
-            tags: toTags(d.tags),
+            tags: tagRecord(d.tags),
           };
         }),
         create: Effect.fn(function* ({ id, news: newsIn, session }) {
@@ -181,7 +182,7 @@ export const DomainNameProvider = () =>
             distributionDomainName: d.distributionDomainName,
             distributionHostedZoneId: d.distributionHostedZoneId,
             domainNameArn: d.domainNameArn,
-            tags: toTags(d.tags),
+            tags: tagRecord(d.tags),
           };
         }),
         update: Effect.fn(function* ({
@@ -221,10 +222,14 @@ export const DomainNameProvider = () =>
             });
           }
           if (patches.length > 0) {
-            yield* ag.updateDomainName({
-              domainName: output.domainName,
-              patchOperations: patches,
-            });
+            // Domain name mutations can briefly conflict while API Gateway
+            // propagates certificate, policy, or routing changes.
+            yield* ag
+              .updateDomainName({
+                domainName: output.domainName,
+                patchOperations: patches,
+              })
+              .pipe(retryDomainNameMutation);
           }
 
           const internalTags = yield* createInternalTags(id);
@@ -246,13 +251,14 @@ export const DomainNameProvider = () =>
             distributionDomainName: d.distributionDomainName,
             distributionHostedZoneId: d.distributionHostedZoneId,
             domainNameArn: d.domainNameArn,
-            tags: toTags(d.tags),
+            tags: tagRecord(d.tags),
           };
         }),
         delete: Effect.fn(function* ({ output, session }) {
-          yield* ag
-            .deleteDomainName({ domainName: output.domainName })
-            .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
+          yield* ag.deleteDomainName({ domainName: output.domainName }).pipe(
+            Effect.catchTag("NotFoundException", () => Effect.void),
+            retryDomainNameMutation,
+          );
           yield* session.note(`Deleted domain name ${output.domainName}`);
         }),
       };

--- a/packages/alchemy/src/AWS/ApiGateway/GatewayResource.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/GatewayResource.ts
@@ -1,0 +1,150 @@
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import * as Effect from "effect/Effect";
+import { isResolved } from "../../Diff.ts";
+import type { Input } from "../../Input.ts";
+import * as Provider from "../../Provider.ts";
+import { Resource } from "../../Resource.ts";
+import type { Providers } from "../Providers.ts";
+
+export interface ApiGatewayResourceProps {
+  /**
+   * Identifier of the parent REST API.
+   */
+  restApiId: Input<string>;
+  /**
+   * Parent resource id (use `RestApi.rootResourceId` for top-level paths).
+   */
+  parentId: Input<string>;
+  /**
+   * Path segment (e.g. `proxy` or `{proxy+}`).
+   */
+  pathPart: string;
+}
+
+export interface ApiGatewayResource extends Resource<
+  "AWS.ApiGateway.Resource",
+  ApiGatewayResourceProps,
+  {
+    resourceId: string;
+    restApiId: string;
+    parentId: string;
+    pathPart: string;
+  },
+  never,
+  Providers
+> {}
+
+/**
+ * A path segment under a REST API resource tree.
+ *
+ * @section Path resources
+ * @example Proxy segment
+ * ```typescript
+ * const proxy = yield* ApiGateway.Resource("ProxyPath", {
+ *   restApiId: api.restApiId,
+ *   parentId: api.rootResourceId,
+ *   pathPart: "{proxy+}",
+ * });
+ * ```
+ */
+const GatewayResource = Resource<ApiGatewayResource>("AWS.ApiGateway.Resource");
+
+export { GatewayResource as Resource };
+
+export const ResourceProvider = () =>
+  Provider.effect(
+    GatewayResource,
+    Effect.gen(function* () {
+      return {
+        stables: ["resourceId", "restApiId", "parentId"] as const,
+        diff: Effect.fn(function* ({ news: newsIn, olds }) {
+          if (!isResolved(newsIn)) return;
+          const news = newsIn as Input.ResolveProps<ApiGatewayResourceProps>;
+          if (
+            news.restApiId !== olds.restApiId ||
+            news.pathPart !== olds.pathPart ||
+            news.parentId !== olds.parentId
+          ) {
+            return { action: "replace" } as const;
+          }
+        }),
+        read: Effect.fn(function* ({ output }) {
+          if (!output?.resourceId) return undefined;
+          const r = yield* ag
+            .getResource({
+              restApiId: output.restApiId,
+              resourceId: output.resourceId,
+            })
+            .pipe(
+              Effect.catchTag("NotFoundException", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+          if (!r?.id) return undefined;
+          return {
+            resourceId: r.id,
+            restApiId: output.restApiId,
+            parentId: r.parentId!,
+            pathPart: r.pathPart!,
+          };
+        }),
+        create: Effect.fn(function* ({ news: newsIn, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("Resource props were not resolved");
+          }
+          const news = newsIn as Input.ResolveProps<ApiGatewayResourceProps>;
+          const created = yield* ag.createResource({
+            restApiId: news.restApiId as string,
+            parentId: news.parentId as string,
+            pathPart: news.pathPart,
+          });
+          if (!created.id) {
+            return yield* Effect.die("createResource missing id");
+          }
+          yield* session.note(
+            `Created API Gateway resource ${created.id} (${news.pathPart})`,
+          );
+          return {
+            resourceId: created.id,
+            restApiId: news.restApiId as string,
+            parentId: news.parentId as string,
+            pathPart: news.pathPart,
+          };
+        }),
+        update: Effect.fn(function* ({ news: newsIn, output, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("Resource props were not resolved");
+          }
+          const news = newsIn as Input.ResolveProps<ApiGatewayResourceProps>;
+          if (news.parentId !== output.parentId) {
+            return yield* Effect.die(
+              "Moving ApiGateway.Resource parentId requires replace",
+            );
+          }
+          yield* ag.updateResource({
+            restApiId: output.restApiId,
+            resourceId: output.resourceId,
+            patchOperations: [
+              { op: "replace", path: "/pathPart", value: news.pathPart },
+            ],
+          });
+          yield* session.note(`Updated resource ${output.resourceId}`);
+          return {
+            resourceId: output.resourceId,
+            restApiId: output.restApiId,
+            parentId: news.parentId,
+            pathPart: news.pathPart,
+          };
+        }),
+        delete: Effect.fn(function* ({ output, session }) {
+          yield* ag
+            .deleteResource({
+              restApiId: output.restApiId,
+              resourceId: output.resourceId,
+            })
+            .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
+          yield* session.note(`Deleted resource ${output.resourceId}`);
+        }),
+      };
+    }),
+  );

--- a/packages/alchemy/src/AWS/ApiGateway/GatewayResponse.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/GatewayResponse.ts
@@ -1,0 +1,138 @@
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import * as Effect from "effect/Effect";
+import { isResolved } from "../../Diff.ts";
+import type { Input } from "../../Input.ts";
+import * as Provider from "../../Provider.ts";
+import { Resource } from "../../Resource.ts";
+import type { Providers } from "../Providers.ts";
+
+export interface GatewayResponseProps {
+  restApiId: Input<string>;
+  responseType: ag.GatewayResponseType;
+  statusCode?: string;
+  responseParameters?: { [key: string]: string | undefined };
+  responseTemplates?: { [key: string]: string | undefined };
+}
+
+export interface GatewayResponse extends Resource<
+  "AWS.ApiGateway.GatewayResponse",
+  GatewayResponseProps,
+  {
+    restApiId: string;
+    responseType: ag.GatewayResponseType;
+    statusCode: string | undefined;
+  },
+  never,
+  Providers
+> {}
+
+/**
+ * Gateway response mapping for a REST API (e.g. DEFAULT_4XX, DEFAULT_5XX).
+ *
+ * @section Gateway responses
+ * @example Default 4xx JSON body
+ * ```typescript
+ * yield* ApiGateway.GatewayResponse("Default4xx", {
+ *   restApiId: api.restApiId,
+ *   responseType: "DEFAULT_4XX",
+ *   responseTemplates: { "application/json": '{"message":$context.error.messageString}' },
+ * });
+ * ```
+ */
+const GatewayResponseResource = Resource<GatewayResponse>(
+  "AWS.ApiGateway.GatewayResponse",
+);
+
+export { GatewayResponseResource as GatewayResponse };
+
+export const GatewayResponseProvider = () =>
+  Provider.effect(
+    GatewayResponseResource,
+    Effect.gen(function* () {
+      return {
+        stables: ["restApiId", "responseType"] as const,
+        diff: Effect.fn(function* ({ news: newsIn, olds }) {
+          if (!isResolved(newsIn)) return;
+          const news = newsIn as Input.ResolveProps<GatewayResponseProps>;
+          if (
+            news.restApiId !== olds.restApiId ||
+            news.responseType !== olds.responseType
+          ) {
+            return { action: "replace" } as const;
+          }
+        }),
+        read: Effect.fn(function* ({ output }) {
+          if (!output) return undefined;
+          const g = yield* ag
+            .getGatewayResponse({
+              restApiId: output.restApiId,
+              responseType: output.responseType,
+            })
+            .pipe(
+              Effect.catchTag("NotFoundException", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+          if (!g?.responseType) return undefined;
+          return {
+            restApiId: output.restApiId,
+            responseType: g.responseType!,
+            statusCode: g.statusCode,
+          };
+        }),
+        create: Effect.fn(function* ({ news: newsIn, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("GatewayResponse props were not resolved");
+          }
+          const news = newsIn as Input.ResolveProps<GatewayResponseProps>;
+          yield* ag.putGatewayResponse({
+            restApiId: news.restApiId as string,
+            responseType: news.responseType,
+            statusCode: news.statusCode,
+            responseParameters: news.responseParameters,
+            responseTemplates: news.responseTemplates,
+          });
+          yield* session.note(
+            `Put gateway response ${news.responseType} on ${news.restApiId}`,
+          );
+          return {
+            restApiId: news.restApiId as string,
+            responseType: news.responseType,
+            statusCode: news.statusCode,
+          };
+        }),
+        update: Effect.fn(function* ({ news: newsIn, output, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("GatewayResponse props were not resolved");
+          }
+          const news = newsIn as Input.ResolveProps<GatewayResponseProps>;
+          yield* ag.putGatewayResponse({
+            restApiId: output.restApiId,
+            responseType: output.responseType,
+            statusCode: news.statusCode,
+            responseParameters: news.responseParameters,
+            responseTemplates: news.responseTemplates,
+          });
+          yield* session.note(
+            `Updated gateway response ${output.responseType}`,
+          );
+          return {
+            restApiId: output.restApiId,
+            responseType: output.responseType,
+            statusCode: news.statusCode,
+          };
+        }),
+        delete: Effect.fn(function* ({ output, session }) {
+          yield* ag
+            .deleteGatewayResponse({
+              restApiId: output.restApiId,
+              responseType: output.responseType,
+            })
+            .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
+          yield* session.note(
+            `Deleted gateway response ${output.responseType}`,
+          );
+        }),
+      };
+    }),
+  );

--- a/packages/alchemy/src/AWS/ApiGateway/Method.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/Method.ts
@@ -1,0 +1,421 @@
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import * as Effect from "effect/Effect";
+import { deepEqual, isResolved } from "../../Diff.ts";
+import type { Input } from "../../Input.ts";
+import * as Provider from "../../Provider.ts";
+import { Resource } from "../../Resource.ts";
+import type { Providers } from "../Providers.ts";
+
+/**
+ * Integration configuration for an API Gateway method (passed to `putIntegration`).
+ */
+export interface MethodIntegrationProps {
+  type: ag.IntegrationType;
+  integrationHttpMethod?: string;
+  uri?: Input<string>;
+  connectionType?: ag.ConnectionType;
+  connectionId?: string;
+  credentials?: string;
+  requestParameters?: { [key: string]: string | undefined };
+  requestTemplates?: { [key: string]: string | undefined };
+  passthroughBehavior?: string;
+  cacheNamespace?: string;
+  cacheKeyParameters?: string[];
+  contentHandling?: ag.ContentHandlingStrategy;
+  timeoutInMillis?: number;
+  tlsConfig?: ag.TlsConfig;
+  responseTransferMode?: ag.ResponseTransferMode;
+  integrationTarget?: string;
+}
+
+export interface MethodProps {
+  restApiId: Input<string>;
+  resourceId: Input<string>;
+  /** HTTP verb, e.g. `GET`, `POST`, `ANY`. */
+  httpMethod: string;
+  /**
+   * Authorization type (`NONE`, `IAM`, `CUSTOM`, `COGNITO_USER_POOLS`, etc.).
+   * @default "NONE"
+   */
+  authorizationType?: string;
+  authorizerId?: string;
+  apiKeyRequired?: boolean;
+  operationName?: string;
+  requestParameters?: { [key: string]: boolean | undefined };
+  requestModels?: { [key: string]: string | undefined };
+  requestValidatorId?: string;
+  authorizationScopes?: string[];
+  /** When set, `putIntegration` is applied after `putMethod`. */
+  integration?: MethodIntegrationProps;
+}
+
+export interface Method extends Resource<
+  "AWS.ApiGateway.Method",
+  MethodProps,
+  {
+    restApiId: string;
+    resourceId: string;
+    httpMethod: string;
+    authorizationType: string;
+    authorizerId: string | undefined;
+    apiKeyRequired: boolean | undefined;
+    operationName: string | undefined;
+    requestParameters: { [key: string]: boolean | undefined } | undefined;
+    requestModels: { [key: string]: string | undefined } | undefined;
+    requestValidatorId: string | undefined;
+    authorizationScopes: string[] | undefined;
+    integration: MethodIntegrationProps | undefined;
+  },
+  never,
+  Providers
+> {}
+
+/**
+ * HTTP method on an API Gateway resource, optionally with Lambda/proxy integration.
+ *
+ * @section Lambda proxy
+ * @example ANY method with AWS_PROXY
+ * ```typescript
+ * yield* ApiGateway.Method("RootAny", {
+ *   restApiId: api.restApiId,
+ *   resourceId: api.rootResourceId,
+ *   httpMethod: "ANY",
+ *   authorizationType: "NONE",
+ *   integration: {
+ *     type: "AWS_PROXY",
+ *     integrationHttpMethod: "POST",
+ *     uri: invokeUri,
+ *   },
+ * });
+ * ```
+ */
+const MethodResource = Resource<Method>("AWS.ApiGateway.Method");
+
+export { MethodResource as Method };
+
+const putIntegrationRequest = (
+  restApiId: string,
+  resourceId: string,
+  httpMethod: string,
+  integration: MethodIntegrationProps,
+): ag.PutIntegrationRequest => ({
+  restApiId,
+  resourceId,
+  httpMethod,
+  type: integration.type,
+  integrationHttpMethod: integration.integrationHttpMethod,
+  uri: integration.uri as string,
+  connectionType: integration.connectionType,
+  connectionId: integration.connectionId,
+  credentials: integration.credentials,
+  requestParameters: integration.requestParameters,
+  requestTemplates: integration.requestTemplates,
+  passthroughBehavior: integration.passthroughBehavior,
+  cacheNamespace: integration.cacheNamespace,
+  cacheKeyParameters: integration.cacheKeyParameters,
+  contentHandling: integration.contentHandling,
+  timeoutInMillis: integration.timeoutInMillis,
+  tlsConfig: integration.tlsConfig,
+  responseTransferMode: integration.responseTransferMode,
+  integrationTarget: integration.integrationTarget,
+});
+
+const putMethod = (news: Input.ResolveProps<MethodProps>) =>
+  ag.putMethod({
+    restApiId: news.restApiId as string,
+    resourceId: news.resourceId as string,
+    httpMethod: news.httpMethod,
+    authorizationType: news.authorizationType ?? "NONE",
+    authorizerId: news.authorizerId,
+    apiKeyRequired: news.apiKeyRequired,
+    operationName: news.operationName,
+    requestParameters: news.requestParameters,
+    requestModels: news.requestModels,
+    requestValidatorId: news.requestValidatorId,
+    authorizationScopes: news.authorizationScopes,
+  });
+
+const deleteIntegrationSafe = (p: {
+  restApiId: string;
+  resourceId: string;
+  httpMethod: string;
+}) =>
+  ag
+    .deleteIntegration({
+      restApiId: p.restApiId,
+      resourceId: p.resourceId,
+      httpMethod: p.httpMethod,
+    })
+    .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
+
+const deleteMethodSafe = (p: {
+  restApiId: string;
+  resourceId: string;
+  httpMethod: string;
+}) =>
+  ag
+    .deleteMethod({
+      restApiId: p.restApiId,
+      resourceId: p.resourceId,
+      httpMethod: p.httpMethod,
+    })
+    .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
+
+const readMethodSnapshot = (p: {
+  restApiId: string;
+  resourceId: string;
+  httpMethod: string;
+}) =>
+  Effect.gen(function* () {
+    const method = yield* ag
+      .getMethod({
+        restApiId: p.restApiId,
+        resourceId: p.resourceId,
+        httpMethod: p.httpMethod,
+      })
+      .pipe(
+        Effect.catchTag("NotFoundException", () => Effect.succeed(undefined)),
+      );
+    if (!method?.httpMethod) return undefined;
+
+    const integ = yield* ag
+      .getIntegration({
+        restApiId: p.restApiId,
+        resourceId: p.resourceId,
+        httpMethod: p.httpMethod,
+      })
+      .pipe(
+        Effect.catchTag("NotFoundException", () => Effect.succeed(undefined)),
+      );
+
+    const integration: MethodIntegrationProps | undefined = integ?.type
+      ? {
+          type: integ.type!,
+          integrationHttpMethod: integ.httpMethod,
+          uri: integ.uri,
+          connectionType: integ.connectionType,
+          connectionId: integ.connectionId,
+          credentials: integ.credentials,
+          requestParameters: integ.requestParameters,
+          requestTemplates: integ.requestTemplates,
+          passthroughBehavior: integ.passthroughBehavior,
+          cacheNamespace: integ.cacheNamespace,
+          cacheKeyParameters: integ.cacheKeyParameters,
+          contentHandling: integ.contentHandling,
+          timeoutInMillis: integ.timeoutInMillis,
+          tlsConfig: integ.tlsConfig,
+          responseTransferMode: integ.responseTransferMode,
+          integrationTarget: integ.integrationTarget,
+        }
+      : undefined;
+
+    return {
+      restApiId: p.restApiId,
+      resourceId: p.resourceId,
+      httpMethod: p.httpMethod,
+      authorizationType: method.authorizationType ?? "NONE",
+      authorizerId: method.authorizerId,
+      apiKeyRequired: method.apiKeyRequired,
+      operationName: method.operationName,
+      requestParameters: method.requestParameters,
+      requestModels: method.requestModels,
+      requestValidatorId: method.requestValidatorId,
+      authorizationScopes: method.authorizationScopes,
+      integration,
+    };
+  });
+
+export const MethodProvider = () =>
+  Provider.effect(
+    MethodResource,
+    Effect.gen(function* () {
+      return {
+        stables: ["restApiId", "resourceId", "httpMethod"] as const,
+        diff: Effect.fn(function* ({ news: newsIn, olds }) {
+          if (!isResolved(newsIn)) return;
+          const news = newsIn as Input.ResolveProps<MethodProps>;
+          if (
+            news.restApiId !== olds.restApiId ||
+            news.resourceId !== olds.resourceId ||
+            news.httpMethod !== olds.httpMethod
+          ) {
+            return { action: "replace" } as const;
+          }
+        }),
+        read: Effect.fn(function* ({ output }) {
+          if (!output) return undefined;
+          return yield* readMethodSnapshot({
+            restApiId: output.restApiId,
+            resourceId: output.resourceId,
+            httpMethod: output.httpMethod,
+          });
+        }),
+        create: Effect.fn(function* ({ news: newsIn, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("Method props were not resolved");
+          }
+          const news = newsIn as Input.ResolveProps<MethodProps>;
+          const authType = news.authorizationType ?? "NONE";
+          yield* putMethod(news);
+          if (news.integration) {
+            yield* ag.putIntegration(
+              putIntegrationRequest(
+                news.restApiId as string,
+                news.resourceId as string,
+                news.httpMethod,
+                news.integration,
+              ),
+            );
+          }
+          yield* session.note(
+            `Put method ${news.httpMethod} on resource ${news.resourceId}`,
+          );
+          return {
+            restApiId: news.restApiId as string,
+            resourceId: news.resourceId as string,
+            httpMethod: news.httpMethod,
+            authorizationType: authType,
+            authorizerId: news.authorizerId,
+            apiKeyRequired: news.apiKeyRequired,
+            operationName: news.operationName,
+            requestParameters: news.requestParameters,
+            requestModels: news.requestModels,
+            requestValidatorId: news.requestValidatorId,
+            authorizationScopes: news.authorizationScopes,
+            integration: news.integration,
+          };
+        }),
+        update: Effect.fn(function* ({ news: newsIn, output, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("Method props were not resolved");
+          }
+          const news = newsIn as Input.ResolveProps<MethodProps>;
+          const authType = news.authorizationType ?? "NONE";
+
+          if (
+            news.operationName !== output.operationName ||
+            !deepEqual(news.requestParameters, output.requestParameters) ||
+            !deepEqual(news.requestModels, output.requestModels) ||
+            news.requestValidatorId !== output.requestValidatorId ||
+            !deepEqual(news.authorizationScopes, output.authorizationScopes)
+          ) {
+            yield* deleteIntegrationSafe({
+              restApiId: output.restApiId,
+              resourceId: output.resourceId,
+              httpMethod: output.httpMethod,
+            });
+            yield* deleteMethodSafe({
+              restApiId: output.restApiId,
+              resourceId: output.resourceId,
+              httpMethod: output.httpMethod,
+            });
+            yield* putMethod({
+              ...news,
+              restApiId: output.restApiId,
+              resourceId: output.resourceId,
+              httpMethod: output.httpMethod,
+            });
+            if (news.integration) {
+              yield* ag.putIntegration(
+                putIntegrationRequest(
+                  output.restApiId,
+                  output.resourceId,
+                  output.httpMethod,
+                  news.integration,
+                ),
+              );
+            }
+            yield* session.note(`Recreated method ${output.httpMethod}`);
+            return {
+              restApiId: output.restApiId,
+              resourceId: output.resourceId,
+              httpMethod: output.httpMethod,
+              authorizationType: authType,
+              authorizerId: news.authorizerId,
+              apiKeyRequired: news.apiKeyRequired,
+              operationName: news.operationName,
+              requestParameters: news.requestParameters,
+              requestModels: news.requestModels,
+              requestValidatorId: news.requestValidatorId,
+              authorizationScopes: news.authorizationScopes,
+              integration: news.integration,
+            };
+          }
+
+          const patches: ag.PatchOperation[] = [];
+          if (authType !== output.authorizationType) {
+            patches.push({
+              op: "replace",
+              path: "/authorizationType",
+              value: authType,
+            });
+          }
+          if (news.authorizerId !== output.authorizerId) {
+            patches.push({
+              op: "replace",
+              path: "/authorizerId",
+              value: news.authorizerId ?? "",
+            });
+          }
+          if (news.apiKeyRequired !== output.apiKeyRequired) {
+            patches.push({
+              op: "replace",
+              path: "/apiKeyRequired",
+              value: String(news.apiKeyRequired ?? false),
+            });
+          }
+          if (patches.length > 0) {
+            yield* ag.updateMethod({
+              restApiId: output.restApiId,
+              resourceId: output.resourceId,
+              httpMethod: output.httpMethod,
+              patchOperations: patches,
+            });
+          }
+
+          if (!deepEqual(news.integration, output.integration)) {
+            if (news.integration) {
+              yield* ag.putIntegration(
+                putIntegrationRequest(
+                  output.restApiId,
+                  output.resourceId,
+                  output.httpMethod,
+                  news.integration,
+                ),
+              );
+            } else {
+              yield* deleteIntegrationSafe({
+                restApiId: output.restApiId,
+                resourceId: output.resourceId,
+                httpMethod: output.httpMethod,
+              });
+            }
+          }
+
+          yield* session.note(`Updated method ${output.httpMethod}`);
+          const snap = yield* readMethodSnapshot({
+            restApiId: output.restApiId,
+            resourceId: output.resourceId,
+            httpMethod: output.httpMethod,
+          });
+          if (!snap) {
+            return yield* Effect.die("getMethod missing after update");
+          }
+          return snap;
+        }),
+        delete: Effect.fn(function* ({ output, session }) {
+          yield* deleteIntegrationSafe({
+            restApiId: output.restApiId,
+            resourceId: output.resourceId,
+            httpMethod: output.httpMethod,
+          });
+          yield* deleteMethodSafe({
+            restApiId: output.restApiId,
+            resourceId: output.resourceId,
+            httpMethod: output.httpMethod,
+          });
+          yield* session.note(`Deleted method ${output.httpMethod}`);
+        }),
+      };
+    }),
+  );

--- a/packages/alchemy/src/AWS/ApiGateway/Method.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/Method.ts
@@ -15,6 +15,11 @@ export interface MethodIntegrationProps {
   uri?: Input<string>;
   connectionType?: ag.ConnectionType;
   connectionId?: string;
+  /**
+   * IAM role ARN used by API Gateway for integration credentials.
+   *
+   * This is not a secret value; API Gateway stores an ARN or passthrough marker.
+   */
   credentials?: string;
   requestParameters?: { [key: string]: string | undefined };
   requestTemplates?: { [key: string]: string | undefined };

--- a/packages/alchemy/src/AWS/ApiGateway/RestApi.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/RestApi.ts
@@ -1,0 +1,304 @@
+import { Region } from "@distilled.cloud/aws/Region";
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import * as Effect from "effect/Effect";
+import { deepEqual, isResolved } from "../../Diff.ts";
+import * as Provider from "../../Provider.ts";
+import { Resource } from "../../Resource.ts";
+import type { Providers } from "../Providers.ts";
+import { createInternalTags } from "../../Tags.ts";
+
+import { restApiArn, syncTags } from "./common.ts";
+
+export interface RestApiProps {
+  /**
+   * Name of the REST API.
+   */
+  name: string;
+  description?: string;
+  version?: string;
+  cloneFrom?: string;
+  binaryMediaTypes?: string[];
+  minimumCompressionSize?: number;
+  apiKeySource?: ag.ApiKeySourceType;
+  endpointConfiguration?: ag.EndpointConfiguration;
+  /** Resource policy document as a JSON string. */
+  policy?: string;
+  disableExecuteApiEndpoint?: boolean;
+  securityPolicy?: ag.SecurityPolicy;
+  endpointAccessMode?: ag.EndpointAccessMode;
+  /** User-defined tags (Alchemy internal tags are merged automatically). */
+  tags?: Record<string, string>;
+}
+
+export interface RestApi extends Resource<
+  "AWS.ApiGateway.RestApi",
+  RestApiProps,
+  {
+    restApiId: string;
+    rootResourceId: string;
+    name: string;
+    description: string | undefined;
+    version: string | undefined;
+    binaryMediaTypes: string[] | undefined;
+    minimumCompressionSize: number | undefined;
+    apiKeySource: ag.ApiKeySourceType | undefined;
+    endpointConfiguration: ag.EndpointConfiguration | undefined;
+    policy: string | undefined;
+    disableExecuteApiEndpoint: boolean | undefined;
+    securityPolicy: ag.SecurityPolicy | undefined;
+    endpointAccessMode: ag.EndpointAccessMode | undefined;
+    tags: Record<string, string>;
+  },
+  never,
+  Providers
+> {}
+
+/**
+ * An Amazon API Gateway REST API (v1).
+ *
+ * @section Creating an API
+ * @example Regional REST API
+ * ```typescript
+ * import * as ApiGateway from "alchemy/AWS/ApiGateway";
+ *
+ * const api = yield* ApiGateway.RestApi("PublicApi", {
+ *   name: "my-api",
+ *   endpointConfiguration: { types: ["REGIONAL"] },
+ * });
+ * ```
+ */
+export const RestApi = Resource<RestApi>("AWS.ApiGateway.RestApi");
+
+const toAttrTags = (tags: ag.RestApi["tags"]) =>
+  Object.fromEntries(
+    Object.entries(tags ?? {}).filter(
+      (e): e is [string, string] => e[1] !== undefined,
+    ),
+  );
+
+const snapshotFromApi = (api: ag.RestApi) => ({
+  restApiId: api.id!,
+  rootResourceId: api.rootResourceId!,
+  name: api.name ?? "",
+  description: api.description,
+  version: api.version,
+  binaryMediaTypes: api.binaryMediaTypes,
+  minimumCompressionSize: api.minimumCompressionSize,
+  apiKeySource: api.apiKeySource,
+  endpointConfiguration: api.endpointConfiguration,
+  policy: api.policy,
+  disableExecuteApiEndpoint: api.disableExecuteApiEndpoint,
+  securityPolicy: api.securityPolicy,
+  endpointAccessMode: api.endpointAccessMode,
+  tags: toAttrTags(api.tags),
+});
+
+const patchReplace = (path: string, value: string): ag.PatchOperation => ({
+  op: "replace",
+  path,
+  value,
+});
+
+const encodeJsonPointerSegment = (s: string) =>
+  s.replace(/~/g, "~0").replace(/\//g, "~1");
+
+const binaryMediaTypePath = (mediaType: string) =>
+  `/binaryMediaTypes/${encodeJsonPointerSegment(mediaType)}`;
+
+const buildBinaryMediaTypePatches = (
+  prev: string[] | undefined,
+  next: string[] | undefined,
+): ag.PatchOperation[] => {
+  const prevSet = [...new Set(prev ?? [])];
+  const nextSet = [...new Set(next ?? [])];
+  const patches: ag.PatchOperation[] = [];
+  for (const m of prevSet) {
+    if (!nextSet.includes(m)) {
+      patches.push({ op: "remove", path: binaryMediaTypePath(m) });
+    }
+  }
+  for (const m of nextSet) {
+    if (!prevSet.includes(m)) {
+      patches.push({
+        op: "add",
+        path: binaryMediaTypePath(m),
+        value: m,
+      });
+    }
+  }
+  return patches;
+};
+
+const buildUpdatePatches = (
+  news: RestApiProps,
+  prev: RestApi["Attributes"],
+): ag.PatchOperation[] => {
+  const patches: ag.PatchOperation[] = [];
+  if (news.name !== prev.name) patches.push(patchReplace("/name", news.name));
+  if (news.description !== prev.description) {
+    patches.push(patchReplace("/description", news.description ?? ""));
+  }
+  if (news.version !== prev.version) {
+    patches.push(patchReplace("/version", news.version ?? ""));
+  }
+  patches.push(
+    ...buildBinaryMediaTypePatches(
+      prev.binaryMediaTypes,
+      news.binaryMediaTypes,
+    ),
+  );
+  if (news.minimumCompressionSize !== prev.minimumCompressionSize) {
+    patches.push(
+      patchReplace(
+        "/minimumCompressionSize",
+        String(news.minimumCompressionSize ?? ""),
+      ),
+    );
+  }
+  if (news.apiKeySource !== prev.apiKeySource) {
+    patches.push(patchReplace("/apiKeySource", news.apiKeySource ?? "HEADER"));
+  }
+  if (news.policy !== prev.policy) {
+    patches.push(patchReplace("/policy", news.policy ?? ""));
+  }
+  if (news.disableExecuteApiEndpoint !== prev.disableExecuteApiEndpoint) {
+    patches.push(
+      patchReplace(
+        "/disableExecuteApiEndpoint",
+        String(!!news.disableExecuteApiEndpoint),
+      ),
+    );
+  }
+  if (news.securityPolicy !== prev.securityPolicy) {
+    patches.push(
+      patchReplace("/securityPolicy", news.securityPolicy ?? "TLS_1_0"),
+    );
+  }
+  if (news.endpointAccessMode !== prev.endpointAccessMode) {
+    patches.push(
+      patchReplace("/endpointAccessMode", news.endpointAccessMode ?? ""),
+    );
+  }
+  return patches;
+};
+
+export const RestApiProvider = () =>
+  Provider.effect(
+    RestApi,
+    Effect.gen(function* () {
+      const awsRegion = yield* Region;
+
+      return {
+        stables: ["restApiId", "rootResourceId"] as const,
+        diff: Effect.fn(function* ({ news: newsIn, olds }) {
+          if (!isResolved(newsIn)) return;
+          const news = newsIn as RestApiProps;
+          if (
+            !deepEqual(
+              news.endpointConfiguration?.types,
+              olds.endpointConfiguration?.types,
+            ) ||
+            !deepEqual(
+              news.endpointConfiguration?.vpcEndpointIds,
+              olds.endpointConfiguration?.vpcEndpointIds,
+            ) ||
+            !deepEqual(
+              news.endpointConfiguration?.ipAddressType,
+              olds.endpointConfiguration?.ipAddressType,
+            )
+          ) {
+            return { action: "replace" } as const;
+          }
+        }),
+        read: Effect.fn(function* ({ output }) {
+          if (!output?.restApiId) return undefined;
+          const api = yield* ag
+            .getRestApi({ restApiId: output.restApiId })
+            .pipe(
+              Effect.catchTag("NotFoundException", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+          if (!api?.id) return undefined;
+          return snapshotFromApi(api);
+        }),
+        create: Effect.fn(function* ({ id, news: newsIn, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("RestApi props were not resolved");
+          }
+          const news = newsIn as RestApiProps;
+          const internalTags = yield* createInternalTags(id);
+          const userTags = news.tags ?? {};
+          const allTags = { ...userTags, ...internalTags };
+
+          const created = yield* ag.createRestApi({
+            name: news.name,
+            description: news.description,
+            version: news.version,
+            cloneFrom: news.cloneFrom,
+            binaryMediaTypes: news.binaryMediaTypes,
+            minimumCompressionSize: news.minimumCompressionSize,
+            apiKeySource: news.apiKeySource,
+            endpointConfiguration: news.endpointConfiguration,
+            policy: news.policy,
+            tags: allTags,
+            disableExecuteApiEndpoint: news.disableExecuteApiEndpoint,
+            securityPolicy: news.securityPolicy,
+            endpointAccessMode: news.endpointAccessMode,
+          });
+
+          if (!created.id || !created.rootResourceId) {
+            return yield* Effect.die(
+              "createRestApi missing id or rootResourceId",
+            );
+          }
+
+          yield* session.note(`Created REST API ${created.id}`);
+
+          const full = yield* ag.getRestApi({ restApiId: created.id });
+          if (!full.id || !full.rootResourceId) {
+            return yield* Effect.die("getRestApi missing id or rootResourceId");
+          }
+          return snapshotFromApi(full);
+        }),
+        update: Effect.fn(function* ({ id, news: newsIn, output, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("RestApi props were not resolved");
+          }
+          const news = newsIn as RestApiProps;
+          const patches = buildUpdatePatches(news, output);
+          if (patches.length > 0) {
+            yield* ag.updateRestApi({
+              restApiId: output.restApiId,
+              patchOperations: patches,
+            });
+          }
+
+          const internalTags = yield* createInternalTags(id);
+          const newTags = { ...news.tags, ...internalTags };
+          if (!deepEqual(output.tags, newTags)) {
+            const arn = restApiArn(awsRegion, output.restApiId);
+            yield* syncTags({
+              resourceArn: arn,
+              oldTags: output.tags,
+              newTags,
+            });
+          }
+
+          yield* session.note(`Updated REST API ${output.restApiId}`);
+
+          const full = yield* ag.getRestApi({ restApiId: output.restApiId });
+          if (!full.id) {
+            return yield* Effect.die("getRestApi missing id after update");
+          }
+          return snapshotFromApi(full);
+        }),
+        delete: Effect.fn(function* ({ output, session }) {
+          yield* ag
+            .deleteRestApi({ restApiId: output.restApiId })
+            .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
+          yield* session.note(`Deleted REST API ${output.restApiId}`);
+        }),
+      };
+    }),
+  );

--- a/packages/alchemy/src/AWS/ApiGateway/RestApi.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/RestApi.ts
@@ -2,18 +2,21 @@ import { Region } from "@distilled.cloud/aws/Region";
 import * as ag from "@distilled.cloud/aws/api-gateway";
 import * as Effect from "effect/Effect";
 import { deepEqual, isResolved } from "../../Diff.ts";
+import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
-import { createInternalTags } from "../../Tags.ts";
+import { createInternalTags, tagRecord } from "../../Tags.ts";
 
 import { restApiArn, syncTags } from "./common.ts";
 
 export interface RestApiProps {
   /**
    * Name of the REST API.
+   *
+   * If omitted, Alchemy generates a deterministic physical name.
    */
-  name: string;
+  name?: string;
   description?: string;
   version?: string;
   cloneFrom?: string;
@@ -56,25 +59,68 @@ export interface RestApi extends Resource<
 /**
  * An Amazon API Gateway REST API (v1).
  *
+ * This is the low-level REST API primitive. Compose it with
+ * `GatewayResource`, `Method`, `Deployment`, and `Stage` when you need
+ * precise control over REST API configuration. Higher-level OpenAPI or
+ * Effect HttpApi schema generation can be layered on top separately.
+ *
  * @section Creating an API
- * @example Regional REST API
+ * @example Regional REST API with Generated Name
  * ```typescript
  * import * as ApiGateway from "alchemy/AWS/ApiGateway";
  *
  * const api = yield* ApiGateway.RestApi("PublicApi", {
- *   name: "my-api",
  *   endpointConfiguration: { types: ["REGIONAL"] },
+ *   tags: { service: "orders" },
+ * });
+ * ```
+ *
+ * @example Private REST API
+ * ```typescript
+ * const api = yield* ApiGateway.RestApi("PrivateApi", {
+ *   endpointConfiguration: {
+ *     types: ["PRIVATE"],
+ *     vpcEndpointIds: [endpoint.vpcEndpointId],
+ *   },
+ *   policy: JSON.stringify({
+ *     Version: "2012-10-17",
+ *     Statement: [{
+ *       Effect: "Allow",
+ *       Principal: "*",
+ *       Action: "execute-api:Invoke",
+ *       Resource: "*",
+ *     }],
+ *   }),
+ * });
+ * ```
+ *
+ * @section Binary payloads
+ * @example Enable Binary Media Types
+ * ```typescript
+ * const api = yield* ApiGateway.RestApi("BinaryApi", {
+ *   binaryMediaTypes: ["application/octet-stream", "image/png"],
+ *   minimumCompressionSize: 1024,
+ * });
+ * ```
+ *
+ * @section Endpoint hardening
+ * @example Disable Default Execute API Endpoint
+ * ```typescript
+ * const api = yield* ApiGateway.RestApi("CustomDomainOnlyApi", {
+ *   endpointConfiguration: { types: ["REGIONAL"] },
+ *   disableExecuteApiEndpoint: true,
  * });
  * ```
  */
 export const RestApi = Resource<RestApi>("AWS.ApiGateway.RestApi");
 
-const toAttrTags = (tags: ag.RestApi["tags"]) =>
-  Object.fromEntries(
-    Object.entries(tags ?? {}).filter(
-      (e): e is [string, string] => e[1] !== undefined,
-    ),
-  );
+const generatedName = (id: string, props: RestApiProps) =>
+  props.name
+    ? Effect.succeed(props.name)
+    : createPhysicalName({
+        id,
+        maxLength: 128,
+      });
 
 const snapshotFromApi = (api: ag.RestApi) => ({
   restApiId: api.id!,
@@ -90,7 +136,7 @@ const snapshotFromApi = (api: ag.RestApi) => ({
   disableExecuteApiEndpoint: api.disableExecuteApiEndpoint,
   securityPolicy: api.securityPolicy,
   endpointAccessMode: api.endpointAccessMode,
-  tags: toAttrTags(api.tags),
+  tags: tagRecord(api.tags),
 });
 
 const patchReplace = (path: string, value: string): ag.PatchOperation => ({
@@ -134,7 +180,9 @@ const buildUpdatePatches = (
   prev: RestApi["Attributes"],
 ): ag.PatchOperation[] => {
   const patches: ag.PatchOperation[] = [];
-  if (news.name !== prev.name) patches.push(patchReplace("/name", news.name));
+  if (news.name !== undefined && news.name !== prev.name) {
+    patches.push(patchReplace("/name", news.name));
+  }
   if (news.description !== prev.description) {
     patches.push(patchReplace("/description", news.description ?? ""));
   }
@@ -194,6 +242,9 @@ export const RestApiProvider = () =>
           if (!isResolved(newsIn)) return;
           const news = newsIn as RestApiProps;
           if (
+            // Endpoint type, private endpoint IDs, and IP address type are part
+            // of the REST API endpoint shape; replacing avoids partial endpoint
+            // drift that API Gateway cannot consistently patch in place.
             !deepEqual(
               news.endpointConfiguration?.types,
               olds.endpointConfiguration?.types,
@@ -227,12 +278,13 @@ export const RestApiProvider = () =>
             return yield* Effect.die("RestApi props were not resolved");
           }
           const news = newsIn as RestApiProps;
+          const name = yield* generatedName(id, news);
           const internalTags = yield* createInternalTags(id);
           const userTags = news.tags ?? {};
           const allTags = { ...userTags, ...internalTags };
 
           const created = yield* ag.createRestApi({
-            name: news.name,
+            name,
             description: news.description,
             version: news.version,
             cloneFrom: news.cloneFrom,

--- a/packages/alchemy/src/AWS/ApiGateway/Stage.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/Stage.ts
@@ -1,0 +1,514 @@
+import { Region } from "@distilled.cloud/aws/Region";
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import * as Effect from "effect/Effect";
+import { deepEqual, isResolved } from "../../Diff.ts";
+import type { Input } from "../../Input.ts";
+import * as Provider from "../../Provider.ts";
+import { Resource } from "../../Resource.ts";
+import type { Providers } from "../Providers.ts";
+import { createInternalTags } from "../../Tags.ts";
+
+import { stageArn, syncTags } from "./common.ts";
+
+export interface StageProps {
+  restApiId: Input<string>;
+  stageName: string;
+  deploymentId: Input<string>;
+  description?: string;
+  cacheClusterEnabled?: boolean;
+  cacheClusterSize?: ag.CacheClusterSize;
+  variables?: { [key: string]: string | undefined };
+  documentationVersion?: string;
+  canarySettings?: ag.CanarySettings;
+  tracingEnabled?: boolean;
+  /**
+   * Map of resource path pattern to method settings; keys use `{resourcePath}/{httpMethod}`.
+   */
+  methodSettings?: { [key: string]: ag.MethodSetting | undefined };
+  accessLogSettings?: ag.AccessLogSettings;
+  webAclArn?: string;
+  tags?: Record<string, string>;
+}
+
+export interface ApiGatewayStage extends Resource<
+  "AWS.ApiGateway.Stage",
+  StageProps,
+  {
+    restApiId: string;
+    stageName: string;
+    deploymentId: string;
+    description: string | undefined;
+    cacheClusterEnabled: boolean | undefined;
+    cacheClusterSize: ag.CacheClusterSize | undefined;
+    variables: { [key: string]: string | undefined } | undefined;
+    documentationVersion: string | undefined;
+    canarySettings: ag.CanarySettings | undefined;
+    tracingEnabled: boolean | undefined;
+    methodSettings: { [key: string]: ag.MethodSetting | undefined } | undefined;
+    accessLogSettings: ag.AccessLogSettings | undefined;
+    webAclArn: string | undefined;
+    tags: Record<string, string>;
+  },
+  never,
+  Providers
+> {}
+
+/**
+ * A stage for a REST API deployment.
+ *
+ * @section Stages
+ * @example Dev stage
+ * ```typescript
+ * const stage = yield* ApiGateway.Stage("Dev", {
+ *   restApiId: api.restApiId,
+ *   stageName: "dev",
+ *   deploymentId: deployment.deploymentId,
+ * });
+ * ```
+ */
+const StageResource = Resource<ApiGatewayStage>("AWS.ApiGateway.Stage");
+
+export { StageResource as Stage };
+
+const toTagRecord = (tags: ag.Stage["tags"]) =>
+  Object.fromEntries(
+    Object.entries(tags ?? {}).filter(
+      (e): e is [string, string] => e[1] !== undefined,
+    ),
+  );
+
+const encodeJsonPointerSegment = (s: string) =>
+  s.replace(/~/g, "~0").replace(/\//g, "~1");
+
+const snapshotStage = (s: ag.Stage, restApiId: string, stageName: string) => ({
+  restApiId,
+  stageName,
+  deploymentId: s.deploymentId!,
+  description: s.description,
+  cacheClusterEnabled: s.cacheClusterEnabled,
+  cacheClusterSize: s.cacheClusterSize,
+  variables: s.variables,
+  documentationVersion: s.documentationVersion,
+  canarySettings: s.canarySettings,
+  tracingEnabled: s.tracingEnabled,
+  methodSettings: s.methodSettings,
+  accessLogSettings: s.accessLogSettings,
+  webAclArn: s.webAclArn,
+  tags: toTagRecord(s.tags),
+});
+
+const parseMethodSettingKey = (key: string) => {
+  const idx = key.lastIndexOf("/");
+  if (idx <= 0) {
+    return { resourcePath: key, httpMethod: "*" };
+  }
+  return {
+    resourcePath: key.slice(0, idx),
+    httpMethod: key.slice(idx + 1),
+  };
+};
+
+function methodSettingScalarPatch(
+  base: string,
+  field: keyof ag.MethodSetting,
+  prev: ag.MethodSetting | undefined,
+  next: ag.MethodSetting | undefined,
+): ag.PatchOperation | undefined {
+  if (prev?.[field] === next?.[field]) return undefined;
+  const v = next?.[field];
+  if (v === undefined) {
+    return { op: "remove", path: `${base}/${field}` };
+  }
+  return {
+    op: "replace",
+    path: `${base}/${field}`,
+    value: typeof v === "boolean" ? String(v) : String(v),
+  };
+}
+
+const buildMethodSettingPatches = (
+  prev: { [key: string]: ag.MethodSetting | undefined } | undefined,
+  next: { [key: string]: ag.MethodSetting | undefined } | undefined,
+): ag.PatchOperation[] => {
+  const keys = new Set([
+    ...Object.keys(prev ?? {}),
+    ...Object.keys(next ?? {}),
+  ]);
+  const patches: ag.PatchOperation[] = [];
+  const fields: (keyof ag.MethodSetting)[] = [
+    "metricsEnabled",
+    "loggingLevel",
+    "dataTraceEnabled",
+    "throttlingBurstLimit",
+    "throttlingRateLimit",
+    "cachingEnabled",
+    "cacheTtlInSeconds",
+    "cacheDataEncrypted",
+    "requireAuthorizationForCacheControl",
+    "unauthorizedCacheControlHeaderStrategy",
+  ];
+  for (const key of keys) {
+    const p = prev?.[key];
+    const n = next?.[key];
+    if (!n && !p) continue;
+    const { resourcePath, httpMethod } = parseMethodSettingKey(key);
+    const rp = encodeJsonPointerSegment(resourcePath);
+    const hm = encodeJsonPointerSegment(httpMethod);
+    const base = `/${rp}/${hm}`;
+    if (!n) {
+      for (const f of fields) {
+        const op = methodSettingScalarPatch(base, f, p, undefined);
+        if (op) patches.push(op);
+      }
+      continue;
+    }
+    if (p && deepEqual(p, n)) continue;
+    for (const f of fields) {
+      const op = methodSettingScalarPatch(base, f, p, n);
+      if (op) patches.push(op);
+    }
+  }
+  return patches;
+};
+
+const buildVariablePatches = (
+  prev: { [key: string]: string | undefined } | undefined,
+  next: { [key: string]: string | undefined } | undefined,
+): ag.PatchOperation[] => {
+  const keys = new Set([
+    ...Object.keys(prev ?? {}),
+    ...Object.keys(next ?? {}),
+  ]);
+  const patches: ag.PatchOperation[] = [];
+  for (const k of keys) {
+    const pv = prev?.[k];
+    const nv = next?.[k];
+    if (pv === nv) continue;
+    const enc = encodeJsonPointerSegment(k);
+    if (nv === undefined) {
+      patches.push({ op: "remove", path: `/variables/${enc}` });
+    } else {
+      patches.push({ op: "replace", path: `/variables/${enc}`, value: nv });
+    }
+  }
+  return patches;
+};
+
+const buildAccessLogPatches = (
+  prev: ag.AccessLogSettings | undefined,
+  next: ag.AccessLogSettings | undefined,
+): ag.PatchOperation[] => {
+  const patches: ag.PatchOperation[] = [];
+  if (prev?.destinationArn !== next?.destinationArn) {
+    if (
+      next?.destinationArn === undefined &&
+      prev?.destinationArn !== undefined
+    ) {
+      patches.push({ op: "remove", path: "/accessLogSettings/destinationArn" });
+    } else if (next?.destinationArn !== undefined) {
+      patches.push({
+        op: "replace",
+        path: "/accessLogSettings/destinationArn",
+        value: next.destinationArn,
+      });
+    }
+  }
+  if (prev?.format !== next?.format) {
+    if (next?.format === undefined && prev?.format !== undefined) {
+      patches.push({ op: "remove", path: "/accessLogSettings/format" });
+    } else if (next?.format !== undefined) {
+      patches.push({
+        op: "replace",
+        path: "/accessLogSettings/format",
+        value: next.format,
+      });
+    }
+  }
+  return patches;
+};
+
+const buildCanaryOverridePatches = (
+  prev: { [key: string]: string | undefined } | undefined,
+  next: { [key: string]: string | undefined } | undefined,
+): ag.PatchOperation[] => {
+  const keys = new Set([
+    ...Object.keys(prev ?? {}),
+    ...Object.keys(next ?? {}),
+  ]);
+  const patches: ag.PatchOperation[] = [];
+  for (const k of keys) {
+    const pv = prev?.[k];
+    const nv = next?.[k];
+    if (pv === nv) continue;
+    const enc = encodeJsonPointerSegment(k);
+    if (nv === undefined) {
+      patches.push({
+        op: "remove",
+        path: `/canarySettings/stageVariableOverrides/${enc}`,
+      });
+    } else {
+      patches.push({
+        op: "replace",
+        path: `/canarySettings/stageVariableOverrides/${enc}`,
+        value: nv,
+      });
+    }
+  }
+  return patches;
+};
+
+const buildCanaryPatches = (
+  prev: ag.CanarySettings | undefined,
+  next: ag.CanarySettings | undefined,
+): ag.PatchOperation[] => {
+  const patches: ag.PatchOperation[] = [];
+  if (prev?.percentTraffic !== next?.percentTraffic) {
+    if (
+      next?.percentTraffic === undefined &&
+      prev?.percentTraffic !== undefined
+    ) {
+      patches.push({ op: "remove", path: "/canarySettings/percentTraffic" });
+    } else if (next?.percentTraffic !== undefined) {
+      patches.push({
+        op: "replace",
+        path: "/canarySettings/percentTraffic",
+        value: String(next.percentTraffic),
+      });
+    }
+  }
+  if (prev?.deploymentId !== next?.deploymentId) {
+    if (next?.deploymentId === undefined && prev?.deploymentId !== undefined) {
+      patches.push({ op: "remove", path: "/canarySettings/deploymentId" });
+    } else if (next?.deploymentId !== undefined) {
+      patches.push({
+        op: "replace",
+        path: "/canarySettings/deploymentId",
+        value: next.deploymentId,
+      });
+    }
+  }
+  if (prev?.useStageCache !== next?.useStageCache) {
+    if (next?.useStageCache === undefined) {
+      patches.push({ op: "remove", path: "/canarySettings/useStageCache" });
+    } else {
+      patches.push({
+        op: "replace",
+        path: "/canarySettings/useStageCache",
+        value: String(next.useStageCache),
+      });
+    }
+  }
+  patches.push(
+    ...buildCanaryOverridePatches(
+      prev?.stageVariableOverrides,
+      next?.stageVariableOverrides,
+    ),
+  );
+  return patches;
+};
+
+const buildStagePatches = (
+  prev: ApiGatewayStage["Attributes"],
+  news: Input.ResolveProps<StageProps>,
+): ag.PatchOperation[] => {
+  const patches: ag.PatchOperation[] = [];
+  if (news.deploymentId !== prev.deploymentId) {
+    patches.push({
+      op: "replace",
+      path: "/deploymentId",
+      value: news.deploymentId as string,
+    });
+  }
+  if (news.description !== prev.description) {
+    patches.push({
+      op: "replace",
+      path: "/description",
+      value: news.description ?? "",
+    });
+  }
+  if (news.cacheClusterEnabled !== prev.cacheClusterEnabled) {
+    patches.push({
+      op: "replace",
+      path: "/cacheClusterEnabled",
+      value: String(news.cacheClusterEnabled ?? false),
+    });
+  }
+  if (news.cacheClusterSize !== prev.cacheClusterSize) {
+    if (news.cacheClusterSize === undefined) {
+      patches.push({ op: "remove", path: "/cacheClusterSize" });
+    } else {
+      patches.push({
+        op: "replace",
+        path: "/cacheClusterSize",
+        value: news.cacheClusterSize,
+      });
+    }
+  }
+  if (news.documentationVersion !== prev.documentationVersion) {
+    if (news.documentationVersion === undefined) {
+      patches.push({ op: "remove", path: "/documentationVersion" });
+    } else {
+      patches.push({
+        op: "replace",
+        path: "/documentationVersion",
+        value: news.documentationVersion,
+      });
+    }
+  }
+  if (news.tracingEnabled !== prev.tracingEnabled) {
+    patches.push({
+      op: "replace",
+      path: "/tracingEnabled",
+      value: String(news.tracingEnabled ?? false),
+    });
+  }
+  if (news.webAclArn !== prev.webAclArn) {
+    if (news.webAclArn === undefined || news.webAclArn === "") {
+      patches.push({ op: "remove", path: "/webAclArn" });
+    } else {
+      patches.push({
+        op: "replace",
+        path: "/webAclArn",
+        value: news.webAclArn,
+      });
+    }
+  }
+  patches.push(...buildVariablePatches(prev.variables, news.variables));
+  patches.push(
+    ...buildMethodSettingPatches(prev.methodSettings, news.methodSettings),
+  );
+  patches.push(
+    ...buildAccessLogPatches(prev.accessLogSettings, news.accessLogSettings),
+  );
+  if (!deepEqual(news.canarySettings, prev.canarySettings)) {
+    patches.push(
+      ...buildCanaryPatches(prev.canarySettings, news.canarySettings),
+    );
+  }
+  return patches;
+};
+
+export const StageProvider = () =>
+  Provider.effect(
+    StageResource,
+    Effect.gen(function* () {
+      const awsRegion = yield* Region;
+
+      return {
+        stables: ["restApiId", "stageName"] as const,
+        diff: Effect.fn(function* ({ news: newsIn, olds }) {
+          if (!isResolved(newsIn)) return;
+          const news = newsIn as Input.ResolveProps<StageProps>;
+          if (
+            news.restApiId !== olds.restApiId ||
+            news.stageName !== olds.stageName
+          ) {
+            return { action: "replace" } as const;
+          }
+        }),
+        read: Effect.fn(function* ({ output }) {
+          if (!output) return undefined;
+          const s = yield* ag
+            .getStage({
+              restApiId: output.restApiId,
+              stageName: output.stageName,
+            })
+            .pipe(
+              Effect.catchTag("NotFoundException", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+          if (!s?.stageName) return undefined;
+          return snapshotStage(s, output.restApiId, s.stageName);
+        }),
+        create: Effect.fn(function* ({ id, news: newsIn, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("Stage props were not resolved");
+          }
+          const news = newsIn as Input.ResolveProps<StageProps>;
+          const internalTags = yield* createInternalTags(id);
+          const allTags = { ...news.tags, ...internalTags };
+
+          yield* ag.createStage({
+            restApiId: news.restApiId as string,
+            stageName: news.stageName,
+            deploymentId: news.deploymentId as string,
+            description: news.description,
+            cacheClusterEnabled: news.cacheClusterEnabled,
+            cacheClusterSize: news.cacheClusterSize,
+            variables: news.variables,
+            documentationVersion: news.documentationVersion,
+            canarySettings: news.canarySettings,
+            tracingEnabled: news.tracingEnabled,
+            tags: allTags,
+          });
+
+          const s0 = yield* ag.getStage({
+            restApiId: news.restApiId as string,
+            stageName: news.stageName,
+          });
+          const prev = snapshotStage(
+            s0,
+            news.restApiId as string,
+            news.stageName,
+          );
+          const patches = buildStagePatches(prev, news);
+          if (patches.length > 0) {
+            yield* ag.updateStage({
+              restApiId: news.restApiId as string,
+              stageName: news.stageName,
+              patchOperations: patches,
+            });
+          }
+
+          yield* session.note(`Created stage ${news.stageName}`);
+          const s = yield* ag.getStage({
+            restApiId: news.restApiId as string,
+            stageName: news.stageName,
+          });
+          return snapshotStage(s, news.restApiId as string, news.stageName);
+        }),
+        update: Effect.fn(function* ({ id, news: newsIn, output, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("Stage props were not resolved");
+          }
+          const news = newsIn as Input.ResolveProps<StageProps>;
+          const patches = buildStagePatches(output, news);
+          if (patches.length > 0) {
+            yield* ag.updateStage({
+              restApiId: output.restApiId,
+              stageName: output.stageName,
+              patchOperations: patches,
+            });
+          }
+
+          const internalTags = yield* createInternalTags(id);
+          const newTags = { ...news.tags, ...internalTags };
+          if (!deepEqual(output.tags, newTags)) {
+            const arn = stageArn(awsRegion, output.restApiId, output.stageName);
+            yield* syncTags({
+              resourceArn: arn,
+              oldTags: output.tags,
+              newTags,
+            });
+          }
+
+          yield* session.note(`Updated stage ${output.stageName}`);
+          const s = yield* ag.getStage({
+            restApiId: output.restApiId,
+            stageName: output.stageName,
+          });
+          return snapshotStage(s, output.restApiId, output.stageName);
+        }),
+        delete: Effect.fn(function* ({ output, session }) {
+          yield* ag
+            .deleteStage({
+              restApiId: output.restApiId,
+              stageName: output.stageName,
+            })
+            .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
+          yield* session.note(`Deleted stage ${output.stageName}`);
+        }),
+      };
+    }),
+  );

--- a/packages/alchemy/src/AWS/ApiGateway/UsagePlan.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/UsagePlan.ts
@@ -1,0 +1,331 @@
+import { Region } from "@distilled.cloud/aws/Region";
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import * as Effect from "effect/Effect";
+import { deepEqual, isResolved } from "../../Diff.ts";
+import * as Provider from "../../Provider.ts";
+import { Resource } from "../../Resource.ts";
+import type { Providers } from "../Providers.ts";
+import { createInternalTags } from "../../Tags.ts";
+
+import { syncTags, usagePlanArn } from "./common.ts";
+
+export interface UsagePlanProps {
+  name: string;
+  description?: string;
+  apiStages?: ag.ApiStage[];
+  throttle?: ag.ThrottleSettings;
+  quota?: ag.QuotaSettings;
+  tags?: Record<string, string>;
+}
+
+export interface UsagePlan extends Resource<
+  "AWS.ApiGateway.UsagePlan",
+  UsagePlanProps,
+  {
+    id: string;
+    name: string | undefined;
+    description: string | undefined;
+    apiStages: ag.ApiStage[] | undefined;
+    throttle: ag.ThrottleSettings | undefined;
+    quota: ag.QuotaSettings | undefined;
+    tags: Record<string, string>;
+  },
+  never,
+  Providers
+> {}
+
+/**
+ * Usage plan for API stages, throttling, and quotas.
+ *
+ * @section Usage plans
+ * @example Usage plan with stage
+ * ```typescript
+ * const plan = yield* ApiGateway.UsagePlan("Standard", {
+ *   name: "standard",
+ *   apiStages: [{ apiId: api.restApiId, stage: stage.stageName }],
+ * });
+ * ```
+ */
+const UsagePlanResource = Resource<UsagePlan>("AWS.ApiGateway.UsagePlan");
+
+export { UsagePlanResource as UsagePlan };
+
+const toTags = (tags: ag.UsagePlan["tags"]) =>
+  Object.fromEntries(
+    Object.entries(tags ?? {}).filter(
+      (e): e is [string, string] => e[1] !== undefined,
+    ),
+  );
+
+const encodeJsonPointerSegment = (s: string) =>
+  s.replace(/~/g, "~0").replace(/\//g, "~1");
+
+const apiStageKey = (stage: ag.ApiStage) => `${stage.apiId}:${stage.stage}`;
+
+const parseThrottleKey = (key: string) => {
+  const idx = key.lastIndexOf("/");
+  if (idx <= 0) return { resourcePath: key, httpMethod: "*" };
+  return {
+    resourcePath: key.slice(0, idx),
+    httpMethod: key.slice(idx + 1),
+  };
+};
+
+const buildApiStageThrottlePatches = (
+  stageKey: string,
+  prev: { [key: string]: ag.ThrottleSettings | undefined } | undefined,
+  next: { [key: string]: ag.ThrottleSettings | undefined } | undefined,
+): ag.PatchOperation[] => {
+  const keys = new Set([
+    ...Object.keys(prev ?? {}),
+    ...Object.keys(next ?? {}),
+  ]);
+  const patches: ag.PatchOperation[] = [];
+  for (const key of keys) {
+    const old = prev?.[key];
+    const current = next?.[key];
+    const { resourcePath, httpMethod } = parseThrottleKey(key);
+    const base = `/apiStages/${encodeJsonPointerSegment(stageKey)}/throttle/${encodeJsonPointerSegment(resourcePath)}/${encodeJsonPointerSegment(httpMethod)}`;
+    if (current?.burstLimit !== old?.burstLimit) {
+      patches.push(
+        current?.burstLimit === undefined
+          ? { op: "remove", path: `${base}/burstLimit` }
+          : {
+              op: "replace",
+              path: `${base}/burstLimit`,
+              value: String(current.burstLimit),
+            },
+      );
+    }
+    if (current?.rateLimit !== old?.rateLimit) {
+      patches.push(
+        current?.rateLimit === undefined
+          ? { op: "remove", path: `${base}/rateLimit` }
+          : {
+              op: "replace",
+              path: `${base}/rateLimit`,
+              value: String(current.rateLimit),
+            },
+      );
+    }
+  }
+  return patches;
+};
+
+const buildApiStagePatches = (
+  prev: ag.ApiStage[] | undefined,
+  next: ag.ApiStage[] | undefined,
+): ag.PatchOperation[] => {
+  const prevMap = new Map((prev ?? []).map((s) => [apiStageKey(s), s]));
+  const nextMap = new Map((next ?? []).map((s) => [apiStageKey(s), s]));
+  const patches: ag.PatchOperation[] = [];
+  for (const [key] of prevMap) {
+    if (!nextMap.has(key)) {
+      patches.push({ op: "remove", path: "/apiStages", value: key });
+    }
+  }
+  for (const [key, stage] of nextMap) {
+    const old = prevMap.get(key);
+    if (!old) {
+      patches.push({ op: "add", path: "/apiStages", value: key });
+      patches.push(
+        ...buildApiStageThrottlePatches(key, undefined, stage.throttle),
+      );
+      continue;
+    }
+    if (!deepEqual(stage.throttle, old.throttle)) {
+      patches.push(
+        ...buildApiStageThrottlePatches(key, old.throttle, stage.throttle),
+      );
+    }
+  }
+  return patches;
+};
+
+const buildThrottlePatches = (
+  prev: ag.ThrottleSettings | undefined,
+  next: ag.ThrottleSettings | undefined,
+) => {
+  const patches: ag.PatchOperation[] = [];
+  if (next?.burstLimit !== prev?.burstLimit) {
+    patches.push(
+      next?.burstLimit === undefined
+        ? { op: "remove", path: "/throttle/burstLimit" }
+        : {
+            op: "replace",
+            path: "/throttle/burstLimit",
+            value: String(next.burstLimit),
+          },
+    );
+  }
+  if (next?.rateLimit !== prev?.rateLimit) {
+    patches.push(
+      next?.rateLimit === undefined
+        ? { op: "remove", path: "/throttle/rateLimit" }
+        : {
+            op: "replace",
+            path: "/throttle/rateLimit",
+            value: String(next.rateLimit),
+          },
+    );
+  }
+  return patches;
+};
+
+const buildQuotaPatches = (
+  prev: ag.QuotaSettings | undefined,
+  next: ag.QuotaSettings | undefined,
+) => {
+  const patches: ag.PatchOperation[] = [];
+  if (next?.limit !== prev?.limit) {
+    patches.push(
+      next?.limit === undefined
+        ? { op: "remove", path: "/quota/limit" }
+        : {
+            op: "replace",
+            path: "/quota/limit",
+            value: String(next.limit),
+          },
+    );
+  }
+  if (next?.offset !== prev?.offset) {
+    patches.push(
+      next?.offset === undefined
+        ? { op: "remove", path: "/quota/offset" }
+        : {
+            op: "replace",
+            path: "/quota/offset",
+            value: String(next.offset),
+          },
+    );
+  }
+  if (next?.period !== prev?.period) {
+    patches.push(
+      next?.period === undefined
+        ? { op: "remove", path: "/quota/period" }
+        : { op: "replace", path: "/quota/period", value: next.period },
+    );
+  }
+  return patches;
+};
+
+export const UsagePlanProvider = () =>
+  Provider.effect(
+    UsagePlanResource,
+    Effect.gen(function* () {
+      const awsRegion = yield* Region;
+
+      return {
+        stables: ["id"] as const,
+        diff: Effect.fn(function* ({ news: newsIn, olds }) {
+          if (!isResolved(newsIn)) return;
+          const news = newsIn as UsagePlanProps;
+          if (news.name !== olds.name) {
+            return { action: "replace" } as const;
+          }
+        }),
+        read: Effect.fn(function* ({ output }) {
+          if (!output?.id) return undefined;
+          const p = yield* ag
+            .getUsagePlan({ usagePlanId: output.id })
+            .pipe(
+              Effect.catchTag("NotFoundException", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+          if (!p?.id) return undefined;
+          return {
+            id: p.id,
+            name: p.name,
+            description: p.description,
+            apiStages: p.apiStages,
+            throttle: p.throttle,
+            quota: p.quota,
+            tags: toTags(p.tags),
+          };
+        }),
+        create: Effect.fn(function* ({ id, news: newsIn, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("UsagePlan props were not resolved");
+          }
+          const news = newsIn as UsagePlanProps;
+          const internalTags = yield* createInternalTags(id);
+          const allTags = { ...news.tags, ...internalTags };
+
+          const p = yield* ag.createUsagePlan({
+            name: news.name,
+            description: news.description,
+            apiStages: news.apiStages,
+            throttle: news.throttle,
+            quota: news.quota,
+            tags: allTags,
+          });
+          if (!p.id) return yield* Effect.die("createUsagePlan missing id");
+          yield* session.note(`Created usage plan ${p.id}`);
+          const full = yield* ag.getUsagePlan({ usagePlanId: p.id });
+          return {
+            id: p.id,
+            name: full.name,
+            description: full.description,
+            apiStages: full.apiStages,
+            throttle: full.throttle,
+            quota: full.quota,
+            tags: toTags(full.tags),
+          };
+        }),
+        update: Effect.fn(function* ({ id, news: newsIn, output, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("UsagePlan props were not resolved");
+          }
+          const news = newsIn as UsagePlanProps;
+          const patches: ag.PatchOperation[] = [];
+          if (news.description !== output.description) {
+            patches.push({
+              op: "replace",
+              path: "/description",
+              value: news.description ?? "",
+            });
+          }
+          patches.push(
+            ...buildApiStagePatches(output.apiStages, news.apiStages),
+          );
+          patches.push(...buildThrottlePatches(output.throttle, news.throttle));
+          patches.push(...buildQuotaPatches(output.quota, news.quota));
+          if (patches.length > 0) {
+            yield* ag.updateUsagePlan({
+              usagePlanId: output.id,
+              patchOperations: patches,
+            });
+          }
+
+          const internalTags = yield* createInternalTags(id);
+          const newTags = { ...news.tags, ...internalTags };
+          if (!deepEqual(output.tags, newTags)) {
+            yield* syncTags({
+              resourceArn: usagePlanArn(awsRegion, output.id),
+              oldTags: output.tags,
+              newTags,
+            });
+          }
+
+          yield* session.note(`Updated usage plan ${output.id}`);
+          const full = yield* ag.getUsagePlan({ usagePlanId: output.id });
+          return {
+            id: output.id,
+            name: full.name,
+            description: full.description,
+            apiStages: full.apiStages,
+            throttle: full.throttle,
+            quota: full.quota,
+            tags: toTags(full.tags),
+          };
+        }),
+        delete: Effect.fn(function* ({ output, session }) {
+          yield* ag
+            .deleteUsagePlan({ usagePlanId: output.id })
+            .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
+          yield* session.note(`Deleted usage plan ${output.id}`);
+        }),
+      };
+    }),
+  );

--- a/packages/alchemy/src/AWS/ApiGateway/UsagePlan.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/UsagePlan.ts
@@ -2,19 +2,40 @@ import { Region } from "@distilled.cloud/aws/Region";
 import * as ag from "@distilled.cloud/aws/api-gateway";
 import * as Effect from "effect/Effect";
 import { deepEqual, isResolved } from "../../Diff.ts";
+import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
-import { createInternalTags } from "../../Tags.ts";
+import { createInternalTags, tagRecord } from "../../Tags.ts";
 
 import { syncTags, usagePlanArn } from "./common.ts";
 
 export interface UsagePlanProps {
-  name: string;
+  /**
+   * Friendly name for the usage plan.
+   *
+   * If omitted, Alchemy generates a deterministic physical name.
+   */
+  name?: string;
+  /**
+   * Human-readable description for operators.
+   */
   description?: string;
+  /**
+   * API stages associated with this plan.
+   */
   apiStages?: ag.ApiStage[];
+  /**
+   * Default request throttle applied by the plan.
+   */
   throttle?: ag.ThrottleSettings;
+  /**
+   * Quota limit and period applied by the plan.
+   */
   quota?: ag.QuotaSettings;
+  /**
+   * User-defined tags. Alchemy internal tags are merged automatically.
+   */
   tags?: Record<string, string>;
 }
 
@@ -41,7 +62,6 @@ export interface UsagePlan extends Resource<
  * @example Usage plan with stage
  * ```typescript
  * const plan = yield* ApiGateway.UsagePlan("Standard", {
- *   name: "standard",
  *   apiStages: [{ apiId: api.restApiId, stage: stage.stageName }],
  * });
  * ```
@@ -50,12 +70,13 @@ const UsagePlanResource = Resource<UsagePlan>("AWS.ApiGateway.UsagePlan");
 
 export { UsagePlanResource as UsagePlan };
 
-const toTags = (tags: ag.UsagePlan["tags"]) =>
-  Object.fromEntries(
-    Object.entries(tags ?? {}).filter(
-      (e): e is [string, string] => e[1] !== undefined,
-    ),
-  );
+const generatedName = (id: string, props: UsagePlanProps) =>
+  props.name
+    ? Effect.succeed(props.name)
+    : createPhysicalName({
+        id,
+        maxLength: 128,
+      });
 
 const encodeJsonPointerSegment = (s: string) =>
   s.replace(/~/g, "~0").replace(/\//g, "~1");
@@ -220,7 +241,7 @@ export const UsagePlanProvider = () =>
         diff: Effect.fn(function* ({ news: newsIn, olds }) {
           if (!isResolved(newsIn)) return;
           const news = newsIn as UsagePlanProps;
-          if (news.name !== olds.name) {
+          if (news.name !== undefined && news.name !== olds.name) {
             return { action: "replace" } as const;
           }
         }),
@@ -241,7 +262,7 @@ export const UsagePlanProvider = () =>
             apiStages: p.apiStages,
             throttle: p.throttle,
             quota: p.quota,
-            tags: toTags(p.tags),
+            tags: tagRecord(p.tags),
           };
         }),
         create: Effect.fn(function* ({ id, news: newsIn, session }) {
@@ -249,11 +270,12 @@ export const UsagePlanProvider = () =>
             return yield* Effect.die("UsagePlan props were not resolved");
           }
           const news = newsIn as UsagePlanProps;
+          const name = yield* generatedName(id, news);
           const internalTags = yield* createInternalTags(id);
           const allTags = { ...news.tags, ...internalTags };
 
           const p = yield* ag.createUsagePlan({
-            name: news.name,
+            name,
             description: news.description,
             apiStages: news.apiStages,
             throttle: news.throttle,
@@ -270,7 +292,7 @@ export const UsagePlanProvider = () =>
             apiStages: full.apiStages,
             throttle: full.throttle,
             quota: full.quota,
-            tags: toTags(full.tags),
+            tags: tagRecord(full.tags),
           };
         }),
         update: Effect.fn(function* ({ id, news: newsIn, output, session }) {
@@ -317,7 +339,7 @@ export const UsagePlanProvider = () =>
             apiStages: full.apiStages,
             throttle: full.throttle,
             quota: full.quota,
-            tags: toTags(full.tags),
+            tags: tagRecord(full.tags),
           };
         }),
         delete: Effect.fn(function* ({ output, session }) {

--- a/packages/alchemy/src/AWS/ApiGateway/UsagePlanKey.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/UsagePlanKey.ts
@@ -1,0 +1,119 @@
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import * as Effect from "effect/Effect";
+import { isResolved } from "../../Diff.ts";
+import type { Input } from "../../Input.ts";
+import * as Provider from "../../Provider.ts";
+import { Resource } from "../../Resource.ts";
+import type { Providers } from "../Providers.ts";
+
+export interface UsagePlanKeyProps {
+  usagePlanId: Input<string>;
+  keyId: Input<string>;
+  /**
+   * @default "API_KEY"
+   */
+  keyType?: string;
+}
+
+export interface UsagePlanKey extends Resource<
+  "AWS.ApiGateway.UsagePlanKey",
+  UsagePlanKeyProps,
+  {
+    usagePlanId: string;
+    keyId: string;
+    keyType: string;
+    name: string | undefined;
+  },
+  never,
+  Providers
+> {}
+
+/**
+ * Associates an API key with a usage plan.
+ *
+ * @section Usage plan keys
+ * @example Associate key with plan
+ * ```typescript
+ * yield* ApiGateway.UsagePlanKey("PlanKey", {
+ *   usagePlanId: plan.id,
+ *   keyId: key.id,
+ * });
+ * ```
+ */
+const UsagePlanKeyResource = Resource<UsagePlanKey>(
+  "AWS.ApiGateway.UsagePlanKey",
+);
+
+export { UsagePlanKeyResource as UsagePlanKey };
+
+export const UsagePlanKeyProvider = () =>
+  Provider.effect(
+    UsagePlanKeyResource,
+    Effect.gen(function* () {
+      return {
+        stables: ["usagePlanId", "keyId"] as const,
+        diff: Effect.fn(function* ({ news: newsIn, olds }) {
+          if (!isResolved(newsIn)) return;
+          const news = newsIn as UsagePlanKeyProps;
+          if (
+            news.usagePlanId !== olds.usagePlanId ||
+            news.keyId !== olds.keyId
+          ) {
+            return { action: "replace" } as const;
+          }
+        }),
+        read: Effect.fn(function* ({ output }) {
+          if (!output) return undefined;
+          const k = yield* ag
+            .getUsagePlanKey({
+              usagePlanId: output.usagePlanId,
+              keyId: output.keyId,
+            })
+            .pipe(
+              Effect.catchTag("NotFoundException", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+          if (!k?.id) return undefined;
+          return {
+            usagePlanId: output.usagePlanId,
+            keyId: k.id,
+            keyType: k.type ?? "API_KEY",
+            name: k.name,
+          };
+        }),
+        create: Effect.fn(function* ({ news: newsIn, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("UsagePlanKey props were not resolved");
+          }
+          const news = newsIn as Input.ResolveProps<UsagePlanKeyProps>;
+          const k = yield* ag.createUsagePlanKey({
+            usagePlanId: news.usagePlanId as string,
+            keyId: news.keyId as string,
+            keyType: news.keyType ?? "API_KEY",
+          });
+          yield* session.note(
+            `Linked key ${news.keyId} to usage plan ${news.usagePlanId}`,
+          );
+          return {
+            usagePlanId: news.usagePlanId as string,
+            keyId: k.id!,
+            keyType: k.type ?? "API_KEY",
+            name: k.name,
+          };
+        }),
+        update: Effect.fn(function* ({ output }) {
+          return output;
+        }),
+        delete: Effect.fn(function* ({ output, session }) {
+          yield* ag
+            .deleteUsagePlanKey({
+              usagePlanId: output.usagePlanId,
+              keyId: output.keyId,
+            })
+            .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
+          yield* session.note(`Removed key from usage plan`);
+        }),
+      };
+    }),
+  );

--- a/packages/alchemy/src/AWS/ApiGateway/VpcLink.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/VpcLink.ts
@@ -1,0 +1,196 @@
+import { Region } from "@distilled.cloud/aws/Region";
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import { deepEqual, isResolved } from "../../Diff.ts";
+import * as Provider from "../../Provider.ts";
+import { Resource } from "../../Resource.ts";
+import type { Providers } from "../Providers.ts";
+import { createInternalTags } from "../../Tags.ts";
+
+import { syncTags, vpcLinkArn } from "./common.ts";
+
+export interface VpcLinkProps {
+  /**
+   * Name of the VPC link (required by AWS).
+   */
+  name: string;
+  /**
+   * Target ARNs for the integration (e.g. load balancer ARNs).
+   */
+  targetArns: string[];
+  description?: string;
+  tags?: Record<string, string>;
+}
+
+export interface VpcLink extends Resource<
+  "AWS.ApiGateway.VpcLink",
+  VpcLinkProps,
+  {
+    vpcLinkId: string;
+    name: string | undefined;
+    description: string | undefined;
+    targetArns: string[] | undefined;
+    status: ag.VpcLinkStatus | undefined;
+    statusMessage: string | undefined;
+    tags: Record<string, string>;
+  },
+  never,
+  Providers
+> {}
+
+/**
+ * VPC link for private integrations (`connectionType: "VPC_LINK"` on a method integration).
+ *
+ * @section Private integrations
+ * @example Create a VPC link
+ * ```typescript
+ * const link = yield* ApiGateway.VpcLink("NlbLink", {
+ *   name: "nlb-link",
+ *   description: "Link to internal NLB",
+ *   targetArns: [nlb.loadBalancerArn],
+ * });
+ *
+ * yield* ApiGateway.Method("PrivateGet", {
+ *   restApiId: api.restApiId,
+ *   resourceId: resource.resourceId,
+ *   httpMethod: "GET",
+ *   integration: {
+ *     type: "HTTP_PROXY",
+ *     integrationHttpMethod: "GET",
+ *     uri: "https://api.internal.example.com/hello",
+ *     connectionType: "VPC_LINK",
+ *     connectionId: link.vpcLinkId,
+ *   },
+ * });
+ * ```
+ */
+const VpcLinkResource = Resource<VpcLink>("AWS.ApiGateway.VpcLink");
+
+export { VpcLinkResource as VpcLink };
+
+const toTags = (tags: ag.VpcLink["tags"]) =>
+  Object.fromEntries(
+    Object.entries(tags ?? {}).filter(
+      (e): e is [string, string] => e[1] !== undefined,
+    ),
+  );
+
+const snapshotFromVpcLink = (
+  v: ag.VpcLink,
+  tags: Record<string, string>,
+): VpcLink["Attributes"] => ({
+  vpcLinkId: v.id!,
+  name: v.name,
+  description: v.description,
+  targetArns: v.targetArns,
+  status: v.status,
+  statusMessage: v.statusMessage,
+  tags,
+});
+
+export const VpcLinkProvider = () =>
+  Provider.effect(
+    VpcLinkResource,
+    Effect.gen(function* () {
+      const awsRegion = yield* Region;
+
+      return {
+        stables: ["vpcLinkId"] as const,
+        diff: Effect.fn(function* ({ news: newsIn, olds }) {
+          if (!isResolved(newsIn)) return;
+          const news = newsIn as VpcLinkProps;
+          if (!deepEqual(news.targetArns, olds.targetArns)) {
+            return { action: "replace" } as const;
+          }
+        }),
+        read: Effect.fn(function* ({ output }) {
+          if (!output?.vpcLinkId) return undefined;
+          const v = yield* ag
+            .getVpcLink({ vpcLinkId: output.vpcLinkId })
+            .pipe(
+              Effect.catchTag("NotFoundException", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+          if (!v?.id) return undefined;
+          return snapshotFromVpcLink(v, toTags(v.tags));
+        }),
+        create: Effect.fn(function* ({ id, news: newsIn, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("VpcLink props were not resolved");
+          }
+          const news = newsIn as VpcLinkProps;
+          const internalTags = yield* createInternalTags(id);
+          const allTags = { ...news.tags, ...internalTags };
+
+          const created = yield* ag.createVpcLink({
+            name: news.name,
+            description: news.description,
+            targetArns: news.targetArns,
+            tags: allTags,
+          });
+          if (!created.id) {
+            return yield* Effect.die("createVpcLink missing id");
+          }
+          yield* session.note(`Created VPC link ${created.id}`);
+
+          const v = yield* ag.getVpcLink({ vpcLinkId: created.id });
+          if (!v.id) return yield* Effect.die("getVpcLink missing id");
+          return snapshotFromVpcLink(v, toTags(v.tags));
+        }),
+        update: Effect.fn(function* ({ id, news: newsIn, output, session }) {
+          if (!isResolved(newsIn)) {
+            return yield* Effect.die("VpcLink props were not resolved");
+          }
+          const news = newsIn as VpcLinkProps;
+          const patches: ag.PatchOperation[] = [];
+          if (news.description !== output.description) {
+            patches.push({
+              op: "replace",
+              path: "/description",
+              value: news.description ?? "",
+            });
+          }
+          if (news.name !== output.name) {
+            patches.push({
+              op: "replace",
+              path: "/name",
+              value: news.name,
+            });
+          }
+          if (patches.length > 0) {
+            yield* ag.updateVpcLink({
+              vpcLinkId: output.vpcLinkId,
+              patchOperations: patches,
+            });
+          }
+
+          const internalTags = yield* createInternalTags(id);
+          const newTags = { ...news.tags, ...internalTags };
+          if (!deepEqual(output.tags, newTags)) {
+            yield* syncTags({
+              resourceArn: vpcLinkArn(awsRegion, output.vpcLinkId),
+              oldTags: output.tags,
+              newTags,
+            });
+          }
+
+          yield* session.note(`Updated VPC link ${output.vpcLinkId}`);
+          const v = yield* ag.getVpcLink({ vpcLinkId: output.vpcLinkId });
+          return snapshotFromVpcLink(v, toTags(v.tags));
+        }),
+        delete: Effect.fn(function* ({ output, session }) {
+          yield* ag.deleteVpcLink({ vpcLinkId: output.vpcLinkId }).pipe(
+            Effect.retry({
+              while: (e) => e._tag === "ConflictException",
+              schedule: Schedule.spaced("1 second"),
+              times: 8,
+            }),
+            Effect.catchTag("NotFoundException", () => Effect.void),
+          );
+          yield* session.note(`Deleted VPC link ${output.vpcLinkId}`);
+        }),
+      };
+    }),
+  );

--- a/packages/alchemy/src/AWS/ApiGateway/VpcLink.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/VpcLink.ts
@@ -3,18 +3,21 @@ import * as ag from "@distilled.cloud/aws/api-gateway";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 import { deepEqual, isResolved } from "../../Diff.ts";
+import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
-import { createInternalTags } from "../../Tags.ts";
+import { createInternalTags, tagRecord } from "../../Tags.ts";
 
 import { syncTags, vpcLinkArn } from "./common.ts";
 
 export interface VpcLinkProps {
   /**
-   * Name of the VPC link (required by AWS).
+   * Name of the VPC link.
+   *
+   * If omitted, Alchemy generates a deterministic physical name.
    */
-  name: string;
+  name?: string;
   /**
    * Target ARNs for the integration (e.g. load balancer ARNs).
    */
@@ -46,7 +49,6 @@ export interface VpcLink extends Resource<
  * @example Create a VPC link
  * ```typescript
  * const link = yield* ApiGateway.VpcLink("NlbLink", {
- *   name: "nlb-link",
  *   description: "Link to internal NLB",
  *   targetArns: [nlb.loadBalancerArn],
  * });
@@ -69,12 +71,13 @@ const VpcLinkResource = Resource<VpcLink>("AWS.ApiGateway.VpcLink");
 
 export { VpcLinkResource as VpcLink };
 
-const toTags = (tags: ag.VpcLink["tags"]) =>
-  Object.fromEntries(
-    Object.entries(tags ?? {}).filter(
-      (e): e is [string, string] => e[1] !== undefined,
-    ),
-  );
+const generatedName = (id: string, props: VpcLinkProps) =>
+  props.name
+    ? Effect.succeed(props.name)
+    : createPhysicalName({
+        id,
+        maxLength: 128,
+      });
 
 const snapshotFromVpcLink = (
   v: ag.VpcLink,
@@ -114,18 +117,19 @@ export const VpcLinkProvider = () =>
               ),
             );
           if (!v?.id) return undefined;
-          return snapshotFromVpcLink(v, toTags(v.tags));
+          return snapshotFromVpcLink(v, tagRecord(v.tags));
         }),
         create: Effect.fn(function* ({ id, news: newsIn, session }) {
           if (!isResolved(newsIn)) {
             return yield* Effect.die("VpcLink props were not resolved");
           }
           const news = newsIn as VpcLinkProps;
+          const name = yield* generatedName(id, news);
           const internalTags = yield* createInternalTags(id);
           const allTags = { ...news.tags, ...internalTags };
 
           const created = yield* ag.createVpcLink({
-            name: news.name,
+            name,
             description: news.description,
             targetArns: news.targetArns,
             tags: allTags,
@@ -137,7 +141,7 @@ export const VpcLinkProvider = () =>
 
           const v = yield* ag.getVpcLink({ vpcLinkId: created.id });
           if (!v.id) return yield* Effect.die("getVpcLink missing id");
-          return snapshotFromVpcLink(v, toTags(v.tags));
+          return snapshotFromVpcLink(v, tagRecord(v.tags));
         }),
         update: Effect.fn(function* ({ id, news: newsIn, output, session }) {
           if (!isResolved(newsIn)) {
@@ -152,7 +156,7 @@ export const VpcLinkProvider = () =>
               value: news.description ?? "",
             });
           }
-          if (news.name !== output.name) {
+          if (news.name !== undefined && news.name !== output.name) {
             patches.push({
               op: "replace",
               path: "/name",
@@ -178,7 +182,7 @@ export const VpcLinkProvider = () =>
 
           yield* session.note(`Updated VPC link ${output.vpcLinkId}`);
           const v = yield* ag.getVpcLink({ vpcLinkId: output.vpcLinkId });
-          return snapshotFromVpcLink(v, toTags(v.tags));
+          return snapshotFromVpcLink(v, tagRecord(v.tags));
         }),
         delete: Effect.fn(function* ({ output, session }) {
           yield* ag.deleteVpcLink({ vpcLinkId: output.vpcLinkId }).pipe(

--- a/packages/alchemy/src/AWS/ApiGateway/common.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/common.ts
@@ -1,0 +1,53 @@
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import * as Effect from "effect/Effect";
+import { diffTags, normalizeTags } from "../../Tags.ts";
+
+export const restApiArn = (region: string, restApiId: string) =>
+  `arn:aws:apigateway:${region}::/restapis/${restApiId}`;
+
+export const stageArn = (
+  region: string,
+  restApiId: string,
+  stageName: string,
+) => `arn:aws:apigateway:${region}::/restapis/${restApiId}/stages/${stageName}`;
+
+export const apiKeyArn = (region: string, apiKeyId: string) =>
+  `arn:aws:apigateway:${region}::/apikeys/${apiKeyId}`;
+
+export const usagePlanArn = (region: string, usagePlanId: string) =>
+  `arn:aws:apigateway:${region}::/usageplans/${usagePlanId}`;
+
+export const domainNameArn = (region: string, domainName: string) =>
+  `arn:aws:apigateway:${region}::/domainnames/${domainName}`;
+
+export const vpcLinkArn = (region: string, vpcLinkId: string) =>
+  `arn:aws:apigateway:${region}::/vpclinks/${vpcLinkId}`;
+
+export const syncTags = Effect.fn(function* ({
+  resourceArn,
+  oldTags,
+  newTags,
+}: {
+  resourceArn: string;
+  oldTags: Record<string, string>;
+  newTags: Record<string, string>;
+}) {
+  const { removed, upsert } = diffTags(oldTags, newTags);
+  if (removed.length > 0) {
+    yield* ag
+      .untagResource({
+        resourceArn,
+        tagKeys: removed,
+      })
+      .pipe(
+        Effect.catchTag("NotFoundException", () => Effect.void),
+        Effect.catchTag("BadRequestException", () => Effect.void),
+      );
+  }
+  if (upsert.length > 0) {
+    yield* ag.tagResource({
+      resourceArn,
+      tags: normalizeTags(upsert),
+    });
+  }
+});

--- a/packages/alchemy/src/AWS/ApiGateway/index.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/index.ts
@@ -1,0 +1,61 @@
+export { Account, AccountProvider, type AccountProps } from "./Account.ts";
+export { ApiKey, ApiKeyProvider, type ApiKeyProps } from "./ApiKey.ts";
+export {
+  BasePathMapping,
+  BasePathMappingProvider,
+  type BasePathMappingProps,
+} from "./BasePathMapping.ts";
+export {
+  Deployment,
+  DeploymentProvider,
+  type DeploymentProps,
+} from "./Deployment.ts";
+export {
+  DomainName,
+  DomainNameProvider,
+  type DomainNameProps,
+} from "./DomainName.ts";
+export {
+  GatewayResponse,
+  GatewayResponseProvider,
+  type GatewayResponseProps,
+} from "./GatewayResponse.ts";
+export {
+  Resource,
+  ResourceProvider,
+  type ApiGatewayResource,
+  type ApiGatewayResourceProps,
+} from "./GatewayResource.ts";
+export {
+  Method,
+  MethodProvider,
+  type MethodIntegrationProps,
+  type MethodProps,
+} from "./Method.ts";
+export { RestApi, RestApiProvider, type RestApiProps } from "./RestApi.ts";
+export { Stage, StageProvider, type StageProps } from "./Stage.ts";
+export {
+  UsagePlan,
+  UsagePlanProvider,
+  type UsagePlanProps,
+} from "./UsagePlan.ts";
+export {
+  UsagePlanKey,
+  UsagePlanKeyProvider,
+  type UsagePlanKeyProps,
+} from "./UsagePlanKey.ts";
+export {
+  Authorizer,
+  AuthorizerProvider,
+  type AuthorizerProps,
+} from "./Authorizer.ts";
+export {
+  restApiArn,
+  stageArn,
+  apiKeyArn,
+  usagePlanArn,
+  domainNameArn,
+  vpcLinkArn,
+  syncTags,
+} from "./common.ts";
+export { VpcLink, VpcLinkProvider, type VpcLinkProps } from "./VpcLink.ts";

--- a/packages/alchemy/src/AWS/Providers.ts
+++ b/packages/alchemy/src/AWS/Providers.ts
@@ -3,6 +3,7 @@ import { Command, CommandProvider } from "../Build/Command.ts";
 import * as Provider from "../Provider.ts";
 import { Random, RandomProvider } from "../Random.ts";
 import * as ACM from "./ACM/index.ts";
+import * as ApiGateway from "./ApiGateway/index.ts";
 import * as Assets from "./Assets.ts";
 import { AwsAuth } from "./AuthProvider.ts";
 import * as AutoScaling from "./AutoScaling/index.ts";
@@ -46,6 +47,20 @@ export const providers = () =>
       Command,
       Random,
       ACM.Certificate,
+      ApiGateway.Account,
+      ApiGateway.ApiKey,
+      ApiGateway.Authorizer,
+      ApiGateway.BasePathMapping,
+      ApiGateway.Deployment,
+      ApiGateway.DomainName,
+      ApiGateway.GatewayResponse,
+      ApiGateway.Method,
+      ApiGateway.Resource,
+      ApiGateway.RestApi,
+      ApiGateway.Stage,
+      ApiGateway.UsagePlan,
+      ApiGateway.UsagePlanKey,
+      ApiGateway.VpcLink,
       AutoScaling.AutoScalingGroup,
       AutoScaling.LaunchTemplate,
       AutoScaling.ScalingPolicy,
@@ -285,6 +300,20 @@ export const providers = () =>
     Layer.provide(
       Layer.mergeAll(
         ACM.CertificateProvider(),
+        ApiGateway.AccountProvider(),
+        ApiGateway.ApiKeyProvider(),
+        ApiGateway.AuthorizerProvider(),
+        ApiGateway.BasePathMappingProvider(),
+        ApiGateway.DeploymentProvider(),
+        ApiGateway.DomainNameProvider(),
+        ApiGateway.GatewayResponseProvider(),
+        ApiGateway.MethodProvider(),
+        ApiGateway.ResourceProvider(),
+        ApiGateway.RestApiProvider(),
+        ApiGateway.StageProvider(),
+        ApiGateway.UsagePlanProvider(),
+        ApiGateway.UsagePlanKeyProvider(),
+        ApiGateway.VpcLinkProvider(),
         AutoScaling.AutoScalingGroupProvider(),
         AutoScaling.LaunchTemplateProvider(),
         AutoScaling.ScalingPolicyProvider(),

--- a/packages/alchemy/src/AWS/index.ts
+++ b/packages/alchemy/src/AWS/index.ts
@@ -8,6 +8,7 @@ export * from "./Providers.ts";
 export { Region } from "@distilled.cloud/aws/Region";
 
 export * as ACM from "./ACM/index.ts";
+export * as ApiGateway from "./ApiGateway/index.ts";
 export * as AutoScaling from "./AutoScaling/index.ts";
 export * as CloudFront from "./CloudFront/index.ts";
 export * as CloudWatch from "./CloudWatch/index.ts";

--- a/packages/alchemy/src/Tags.ts
+++ b/packages/alchemy/src/Tags.ts
@@ -7,7 +7,7 @@ export type Tags =
   | [string, string][]
   | { Key: string; Value: string }[];
 
-const normalizeTags = (tags: Tags) =>
+export const normalizeTags = (tags: Tags) =>
   Array.isArray(tags)
     ? Object.fromEntries(
         tags.map((tag) =>

--- a/packages/alchemy/src/Tags.ts
+++ b/packages/alchemy/src/Tags.ts
@@ -16,6 +16,13 @@ export const normalizeTags = (tags: Tags) =>
       )
     : tags;
 
+export const tagRecord = (tags: Tags | undefined): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(normalizeTags(tags ?? {})).filter(
+      (entry): entry is [string, string] => entry[1] !== undefined,
+    ),
+  );
+
 export const hasTags = (expectedTags: Tags, tags: Tags | undefined) => {
   const actualTags = normalizeTags(tags ?? []);
   return Object.entries(normalizeTags(expectedTags)).every(

--- a/packages/alchemy/test/AWS/ApiGateway/Account.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/Account.test.ts
@@ -1,0 +1,28 @@
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Vitest";
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+test.provider("patch API Gateway account settings", (stack) =>
+  Effect.gen(function* () {
+    const before = yield* ag.getAccount({});
+
+    yield* stack.deploy(
+      Effect.gen(function* () {
+        yield* AWS.ApiGateway.Account("AgAccount", {});
+        return undefined;
+      }),
+    );
+
+    const account = yield* ag.getAccount({});
+    expect(account).toBeDefined();
+
+    yield* stack.destroy();
+
+    const after = yield* ag.getAccount({});
+    expect(after.cloudwatchRoleArn).toEqual(before.cloudwatchRoleArn);
+  }),
+);

--- a/packages/alchemy/test/AWS/ApiGateway/ApiKey.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/ApiKey.test.ts
@@ -1,0 +1,42 @@
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+test.provider("create and delete API key", (stack) =>
+  Effect.gen(function* () {
+    const key = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* AWS.ApiGateway.ApiKey("AgApiKey", {
+          name: "alchemy-test-ag-apikey",
+          generateDistinctId: true,
+          enabled: true,
+        });
+      }),
+    );
+
+    expect(key.id).toBeDefined();
+
+    yield* stack.destroy();
+  }),
+);
+
+test.provider("custom API key value is not returned in outputs", (stack) =>
+  Effect.gen(function* () {
+    const key = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* AWS.ApiGateway.ApiKey("AgApiKeySecret", {
+          name: "alchemy-test-ag-apikey-secret",
+          value: "alchemy-test-secret-value-abc123",
+        });
+      }),
+    );
+
+    expect(key.id).toBeDefined();
+    expect(Object.keys(key as Record<string, unknown>)).not.toContain("value");
+
+    yield* stack.destroy();
+  }),
+);

--- a/packages/alchemy/test/AWS/ApiGateway/ApiKey.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/ApiKey.test.ts
@@ -2,6 +2,7 @@ import * as AWS from "@/AWS";
 import * as Test from "@/Test/Vitest";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
 
 const { test } = Test.make({ providers: AWS.providers() });
 
@@ -10,7 +11,6 @@ test.provider("create and delete API key", (stack) =>
     const key = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* AWS.ApiGateway.ApiKey("AgApiKey", {
-          name: "alchemy-test-ag-apikey",
           generateDistinctId: true,
           enabled: true,
         });
@@ -28,8 +28,7 @@ test.provider("custom API key value is not returned in outputs", (stack) =>
     const key = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* AWS.ApiGateway.ApiKey("AgApiKeySecret", {
-          name: "alchemy-test-ag-apikey-secret",
-          value: "alchemy-test-secret-value-abc123",
+          value: Redacted.make("alchemy-test-secret-value-abc123"),
         });
       }),
     );

--- a/packages/alchemy/test/AWS/ApiGateway/Authorizer.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/Authorizer.test.ts
@@ -1,0 +1,7 @@
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Vitest";
+import { describe } from "@effect/vitest";
+
+Test.make({ providers: AWS.providers() });
+
+describe.skip("ApiGateway.Authorizer", () => {});

--- a/packages/alchemy/test/AWS/ApiGateway/Authorizer.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/Authorizer.test.ts
@@ -1,7 +1,59 @@
 import * as AWS from "@/AWS";
 import * as Test from "@/Test/Vitest";
-import { describe } from "@effect/vitest";
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
 
-Test.make({ providers: AWS.providers() });
+const { test } = Test.make({ providers: AWS.providers() });
 
-describe.skip("ApiGateway.Authorizer", () => {});
+const authorizerUri = process.env.ALCHEMY_TEST_AUTHORIZER_URI;
+
+/**
+ * Requires a Lambda authorizer invocation URI accepted by API Gateway.
+ */
+test.provider.skipIf(!authorizerUri)(
+  "create and update Lambda TOKEN authorizer",
+  (stack) =>
+    Effect.gen(function* () {
+      const uri = authorizerUri!;
+
+      const { api, authorizer } = yield* stack.deploy(
+        Effect.gen(function* () {
+          const api = yield* AWS.ApiGateway.RestApi("AgAuthorizerApi", {
+            endpointConfiguration: { types: ["REGIONAL"] },
+          });
+          const authorizer = yield* AWS.ApiGateway.Authorizer("AgAuthorizer", {
+            restApiId: api.restApiId,
+            type: "TOKEN",
+            authorizerUri: uri,
+            identitySource: "method.request.header.Authorization",
+            authorizerResultTtlInSeconds: 60,
+          });
+          return { api, authorizer };
+        }),
+      );
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          const apiAgain = yield* AWS.ApiGateway.RestApi("AgAuthorizerApi", {
+            endpointConfiguration: { types: ["REGIONAL"] },
+          });
+          yield* AWS.ApiGateway.Authorizer("AgAuthorizer", {
+            restApiId: apiAgain.restApiId,
+            type: "TOKEN",
+            authorizerUri: uri,
+            identitySource: "method.request.header.Authorization",
+            authorizerResultTtlInSeconds: 120,
+          });
+        }),
+      );
+
+      const remote = yield* ag.getAuthorizer({
+        restApiId: api.restApiId,
+        authorizerId: authorizer.authorizerId,
+      });
+      expect(remote.authorizerResultTtlInSeconds).toEqual(120);
+
+      yield* stack.destroy();
+    }),
+);

--- a/packages/alchemy/test/AWS/ApiGateway/BasePathMapping.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/BasePathMapping.test.ts
@@ -1,0 +1,7 @@
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Vitest";
+import { describe } from "@effect/vitest";
+
+Test.make({ providers: AWS.providers() });
+
+describe.skip("ApiGateway.BasePathMapping", () => {});

--- a/packages/alchemy/test/AWS/ApiGateway/Bindings.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/Bindings.test.ts
@@ -1,0 +1,9 @@
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Vitest";
+import { describe, it } from "vitest";
+
+Test.make({ providers: AWS.providers() });
+
+describe("ApiGateway bindings", () => {
+  it.skip("placeholder — no runtime bindings for REST v1 in this slice", () => {});
+});

--- a/packages/alchemy/test/AWS/ApiGateway/Deployment.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/Deployment.test.ts
@@ -1,0 +1,87 @@
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+test.provider("create and delete deployment", (stack) =>
+  Effect.gen(function* () {
+    const { api, deployment } = yield* stack.deploy(
+      Effect.gen(function* () {
+        const api = yield* AWS.ApiGateway.RestApi("AgDepApi", {
+          name: "alchemy-test-ag-deployment",
+          endpointConfiguration: { types: ["REGIONAL"] },
+        });
+        yield* AWS.ApiGateway.Method("AgDepMock", {
+          restApiId: api.restApiId,
+          resourceId: api.rootResourceId,
+          httpMethod: "GET",
+          authorizationType: "NONE",
+          integration: { type: "MOCK" },
+        });
+        const deployment = yield* AWS.ApiGateway.Deployment("AgDep", {
+          restApiId: api.restApiId,
+          description: "alchemy-test-deployment",
+        });
+        return { api, deployment };
+      }),
+    );
+
+    expect(deployment.deploymentId).toBeDefined();
+
+    yield* stack.destroy();
+  }),
+);
+
+test.provider("deployment trigger change creates new deployment", (stack) =>
+  Effect.gen(function* () {
+    const { api, d1 } = yield* stack.deploy(
+      Effect.gen(function* () {
+        const api = yield* AWS.ApiGateway.RestApi("AgTrigApi", {
+          name: "alchemy-test-ag-dep-triggers",
+          endpointConfiguration: { types: ["REGIONAL"] },
+        });
+        yield* AWS.ApiGateway.Method("AgTrigMock", {
+          restApiId: api.restApiId,
+          resourceId: api.rootResourceId,
+          httpMethod: "GET",
+          authorizationType: "NONE",
+          integration: { type: "MOCK" },
+        });
+        const deployment = yield* AWS.ApiGateway.Deployment("AgTrigDep", {
+          restApiId: api.restApiId,
+          description: "v1",
+          triggers: { t: "a" },
+        });
+        return { api, d1: deployment };
+      }),
+    );
+
+    const { d2 } = yield* stack.deploy(
+      Effect.gen(function* () {
+        const api = yield* AWS.ApiGateway.RestApi("AgTrigApi", {
+          name: "alchemy-test-ag-dep-triggers",
+          endpointConfiguration: { types: ["REGIONAL"] },
+        });
+        yield* AWS.ApiGateway.Method("AgTrigMock", {
+          restApiId: api.restApiId,
+          resourceId: api.rootResourceId,
+          httpMethod: "GET",
+          authorizationType: "NONE",
+          integration: { type: "MOCK" },
+        });
+        const deployment = yield* AWS.ApiGateway.Deployment("AgTrigDep", {
+          restApiId: api.restApiId,
+          description: "v1",
+          triggers: { t: "b" },
+        });
+        return { d2: deployment };
+      }),
+    );
+
+    expect(d2.deploymentId).not.toEqual(d1.deploymentId);
+
+    yield* stack.destroy();
+  }),
+);

--- a/packages/alchemy/test/AWS/ApiGateway/Deployment.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/Deployment.test.ts
@@ -10,7 +10,6 @@ test.provider("create and delete deployment", (stack) =>
     const { api, deployment } = yield* stack.deploy(
       Effect.gen(function* () {
         const api = yield* AWS.ApiGateway.RestApi("AgDepApi", {
-          name: "alchemy-test-ag-deployment",
           endpointConfiguration: { types: ["REGIONAL"] },
         });
         yield* AWS.ApiGateway.Method("AgDepMock", {
@@ -39,7 +38,6 @@ test.provider("deployment trigger change creates new deployment", (stack) =>
     const { api, d1 } = yield* stack.deploy(
       Effect.gen(function* () {
         const api = yield* AWS.ApiGateway.RestApi("AgTrigApi", {
-          name: "alchemy-test-ag-dep-triggers",
           endpointConfiguration: { types: ["REGIONAL"] },
         });
         yield* AWS.ApiGateway.Method("AgTrigMock", {
@@ -61,7 +59,6 @@ test.provider("deployment trigger change creates new deployment", (stack) =>
     const { d2 } = yield* stack.deploy(
       Effect.gen(function* () {
         const api = yield* AWS.ApiGateway.RestApi("AgTrigApi", {
-          name: "alchemy-test-ag-dep-triggers",
           endpointConfiguration: { types: ["REGIONAL"] },
         });
         yield* AWS.ApiGateway.Method("AgTrigMock", {

--- a/packages/alchemy/test/AWS/ApiGateway/DomainName.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/DomainName.test.ts
@@ -1,0 +1,7 @@
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Vitest";
+import { describe } from "@effect/vitest";
+
+Test.make({ providers: AWS.providers() });
+
+describe.skip("ApiGateway.DomainName", () => {});

--- a/packages/alchemy/test/AWS/ApiGateway/GatewayResponse.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/GatewayResponse.test.ts
@@ -1,0 +1,36 @@
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Vitest";
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+test.provider("create and delete gateway response", (stack) =>
+  Effect.gen(function* () {
+    const { api } = yield* stack.deploy(
+      Effect.gen(function* () {
+        const api = yield* AWS.ApiGateway.RestApi("AgGwRespApi", {
+          name: "alchemy-test-ag-gateway-response",
+          endpointConfiguration: { types: ["REGIONAL"] },
+        });
+        yield* AWS.ApiGateway.GatewayResponse("AgDefault4xx", {
+          restApiId: api.restApiId,
+          responseType: "DEFAULT_4XX",
+          responseTemplates: {
+            "application/json": '{"message":"test"}',
+          },
+        });
+        return { api };
+      }),
+    );
+
+    const g = yield* ag.getGatewayResponse({
+      restApiId: api.restApiId,
+      responseType: "DEFAULT_4XX",
+    });
+    expect(g.responseType).toEqual("DEFAULT_4XX");
+
+    yield* stack.destroy();
+  }),
+);

--- a/packages/alchemy/test/AWS/ApiGateway/GatewayResponse.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/GatewayResponse.test.ts
@@ -11,7 +11,6 @@ test.provider("create and delete gateway response", (stack) =>
     const { api } = yield* stack.deploy(
       Effect.gen(function* () {
         const api = yield* AWS.ApiGateway.RestApi("AgGwRespApi", {
-          name: "alchemy-test-ag-gateway-response",
           endpointConfiguration: { types: ["REGIONAL"] },
         });
         yield* AWS.ApiGateway.GatewayResponse("AgDefault4xx", {
@@ -30,6 +29,54 @@ test.provider("create and delete gateway response", (stack) =>
       responseType: "DEFAULT_4XX",
     });
     expect(g.responseType).toEqual("DEFAULT_4XX");
+
+    yield* stack.destroy();
+  }),
+);
+
+test.provider("update gateway response status and templates", (stack) =>
+  Effect.gen(function* () {
+    const { api } = yield* stack.deploy(
+      Effect.gen(function* () {
+        const api = yield* AWS.ApiGateway.RestApi("AgGwRespUpdateApi", {
+          endpointConfiguration: { types: ["REGIONAL"] },
+        });
+        yield* AWS.ApiGateway.GatewayResponse("AgDefault5xx", {
+          restApiId: api.restApiId,
+          responseType: "DEFAULT_5XX",
+          statusCode: "500",
+          responseTemplates: {
+            "application/json": '{"message":"v1"}',
+          },
+        });
+        return { api };
+      }),
+    );
+
+    yield* stack.deploy(
+      Effect.gen(function* () {
+        const apiAgain = yield* AWS.ApiGateway.RestApi("AgGwRespUpdateApi", {
+          endpointConfiguration: { types: ["REGIONAL"] },
+        });
+        yield* AWS.ApiGateway.GatewayResponse("AgDefault5xx", {
+          restApiId: apiAgain.restApiId,
+          responseType: "DEFAULT_5XX",
+          statusCode: "502",
+          responseTemplates: {
+            "application/json": '{"message":"v2"}',
+          },
+        });
+      }),
+    );
+
+    const g = yield* ag.getGatewayResponse({
+      restApiId: api.restApiId,
+      responseType: "DEFAULT_5XX",
+    });
+    expect(g.statusCode).toEqual("502");
+    expect(g.responseTemplates?.["application/json"]).toEqual(
+      '{"message":"v2"}',
+    );
 
     yield* stack.destroy();
   }),

--- a/packages/alchemy/test/AWS/ApiGateway/Method.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/Method.test.ts
@@ -1,0 +1,40 @@
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Vitest";
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+test.provider("create and delete MOCK method", (stack) =>
+  Effect.gen(function* () {
+    const { api } = yield* stack.deploy(
+      Effect.gen(function* () {
+        const api = yield* AWS.ApiGateway.RestApi("AgMethodApi", {
+          name: "alchemy-test-ag-method",
+          endpointConfiguration: { types: ["REGIONAL"] },
+        });
+        yield* AWS.ApiGateway.Method("AgMockGet", {
+          restApiId: api.restApiId,
+          resourceId: api.rootResourceId,
+          httpMethod: "GET",
+          authorizationType: "NONE",
+          integration: {
+            type: "MOCK",
+            requestTemplates: { "application/json": '{"statusCode": 200}' },
+          },
+        });
+        return { api };
+      }),
+    );
+
+    const method = yield* ag.getMethod({
+      restApiId: api.restApiId,
+      resourceId: api.rootResourceId,
+      httpMethod: "GET",
+    });
+    expect(method.httpMethod).toEqual("GET");
+
+    yield* stack.destroy();
+  }),
+);

--- a/packages/alchemy/test/AWS/ApiGateway/Method.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/Method.test.ts
@@ -11,7 +11,6 @@ test.provider("create and delete MOCK method", (stack) =>
     const { api } = yield* stack.deploy(
       Effect.gen(function* () {
         const api = yield* AWS.ApiGateway.RestApi("AgMethodApi", {
-          name: "alchemy-test-ag-method",
           endpointConfiguration: { types: ["REGIONAL"] },
         });
         yield* AWS.ApiGateway.Method("AgMockGet", {

--- a/packages/alchemy/test/AWS/ApiGateway/Resource.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/Resource.test.ts
@@ -1,0 +1,34 @@
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Vitest";
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+test.provider("create and delete API Gateway resource", (stack) =>
+  Effect.gen(function* () {
+    const { api, res } = yield* stack.deploy(
+      Effect.gen(function* () {
+        const api = yield* AWS.ApiGateway.RestApi("AgResApi", {
+          name: "alchemy-test-ag-resource",
+          endpointConfiguration: { types: ["REGIONAL"] },
+        });
+        const res = yield* AWS.ApiGateway.Resource("AgSubPath", {
+          restApiId: api.restApiId,
+          parentId: api.rootResourceId,
+          pathPart: "items",
+        });
+        return { api, res };
+      }),
+    );
+
+    const remote = yield* ag.getResource({
+      restApiId: api.restApiId,
+      resourceId: res.resourceId,
+    });
+    expect(remote.pathPart).toEqual("items");
+
+    yield* stack.destroy();
+  }),
+);

--- a/packages/alchemy/test/AWS/ApiGateway/Resource.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/Resource.test.ts
@@ -11,7 +11,6 @@ test.provider("create and delete API Gateway resource", (stack) =>
     const { api, res } = yield* stack.deploy(
       Effect.gen(function* () {
         const api = yield* AWS.ApiGateway.RestApi("AgResApi", {
-          name: "alchemy-test-ag-resource",
           endpointConfiguration: { types: ["REGIONAL"] },
         });
         const res = yield* AWS.ApiGateway.Resource("AgSubPath", {

--- a/packages/alchemy/test/AWS/ApiGateway/RestApi.smoke.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/RestApi.smoke.test.ts
@@ -1,0 +1,104 @@
+import * as AWS from "@/AWS";
+import { AWSEnvironment } from "@/AWS/Environment";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import { TestFunction, TestFunctionLive } from "../Lambda/handler.ts";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+test.provider(
+  "REST API proxies to Lambda (primitives)",
+  (stack) =>
+    Effect.gen(function* () {
+      const { region, accountId } = yield* AWSEnvironment;
+
+      const out = yield* stack.deploy(
+        Effect.gen(function* () {
+          const fn = yield* TestFunction.asEffect().pipe(
+            Effect.provide(TestFunctionLive),
+          );
+
+          const api = yield* AWS.ApiGateway.RestApi("AgSmokeApi", {
+            name: "alchemy-test-ag-smoke-rest",
+            endpointConfiguration: { types: ["REGIONAL"] },
+          });
+
+          const proxyResource = yield* AWS.ApiGateway.Resource("AgSmokeProxy", {
+            restApiId: api.restApiId,
+            parentId: api.rootResourceId,
+            pathPart: "{proxy+}",
+          });
+
+          const invokeUri = `arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/${fn.functionArn}/invocations`;
+
+          yield* AWS.ApiGateway.Method("AgSmokeRootAny", {
+            restApiId: api.restApiId,
+            resourceId: api.rootResourceId,
+            httpMethod: "ANY",
+            authorizationType: "NONE",
+            integration: {
+              type: "AWS_PROXY",
+              integrationHttpMethod: "POST",
+              uri: invokeUri,
+            },
+          });
+
+          yield* AWS.ApiGateway.Method("AgSmokeProxyAny", {
+            restApiId: api.restApiId,
+            resourceId: proxyResource.resourceId,
+            httpMethod: "ANY",
+            authorizationType: "NONE",
+            integration: {
+              type: "AWS_PROXY",
+              integrationHttpMethod: "POST",
+              uri: invokeUri,
+            },
+          });
+
+          const deployment = yield* AWS.ApiGateway.Deployment("AgSmokeDep", {
+            restApiId: api.restApiId,
+            description: "smoke",
+          });
+
+          const stage = yield* AWS.ApiGateway.Stage("AgSmokeStage", {
+            restApiId: api.restApiId,
+            stageName: "test",
+            deploymentId: deployment.deploymentId,
+          });
+
+          yield* AWS.Lambda.Permission("AgSmokePerm", {
+            action: "lambda:InvokeFunction",
+            functionName: fn.functionName,
+            principal: "apigateway.amazonaws.com",
+            sourceArn: `arn:aws:execute-api:${region}:${accountId}:${api.restApiId}/*/*/*`,
+          });
+
+          const invokeUrl = `https://${api.restApiId}.execute-api.${region}.amazonaws.com/${stage.stageName}/`;
+
+          return { invokeUrl };
+        }),
+      );
+
+      const response = yield* HttpClient.get(out.invokeUrl).pipe(
+        Effect.flatMap((response) =>
+          response.status === 200
+            ? Effect.succeed(response)
+            : Effect.fail(new Error(`invoke URL returned ${response.status}`)),
+        ),
+        Effect.retry({
+          schedule: Schedule.exponential(500).pipe(
+            Schedule.both(Schedule.recurs(10)),
+          ),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(yield* response.text).toBe("Hello, world!");
+
+      yield* stack.destroy();
+    }),
+  { timeout: 300_000 },
+);

--- a/packages/alchemy/test/AWS/ApiGateway/RestApi.smoke.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/RestApi.smoke.test.ts
@@ -22,7 +22,6 @@ test.provider(
           );
 
           const api = yield* AWS.ApiGateway.RestApi("AgSmokeApi", {
-            name: "alchemy-test-ag-smoke-rest",
             endpointConfiguration: { types: ["REGIONAL"] },
           });
 

--- a/packages/alchemy/test/AWS/ApiGateway/RestApi.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/RestApi.test.ts
@@ -1,0 +1,61 @@
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Vitest";
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+test.provider("create and delete REST API", (stack) =>
+  Effect.gen(function* () {
+    const api = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* AWS.ApiGateway.RestApi("AgRestApiLifecycle", {
+          name: "alchemy-test-ag-restapi-lifecycle",
+          endpointConfiguration: { types: ["REGIONAL"] },
+        });
+      }),
+    );
+
+    expect(api.restApiId).toBeDefined();
+    expect(api.rootResourceId).toBeDefined();
+
+    const remote = yield* ag.getRestApi({ restApiId: api.restApiId });
+    expect(remote.id).toEqual(api.restApiId);
+
+    yield* stack.destroy();
+  }),
+);
+
+test.provider("binary media types update applies via patch", (stack) =>
+  Effect.gen(function* () {
+    const api = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* AWS.ApiGateway.RestApi("AgRestApiBinary", {
+          name: "alchemy-test-ag-restapi-binary",
+          endpointConfiguration: { types: ["REGIONAL"] },
+          binaryMediaTypes: ["application/octet-stream"],
+        });
+      }),
+    );
+
+    expect(api.binaryMediaTypes?.includes("application/octet-stream")).toBe(
+      true,
+    );
+
+    yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* AWS.ApiGateway.RestApi("AgRestApiBinary", {
+          name: "alchemy-test-ag-restapi-binary",
+          endpointConfiguration: { types: ["REGIONAL"] },
+          binaryMediaTypes: ["application/octet-stream", "image/png"],
+        });
+      }),
+    );
+
+    const remote = yield* ag.getRestApi({ restApiId: api.restApiId });
+    expect(remote.binaryMediaTypes?.includes("image/png")).toBe(true);
+
+    yield* stack.destroy();
+  }),
+);

--- a/packages/alchemy/test/AWS/ApiGateway/RestApi.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/RestApi.test.ts
@@ -11,7 +11,6 @@ test.provider("create and delete REST API", (stack) =>
     const api = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* AWS.ApiGateway.RestApi("AgRestApiLifecycle", {
-          name: "alchemy-test-ag-restapi-lifecycle",
           endpointConfiguration: { types: ["REGIONAL"] },
         });
       }),
@@ -32,7 +31,6 @@ test.provider("binary media types update applies via patch", (stack) =>
     const api = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* AWS.ApiGateway.RestApi("AgRestApiBinary", {
-          name: "alchemy-test-ag-restapi-binary",
           endpointConfiguration: { types: ["REGIONAL"] },
           binaryMediaTypes: ["application/octet-stream"],
         });
@@ -46,7 +44,6 @@ test.provider("binary media types update applies via patch", (stack) =>
     yield* stack.deploy(
       Effect.gen(function* () {
         return yield* AWS.ApiGateway.RestApi("AgRestApiBinary", {
-          name: "alchemy-test-ag-restapi-binary",
           endpointConfiguration: { types: ["REGIONAL"] },
           binaryMediaTypes: ["application/octet-stream", "image/png"],
         });
@@ -55,6 +52,36 @@ test.provider("binary media types update applies via patch", (stack) =>
 
     const remote = yield* ag.getRestApi({ restApiId: api.restApiId });
     expect(remote.binaryMediaTypes?.includes("image/png")).toBe(true);
+
+    yield* stack.destroy();
+  }),
+);
+
+test.provider("binary media types removal applies via patch", (stack) =>
+  Effect.gen(function* () {
+    const api = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* AWS.ApiGateway.RestApi("AgRestApiBinaryRemoval", {
+          endpointConfiguration: { types: ["REGIONAL"] },
+          binaryMediaTypes: ["application/octet-stream", "image/png"],
+        });
+      }),
+    );
+
+    yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* AWS.ApiGateway.RestApi("AgRestApiBinaryRemoval", {
+          endpointConfiguration: { types: ["REGIONAL"] },
+          binaryMediaTypes: ["image/png"],
+        });
+      }),
+    );
+
+    const remote = yield* ag.getRestApi({ restApiId: api.restApiId });
+    expect(remote.binaryMediaTypes?.includes("image/png")).toBe(true);
+    expect(remote.binaryMediaTypes?.includes("application/octet-stream")).toBe(
+      false,
+    );
 
     yield* stack.destroy();
   }),

--- a/packages/alchemy/test/AWS/ApiGateway/Stage.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/Stage.test.ts
@@ -1,0 +1,179 @@
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Vitest";
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+test.provider("create and delete stage", (stack) =>
+  Effect.gen(function* () {
+    const { stage } = yield* stack.deploy(
+      Effect.gen(function* () {
+        const api = yield* AWS.ApiGateway.RestApi("AgStageApi", {
+          name: "alchemy-test-ag-stage",
+          endpointConfiguration: { types: ["REGIONAL"] },
+        });
+        yield* AWS.ApiGateway.Method("AgStageMock", {
+          restApiId: api.restApiId,
+          resourceId: api.rootResourceId,
+          httpMethod: "GET",
+          authorizationType: "NONE",
+          integration: { type: "MOCK" },
+        });
+        const deployment = yield* AWS.ApiGateway.Deployment("AgStageDep", {
+          restApiId: api.restApiId,
+        });
+        const stage = yield* AWS.ApiGateway.Stage("AgStageDev", {
+          restApiId: api.restApiId,
+          stageName: "dev",
+          deploymentId: deployment.deploymentId,
+        });
+        return { stage };
+      }),
+    );
+
+    expect(stage.stageName).toEqual("dev");
+
+    yield* stack.destroy();
+  }),
+);
+
+test.provider("stage variables update in place", (stack) =>
+  Effect.gen(function* () {
+    const { api, deployment } = yield* stack.deploy(
+      Effect.gen(function* () {
+        const api = yield* AWS.ApiGateway.RestApi("AgStageVarApi", {
+          name: "alchemy-test-ag-stage-vars",
+          endpointConfiguration: { types: ["REGIONAL"] },
+        });
+        yield* AWS.ApiGateway.Method("AgStageVarMock", {
+          restApiId: api.restApiId,
+          resourceId: api.rootResourceId,
+          httpMethod: "GET",
+          authorizationType: "NONE",
+          integration: { type: "MOCK" },
+        });
+        const deployment = yield* AWS.ApiGateway.Deployment("AgStageVarDep", {
+          restApiId: api.restApiId,
+        });
+        const stage = yield* AWS.ApiGateway.Stage("AgStageVar", {
+          restApiId: api.restApiId,
+          stageName: "dev",
+          deploymentId: deployment.deploymentId,
+          variables: { K: "1" },
+        });
+        return { api, stage, deployment };
+      }),
+    );
+
+    yield* stack.deploy(
+      Effect.gen(function* () {
+        const api = yield* AWS.ApiGateway.RestApi("AgStageVarApi", {
+          name: "alchemy-test-ag-stage-vars",
+          endpointConfiguration: { types: ["REGIONAL"] },
+        });
+        yield* AWS.ApiGateway.Method("AgStageVarMock", {
+          restApiId: api.restApiId,
+          resourceId: api.rootResourceId,
+          httpMethod: "GET",
+          authorizationType: "NONE",
+          integration: { type: "MOCK" },
+        });
+        const deployment = yield* AWS.ApiGateway.Deployment("AgStageVarDep", {
+          restApiId: api.restApiId,
+        });
+        yield* AWS.ApiGateway.Stage("AgStageVar", {
+          restApiId: api.restApiId,
+          stageName: "dev",
+          deploymentId: deployment.deploymentId,
+          variables: { K: "2" },
+        });
+        return undefined;
+      }),
+    );
+
+    const remote = yield* ag.getStage({
+      restApiId: api.restApiId,
+      stageName: "dev",
+    });
+    expect(remote.variables?.K).toEqual("2");
+
+    yield* stack.destroy();
+  }),
+);
+
+test.provider("stage method settings update in place", (stack) =>
+  Effect.gen(function* () {
+    const { api } = yield* stack.deploy(
+      Effect.gen(function* () {
+        const api = yield* AWS.ApiGateway.RestApi("AgStageMethodApi", {
+          name: "alchemy-test-ag-stage-method",
+          endpointConfiguration: { types: ["REGIONAL"] },
+        });
+        yield* AWS.ApiGateway.Method("AgStageMethodMock", {
+          restApiId: api.restApiId,
+          resourceId: api.rootResourceId,
+          httpMethod: "GET",
+          authorizationType: "NONE",
+          integration: { type: "MOCK" },
+        });
+        const deployment = yield* AWS.ApiGateway.Deployment(
+          "AgStageMethodDep",
+          {
+            restApiId: api.restApiId,
+          },
+        );
+        yield* AWS.ApiGateway.Stage("AgStageMethod", {
+          restApiId: api.restApiId,
+          stageName: "dev",
+          deploymentId: deployment.deploymentId,
+          methodSettings: {
+            "*/*": { throttlingBurstLimit: 10, throttlingRateLimit: 100 },
+          },
+        });
+        return { api };
+      }),
+    );
+
+    yield* stack.deploy(
+      Effect.gen(function* () {
+        const api = yield* AWS.ApiGateway.RestApi("AgStageMethodApi", {
+          name: "alchemy-test-ag-stage-method",
+          endpointConfiguration: { types: ["REGIONAL"] },
+        });
+        yield* AWS.ApiGateway.Method("AgStageMethodMock", {
+          restApiId: api.restApiId,
+          resourceId: api.rootResourceId,
+          httpMethod: "GET",
+          authorizationType: "NONE",
+          integration: { type: "MOCK" },
+        });
+        const deployment = yield* AWS.ApiGateway.Deployment(
+          "AgStageMethodDep",
+          {
+            restApiId: api.restApiId,
+          },
+        );
+        yield* AWS.ApiGateway.Stage("AgStageMethod", {
+          restApiId: api.restApiId,
+          stageName: "dev",
+          deploymentId: deployment.deploymentId,
+          methodSettings: {
+            "*/*": { throttlingBurstLimit: 20, throttlingRateLimit: 200 },
+          },
+        });
+        return undefined;
+      }),
+    );
+
+    const remote = yield* ag.getStage({
+      restApiId: api.restApiId,
+      stageName: "dev",
+    });
+    expect(remote.methodSettings?.["*/*"]?.throttlingBurstLimit).toEqual(20);
+    expect(remote.methodSettings?.["*/*"]?.throttlingRateLimit).toEqual(200);
+
+    yield* stack.destroy();
+  }),
+);

--- a/packages/alchemy/test/AWS/ApiGateway/Stage.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/Stage.test.ts
@@ -11,7 +11,6 @@ test.provider("create and delete stage", (stack) =>
     const { stage } = yield* stack.deploy(
       Effect.gen(function* () {
         const api = yield* AWS.ApiGateway.RestApi("AgStageApi", {
-          name: "alchemy-test-ag-stage",
           endpointConfiguration: { types: ["REGIONAL"] },
         });
         yield* AWS.ApiGateway.Method("AgStageMock", {
@@ -44,7 +43,6 @@ test.provider("stage variables update in place", (stack) =>
     const { api, deployment } = yield* stack.deploy(
       Effect.gen(function* () {
         const api = yield* AWS.ApiGateway.RestApi("AgStageVarApi", {
-          name: "alchemy-test-ag-stage-vars",
           endpointConfiguration: { types: ["REGIONAL"] },
         });
         yield* AWS.ApiGateway.Method("AgStageVarMock", {
@@ -70,7 +68,6 @@ test.provider("stage variables update in place", (stack) =>
     yield* stack.deploy(
       Effect.gen(function* () {
         const api = yield* AWS.ApiGateway.RestApi("AgStageVarApi", {
-          name: "alchemy-test-ag-stage-vars",
           endpointConfiguration: { types: ["REGIONAL"] },
         });
         yield* AWS.ApiGateway.Method("AgStageVarMock", {
@@ -108,7 +105,6 @@ test.provider("stage method settings update in place", (stack) =>
     const { api } = yield* stack.deploy(
       Effect.gen(function* () {
         const api = yield* AWS.ApiGateway.RestApi("AgStageMethodApi", {
-          name: "alchemy-test-ag-stage-method",
           endpointConfiguration: { types: ["REGIONAL"] },
         });
         yield* AWS.ApiGateway.Method("AgStageMethodMock", {
@@ -139,7 +135,6 @@ test.provider("stage method settings update in place", (stack) =>
     yield* stack.deploy(
       Effect.gen(function* () {
         const api = yield* AWS.ApiGateway.RestApi("AgStageMethodApi", {
-          name: "alchemy-test-ag-stage-method",
           endpointConfiguration: { types: ["REGIONAL"] },
         });
         yield* AWS.ApiGateway.Method("AgStageMethodMock", {

--- a/packages/alchemy/test/AWS/ApiGateway/UsagePlan.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/UsagePlan.test.ts
@@ -1,0 +1,52 @@
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Vitest";
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+test.provider("create and delete usage plan", (stack) =>
+  Effect.gen(function* () {
+    const plan = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* AWS.ApiGateway.UsagePlan("AgUsagePlan", {
+          name: "alchemy-test-ag-usageplan",
+          description: "test plan",
+        });
+      }),
+    );
+
+    expect(plan.id).toBeDefined();
+
+    yield* stack.destroy();
+  }),
+);
+
+test.provider("usage plan throttle updates in place", (stack) =>
+  Effect.gen(function* () {
+    const plan = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* AWS.ApiGateway.UsagePlan("AgUsagePlanThrottle", {
+          name: "alchemy-test-ag-usageplan-throttle",
+          throttle: { burstLimit: 10, rateLimit: 100 },
+        });
+      }),
+    );
+
+    yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* AWS.ApiGateway.UsagePlan("AgUsagePlanThrottle", {
+          name: "alchemy-test-ag-usageplan-throttle",
+          throttle: { burstLimit: 20, rateLimit: 200 },
+        });
+      }),
+    );
+
+    const remote = yield* ag.getUsagePlan({ usagePlanId: plan.id });
+    expect(remote.throttle?.burstLimit).toEqual(20);
+    expect(remote.throttle?.rateLimit).toEqual(200);
+
+    yield* stack.destroy();
+  }),
+);

--- a/packages/alchemy/test/AWS/ApiGateway/UsagePlan.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/UsagePlan.test.ts
@@ -11,7 +11,6 @@ test.provider("create and delete usage plan", (stack) =>
     const plan = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* AWS.ApiGateway.UsagePlan("AgUsagePlan", {
-          name: "alchemy-test-ag-usageplan",
           description: "test plan",
         });
       }),
@@ -28,7 +27,6 @@ test.provider("usage plan throttle updates in place", (stack) =>
     const plan = yield* stack.deploy(
       Effect.gen(function* () {
         return yield* AWS.ApiGateway.UsagePlan("AgUsagePlanThrottle", {
-          name: "alchemy-test-ag-usageplan-throttle",
           throttle: { burstLimit: 10, rateLimit: 100 },
         });
       }),
@@ -37,7 +35,6 @@ test.provider("usage plan throttle updates in place", (stack) =>
     yield* stack.deploy(
       Effect.gen(function* () {
         return yield* AWS.ApiGateway.UsagePlan("AgUsagePlanThrottle", {
-          name: "alchemy-test-ag-usageplan-throttle",
           throttle: { burstLimit: 20, rateLimit: 200 },
         });
       }),

--- a/packages/alchemy/test/AWS/ApiGateway/UsagePlanKey.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/UsagePlanKey.test.ts
@@ -1,0 +1,32 @@
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+test.provider("create and delete usage plan key association", (stack) =>
+  Effect.gen(function* () {
+    const { key, plan } = yield* stack.deploy(
+      Effect.gen(function* () {
+        const key = yield* AWS.ApiGateway.ApiKey("AgUpkKey", {
+          name: "alchemy-test-ag-upk-key",
+          generateDistinctId: true,
+        });
+        const plan = yield* AWS.ApiGateway.UsagePlan("AgUpkPlan", {
+          name: "alchemy-test-ag-upk-plan",
+        });
+        yield* AWS.ApiGateway.UsagePlanKey("AgUpkLink", {
+          usagePlanId: plan.id,
+          keyId: key.id,
+        });
+        return { key, plan };
+      }),
+    );
+
+    expect(key.id).toBeDefined();
+    expect(plan.id).toBeDefined();
+
+    yield* stack.destroy();
+  }),
+);

--- a/packages/alchemy/test/AWS/ApiGateway/UsagePlanKey.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/UsagePlanKey.test.ts
@@ -10,12 +10,9 @@ test.provider("create and delete usage plan key association", (stack) =>
     const { key, plan } = yield* stack.deploy(
       Effect.gen(function* () {
         const key = yield* AWS.ApiGateway.ApiKey("AgUpkKey", {
-          name: "alchemy-test-ag-upk-key",
           generateDistinctId: true,
         });
-        const plan = yield* AWS.ApiGateway.UsagePlan("AgUpkPlan", {
-          name: "alchemy-test-ag-upk-plan",
-        });
+        const plan = yield* AWS.ApiGateway.UsagePlan("AgUpkPlan", {});
         yield* AWS.ApiGateway.UsagePlanKey("AgUpkLink", {
           usagePlanId: plan.id,
           keyId: key.id,

--- a/packages/alchemy/test/AWS/ApiGateway/VpcLink.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/VpcLink.test.ts
@@ -1,0 +1,47 @@
+import * as AWS from "@/AWS";
+import * as Test from "@/Test/Vitest";
+import * as ag from "@distilled.cloud/aws/api-gateway";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+const targetArn = process.env.ALCHEMY_TEST_VPC_LINK_TARGET_ARN;
+
+/**
+ * Requires a load balancer ARN accepted by API Gateway VPC links (set env when running live).
+ */
+test.provider.skipIf(!targetArn)(
+  "create, update description, delete VPC link",
+  (stack) =>
+    Effect.gen(function* () {
+      const arn = targetArn!;
+
+      const link = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AWS.ApiGateway.VpcLink("AgVpcLinkTest", {
+            name: "alchemy-test-vpclink",
+            description: "v1",
+            targetArns: [arn],
+          });
+        }),
+      );
+
+      expect(link.vpcLinkId).toBeDefined();
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AWS.ApiGateway.VpcLink("AgVpcLinkTest", {
+            name: "alchemy-test-vpclink",
+            description: "v2",
+            targetArns: [arn],
+          });
+        }),
+      );
+
+      const remote = yield* ag.getVpcLink({ vpcLinkId: link.vpcLinkId });
+      expect(remote.description).toEqual("v2");
+
+      yield* stack.destroy();
+    }),
+);

--- a/packages/alchemy/test/AWS/ApiGateway/VpcLink.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/VpcLink.test.ts
@@ -20,7 +20,6 @@ test.provider.skipIf(!targetArn)(
       const link = yield* stack.deploy(
         Effect.gen(function* () {
           return yield* AWS.ApiGateway.VpcLink("AgVpcLinkTest", {
-            name: "alchemy-test-vpclink",
             description: "v1",
             targetArns: [arn],
           });
@@ -32,7 +31,6 @@ test.provider.skipIf(!targetArn)(
       yield* stack.deploy(
         Effect.gen(function* () {
           return yield* AWS.ApiGateway.VpcLink("AgVpcLinkTest", {
-            name: "alchemy-test-vpclink",
             description: "v2",
             targetArns: [arn],
           });

--- a/scripts/audit-service.ts
+++ b/scripts/audit-service.ts
@@ -1020,6 +1020,7 @@ async function auditService(serviceName: string): Promise<AuditReport> {
         distilled: "secrets-manager",
         alchemy: "SecretsManager",
       },
+      apigateway: { distilled: "api-gateway", alchemy: "ApiGateway" },
     };
 
   const config = serviceConfig[serviceNameLower] || {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,9 @@
       "path": "./examples/aws-lambda-httpapi/tsconfig.json"
     },
     {
+      "path": "./examples/aws-rest-api/tsconfig.json"
+    },
+    {
       "path": "./examples/aws-lambda-rpc/tsconfig.json"
     },
     {

--- a/website/src/content/docs/tutorial/aws/api-gateway.mdx
+++ b/website/src/content/docs/tutorial/aws/api-gateway.mdx
@@ -1,0 +1,74 @@
+---
+title: REST API (API Gateway v1)
+description: Expose a Lambda with a regional Amazon API Gateway REST API using RestApi, Resource, Method, Deployment, and Stage primitives.
+sidebar:
+  order: 8
+---
+
+The [Deploy a Lambda Function](/tutorial/aws/lambda) tutorial uses a **Function URL** for HTTP. Many teams still use **Amazon API Gateway** (REST, v1) as the front door.
+
+Alchemy models the v1 REST control plane as separate resources so you can wire integrations, stages, and custom domains explicitly.
+
+## Try the example
+
+The repo includes **`examples/aws-rest-api`**: a minimal **regional** REST API with `ANY` on the root and a `{proxy+}` resource, **AWS_PROXY** integration to a Lambda, then **Deployment**, **Stage** (`prod`), and **Lambda.Permission** so API Gateway can invoke the function.
+
+```sh
+cd examples/aws-rest-api
+bun install
+bun run deploy
+```
+
+After deploy, open the printed `invokeUrl` in a browser; you should see the Lambda’s text response.
+
+## Shape of the stack
+
+Typical order inside `Effect.gen`:
+
+1. **`AWS.ApiGateway.RestApi`** — creates the API and exposes `restApiId` / `rootResourceId`.
+2. **`AWS.ApiGateway.Resource`** — optional path segments (e.g. `{proxy+}`).
+3. **`AWS.ApiGateway.Method`** — HTTP verb + integration (`AWS_PROXY` Lambda ARNs use `Output.interpolate` with `arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/${functionArn}/invocations`).
+4. **`AWS.ApiGateway.Deployment`** — snapshots the current resource graph; change **`triggers`** (or other props) to force a new deployment when only integrations changed.
+5. **`AWS.ApiGateway.Stage`** — attaches a deployment to a named stage (`prod`, `dev`, …).
+6. **`AWS.Lambda.Permission`** — `principal: "apigateway.amazonaws.com"` and `sourceArn` covering `execute-api` for your API.
+
+Use **`yield* AWS.AWSEnvironment`** for `region` and `accountId` when building ARNs (as in the example).
+
+## Private integration (VPC link)
+
+For **private** HTTP integrations, create a **`AWS.ApiGateway.VpcLink`** with your load balancer target ARNs, then reference `vpcLinkId` as **`integration.connectionId`** with **`connectionType: "VPC_LINK"`** on `AWS.ApiGateway.Method` (`integration.uri` points at your private backend URL).
+
+```typescript
+const link = yield* AWS.ApiGateway.VpcLink("InternalLink", {
+  name: "internal-nlb",
+  targetArns: [loadBalancer.loadBalancerArn],
+});
+
+yield* AWS.ApiGateway.Method("PrivateGet", {
+  restApiId: api.restApiId,
+  resourceId: resource.resourceId,
+  httpMethod: "GET",
+  integration: {
+    type: "HTTP_PROXY",
+    integrationHttpMethod: "GET",
+    uri: "https://api.internal.example/resource",
+    connectionType: "VPC_LINK",
+    connectionId: link.vpcLinkId,
+  },
+});
+```
+
+See also [VpcLink](/providers/aws/apigateway/vpclink) in the generated API reference.
+
+## API reference
+
+Generated docs for each primitive live under **Providers → AWS → ApiGateway** in the sidebar (for example [RestApi](/providers/aws/apigateway/restapi)). Run `bun generate:api-reference` locally after changing JSDoc on resources.
+
+## Next steps
+
+- **Custom domains:** `AWS.ApiGateway.DomainName` and `AWS.ApiGateway.BasePathMapping`.
+- **API keys / throttling:** `ApiKey`, `UsagePlan`, `UsagePlanKey`.
+- **Authorizers:** `Authorizer` for Cognito or Lambda TOKEN / REQUEST flows.
+- **Gateway responses:** `GatewayResponse` for consistent 4xx/5xx bodies.
+
+HTTP APIs (v2) are a different product; this tutorial is **REST v1** only.


### PR DESCRIPTION
## Summary

Adds AWS API Gateway (REST API v1) resource providers to `packages/alchemy`, plus lifecycle tests, an `examples/aws-rest-api` reference stack, and tutorial content (`website/src/content/docs/tutorial/aws/api-gateway.mdx`).

## Includes

- REST API primitives: `RestApi`, `Deployment`, `Stage`, `Method`, `GatewayResource`, `Authorizer`, `ApiKey`, `UsagePlan`, `UsagePlanKey`, `DomainName`, `BasePathMapping`, `GatewayResponse`, `Account`, `VpcLink`, shared helpers
- Provider registration and `normalizeTags` export used by ApiGateway tagging
- `scripts/audit-service.ts` mapping for `apigateway`
- Root `tsconfig.json` project reference for `examples/aws-rest-api`

## Notes

- Integration tests require AWS credentials (e.g. configured profile in CI).
- Optional `VpcLink` test can be enabled with `ALCHEMY_TEST_VPC_LINK_TARGET_ARN`.

Refs: none