### PR TITLE
feat(telemetry): add state_store.init span and rework adoption dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -508,8 +508,23 @@ When you automatically open a PR, it MUST follow this structure:
 - **Description heading levels**: NEVER use `#` or `##` in the PR description. The smallest heading allowed is `###`. The PR description must NOT begin with its own title heading — GitHub already renders the PR title above it.
 - **Content**: Aim for the minimal content needed to convey the idea.
   - Use simple sentences. If there are multiple discrete changes, use bullet points.
-  - For anything that warrants it (new features, new resources, serious changes to existing resources, API/behavior changes), include code snippets and/or ` ```diff ` blocks showing what changes from the user's perspective.
+  - **Prefer code snippets over prose.** A short ` ```ts ` or ` ```diff ` block showing the new/changed shape is worth more than a paragraph explaining it. Reach for code first; only add prose to fill in the "why" the snippet can't show on its own.
+  - Be direct and succinct. Cut adjectives, justifications, and anything that reads like marketing copy. If a sentence is restating what the diff already shows, delete it.
+  - **Never include a "Test plan", "Testing", or checklist of TODOs.** PR descriptions document the change, not the verification process. If something needs manual verification, follow the draft-PR rule below.
   - Skip examples for trivial fixes, internal refactors, or doc-only changes.
+
+Example PR description (good — code snippet does the talking):
+
+````
+Track which state-store backend each project uses by emitting a `state_store.init` span tagged with `alchemy.state_store.kind`.
+
+```ts
+// every Layer.effect(State, …) site now wraps construction:
+makeLocalState().pipe(recordStateStoreInit("local"))
+```
+
+Dashboard groups projects by kind from these spans (Axiom can't APL-query metric datasets).
+````
 - **Outstanding work / testing / review needed**: If there are outstanding steps, manual testing required, or review items, DO NOT leave a comment on the PR and DO NOT include them in the PR description. Instead:
   1. Mark the PR as **draft**.
   2. Tell the user (in the chat that initiated the PR creation) what is outstanding.

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -19,7 +19,7 @@ import * as Alchemy from "../../Stack.ts";
 import { StateApi } from "../../State/HttpStateApi.ts";
 import {
   makeHttpStateStore,
-  type HttpStateStoreProps,
+  type HttpStateStoreCredentials,
 } from "../../State/HttpStateStore.ts";
 import * as CloudflareEnvironment from "../CloudflareEnvironment.ts";
 import * as Credentials from "../Credentials.ts";
@@ -112,7 +112,7 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
       );
       const credentials = yield* loginWithCloudflare();
       if (!isCI) {
-        yield* writeCredentials<HttpStateStoreProps>(
+        yield* writeCredentials<HttpStateStoreCredentials>(
           profileName,
           CREDENTIALS_FILE,
           credentials,
@@ -154,7 +154,7 @@ export const state = (props?: {
       const isCI = yield* Config.boolean("CI").pipe(Config.withDefault(false));
       const alchemyContext = yield* AlchemyContext;
       const profileName = yield* ALCHEMY_PROFILE;
-      const credentials = yield* readCredentials<HttpStateStoreProps>(
+      const credentials = yield* readCredentials<HttpStateStoreCredentials>(
         profileName,
         CREDENTIALS_FILE,
       );
@@ -233,7 +233,7 @@ export const state = (props?: {
         // it exists, so fetch the secret token
         const credentials = yield* loginWithCloudflare();
         if (!isCI) {
-          yield* writeCredentials<HttpStateStoreProps>(
+          yield* writeCredentials<HttpStateStoreCredentials>(
             profileName,
             CREDENTIALS_FILE,
             credentials,
@@ -499,7 +499,7 @@ export const loginWithCloudflare = () =>
     if (!isCI) {
       // 4. Persist credentials. The profile entry is managed by
       //    `loadOrConfigure` when this is invoked through `configure`.
-      yield* writeCredentials<HttpStateStoreProps>(
+      yield* writeCredentials<HttpStateStoreCredentials>(
         profileName,
         CREDENTIALS_FILE,
         {

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -27,7 +27,10 @@ import * as Credentials from "../Credentials.ts";
 import { AlchemyContext } from "../../AlchemyContext.ts";
 import { makeLocalState } from "../../State/LocalState.ts";
 import { State, type StateService } from "../../State/State.ts";
-import { recordStateStoreOp } from "../../Telemetry/Metrics.ts";
+import {
+  recordStateStoreInit,
+  recordStateStoreOp,
+} from "../../Telemetry/Metrics.ts";
 import * as Clank from "../../Util/Clank.ts";
 import * as Access from "../Access.ts";
 import { CloudflareAuth } from "../Auth/AuthProvider.ts";
@@ -279,7 +282,7 @@ export const state = (props?: {
         localState,
         isCI,
       });
-    }).pipe(Effect.orDie),
+    }).pipe(recordStateStoreInit("cloudflare-http"), Effect.orDie),
   ).pipe(
     Layer.provideMerge(Credentials.fromAuthProvider()),
     Layer.provideMerge(CloudflareEnvironment.fromProfile()),

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -282,7 +282,7 @@ export const state = (props?: {
         localState,
         isCI,
       });
-    }).pipe(recordStateStoreInit("cloudflare-http"), Effect.orDie),
+    }).pipe(recordStateStoreInit, Effect.orDie),
   ).pipe(
     Layer.provideMerge(Credentials.fromAuthProvider()),
     Layer.provideMerge(CloudflareEnvironment.fromProfile()),
@@ -304,6 +304,7 @@ const makeCloudflareStateStore = Effect.fnUntraced(function* ({
     url,
     authToken,
     transformClient: HttpClientRequest.setHeaders(accessHeaders),
+    id: "cloudflare-http",
   });
 });
 

--- a/packages/alchemy/src/State/HttpStateStore.ts
+++ b/packages/alchemy/src/State/HttpStateStore.ts
@@ -17,12 +17,19 @@ export interface HttpStateStoreProps {
   transformClient?: (
     client: HttpClientRequest.HttpClientRequest,
   ) => HttpClientRequest.HttpClientRequest;
+  /**
+   * `StateService.id` slug for telemetry. Defaults to `"http"`. The
+   * Cloudflare-deployed HTTP state store overrides this to
+   * `"cloudflare-http"`.
+   */
+  id?: string;
 }
 
 export const makeHttpStateStore = ({
   url,
   authToken,
   transformClient,
+  id = "http",
 }: HttpStateStoreProps) =>
   Effect.gen(function* () {
     const apiClient = yield* HttpApiClient.make(StateApi, {
@@ -37,6 +44,7 @@ export const makeHttpStateStore = ({
     const state = apiClient.state;
 
     const service: StateService = {
+      id,
       listStacks: () =>
         state.listStacks().pipe(
           Effect.map((stacks) => [...stacks]),

--- a/packages/alchemy/src/State/HttpStateStore.ts
+++ b/packages/alchemy/src/State/HttpStateStore.ts
@@ -10,26 +10,36 @@ import type { ReplacedResourceState, ResourceState } from "./ResourceState.ts";
 import { StateStoreError, type StateService } from "./State.ts";
 import { encodeState, reviveStateRecursive } from "./StateEncoding.ts";
 
-export interface HttpStateStoreProps {
+/**
+ * Persisted shape of an HTTP state store endpoint — `{ url, authToken }`.
+ * Stored in the credentials file alongside other per-profile secrets.
+ * Deliberately separate from {@link HttpStateStoreProps}: `id` and
+ * `transformClient` are deployment-time choices, not credentials.
+ */
+export interface HttpStateStoreCredentials {
   url: string;
   /** Bearer token used to authenticate every request. */
   authToken: string;
+}
+
+export interface HttpStateStoreProps extends HttpStateStoreCredentials {
+  /**
+   * `StateService.id` slug for telemetry — e.g. `"http"` for a bare
+   * HTTP store, `"cloudflare-http"` for the Cloudflare-deployed
+   * variant. Required so every concrete deployment of this state-store
+   * shape shows up distinctly on the adoption dashboard.
+   */
+  id: string;
   transformClient?: (
     client: HttpClientRequest.HttpClientRequest,
   ) => HttpClientRequest.HttpClientRequest;
-  /**
-   * `StateService.id` slug for telemetry. Defaults to `"http"`. The
-   * Cloudflare-deployed HTTP state store overrides this to
-   * `"cloudflare-http"`.
-   */
-  id?: string;
 }
 
 export const makeHttpStateStore = ({
   url,
   authToken,
   transformClient,
-  id = "http",
+  id,
 }: HttpStateStoreProps) =>
   Effect.gen(function* () {
     const apiClient = yield* HttpApiClient.make(StateApi, {

--- a/packages/alchemy/src/State/InMemoryState.ts
+++ b/packages/alchemy/src/State/InMemoryState.ts
@@ -1,5 +1,6 @@
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import { recordStateStoreInit } from "../Telemetry/Metrics.ts";
 import type { ResourceState } from "./ResourceState.ts";
 import { State } from "./State.ts";
 
@@ -12,7 +13,13 @@ export const inMemoryState = (
     StackId,
     Record<StageId, Record<Fqn, ResourceState>>
   > = {},
-) => Layer.succeed(State, InMemoryService(initialState));
+) =>
+  Layer.effect(
+    State,
+    Effect.succeed(InMemoryService(initialState)).pipe(
+      recordStateStoreInit("inmemory"),
+    ),
+  );
 
 export const InMemoryService = (
   state: Record<StackId, Record<StageId, Record<Fqn, ResourceState>>> = {},

--- a/packages/alchemy/src/State/InMemoryState.ts
+++ b/packages/alchemy/src/State/InMemoryState.ts
@@ -16,15 +16,14 @@ export const inMemoryState = (
 ) =>
   Layer.effect(
     State,
-    Effect.succeed(InMemoryService(initialState)).pipe(
-      recordStateStoreInit("inmemory"),
-    ),
+    Effect.succeed(InMemoryService(initialState)).pipe(recordStateStoreInit),
   );
 
 export const InMemoryService = (
   state: Record<StackId, Record<StageId, Record<Fqn, ResourceState>>> = {},
 ) =>
   State.of({
+    id: "inmemory",
     listStacks: () => Effect.succeed(Array.from(Object.keys(state))),
     listStages: (stack: string) =>
       Effect.succeed(

--- a/packages/alchemy/src/State/LocalState.ts
+++ b/packages/alchemy/src/State/LocalState.ts
@@ -9,7 +9,7 @@ import { State, StateStoreError, type StateService } from "./State.ts";
 import { encodeState, reviveState } from "./StateEncoding.ts";
 
 export const localState = () =>
-  Layer.effect(State, makeLocalState().pipe(recordStateStoreInit("local")));
+  Layer.effect(State, makeLocalState().pipe(recordStateStoreInit));
 
 export const makeLocalState = () =>
   Effect.gen(function* () {
@@ -56,6 +56,7 @@ export const makeLocalState = () =>
             .pipe(Effect.tap(() => Effect.sync(() => created.add(dir))));
 
     const state: StateService = {
+      id: "local",
       listStacks: () =>
         fs.readDirectory(stateDir).pipe(
           recover,

--- a/packages/alchemy/src/State/LocalState.ts
+++ b/packages/alchemy/src/State/LocalState.ts
@@ -4,10 +4,12 @@ import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import type { PlatformError } from "effect/PlatformError";
 import { decodeFqn, encodeFqn } from "../FQN.ts";
+import { recordStateStoreInit } from "../Telemetry/Metrics.ts";
 import { State, StateStoreError, type StateService } from "./State.ts";
 import { encodeState, reviveState } from "./StateEncoding.ts";
 
-export const localState = () => Layer.effect(State, makeLocalState());
+export const localState = () =>
+  Layer.effect(State, makeLocalState().pipe(recordStateStoreInit("local")));
 
 export const makeLocalState = () =>
   Effect.gen(function* () {

--- a/packages/alchemy/src/State/State.ts
+++ b/packages/alchemy/src/State/State.ts
@@ -21,6 +21,15 @@ export class State extends Context.Service<State, StateService>()(
  * for provider operations.
  */
 export interface StateService {
+  /**
+   * Stable identifier for the State store implementation, used for
+   * telemetry tagging (`alchemy.state_store.id`) so we can answer
+   * "which backends are people using" without hard-coding a closed
+   * union. Examples: `"local"`, `"inmemory"`, `"http"`,
+   * `"cloudflare-http"`. Third-party state stores should pick a short,
+   * stable, kebab-case slug.
+   */
+  readonly id: string;
   listStacks(): Effect.Effect<readonly string[], StateStoreError, never>;
   listStages(
     stack: string,

--- a/packages/alchemy/src/Telemetry/Metrics.ts
+++ b/packages/alchemy/src/Telemetry/Metrics.ts
@@ -49,6 +49,32 @@ export const stateStoreCounter = Metric.counter(
 export type StateStoreOp = "deploy";
 
 /**
+ * Discriminator for a State store implementation. Recorded once per
+ * process via {@link recordStateStoreInit} when the State layer is
+ * constructed, so the dashboard can break projects down by which
+ * backend they're using.
+ *
+ * - `local` — filesystem-backed `localState()` (the default).
+ * - `inmemory` — `inMemoryState()` (tests, throwaway).
+ * - `http` — bare `makeHttpStateStore` against an arbitrary URL.
+ * - `cloudflare-http` — the Cloudflare-deployed HTTP state store.
+ */
+export type StateStoreKind = "local" | "inmemory" | "http" | "cloudflare-http";
+
+/**
+ * Counter for State store layer construction. Tagged with `kind` so we
+ * can answer "how many distinct projects are using each backend" from
+ * the corresponding `state_store.init` spans.
+ */
+export const stateStoreInitCounter = Metric.counter(
+  "alchemy.state_store.inits",
+  {
+    description: "Number of times a State store layer is constructed.",
+    incremental: true,
+  },
+);
+
+/**
  * Wraps a resource lifecycle Effect to record a counter + timer entry,
  * tagged with `resource_type`, `op`, and `status` (`success`/`error`).
  *
@@ -111,6 +137,31 @@ export const recordStateStoreOp =
           1,
         ),
       ),
+    );
+
+/**
+ * Wraps a State store construction Effect to:
+ *
+ * 1. Bump {@link stateStoreInitCounter} tagged with `kind`.
+ * 2. Open a `state_store.init` span carrying
+ *    `alchemy.state_store.kind` so Axiom (which can't query metric
+ *    datasets via APL) can group projects by backend.
+ *
+ * Apply at every `Layer.effect(State, …)` site exactly once.
+ */
+export const recordStateStoreInit =
+  (kind: StateStoreKind) =>
+  <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+    self.pipe(
+      Effect.tap(() =>
+        Metric.update(
+          Metric.withAttributes(stateStoreInitCounter, { kind }),
+          1,
+        ),
+      ),
+      Effect.withSpan("state_store.init", {
+        attributes: { "alchemy.state_store.kind": kind },
+      }),
     );
 
 export type ResourceOp = "precreate" | "create" | "update" | "delete" | "read";

--- a/packages/alchemy/src/Telemetry/Metrics.ts
+++ b/packages/alchemy/src/Telemetry/Metrics.ts
@@ -49,22 +49,11 @@ export const stateStoreCounter = Metric.counter(
 export type StateStoreOp = "deploy";
 
 /**
- * Discriminator for a State store implementation. Recorded once per
- * process via {@link recordStateStoreInit} when the State layer is
- * constructed, so the dashboard can break projects down by which
- * backend they're using.
- *
- * - `local` — filesystem-backed `localState()` (the default).
- * - `inmemory` — `inMemoryState()` (tests, throwaway).
- * - `http` — bare `makeHttpStateStore` against an arbitrary URL.
- * - `cloudflare-http` — the Cloudflare-deployed HTTP state store.
- */
-export type StateStoreKind = "local" | "inmemory" | "http" | "cloudflare-http";
-
-/**
- * Counter for State store layer construction. Tagged with `kind` so we
- * can answer "how many distinct projects are using each backend" from
- * the corresponding `state_store.init` spans.
+ * Counter for State store layer construction. Tagged with `id` (the
+ * `StateService.id` slug) so we can answer "how many distinct projects
+ * are using each backend" from the corresponding `state_store.init`
+ * spans. Open-ended on purpose: third-party state stores get counted
+ * automatically by setting their `StateService.id`.
  */
 export const stateStoreInitCounter = Metric.counter(
   "alchemy.state_store.inits",
@@ -142,27 +131,38 @@ export const recordStateStoreOp =
 /**
  * Wraps a State store construction Effect to:
  *
- * 1. Bump {@link stateStoreInitCounter} tagged with `kind`.
+ * 1. Bump {@link stateStoreInitCounter} tagged with `id`.
  * 2. Open a `state_store.init` span carrying
- *    `alchemy.state_store.kind` so Axiom (which can't query metric
+ *    `alchemy.state_store.id` so Axiom (which can't query metric
  *    datasets via APL) can group projects by backend.
  *
- * Apply at every `Layer.effect(State, …)` site exactly once.
+ * The `id` is read off the constructed `StateService.id` field, so any
+ * third-party state-store implementation gets tracked just by setting
+ * a stable slug there. Apply at every `Layer.effect(State, …)` site
+ * exactly once.
  */
-export const recordStateStoreInit =
-  (kind: StateStoreKind) =>
-  <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
-    self.pipe(
-      Effect.tap(() =>
-        Metric.update(
-          Metric.withAttributes(stateStoreInitCounter, { kind }),
-          1,
-        ),
+export const recordStateStoreInit = <
+  A extends { readonly id: string },
+  E,
+  R,
+>(
+  self: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  self.pipe(
+    Effect.tap((service) =>
+      Effect.all(
+        [
+          Metric.update(
+            Metric.withAttributes(stateStoreInitCounter, { id: service.id }),
+            1,
+          ),
+          Effect.annotateCurrentSpan("alchemy.state_store.id", service.id),
+        ],
+        { discard: true },
       ),
-      Effect.withSpan("state_store.init", {
-        attributes: { "alchemy.state_store.kind": kind },
-      }),
-    );
+    ),
+    Effect.withSpan("state_store.init"),
+  );
 
 export type ResourceOp = "precreate" | "create" | "update" | "delete" | "read";
 

--- a/stacks/otel/Dashboard.ts
+++ b/stacks/otel/Dashboard.ts
@@ -6,22 +6,31 @@ import { Effect } from "effect";
 import { Traces } from "./Datasets.ts";
 
 /**
- * `${stage} alchemy CLI overview` — a single dashboard composing the
- * same insights exposed as `Axiom.View`s in `./Views.ts`, laid out on
- * a 12-column grid.
+ * `${stage} alchemy CLI overview` — a single dashboard answering the
+ * four questions we actually care about, laid out on a 12-column grid:
  *
- * Layout (rows top-to-bottom, all in 12 cols):
+ *   1. **How many active users are working on a project?**
+ *      Distinct `alchemy.user.id` per `alchemy.git.origin_hash`.
+ *   2. **How many distinct projects are there?**
+ *      Distinct `alchemy.git.origin_hash`.
+ *   3. **How many projects use CI/CD?**
+ *      Distinct `alchemy.git.origin_hash` where `alchemy.ci=true`.
+ *   4. **What state stores are people using?**
+ *      Sourced from `state_store.init` spans tagged with
+ *      `alchemy.state_store.kind` (`local` | `inmemory` | `http` |
+ *      `cloudflare-http`). Emitted once per process via
+ *      `recordStateStoreInit` at every `Layer.effect(State, …)` site.
  *
- * 1. Active users (7d) | CLI invocations (24h) | Active users / hour
- * 2. Deploy/destroy latency p50/p95 | CLI invocations by command/status
- * 3. Top resources by op count | Resource latency p95 by type/op
- * 4. Active users by version | Resource error rate
- * 5. State store deploy success vs error | State store deploy error rate
- * 6. CLI failure rate by command | (reserved)
+ * Project identity uses `alchemy.git.origin_hash` rather than
+ * `alchemy.user.id`: ephemeral CI runners regenerate `~/.alchemy/id`
+ * every job, which dramatically inflates the user count. The git
+ * origin hash is stable across runs of the same repo and is the
+ * closest proxy we have for "a project".
  *
  * All queries target `${stage}-traces` — Axiom's metrics datasets
  * cannot be queried via APL, but every metric we emit has an
- * equivalent span (`cli.<command>`, `provider.<op>`).
+ * equivalent span (`cli.<command>`, `provider.<op>`,
+ * `state_store.deploy`, `state_store.init`).
  *
  * Each chart's APL query is built with `Output.interpolate` against
  * `traces.name` so Alchemy sequences the dashboard after the dataset
@@ -34,125 +43,166 @@ export const CliOverviewDashboard = Axiom.Dashboard(
     Effect.map(([stack, traces]) => {
       const t = traces.name;
       const charts: Input<Axiom.Chart>[] = [
+        // Row 1 — top-line counts answering Qs 1, 2, 3.
+        {
+          id: "distinct-projects",
+          name: "Distinct projects (7d)",
+          type: "Statistic",
+          query: {
+            apl: Output.interpolate`
+              ['${t}']
+              | extend project=tostring(['resource.custom']['alchemy.git.origin_hash'])
+              | where project != ""
+              | summarize projects=dcount(project)
+            `,
+          },
+        },
+        {
+          id: "projects-using-ci",
+          name: "Projects using CI/CD (7d)",
+          type: "Statistic",
+          query: {
+            apl: Output.interpolate`
+              ['${t}']
+              | extend project=tostring(['resource.custom']['alchemy.git.origin_hash']),
+                       ci=tostring(['resource.custom']['alchemy.ci'])
+              | where project != "" and ci == "true"
+              | summarize projects=dcount(project)
+            `,
+          },
+        },
         {
           id: "active-users-7d",
-          name: "Active users",
+          name: "Active users — non-CI (7d)",
           type: "Statistic",
-          query: {
-            apl: Output.interpolate`
-              ['${t}']
-              | extend uid=tostring(['resource.custom']['alchemy.user.id'])
-              | summarize users=dcount(uid)
-            `,
-          },
-        },
-        {
-          id: "cli-invocations-24h",
-          name: "CLI invocations",
-          type: "Statistic",
-          query: {
-            apl: Output.interpolate`
-              ['${t}']
-              | where name startswith "cli."
-              | summarize total=count()
-            `,
-          },
-        },
-        {
-          id: "active-users-hourly",
-          name: "Active users / hour",
-          type: "TimeSeries",
-          query: {
-            apl: Output.interpolate`
-              ['${t}']
-              | extend uid=tostring(['resource.custom']['alchemy.user.id'])
-              | summarize users=dcount(uid) by bin_auto(_time)
-              | order by _time asc
-            `,
-          },
-        },
-        {
-          id: "deploy-destroy-latency",
-          name: "Deploy / destroy latency",
-          type: "TimeSeries",
-          query: {
-            apl: Output.interpolate`
-              ['${t}']
-              | where name in ("cli.deploy", "cli.destroy")
-              | summarize p50=percentile(duration, 50),
-                          p95=percentile(duration, 95)
-                  by name, bin_auto(_time)
-              | order by _time asc
-            `,
-          },
-        },
-        {
-          id: "cli-invocations-by-command",
-          name: "CLI invocations by command / status",
-          type: "TimeSeries",
-          query: {
-            apl: Output.interpolate`
-              ['${t}']
-              | where name startswith "cli."
-              | extend command=extract("cli\\\\.(.+)", 1, name),
-                       status=iff(tobool(['error']), "error", "success")
-              | summarize count=count() by command, status, bin_auto(_time)
-              | order by _time asc
-            `,
-          },
-        },
-        {
-          id: "top-resources",
-          name: "Top resources by op count",
-          type: "Table",
-          query: {
-            apl: Output.interpolate`
-              ['${t}']
-              | where name startswith "provider."
-              | extend rt=tostring(['attributes.custom']['alchemy.resource.type']),
-                       op=tostring(['attributes.custom']['alchemy.resource.op'])
-              | summarize ops=count() by rt, op
-              | order by ops desc
-              | take 50
-            `,
-          },
-        },
-        {
-          id: "resource-latency",
-          name: "Resource latency p95 (provider.<op>)",
-          type: "Table",
-          query: {
-            apl: Output.interpolate`
-              ['${t}']
-              | where name startswith "provider."
-              | extend rt=tostring(['attributes.custom']['alchemy.resource.type']),
-                       op=tostring(['attributes.custom']['alchemy.resource.op'])
-              | summarize p50=percentile(duration, 50),
-                          p95=percentile(duration, 95),
-                          count=count()
-                  by rt, op
-              | order by p95 desc
-              | take 50
-            `,
-          },
-        },
-        {
-          id: "active-users-by-version",
-          name: "Active users by alchemy version",
-          type: "Table",
           query: {
             apl: Output.interpolate`
               ['${t}']
               | extend uid=tostring(['resource.custom']['alchemy.user.id']),
