### PR TITLE
chore(website): brighten beta badge border

### DIFF
--- a/website/src/components/marketing/BetaBadge.astro
+++ b/website/src/components/marketing/BetaBadge.astro
@@ -17,7 +17,7 @@ import { alchemyVersion } from "../../versions";
     padding: 5px 12px;
     border-radius: 999px;
     white-space: nowrap;
-    border: 1px solid var(--alc-hairline-2);
+    border: 1px solid var(--alc-hairline-3);
     background: var(--alc-bg-elev-1);
     font-family: var(--alc-font-mono);
     font-size: 11.5px;


### PR DESCRIPTION
Bump the BETA · v… pill border from `--alc-hairline-2` (0.14 alpha) to `--alc-hairline-3` (0.22 alpha) so it reads more clearly against the parchment / walnut background.