### PR TITLE
fix(website): mobile dark hero, theme reactivity, brighter beta badge, OG host

### DIFF
--- a/website/src/components/marketing/BetaBadge.astro
+++ b/website/src/components/marketing/BetaBadge.astro
@@ -17,7 +17,7 @@ import { alchemyVersion } from "../../versions";
     padding: 5px 12px;
     border-radius: 999px;
     white-space: nowrap;
-    border: 1px solid var(--alc-hairline-2);
+    border: 1px solid var(--alc-hairline-3);
     background: var(--alc-bg-elev-1);
     font-family: var(--alc-font-mono);
     font-size: 11.5px;

--- a/website/src/components/marketing/HeroBgGraph.astro
+++ b/website/src/components/marketing/HeroBgGraph.astro
@@ -396,6 +396,21 @@ const {
     };
     window.addEventListener("resize", onResize, { passive: true });
 
+    // The stroke color is derived from `getComputedStyle(canvas).color`,
+    // which resolves `var(--alc-fg-1)` against the current theme. When
+    // the user toggles light/dark mid-session the cached `rgb` would
+    // otherwise stay frozen on the previous theme until the next resize
+    // — observable as a flash of stale-color strokes after the theme
+    // switch. Re-resolve whenever `<html data-theme>` changes.
+    const themeObs = new MutationObserver(() => {
+      rgb = resolveRGB();
+      if (reduced) draw(0);
+    });
+    themeObs.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+
     // Honor live changes to the user's `prefers-reduced-motion` setting.
     // When the user enables reduced motion mid-session, stop the loop and
     // hold a static frame; when they disable it, resume the animation.

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -340,11 +340,11 @@ between the two files with a short caption explaining each step. */}
   <div class="alc-cta" style="margin-top:48px;text-align:center;">
     <h2 class="alc-h2">
       <HeadingOrnament variant="fleuron" position="prefix" />
-      Paste this into your coding agent{" "}
+      Paste this into your coding agent
+      <br />
       <span style="color:var(--alc-accent-deep);font-style:italic;">
         to get started
-      </span>
-      .
+      </span>.
     </h2>
     <CopyForAgent client:load />
     <div class="cta-buttons" style="margin-top:24px;">

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -340,11 +340,7 @@ between the two files with a short caption explaining each step. */}
   <div class="alc-cta" style="margin-top:48px;text-align:center;">
     <h2 class="alc-h2">
       <HeadingOrnament variant="fleuron" position="prefix" />
-      Paste this into your coding agent
-      <br />
-      <span style="color:var(--alc-accent-deep);font-style:italic;">
-        to get started
-      </span>.
+      Paste this into your coding agent<br /><span style="color:var(--alc-accent-deep);font-style:italic;">to get started</span>.
     </h2>
     <CopyForAgent client:load />
     <div class="cta-buttons" style="margin-top:24px;">

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -86,6 +86,13 @@
   --sl-color-gray-5: var(--alc-walnut-700);
   --sl-color-gray-6: var(--alc-walnut-800);
   --sl-color-gray-7: var(--alc-bg-nav);
+  /* Starlight paints the selected sidebar entry with `--sl-color-text-accent`
+     as background and `--sl-color-text-invert` as text. In dark mode the
+     accent lifts to a bright lime (`--alc-accent-deep` ≈ #a3c473) — cream
+     (`--alc-fg-invert`) on lime is ~1.7:1, well below AA. Flip the invert
+     token to the dark page background so the selected pill reads as dark
+     text on lime (~10:1, AAA). */
+  --sl-color-text-invert: var(--alc-bg);
 }
 
 /* ── Headings: serif for h1/h2, sans for h3/h4 (matches alc-h* scale) ── */

--- a/website/src/styles/marketing.css
+++ b/website/src/styles/marketing.css
@@ -2384,6 +2384,28 @@ body.alc-root,
      compositing brightness so they read clearly above the dark page. */
   filter: brightness(3.6);
 }
+/* On phones the hero canvas takes up a much larger fraction of the
+   viewport than on desktop, so the same brightness multiplier plus
+   wide mask makes the mandala bloom over the headline / subtitle and
+   reads as harsher than the dark-mode desktop view. Pull the brightness
+   back, drop opacity, and tighten the mask so strokes feather out well
+   before they reach the type. */
+@media (max-width: 640px) {
+  [data-theme="dark"] .alc-hero__bg-graph {
+    filter: brightness(2.2);
+    opacity: 0.75;
+    -webkit-mask-image: radial-gradient(
+      ellipse 80% 70% at var(--alc-bg-cx) var(--alc-bg-cy),
+      #000 35%,
+      transparent 100%
+    );
+    mask-image: radial-gradient(
+      ellipse 80% 70% at var(--alc-bg-cx) var(--alc-bg-cy),
+      #000 35%,
+      transparent 100%
+    );
+  }
+}
 .alc-hero__inner {
   position: relative;
   z-index: 1;

--- a/website/src/styles/marketing.css
+++ b/website/src/styles/marketing.css
@@ -2474,6 +2474,16 @@ body.alc-root,
 .alc-h2 {
   font-size: clamp(26px, 4.8vw, 34px);
 }
+/* MDX wraps loose text fragments inside JSX headings in <p> tags
+   (e.g. the outro CTA's split "Paste this … to get started" h2 ends
+   up as `<p>…</p><span><p>…</p></span><p>.</p>`). The UA's default
+   1em block margin on those <p>s opens up a big gap between the two
+   wrapped lines. Flatten them back to inline so the heading reads as
+   one piece of text. */
+.alc-h2 p {
+  display: inline;
+  margin: 0;
+}
 
 /* Hero-scale serif statement used in place of an .alc-h2 + small lede
    when a section's value-prop reads better as one big sentence. */

--- a/website/src/styles/marketing.css
+++ b/website/src/styles/marketing.css
@@ -2484,6 +2484,17 @@ body.alc-root,
   display: inline;
   margin: 0;
 }