-                       version=tostring(['resource.custom']['alchemy.version'])
-              | summarize users=dcount(uid) by version
-              | order by users desc
+                       ci=tostring(['resource.custom']['alchemy.ci'])
+              | where ci != "true"
+              | summarize users=dcount(uid)
+            `,
+          },
+        },
+
+        // Row 2 — Q1 broken out per-project, plus solo-vs-team split.
+        {
+          id: "users-per-project",
+          name: "Active users per project (7d)",
+          type: "Table",
+          query: {
+            apl: Output.interpolate`
+              ['${t}']
+              | extend project=tostring(['resource.custom']['alchemy.git.origin_hash']),
+                       uid=tostring(['resource.custom']['alchemy.user.id']),
+                       ci=tostring(['resource.custom']['alchemy.ci'])
+              | where project != ""
+              | summarize users_total=dcount(uid),
+                          users_local=dcountif(uid, ci != "true"),
+                          users_ci=dcountif(uid, ci == "true"),
+                          events=count()
+                  by project
+              | order by users_total desc
+              | take 100
             `,
           },
         },
         {
+          id: "project-team-size-distribution",
+          name: "Project team-size distribution (local users / project)",
+          type: "Table",
+          query: {
+            apl: Output.interpolate`
+              ['${t}']
+              | extend project=tostring(['resource.custom']['alchemy.git.origin_hash']),
+                       uid=tostring(['resource.custom']['alchemy.user.id']),
+                       ci=tostring(['resource.custom']['alchemy.ci'])
+              | where project != "" and ci != "true"
+              | summarize users=dcount(uid) by project
+              | extend bucket = case(
+                  users == 1, "1 (solo)",
+                  users <= 3, "2-3",
+                  users <= 10, "4-10",
+                  "11+")
+              | summarize projects=count() by bucket
+              | order by bucket asc
+            `,
+          },
+        },
+
+        // Row 3 — Q4: state-store breakdown.
+        {
+          id: "state-store-projects-by-kind",
+          name: "Projects by state store kind (7d)",
+          type: "Table",
+          query: {
+            apl: Output.interpolate`
+              ['${t}']
+              | where name == "state_store.init"
+              | extend kind=tostring(['attributes.custom']['alchemy.state_store.kind']),
+                       project=tostring(['resource.custom']['alchemy.git.origin_hash']),
+                       uid=tostring(['resource.custom']['alchemy.user.id'])
+              | summarize projects=dcountif(project, project != ""),
+                          users=dcount(uid),
+                          inits=count()
+                  by kind
+              | order by projects desc
+            `,
+          },
+        },
+        {
+          id: "state-store-kind-over-time",
+          name: "State store init by kind / hour",
+          type: "TimeSeries",
+          query: {
+            apl: Output.interpolate`
+              ['${t}']
+              | where name == "state_store.init"
+              | extend kind=tostring(['attributes.custom']['alchemy.state_store.kind'])
+              | summarize count=count() by kind, bin_auto(_time)
+              | order by _time asc
+            `,
+          },
+        },
+
+        // Row 4 — adoption shape: project growth + CI-vs-local split.
+        {
+          id: "projects-over-time",
+          name: "Distinct projects per day",
+          type: "TimeSeries",
+          query: {
+            apl: Output.interpolate`
+              ['${t}']
+              | extend project=tostring(['resource.custom']['alchemy.git.origin_hash'])
+              | where project != ""
+              | summarize projects=dcount(project) by bin(_time, 1d)
+              | order by _time asc
+            `,
+          },
+        },
+        {
+          id: "ci-vs-local-projects",
+          name: "Projects: CI vs local per day",
+          type: "TimeSeries",
+          query: {
+            apl: Output.interpolate`
+              ['${t}']
+              | extend project=tostring(['resource.custom']['alchemy.git.origin_hash']),
+                       ci=tostring(['resource.custom']['alchemy.ci'])
+              | where project != ""
+              | extend bucket=iff(ci == "true", "ci", "local")
+              | summarize projects=dcount(project) by bucket, bin(_time, 1d)
+              | order by _time asc
+            `,
+          },
+        },
+
+        // Row 5 — keep the state-store deploy health signals for the
+        // Cloudflare-hosted store (not just init, but actual deploys).
+        {
           id: "state-store-deploys",
-          name: "State store deploys (success vs error)",
+          name: "Cloudflare state store deploys (success vs error)",
           type: "TimeSeries",
           query: {
             apl: Output.interpolate`
