### PR TITLE
fix(Cloudflare/SecretsStore): adoption opt-in by default

### DIFF
--- a/packages/alchemy/src/Cloudflare/SecretsStore/SecretsStore.ts
+++ b/packages/alchemy/src/Cloudflare/SecretsStore/SecretsStore.ts
@@ -58,7 +58,7 @@ export const SecretsStoreProvider = () =>
         stables: ["storeId", "storeName", "accountId"],
         create: Effect.fn(function* () {
           const adoptEnabled = yield* Effect.serviceOption(AdoptPolicy).pipe(
-            Effect.map(Option.getOrElse(() => false)),
+            Effect.map(Option.getOrElse(() => true)),
           );
 
           const adoptExisting = Effect.gen(function* () {


### PR DESCRIPTION
Documentation suggests this should be opt-in by default but it is currently opted-out by default.

The initial Cloudflare state setup creates a state store and 2 secrets (`AlchemyStateStoreEncryptionKey` and `AlchemyStateStoreToken`), meaning any subsequent attempts to work with secrets results in the `maximum stores exceeded` error.