### PR TITLE
fix(website): match beta badge border to BETA label color

### DIFF
--- a/website/src/components/marketing/BetaBadge.astro
+++ b/website/src/components/marketing/BetaBadge.astro
@@ -17,7 +17,7 @@ import { alchemyVersion } from "../../versions";
     padding: 5px 12px;
     border-radius: 999px;
     white-space: nowrap;
-    border: 1px solid var(--alc-hairline-3);
+    border: 1px solid var(--alc-terracotta-deep);
     background: var(--alc-bg-elev-1);
     font-family: var(--alc-font-mono);
     font-size: 11.5px;


### PR DESCRIPTION
Use `--alc-terracotta-deep` for the hero pill border so it matches the BETA label text in both light and dark mode, instead of the neutral hairline.