### PR TITLE
fix(cloudflare/state-store): apply Cloudflare Access headers to HTTP requests

### DIFF
--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
 import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
 
 import * as Config from "effect/Config";
@@ -204,7 +205,7 @@ export const state = (props?: {
         });
         if (fresh) return fresh;
 
-        const httpState = yield* makeHttpStateStore(credentials);
+        const httpState = yield* makeCloudflareStateStore(credentials);
 
         if (alchemyContext.updateStateStore) {
           yield* deployStateStore(scriptName, httpState);
@@ -245,7 +246,7 @@ export const state = (props?: {
         });
         if (fresh) return fresh;
 
-        const httpState = yield* makeHttpStateStore(credentials);
+        const httpState = yield* makeCloudflareStateStore(credentials);
 
         if (alchemyContext.updateStateStore) {
           yield* deployStateStore(scriptName, httpState);
@@ -286,6 +287,18 @@ export const state = (props?: {
     Layer.provideMerge(Access.AccessLive),
     Layer.orDie,
   );
+
+const makeCloudflareStateStore = (props: { url: string; authToken: string }) =>
+  Effect.gen(function* () {
+    const access = yield* Access.Access;
+    const accessHeaders = yield* access.getAccessHeaders(
+      new URL(props.url).host,
+    );
+    return yield* makeHttpStateStore({
+      ...props,
+      transformClient: HttpClientRequest.setHeaders(accessHeaders),
+    });
+  });
 
 /**
  * Non-destructively copy every resource in the
@@ -350,7 +363,7 @@ const finishBootstrap = ({
     // credentials file (skipping the write in CI), so we don't need
     // to do that explicitly here.
     const { url, authToken } = yield* loginWithCloudflare();
-    const httpState = yield* makeHttpStateStore({ url, authToken });
+    const httpState = yield* makeCloudflareStateStore({ url, authToken });
     // `profileName` is intentionally unused here — `loginWithCloudflare`
     // resolves it itself. Reference it to keep the surrounding API
     // explicit and to avoid an unused-parameter lint.

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -288,17 +288,21 @@ export const state = (props?: {
     Layer.orDie,
   );
 
-const makeCloudflareStateStore = (props: { url: string; authToken: string }) =>
-  Effect.gen(function* () {
-    const access = yield* Access.Access;
-    const accessHeaders = yield* access.getAccessHeaders(
-      new URL(props.url).host,
-    );
-    return yield* makeHttpStateStore({
-      ...props,
-      transformClient: HttpClientRequest.setHeaders(accessHeaders),
-    });
+const makeCloudflareStateStore = Effect.fnUntraced(function* ({
+  url,
+  authToken,
+}: {
+  url: string;
+  authToken: string;
+}) {
+  const access = yield* Access.Access;
+  const accessHeaders = yield* access.getAccessHeaders(new URL(url).host);
+  return yield* makeHttpStateStore({
+    url,
+    authToken,
+    transformClient: HttpClientRequest.setHeaders(accessHeaders),
   });
+});
 
 /**
  * Non-destructively copy every resource in the

--- a/packages/alchemy/src/State/HttpStateStore.ts
+++ b/packages/alchemy/src/State/HttpStateStore.ts
@@ -1,9 +1,9 @@
 import * as Effect from "effect/Effect";
+import { identity } from "effect/Function";
 import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
-import { Access } from "../Cloudflare/Access.ts";
 import { StateApi } from "./HttpStateApi.ts";
 
 import type { ReplacedResourceState, ResourceState } from "./ResourceState.ts";
@@ -14,18 +14,23 @@ export interface HttpStateStoreProps {
   url: string;
   /** Bearer token used to authenticate every request. */
   authToken: string;
+  transformClient?: (
+    client: HttpClientRequest.HttpClientRequest,
+  ) => HttpClientRequest.HttpClientRequest;
 }
 
-export const makeHttpStateStore = ({ url, authToken }: HttpStateStoreProps) =>
+export const makeHttpStateStore = ({
+  url,
+  authToken,
+  transformClient,
+}: HttpStateStoreProps) =>
   Effect.gen(function* () {
-    const accessHeaders = yield* Access.use((access) =>
-      access.getAccessHeaders(new URL(url).host),
-    );
     const apiClient = yield* HttpApiClient.make(StateApi, {
       baseUrl: url,
       transformClient: HttpClient.mapRequest((req) =>
-        HttpClientRequest.setHeaders(accessHeaders)(
-          HttpClientRequest.bearerToken(authToken)(req),
+        req.pipe(
+          HttpClientRequest.bearerToken(authToken),
+          transformClient ?? identity,
         ),
       ),
     });

--- a/packages/alchemy/src/State/HttpStateStore.ts
+++ b/packages/alchemy/src/State/HttpStateStore.ts
@@ -3,6 +3,7 @@ import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
+import { Access } from "../Cloudflare/Access.ts";
 import { StateApi } from "./HttpStateApi.ts";
 
 import type { ReplacedResourceState, ResourceState } from "./ResourceState.ts";
@@ -17,10 +18,15 @@ export interface HttpStateStoreProps {
 
 export const makeHttpStateStore = ({ url, authToken }: HttpStateStoreProps) =>
   Effect.gen(function* () {
+    const accessHeaders = yield* Access.use((access) =>
+      access.getAccessHeaders(new URL(url).host),
+    );
     const apiClient = yield* HttpApiClient.make(StateApi, {
       baseUrl: url,
-      transformClient: HttpClient.mapRequest(
-        HttpClientRequest.bearerToken(authToken),
+      transformClient: HttpClient.mapRequest((req) =>
+        HttpClientRequest.setHeaders(accessHeaders)(
+          HttpClientRequest.bearerToken(authToken)(req),
+        ),
       ),
     });
     const state = apiClient.state;


### PR DESCRIPTION
## Summary

When the deployed state-store worker hostname is fronted by Cloudflare Access (e.g. an org-wide policy on `*.workers.dev`), every request to the worker is intercepted before it reaches the script and 302'd to the Access SSO login page. The state-store HTTP client only attaches a bearer token, so `bun alchemy deploy` hangs forever in the 404 retry loop with:

```
HttpClientError: Decode error (404 PUT https://<worker>/state/stacks/CloudflareStateStore/...)
```

`beta.29` wired the `Access` service into `Cloudflare/EdgeSession.ts` for the edge-preview path, but `State/HttpStateStore.ts` was missed — even though `Access.AccessLive` is provided in the surrounding state-store layer (`Cloudflare/StateStore/State.ts:286`), nothing in the state-store request pipeline ever calls `getAccessHeaders`.

This PR mirrors the `Access.use((a) => a.getAccessHeaders(host))` pattern from `EdgeSession.ts:140` and merges the resulting headers (service-token pair or `cloudflared`-issued `CF_Authorization` cookie) into every state-store request alongside the bearer token.

## Repro

1. Have a Cloudflare account where Zero Trust Access fronts `*.workers.dev` (the failure mode in our case is a WorkOS-internal Access policy).
2. `bun alchemy deploy` on a stack that uses `Cloudflare.state()`.
3. The bootstrap deploys fine, then the first PUT to the state-store worker 302s to `*.cloudflareaccess.com` and the deploy hangs in the 404 retry loop.

With this patch + `cloudflared access login <state-store-url>` (or `CLOUDFLARE_ACCESS_CLIENT_ID` / `CLOUDFLARE_ACCESS_CLIENT_SECRET` env vars), the deploy completes normally.

## Test plan

- [x] Reproduced the hang against a Cloudflare Access-fronted account on beta.29
- [x] Verified the patched build deploys end-to-end (state-store + user stack + GET/PUT round trip through the deployed worker)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)