@@ -165,68 +215,20 @@ export const CliOverviewDashboard = Axiom.Dashboard(
           },
         },
         {
-          id: "state-store-error-rate",
-          name: "State store deploy error rate (%)",
-          type: "TimeSeries",
-          query: {
-            apl: Output.interpolate`
-              ['${t}']
-              | where name == "state_store.deploy"
-              | extend is_error=toint(tobool(['error']))
-              | summarize total=count(), errors=sum(is_error) by bin_auto(_time)
-              | extend error_rate_pct=todouble(errors) * 100.0 / todouble(total)
-              | project _time, error_rate_pct
-              | order by _time asc
-            `,
-          },
-        },
-        {
-          id: "cli-failure-rate",
-          name: "CLI failure rate by command (%)",
-          type: "TimeSeries",
-          query: {
-            apl: Output.interpolate`
-              ['${t}']
-              | where name startswith "cli."
-              | extend command=extract("cli\\\\.(.+)", 1, name),
-                       is_error=toint(tobool(['error']))
-              | summarize total=count(), errors=sum(is_error)
-                  by command, bin_auto(_time)
-              | extend failure_rate_pct=todouble(errors) * 100.0 / todouble(total)
-              | project _time, command, failure_rate_pct
-              | order by _time asc
-            `,
-          },
-        },
-        {
-          id: "cli-failure-rate-overall",
-          name: "CLI failure rate by command (7d)",
+          id: "active-users-by-version",
+          name: "Active users by alchemy version (7d)",
           type: "Table",
           query: {
             apl: Output.interpolate`
               ['${t}']
-              | where name startswith "cli."
-              | extend command=extract("cli\\\\.(.+)", 1, name),
-                       is_error=toint(tobool(['error']))
-              | summarize total=count(), errors=sum(is_error) by command
-              | extend failure_rate_pct=todouble(errors) * 100.0 / todouble(total)
-              | project command, total, errors, failure_rate_pct
-              | order by failure_rate_pct desc, total desc
-            `,
-          },
-        },
-        {
-          id: "resource-error-rate",
-          name: "Resource error rate",
-          type: "TimeSeries",
-          query: {
-            apl: Output.interpolate`
-              ['${t}']
-              | where name startswith "provider."
-              | extend rt=tostring(['attributes.custom']['alchemy.resource.type']),
-                       status=iff(tobool(['error']), "error", "success")
-              | summarize total=count() by rt, status, bin_auto(_time)
-              | order by _time asc
+              | extend uid=tostring(['resource.custom']['alchemy.user.id']),
+                       version=tostring(['resource.custom']['alchemy.version']),
+                       ci=tostring(['resource.custom']['alchemy.ci'])
+              | summarize users_total=dcount(uid),
+                          users_local=dcountif(uid, ci != "true"),
+                          users_ci=dcountif(uid, ci == "true")
+                  by version
+              | order by users_total desc
             `,
           },
         },
