### PR TITLE
fix(website): dark mode follow-ups

### DIFF
--- a/website/src/components/ThemeProvider.astro
+++ b/website/src/components/ThemeProvider.astro
@@ -1,16 +1,41 @@
 ---
 /**
- * Pre-paint theme initializer. Mirrors Starlight's default ThemeProvider
- * contract so its built-in `<ThemeSelect>` (and our marketing nav toggle)
- * keep working. Reads `localStorage["starlight-theme"]` first, falls back
- * to `prefers-color-scheme`, and writes `data-theme` on <html> before any
- * paint to avoid a flash.
+ * Pre-paint theme initializer + browser-chrome metadata. Mirrors
+ * Starlight's default ThemeProvider contract so its built-in
+ * `<ThemeSelect>` (and our marketing nav toggle) keep working.
+ *
+ * Reads `localStorage["starlight-theme"]` first, falls back to
+ * `prefers-color-scheme`, and writes `data-theme` on <html> before any
+ * paint to avoid a flash. Imported by both the Starlight head override
+ * and the marketing layout so navigating between docs and marketing
+ * pages doesn't drop the user's theme.
+ *
+ * Also emits the `color-scheme` and `theme-color` meta tags so iOS /
+ * Android paint the URL bar / status bar / bottom nav with the page
+ * background instead of falling back to the OS-default white in dark
+ * mode.
  *
  * Exposes `window.StarlightThemeProvider.updatePickers(theme)` so the
  * `<starlight-theme-select>` web component can sync its UI when storage
  * or system preference changes.
  */
 ---
+
+<meta name="color-scheme" content="light dark" />
+{/* Cream parchment for light, deep walnut for dark — matches `--alc-bg`
+    in tokens.css. The browser picks based on `prefers-color-scheme` so
+    iOS Safari's URL bar / Android's status bar tint correctly even
+    before the inline script writes `data-theme`. */}
+<meta
+  name="theme-color"
+  content="#f5efe3"
+  media="(prefers-color-scheme: light)"
+/>
+<meta
+  name="theme-color"
+  content="#14110d"
+  media="(prefers-color-scheme: dark)"
+/>
 
 <script is:inline>
   window.StarlightThemeProvider = (() => {

--- a/website/src/components/marketing/Button.astro
+++ b/website/src/components/marketing/Button.astro
@@ -85,4 +85,12 @@ const { variant = "primary", icon, href = "#", class: className } = Astro.props;
     background: var(--alc-terracotta);
     color: var(--alc-fg-on-accent);
   }
+  /* MDX wraps the button's slot text in a <p>, which inherits the UA
+     stylesheet's 1em block margin (~14px) and bloats the button
+     vertically. Flatten any <p> inside the button. `display: inline`
+     keeps the icon + label on one row inside the inline-flex anchor. */
+  .alc-btn :global(p) {
+    margin: 0;
+    display: inline;
+  }
 </style>

--- a/website/src/components/marketing/HeroBgGraph.astro
+++ b/website/src/components/marketing/HeroBgGraph.astro
@@ -101,15 +101,28 @@ const {
       }
     };
 
-    const resize = () => {
+    const resize = (): boolean => {
       const rect = canvas.getBoundingClientRect();
-      width = rect.width;
-      height = rect.height;
-      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const newW = rect.width;
+      const newH = rect.height;
+      const newDpr = Math.min(window.devicePixelRatio || 1, 2);
+      // iOS Safari fires `resize` continuously as the URL bar collapses
+      // / expands during scroll. Reassigning `canvas.width`/`height`
+      // wipes the bitmap *even when set to the same value*, which
+      // shows up as the mandala flashing every time you swipe. Skip
+      // when nothing actually changed; only the centerline (handled
+      // separately via ResizeObserver) needs to update on scroll.
+      if (newW === width && newH === height && newDpr === dpr) {
+        return false;
+      }
+      width = newW;
+      height = newH;
+      dpr = newDpr;
       canvas.width = Math.round(width * dpr);
       canvas.height = Math.round(height * dpr);
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
       measureCenter();
+      return true;
     };
 
     const resolveRGB = (): [number, number, number] => {
@@ -372,12 +385,13 @@ const {
       resizeQueued = true;
       requestAnimationFrame(() => {
         resizeQueued = false;
-        resize();
+        const changed = resize();
         rgb = resolveRGB();
-        // In reduced-motion mode the RAF loop is stopped, so we need to
-        // explicitly redraw the static frame after the canvas has been
-        // resized — otherwise the canvas goes blank after a resize.
-        if (reduced) draw(0);
+        // In reduced-motion mode the RAF loop is stopped, so when the
+        // canvas was actually resized we need to explicitly redraw the
+        // static frame. If `resize()` no-op'd (mobile URL-bar wiggle
+        // with unchanged dimensions) we don't need to redraw at all.
+        if (reduced && changed) draw(0);
       });
     };
     window.addEventListener("resize", onResize, { passive: true });

--- a/website/src/layouts/Marketing.astro
+++ b/website/src/layouts/Marketing.astro
@@ -5,6 +5,7 @@ import "../styles/marketing.css";
 import Nav from "../components/marketing/Nav.astro";
 import Footer from "../components/marketing/Footer.astro";
 import PostHog from "../components/analytics/PostHog.astro";
+import ThemeProvider from "../components/ThemeProvider.astro";
 
 interface Props {
   title?: string;
@@ -47,6 +48,11 @@ const canonical = new URL(Astro.url.pathname, Astro.site);
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    {/* Pre-paint theme script + color-scheme/theme-color metas. Must
+        run before any paint so navigating from a docs page (where the
+        Starlight head includes the same partial) doesn't drop the
+        user's theme on a marketing page. */}
+    <ThemeProvider />
     <title>{title}</title>
     {description && <meta name="description" content={description} />}
     <link rel="canonical" href={canonical.href} />


### PR DESCRIPTION
Follow-ups to the dark-mode PR (#125).

- **iOS chrome color**: add `<meta name="color-scheme">` and light/dark `<meta name="theme-color">` via `ThemeProvider.astro` so URL bar / status bar / bottom nav tint to match `--alc-bg`.
- **Hero scroll flash on mobile**: iOS Safari fires `resize` continuously as the URL bar collapses; reassigning `canvas.width`/`height` (even to the same value) wipes the bitmap. `resize()` now no-ops when dimensions are unchanged.
- **Theme reverts on marketing pages**: `Marketing.astro` was missing the pre-paint theme script. Imported `ThemeProvider.astro` into the marketing layout so docs↔marketing navigation keeps `data-theme` on `<html>`.
- **"Read the tutorial" button height**: MDX wraps the slot text in `a.alc-btn > p > "..."`, which inherits the UA `1em` block margin. Added `.alc-btn p { margin: 0; display: inline }`.