### PR TITLE
feat(cloudflare/state-store): version-gate the deployed worker

### DIFF
--- a/packages/alchemy/src/Cloudflare/StateStore/Api.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Api.ts
@@ -21,6 +21,17 @@ import { AuthToken } from "./Token.ts";
 export const STATE_STORE_SCRIPT_NAME = "alchemy-state-store" as const;
 
 /**
+ * Version of the deployed Cloudflare State Store worker contract.
+ *
+ * Bump this whenever the wire format or runtime behaviour of the
+ * worker changes in a way that an older deployed copy can no longer
+ * satisfy. Clients query `/version` on the deployed worker and
+ * compare against this constant; a mismatch (or 404) triggers a
+ * forced redeploy via the bootstrap flow.
+ */
+export const STATE_STORE_VERSION = 1 as const;
+
+/**
  * Path on disk to *this* file, used as the worker's bundling entry.
  *
  * When running from source (e.g. dev / monorepo), `import.meta.url` points
@@ -60,6 +71,12 @@ export default Worker(
           }),
         ),
         Effect.orDie,
+      ),
+    );
+
+    const versionApi = HttpApiBuilder.group(StateApi, "version", (handlers) =>
+      handlers.handle("getVersion", () =>
+        Effect.succeed({ version: STATE_STORE_VERSION }),
       ),
     );
 
@@ -133,6 +150,7 @@ export default Worker(
     return {
       fetch: HttpApiBuilder.layer(StateApi).pipe(
         Layer.provide(stateApi),
+        Layer.provide(versionApi),
         Layer.provide(StateAuthLive),
         Layer.provide(bearerTokenValidator),
         // The state-store worker never serves files, so HttpPlatform's

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -114,23 +114,13 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
           credentials,
         );
       }
-
-      // Even when the worker exists, its deployed code may pre-date
-      // the current `STATE_STORE_VERSION`. If the unauthenticated
-      // `/version` probe 404s or reports a mismatched version, fall
-      // through to the deploy path so the worker is brought up to
-      // the version this CLI was built against.
-      const versionOk = yield* checkStateStoreVersion(credentials.url);
-      if (versionOk) {
-        yield* Clank.success(
-          `Cloudflare State Store '${scriptName}' is ready.`,
-        );
-        return;
-      }
-      yield* Clank.info(
-        `Worker '${scriptName}' is out of date; redeploying...`,
-      );
-      yield* finishBootstrap({ scriptName, profileName, localState, isCI });
+      yield* redeployIfStale({
+        scriptName,
+        profileName,
+        localState,
+        isCI,
+        url: credentials.url,
+      });
       yield* Clank.success(`Cloudflare State Store '${scriptName}' is ready.`);
       return;
     }
@@ -202,23 +192,17 @@ export const state = (props?: {
       if (credentials) {
         // We have local credentials. Before trusting them, verify
         // the deployed worker is on the version this CLI was built
-        // against. A 404 (worker missing or older deploy without the
-        // `/version` route) or a version mismatch means the deployed
-        // code is stale and we must run the bootstrap flow again
-        // rather than silently issuing requests against an
-        // incompatible worker.
-        const versionOk = yield* checkStateStoreVersion(credentials.url);
-        if (!versionOk) {
-          yield* Clank.info(
-            `Cloudflare State Store '${scriptName}' is out of date; redeploying...`,
-          );
-          return yield* finishBootstrap({
-            scriptName,
-            profileName,
-            localState,
-            isCI,
-          });
-        }
+        // against. If it isn't, `redeployIfStale` runs the idempotent
+        // bootstrap flow and short-circuits with the freshly-deployed
+        // store.
+        const fresh = yield* redeployIfStale({
+          scriptName,
+          profileName,
+          localState,
+          isCI,
+          url: credentials.url,
+        });
+        if (fresh) return fresh;
 
         const httpState = yield* makeHttpStateStore(credentials);
 
@@ -252,22 +236,14 @@ export const state = (props?: {
           );
         }
 
-        // The script exists on the account but may have been
-        // deployed by an older CLI. Verify the version contract
-        // before handing the store back; if it's stale, run the
-        // bootstrap flow to bring it up to the current version.
-        const versionOk = yield* checkStateStoreVersion(credentials.url);
-        if (!versionOk) {
-          yield* Clank.info(
-            `Cloudflare State Store '${scriptName}' is out of date; redeploying...`,
-          );
-          return yield* finishBootstrap({
-            scriptName,
-            profileName,
-            localState,
-            isCI,
-          });
-        }
+        const fresh = yield* redeployIfStale({
+          scriptName,
+          profileName,
+          localState,
+          isCI,
+          url: credentials.url,
+        });
+        if (fresh) return fresh;
 
         const httpState = yield* makeHttpStateStore(credentials);
 
@@ -536,6 +512,38 @@ export const loginWithCloudflare = () =>
       ),
     ),
   );
+
+/**
+ * Run {@link finishBootstrap} iff the worker at `url` fails the
+ * version probe; otherwise resolve to `undefined`. Centralises the
+ * "is the deployed worker still compatible?" guard used by every
+ * code path that already has a presumably-valid worker URL.
+ */
+const redeployIfStale = ({
+  url,
+  scriptName,
+  profileName,
+  localState,
+  isCI,
+}: {
+  url: string;
+  scriptName: string;
+  profileName: string;
+  localState: StateService;
+  isCI: boolean;
+}) =>
+  Effect.gen(function* () {
+    if (yield* checkStateStoreVersion(url)) return undefined;
+    yield* Clank.info(
+      `Cloudflare State Store '${scriptName}' is out of date; redeploying...`,
+    );
+    return yield* finishBootstrap({
+      scriptName,
+      profileName,
+      localState,
+      isCI,
+    });
+  });
 
 /**
  * Probe the deployed worker's `/version` endpoint and decide whether

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
 import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
 
 import * as Config from "effect/Config";
 import { adopt } from "../../AdoptPolicy.ts";
@@ -14,6 +15,7 @@ import { ALCHEMY_PROFILE } from "../../Auth/Profile.ts";
 import * as Cloudflare from "../../Cloudflare/Providers.ts";
 import { deploy } from "../../Deploy.ts";
 import * as Alchemy from "../../Stack.ts";
+import { StateApi } from "../../State/HttpStateApi.ts";
 import {
   makeHttpStateStore,
   type HttpStateStoreProps,
@@ -29,7 +31,7 @@ import * as Clank from "../../Util/Clank.ts";
 import * as Access from "../Access.ts";
 import { CloudflareAuth } from "../Auth/AuthProvider.ts";
 import { EdgeSessionError, createEdgeSession } from "../EdgeSession.ts";
-import Api, { STATE_STORE_SCRIPT_NAME } from "./Api.ts";
+import Api, { STATE_STORE_SCRIPT_NAME, STATE_STORE_VERSION } from "./Api.ts";
 import { AuthTokenSecretName, TokenValue } from "./Token.ts";
 
 /** Filename used for stored credentials under the profile directory. */