@@ -234,24 +236,21 @@ export const CliOverviewDashboard = Axiom.Dashboard(
 
       const layout: Axiom.LayoutCell[] = [
         // Row 1
-        { i: "active-users-7d", x: 0, y: 0, w: 3, h: 4 },
-        { i: "cli-invocations-24h", x: 3, y: 0, w: 3, h: 4 },
-        { i: "active-users-hourly", x: 6, y: 0, w: 6, h: 4 },
+        { i: "distinct-projects", x: 0, y: 0, w: 4, h: 4 },
+        { i: "projects-using-ci", x: 4, y: 0, w: 4, h: 4 },
+        { i: "active-users-7d", x: 8, y: 0, w: 4, h: 4 },
         // Row 2
-        { i: "deploy-destroy-latency", x: 0, y: 4, w: 6, h: 6 },
-        { i: "cli-invocations-by-command", x: 6, y: 4, w: 6, h: 6 },
+        { i: "users-per-project", x: 0, y: 4, w: 8, h: 8 },
+        { i: "project-team-size-distribution", x: 8, y: 4, w: 4, h: 8 },
         // Row 3
-        { i: "top-resources", x: 0, y: 10, w: 6, h: 8 },
-        { i: "resource-latency", x: 6, y: 10, w: 6, h: 8 },
+        { i: "state-store-projects-by-kind", x: 0, y: 12, w: 6, h: 6 },
+        { i: "state-store-kind-over-time", x: 6, y: 12, w: 6, h: 6 },
         // Row 4
-        { i: "active-users-by-version", x: 0, y: 18, w: 6, h: 6 },
-        { i: "resource-error-rate", x: 6, y: 18, w: 6, h: 6 },
+        { i: "projects-over-time", x: 0, y: 18, w: 6, h: 6 },
+        { i: "ci-vs-local-projects", x: 6, y: 18, w: 6, h: 6 },
         // Row 5
         { i: "state-store-deploys", x: 0, y: 24, w: 6, h: 6 },
-        { i: "state-store-error-rate", x: 6, y: 24, w: 6, h: 6 },
-        // Row 6
-        { i: "cli-failure-rate", x: 0, y: 30, w: 6, h: 6 },
-        { i: "cli-failure-rate-overall", x: 6, y: 30, w: 6, h: 6 },
+        { i: "active-users-by-version", x: 6, y: 24, w: 6, h: 6 },
       ];
 
       return {
@@ -261,7 +260,10 @@ export const CliOverviewDashboard = Axiom.Dashboard(
           // can't create per-user "private" dashboards.
           owner: "",
           description:
-            "End-user CLI telemetry: active users, resource usage, deploy/destroy and per-resource latency, error rate, and Cloudflare State Store deploy success/error rate.",
+            "Adoption telemetry: distinct projects, active users per project, " +
+            "CI vs local usage, and state-store backend breakdown. " +
+            "Project identity = alchemy.git.origin_hash (stable across CI runs); " +
+            "user identity = alchemy.user.id (ephemeral in CI).",
           refreshTime: 60 as const,
           schemaVersion: 2 as const,
           // Axiom requires the `qr-now-{duration}` form for relative times.

--- a/stacks/otel/Dashboard.ts
+++ b/stacks/otel/Dashboard.ts
@@ -17,8 +17,10 @@ import { Traces } from "./Datasets.ts";
  *      Distinct `alchemy.git.origin_hash` where `alchemy.ci=true`.
  *   4. **What state stores are people using?**
  *      Sourced from `state_store.init` spans tagged with
- *      `alchemy.state_store.kind` (`local` | `inmemory` | `http` |
- *      `cloudflare-http`). Emitted once per process via
+ *      `alchemy.state_store.id` (the open-ended `StateService.id`
+ *      slug; built-ins are `local` / `inmemory` / `http` /
+ *      `cloudflare-http`, third-party stores get tracked automatically
+ *      by setting their own slug). Emitted once per process via
  *      `recordStateStoreInit` at every `Layer.effect(State, …)` site.
  *
  * Project identity uses `alchemy.git.origin_hash` rather than
@@ -133,34 +135,34 @@ export const CliOverviewDashboard = Axiom.Dashboard(
 
         // Row 3 — Q4: state-store breakdown.
         {
-          id: "state-store-projects-by-kind",
-          name: "Projects by state store kind (7d)",
+          id: "state-store-projects-by-id",
+          name: "Projects by state store (7d)",
           type: "Table",
           query: {
             apl: Output.interpolate`
               ['${t}']
               | where name == "state_store.init"
-              | extend kind=tostring(['attributes.custom']['alchemy.state_store.kind']),
+              | extend store=tostring(['attributes.custom']['alchemy.state_store.id']),
                        project=tostring(['resource.custom']['alchemy.git.origin_hash']),
                        uid=tostring(['resource.custom']['alchemy.user.id'])
               | summarize projects=dcountif(project, project != ""),
                           users=dcount(uid),
                           inits=count()
-                  by kind
+                  by store
               | order by projects desc
             `,
           },
         },
         {
-          id: "state-store-kind-over-time",
-          name: "State store init by kind / hour",
+          id: "state-store-by-id-over-time",
+          name: "State store init by store / hour",
           type: "TimeSeries",
           query: {
             apl: Output.interpolate`
               ['${t}']
               | where name == "state_store.init"
-              | extend kind=tostring(['attributes.custom']['alchemy.state_store.kind'])
-              | summarize count=count() by kind, bin_auto(_time)
+              | extend store=tostring(['attributes.custom']['alchemy.state_store.id'])
+              | summarize count=count() by store, bin_auto(_time)
               | order by _time asc
             `,
           },
@@ -243,8 +245,8 @@ export const CliOverviewDashboard = Axiom.Dashboard(
         { i: "users-per-project", x: 0, y: 4, w: 8, h: 8 },
         { i: "project-team-size-distribution", x: 8, y: 4, w: 4, h: 8 },
         // Row 3
-        { i: "state-store-projects-by-kind", x: 0, y: 12, w: 6, h: 6 },
-        { i: "state-store-kind-over-time", x: 6, y: 12, w: 6, h: 6 },
+        { i: "state-store-projects-by-id", x: 0, y: 12, w: 6, h: 6 },
+        { i: "state-store-by-id-over-time", x: 6, y: 12, w: 6, h: 6 },
         // Row 4
         { i: "projects-over-time", x: 0, y: 18, w: 6, h: 6 },
         { i: "ci-vs-local-projects", x: 6, y: 18, w: 6, h: 6 },


### PR DESCRIPTION
Track which state-store backend each project uses, and stop conflating ephemeral CI UUIDs with real users in the dashboard.

- Emit a `state_store.init` span tagged with `alchemy.state_store.kind` (`local` | `inmemory` | `cloudflare-http`) at every `Layer.effect(State, …)` site.

  ```ts
  // packages/alchemy/src/State/LocalState.ts
  Layer.effect(State, makeLocalState().pipe(recordStateStoreInit("local")))
  ```

- Switch the dashboard's project dimension from `alchemy.user.id` to `alchemy.git.origin_hash` (stable across CI runs) and split user counts into `users_local` vs `users_ci` via `dcountif(uid, ci != "true")`. Adds a "Projects by state store kind" table sourced from the new span.

`~/.alchemy/id` regenerates per CI job, so the previous "XXX active users" was mostly CI runners. `alchemy.git.origin_hash` is the closest stable proxy for "a project".