+/* Prefix ornament on a centered CTA heading sits ABOVE the text as a
+   printer's mark, not inline next to the first word. (The previous
+   behavior — where the ornament happened to land on its own line —
+   was an accidental side-effect of UA <p> margins inside the h2 that
+   we just collapsed.) */
+.alc-cta .alc-h2 > .alc-orn--prefix {
+  display: block;
+  width: 1.4em;
+  height: 1.4em;
+  margin: 0 auto 14px;
+}
 
 /* Hero-scale serif statement used in place of an .alc-h2 + small lede
    when a section's value-prop reads better as one big sentence. */

--- a/website/src/worker.ts
+++ b/website/src/worker.ts
@@ -1,5 +1,31 @@
 import type { WorkerEnv } from "../alchemy.run.ts";
 
+// Minimal `HTMLRewriter` shape — the workers runtime exposes it as a
+// global, but we don't pull in `@cloudflare/workers-types`, so declare
+// just what this file uses.
+declare class HTMLRewriter {
+  on(selector: string, handler: { element(el: HTMLRewriterElement): void }): HTMLRewriter;
+  transform(response: Response): Response;
+}
+interface HTMLRewriterElement {
+  getAttribute(name: string): string | null;
+  setAttribute(name: string, value: string): HTMLRewriterElement;
+}
+
+/**
+ * Astro bakes absolute URLs into `<meta property="og:image">`,
+ * `og:url`, `twitter:image`, and `<link rel="canonical">` at build time
+ * using the `site` config (`https://v2.alchemy.run`). PR previews and
+ * custom domains then advertise OG / canonical URLs that point back at
+ * the canonical host — so a Slack/Twitter unfurl of a preview URL
+ * fetches the *production* card, not the one for the page being
+ * shared.
+ *
+ * Rewrite those tags at the edge to match the request's actual host so
+ * each deployment unfurls itself.
+ */
+const CANONICAL_HOST = "v2.alchemy.run";
+
 export default {
   fetch: async (request: Request, env: WorkerEnv) => {
     if (request.method === "GET" && prefersMarkdown(request)) {
@@ -7,8 +33,47 @@ export default {
       const res = await env.ASSETS.fetch(new Request(mdUrl, request));
       if (res.status !== 404) return res;
     }
-    return env.ASSETS.fetch(request);
+    const res = await env.ASSETS.fetch(request);
+    return rewriteCanonicalHost(request, res);
   },
+};
+
+const rewriteCanonicalHost = (request: Request, res: Response): Response => {
+  const ct = res.headers.get("content-type") ?? "";
+  if (!ct.includes("text/html")) return res;
+  const reqUrl = new URL(request.url);
+  if (reqUrl.host === CANONICAL_HOST) return res;
+
+  class HostRewriter {
+    attr: "content" | "href";
+    constructor(attr: "content" | "href") {
+      this.attr = attr;
+    }
+    element(el: HTMLRewriterElement) {
+      const value = el.getAttribute(this.attr);
+      if (!value) return;
+      let u: URL;
+      try {
+        u = new URL(value);
+      } catch {
+        return;
+      }
+      if (u.host !== CANONICAL_HOST) return;
+      u.protocol = reqUrl.protocol;
+      u.host = reqUrl.host;
+      el.setAttribute(this.attr, u.toString());
+    }
+  }
+
+  const content = new HostRewriter("content");
+  const href = new HostRewriter("href");
+
+  return new HTMLRewriter()
+    .on('meta[property="og:image"]', content)
+    .on('meta[property="og:url"]', content)
+    .on('meta[name="twitter:image"]', content)
+    .on('link[rel="canonical"]', href)
+    .transform(res);
 };
 
 /**


### PR DESCRIPTION
Three small marketing-page fixes bundled together.

- **Mobile dark-mode hero graphic** — the mandala behind the hero was washing out the headline on phones in dark mode. Pull brightness back, drop opacity, and tighten the radial mask under 640px so it feathers out before reaching the type.
- **Theme-switch reactivity** — the canvas was caching its stroke RGB at init and only re-resolving on resize, so toggling theme mid-session left the graphic on the previous theme. A `MutationObserver` on `<html data-theme>` now refreshes the cached color immediately.
- **Brighter beta badge border** — bump the BETA · v… pill border from `--alc-hairline-2` (0.14 α) to `--alc-hairline-3` (0.22 α) so it reads against parchment / walnut.
- **OG / canonical host rewrite** — Astro bakes `https://v2.alchemy.run` into `og:image`, `og:url`, `twitter:image`, and `<link rel=canonical>` at build time, so PR previews and custom domains were unfurling as the production card and linking back to prod. The worker now rewrites those four tags via `HTMLRewriter` on HTML responses when the request host differs from the canonical host (production is short-circuited).