@@ -112,6 +114,23 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
           credentials,
         );
       }
+
+      // Even when the worker exists, its deployed code may pre-date
+      // the current `STATE_STORE_VERSION`. If the unauthenticated
+      // `/version` probe 404s or reports a mismatched version, fall
+      // through to the deploy path so the worker is brought up to
+      // the version this CLI was built against.
+      const versionOk = yield* checkStateStoreVersion(credentials.url);
+      if (versionOk) {
+        yield* Clank.success(
+          `Cloudflare State Store '${scriptName}' is ready.`,
+        );
+        return;
+      }
+      yield* Clank.info(
+        `Worker '${scriptName}' is out of date; redeploying...`,
+      );
+      yield* finishBootstrap({ scriptName, profileName, localState, isCI });
       yield* Clank.success(`Cloudflare State Store '${scriptName}' is ready.`);
       return;
     }
@@ -180,9 +199,27 @@ export const state = (props?: {
         });
       }
 
-      // TODO(sam): support upgrading state store, right now we only deploy once
       if (credentials) {
-        // it's in the profile, let's go
+        // We have local credentials. Before trusting them, verify
+        // the deployed worker is on the version this CLI was built
+        // against. A 404 (worker missing or older deploy without the
+        // `/version` route) or a version mismatch means the deployed
+        // code is stale and we must run the bootstrap flow again
+        // rather than silently issuing requests against an
+        // incompatible worker.
+        const versionOk = yield* checkStateStoreVersion(credentials.url);
+        if (!versionOk) {
+          yield* Clank.info(
+            `Cloudflare State Store '${scriptName}' is out of date; redeploying...`,
+          );
+          return yield* finishBootstrap({
+            scriptName,
+            profileName,
+            localState,
+            isCI,
+          });
+        }
+
         const httpState = yield* makeHttpStateStore(credentials);
 
         if (alchemyContext.updateStateStore) {
@@ -214,6 +251,24 @@ export const state = (props?: {
             credentials,
           );
         }
+
+        // The script exists on the account but may have been
+        // deployed by an older CLI. Verify the version contract
+        // before handing the store back; if it's stale, run the
+        // bootstrap flow to bring it up to the current version.
+        const versionOk = yield* checkStateStoreVersion(credentials.url);
+        if (!versionOk) {
+          yield* Clank.info(
+            `Cloudflare State Store '${scriptName}' is out of date; redeploying...`,
+          );
+          return yield* finishBootstrap({
+            scriptName,
+            profileName,
+            localState,
+            isCI,
+          });
+        }
+
         const httpState = yield* makeHttpStateStore(credentials);
 
         if (alchemyContext.updateStateStore) {
@@ -481,6 +536,30 @@ export const loginWithCloudflare = () =>
       ),
     ),
   );
