### PR TITLE
fix: re-enable CLI bundle by routing import.meta through package name

### DIFF
--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -246,7 +246,9 @@
     },
     "./bin/alchemy.js": "./bin/alchemy.js",
     "./bin/exec.ts": "./bin/exec.ts",
-    "./bin/exec.js": "./bin/exec.js"
+    "./bin/exec.js": "./bin/exec.js",
+    "./Cloudflare/Local/SidecarServer.ts": "./src/Cloudflare/Local/SidecarServer.ts",
+    "./Cloudflare/StateStore/Api.ts": "./src/Cloudflare/StateStore/Api.ts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/alchemy/src/Cloudflare/Local/Sidecar.ts
+++ b/packages/alchemy/src/Cloudflare/Local/Sidecar.ts
@@ -38,7 +38,12 @@ export class Sidecar extends RpcClient.RpcClientService<
   }
 >()("Sidecar") {}
 
+// Resolve via the package name rather than `./SidecarServer.ts` so the path
+// stays correct after this module is inlined into `bin/alchemy.js` by tsdown.
+// A relative `import.meta.resolve` would resolve against the bundle's
+// location (`bin/`) instead of the original Sidecar.ts source location.
+// See PR #128 for the same pattern applied to bin/exec.ts.
 export const SidecarLive = RpcClient.layer(Sidecar, {
-  main: import.meta.resolve("./SidecarServer.ts", import.meta.url),
+  main: import.meta.resolve("alchemy/Cloudflare/Local/SidecarServer.ts"),
   schema: SidecarSchema,
 });

--- a/packages/alchemy/src/Cloudflare/StateStore/Api.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Api.ts
@@ -24,17 +24,27 @@ export const STATE_STORE_SCRIPT_NAME = "alchemy-state-store" as const;
 /**
  * Path on disk to *this* file, used as the worker's bundling entry.
  *
- * Resolved via the package name (`alchemy/Cloudflare/StateStore/Api.ts`)
- * rather than `import.meta.filename`, so it keeps pointing at the original
- * source file even after this module is inlined into the CLI's
- * `bin/alchemy.js` bundle. `import.meta.filename` in the bundled case
- * would resolve to `bin/alchemy.js` — which has no `default` export and
- * breaks the worker bundler with
- * `[MISSING_EXPORT] "default" is not exported by "bin/alchemy.js"`.
+ * Two runtimes evaluate this module:
+ *   1. The alchemy CLI (node/bun), at deploy time, where we need a real
+ *      on-disk path so the worker bundler can find Api.ts. Bundled into
+ *      bin/alchemy.js, `import.meta.filename` would resolve to the bundle
+ *      itself (no `default` export → worker bundler dies). Resolve via the
+ *      package name instead so it keeps pointing at the source file.
+ *   2. The Cloudflare Workers runtime, after deploy, where this same module
+ *      *is* the worker entry. The `main` field is unused there, but the
+ *      top-level expression still evaluates — and `import.meta.resolve`
+ *      isn't a function in Workers, so an unguarded call crashes startup
+ *      with `(intermediate value).resolve is not a function`.
+ *
+ * Guard the resolve so the deploy path runs only where it works; in
+ * Workers, fall back to `import.meta.filename` (unused, just non-throwing).
  */
-const apiTsPath = fileURLToPath(
-  import.meta.resolve("alchemy/Cloudflare/StateStore/Api.ts"),
-);
+const apiTsPath =
+  typeof import.meta.resolve === "function"
+    ? fileURLToPath(
+        import.meta.resolve("alchemy/Cloudflare/StateStore/Api.ts"),
+      )
+    : (import.meta.filename ?? "");
 
 export default Worker(
   "Api",

--- a/packages/alchemy/src/Cloudflare/StateStore/Api.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Api.ts
@@ -12,6 +12,7 @@ import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
 import * as HttpApiError from "effect/unstable/httpapi/HttpApiError";
 import crypto from "node:crypto";
+import { fileURLToPath } from "node:url";
 import * as Secret from "../SecretsStore/Secret.ts";
 import { SecretBindingLive } from "../SecretsStore/SecretBinding.ts";
 import { Worker } from "../Workers/Worker.ts";
@@ -23,21 +24,23 @@ export const STATE_STORE_SCRIPT_NAME = "alchemy-state-store" as const;
 /**
  * Path on disk to *this* file, used as the worker's bundling entry.
  *
- * When running from source (e.g. dev / monorepo), `import.meta.url` points
- * at `Api.ts` and we can use it directly. When the alchemy CLI is run from
- * its published `bin/alchemy.js` bundle, this module is inlined into the
- * CLI bundle and `import.meta.url` resolves to `bin/alchemy.js` — which
- * has no `default` export and breaks the worker bundler with
+ * Resolved via the package name (`alchemy/Cloudflare/StateStore/Api.ts`)
+ * rather than `import.meta.filename`, so it keeps pointing at the original
+ * source file even after this module is inlined into the CLI's
+ * `bin/alchemy.js` bundle. `import.meta.filename` in the bundled case
+ * would resolve to `bin/alchemy.js` — which has no `default` export and
+ * breaks the worker bundler with
  * `[MISSING_EXPORT] "default" is not exported by "bin/alchemy.js"`.
- *
- * In the bundled case, fall back to the published source file shipped
- * alongside the CLI under `../src/Cloudflare/StateStore/Api.ts`.
  */
+const apiTsPath = fileURLToPath(
+  import.meta.resolve("alchemy/Cloudflare/StateStore/Api.ts"),
+);
+
 export default Worker(
   "Api",
   {
     name: STATE_STORE_SCRIPT_NAME,
-    main: import.meta.filename,
+    main: apiTsPath,
     url: true,
     compatibility: {
       flags: ["nodejs_compat"],

--- a/packages/alchemy/tsdown.config.ts
+++ b/packages/alchemy/tsdown.config.ts
@@ -1,21 +1,31 @@
 import { defineConfig } from "tsdown";
 
 export default [
-  // bundle the CLi into a standalone executable
-  // defineConfig({
-  //   entry: ["bin/alchemy.ts"],
-  //   format: ["esm"],
-  //   clean: false,
-  //   shims: true,
-  //   outDir: "bin",
-  //   dts: false,
-  //   sourcemap: true,
-  //   outputOptions: {
-  //     inlineDynamicImports: true,
-  //   },
-  //   noExternal: ["execa", "open", "env-paths"],
-  //   tsconfig: "tsconfig.bundle.json",
-  // }),
+  // bundle the CLi into a standalone executable so react/ink/pathe can stay
+  // devDependencies and aren't installed for every consumer of `alchemy`.
+  //
+  // Modules in this bundle that need on-disk paths to themselves (or to
+  // sibling source files) must NOT use relative `import.meta.resolve` /
+  // `import.meta.filename` — after inlining, both point at `bin/alchemy.js`.
+  // Resolve via the package name instead, e.g.
+  //   import.meta.resolve("alchemy/Cloudflare/Local/SidecarServer.ts")
+  // and add a matching entry in the package.json `exports` map so the
+  // resolution succeeds in both source checkouts and published installs.
+  // See PR #128 for the original case (bin/exec.ts).
+  defineConfig({
+    entry: ["bin/alchemy.ts"],
+    format: ["esm"],
+    clean: false,
+    shims: true,
+    outDir: "bin",
+    dts: false,
+    sourcemap: true,
+    outputOptions: {
+      inlineDynamicImports: true,
+    },
+    noExternal: ["execa", "open", "env-paths"],
+    tsconfig: "tsconfig.bundle.json",
+  }),
   // bundle the dev-mode worker entrypoint. dev.ts spawns this in a child bun
   // process; under a published install it loads from node_modules and would
   // otherwise need react/ink/pathe at runtime to resolve InkCLI.tsx as source.


### PR DESCRIPTION
[#135](https://github.com/alchemy-run/alchemy-effect/pull/135) disabled the `bin/alchemy.ts` tsdown bundle because relative `import.meta.*` references inside the CLI's import graph misresolve once inlined into `bin/alchemy.js` — they point at the bundle, not the original source file.

This applies the [#128](https://github.com/alchemy-run/alchemy-effect/pull/128) pattern (`import.meta.resolve("alchemy/...")` + matching `exports` entries) to the two real offenders, then re-enables the tsdown config so react/ink/pathe stay out of consumer-visible runtime deps.

- `Cloudflare/Local/Sidecar.ts` — package-name resolve `SidecarServer.ts` instead of `./SidecarServer.ts`.
- `Cloudflare/StateStore/Api.ts` — package-name resolve `Api.ts` instead of `import.meta.filename`. The bundled value is `bin/alchemy.js`, which has no `default` export and breaks the worker bundler with `[MISSING_EXPORT] "default" is not exported by "bin/alchemy.js"`.
- `package.json` — export `./Cloudflare/Local/SidecarServer.ts` and `./Cloudflare/StateStore/Api.ts`.
- `tsdown.config.ts` — uncomment `bin/alchemy.ts` entry; document the `import.meta` constraint inline.

`Agent/util/parser.ts` also uses `import.meta.url` but isn't in the CLI bundle's import graph (only reached via `Bundle/Docker.ts`), so it's left alone.