+
+/**
+ * Probe the deployed worker's `/version` endpoint and decide whether
+ * it satisfies the current {@link STATE_STORE_VERSION} contract.
+ *
+ * Reuses the same typed {@link StateApi} client the rest of the store
+ * speaks, just without the bearer-token transform — the `/version`
+ * route is intentionally unauthenticated so we can probe it before
+ * trusting any locally-cached credentials.
+ *
+ * Returns `true` only on a successful response carrying the matching
+ * version. Any failure (404 from a pre-`/version` deploy, transport
+ * error, schema mismatch, version mismatch) collapses to `false`,
+ * since the caller's response in every case is the same: fall
+ * through to the idempotent bootstrap flow.
+ */
+const checkStateStoreVersion = (url: string) =>
+  Effect.gen(function* () {
+    const client = yield* HttpApiClient.make(StateApi, { baseUrl: url });
+    const result = yield* client.version
+      .getVersion()
+      .pipe(Effect.catch(() => Effect.succeed(undefined)));
+    return result?.version === STATE_STORE_VERSION;
+  });
 
 /**
  * Tiny ES-module worker that reads `env.SECRET.get()` and echoes it

--- a/packages/alchemy/src/State/HttpStateApi.ts
+++ b/packages/alchemy/src/State/HttpStateApi.ts
@@ -141,6 +141,21 @@ export const GetReplacedResources = HttpApiEndpoint.get(
   },
 );
 
+/** Response shape for the unauthenticated `/version` probe. */
+export const VersionResponse = Schema.Struct({
+  version: Schema.Number,
+});
+
+/**
+ * Unauthenticated probe so clients can detect a stale (or absent)
+ * deployed worker without holding a valid bearer token. The returned
+ * version is bumped whenever the wire / behavioural contract changes
+ * in a way that requires a redeploy.
+ */
+export const GetVersion = HttpApiEndpoint.get("getVersion", "/version", {
+  success: VersionResponse,
+});
+
 export class StateGroup extends HttpApiGroup.make("state")
   .add(ListStacks)
   .add(ListStages)
@@ -152,4 +167,10 @@ export class StateGroup extends HttpApiGroup.make("state")
   .add(DeleteStack)
   .middleware(StateAuth) {}
 
-export class StateApi extends HttpApi.make("alchemy-state").add(StateGroup) {}
+export class VersionGroup extends HttpApiGroup.make("version").add(
+  GetVersion,
+) {}
+
+export class StateApi extends HttpApi.make("alchemy-state")
+  .add(StateGroup)
+  .add(VersionGroup) {}


### PR DESCRIPTION
## Summary

- Adds an unauthenticated `GET /version` endpoint to the HTTP state-store contract (`StateApi`), backed by a new `STATE_STORE_VERSION` constant in the worker.
- During Cloudflare state-store resolution (`state(...)` and `bootstrap(...)`), probes the deployed worker via the typed `HttpApiClient` before trusting cached credentials. On 404 (pre-`/version` deploy), transport error, schema mismatch, or version mismatch, falls through to the existing idempotent `finishBootstrap` flow so the worker is brought up to the current contract instead of silently issuing requests against an incompatible deploy.
- Bump `STATE_STORE_VERSION` whenever the worker's wire/runtime contract changes in a way that requires a redeploy.
