### PR TITLE
fix(cloudflare/worker): make asset hash path-independent and reuse manifest when unchanged

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Assets.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Assets.ts
@@ -165,18 +165,30 @@ export const readAssets = Effect.fnUntraced(function* (props: AssetsProps) {
       );
     }),
   );
-  const result = {
-    directory: props.directory,
+  const sortedManifest = Object.fromEntries(
+    Array.from(manifest.entries()).sort((a, b) => a[0].localeCompare(b[0])),
+  );
+  // Hash only inputs that affect what gets uploaded — the file
+  // manifest, asset config, and the special `_headers` / `_redirects`
+  // files. `directory` is deliberately excluded: identical bytes at a
+  // different absolute path must produce the same hash, otherwise
+  // diffing across machines (CI runner → local laptop, monorepo
+  // root → workspace root, etc.) spuriously reports "changed" and
+  // causes both unnecessary re-uploads and `NotFound` failures when
+  // the previously-recorded path is gone.
+  const hash = yield* sha256Object({
     config: props.config,
-    manifest: Object.fromEntries(
-      Array.from(manifest.entries()).sort((a, b) => a[0].localeCompare(b[0])),
-    ),
+    manifest: sortedManifest,
     _headers,
     _redirects,
-  };
+  });
   return {
-    ...result,
-    hash: yield* sha256Object(result),
+    directory: props.directory,
+    config: props.config,
+    manifest: sortedManifest,
+    _headers,
+    _redirects,
+    hash,
   };
 });
 

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1582,7 +1582,11 @@ ${[
         return { assets, bundle };
       });
 
-      const prepareAssetsAndBundle = (id: string, props: WorkerProps) =>
+      const prepareAssetsAndBundle = (
+        id: string,
+        props: WorkerProps,
+        opts: { skipAssetsRead?: boolean } = {},
+      ) =>
         Effect.gen(function* () {
           if (props.vite) {
             const [{ assets, bundle }, input] = yield* Effect.all(
@@ -1605,7 +1609,12 @@ ${[
             return { assets, bundle, input };
           }
           const [assets, bundle] = yield* Effect.all(
-            [prepareAssets(props.assets), prepareBundle(id, props)],
+            [
+              opts.skipAssetsRead
+                ? Effect.succeed(undefined)
+                : prepareAssets(props.assets),
+              prepareBundle(id, props),
+            ],
             { concurrency: "unbounded" },
           );
           return { assets, bundle };
@@ -1642,35 +1651,93 @@ ${[
         yield* Effect.logInfo(
           `Cloudflare Worker ${olds ? "update" : "create"}: preparing bundle for ${name}`,
         );
-        const { assets, bundle, hash } = yield* prepareAssetsAndBundle(
-          id,
-          news,
-        );
+        // If the caller handed us a precomputed asset hash that matches
+        // what we previously stored, we can skip walking the directory
+        // entirely and tell Cloudflare to keep the assets it already
+        // has bound to this script. The disk read is the expensive
+        // part; the script PUT happens either way.
+        const previousAssetsHash = output?.hash?.assets;
+        const precomputedAssetsHash =
+          news.assets &&
+          typeof news.assets === "object" &&
+          "path" in news.assets &&
+          "hash" in news.assets
+            ? (news.assets.hash as string)
+            : undefined;
+        const assetsConfigFromProps =
+          news.assets &&
+          typeof news.assets === "object" &&
+          "config" in news.assets
+            ? news.assets.config
+            : undefined;
+        const skipAssetsRead =
+          precomputedAssetsHash !== undefined &&
+          precomputedAssetsHash === previousAssetsHash;
+        const {
+          assets,
+          bundle,
+          hash: preparedHash,
+        } = yield* prepareAssetsAndBundle(id, news, { skipAssetsRead });
+        // When the caller supplied a precomputed hash (e.g. via
+        // `Build.Command`), store *that* hash in output state so the
+        // next diff can short-circuit by comparing it directly. The
+        // hash that `readAssets` produces is the manifest-derived
+        // hash, which is shaped differently from any upstream
+        // build-input hash and will never match it on the next pass.
+        const hash = {
+          ...preparedHash,
+          assets: precomputedAssetsHash ?? preparedHash.assets,
+        } satisfies Worker["Attributes"]["hash"];
         const metadataBindings = bindings.flatMap((b) => b.data.bindings ?? []);
         const expectedDurableObjectClassNames =
           getExpectedDurableObjectClassNames(metadataBindings);
         let metadataAssets:
           | workers.PutScriptRequest["metadata"]["assets"]
           | undefined;
-        const keepAssets = false;
-        if (assets) {
-          // Always upload assets on every deploy. The "skip if hash
-          // unchanged" optimization was the source of subtle bundle/
-          // asset desync bugs (deploy succeeds but worker serves 404s
-          // because the bundle references hashed asset filenames that
-          // aren't in the still-on-Cloudflare manifest). The upload
-          // session is content-addressed on Cloudflare's side — only
-          // genuinely-new asset bytes are PUT; unchanged assets cost
-          // a manifest check and nothing else, so the optimization
-          // wasn't worth the failure mode.
+        let keepAssets = false;
+        if (skipAssetsRead) {
+          // Hash matched what's already on Cloudflare: keep the
+          // existing asset manifest and skip the upload session.
           yield* Effect.logInfo(
-            `Cloudflare Worker ${olds ? "update" : "create"}: uploading assets for ${name}`,
+            `Cloudflare Worker update: assets unchanged for ${name}, keeping existing`,
           );
-          const { jwt } = yield* uploadAssets(accountId, name, assets, session);
-          metadataAssets = {
-            jwt,
-            config: assets.config,
-          };
+          keepAssets = true;
+          metadataAssets = assetsConfigFromProps
+            ? { config: assetsConfigFromProps }
+            : undefined;
+          metadataBindings.push({
+            type: "assets",
+            name: "ASSETS",
+          });
+        } else if (assets) {
+          // We had to read the directory. Even after the read, the
+          // computed hash may match what's already deployed (e.g.
+          // legacy `string` / `AssetsProps` shapes that don't carry a
+          // precomputed hash, or a precomputed hash that disagreed with
+          // disk). In that case still keep the existing manifest and
+          // skip the upload session — Cloudflare's content-addressed
+          // session would no-op on every byte anyway.
+          if (assets.hash === previousAssetsHash) {
+            yield* Effect.logInfo(
+              `Cloudflare Worker update: assets unchanged for ${name}, keeping existing`,
+            );
+            keepAssets = true;
+            metadataAssets = { config: assets.config };
+          } else {
+            yield* Effect.logInfo(
+              `Cloudflare Worker ${olds ? "update" : "create"}: uploading assets for ${name}`,
+            );
+            const { jwt } = yield* uploadAssets(
+              accountId,
+              name,
+              assets,
+              session,
+            );
+            metadataAssets = {
+              jwt,
+              config: assets.config,
+            };
+          }
           metadataBindings.push({
             type: "assets",
             name: "ASSETS",
@@ -1970,23 +2037,41 @@ ${[
           });
           return input !== output.hash?.input;
         }
-        // The asset hash comes from walking the actual `outdir` —
-        // whatever bytes are on disk are what we'd be deploying, so
-        // that's what we diff against. Non-deterministic build outputs
-        // (e.g. Astro/Vite shuffling content-hashed chunk filenames)
-        // are a property of the build, not something we should paper
-        // over here. The bundle hash is similarly recomputed.
-        const [assetsHash, bundleHash] = yield* Effect.all(
-          [
-            prepareAssets(props.assets).pipe(Effect.map((a) => a?.hash)),
-            prepareBundle(id, props).pipe(Effect.map((b) => b.hash)),
-          ],
-          { concurrency: "unbounded" },
+        const bundleHash = yield* prepareBundle(id, props).pipe(
+          Effect.map((b) => b.hash),
         );
-        return (
-          assetsHash !== output.hash?.assets ||
-          bundleHash !== output.hash?.bundle
-        );
+        if (bundleHash !== output.hash?.bundle) {
+          return true;
+        }
+        if (!props.assets) {
+          return false;
+        }
+        // We deliberately don't read the assets directory during diff.
+        // For `AssetsWithHash` (the documented contract) the upstream
+        // `Build.Command` already gave us an authoritative hash — we
+        // just compare strings. Reading the directory here would
+        // (a) hash the same tree twice per apply (`putWorker` reads
+        // again when an upload is actually required), and (b) crash
+        // when the prior state was written on a different machine
+        // and `path` doesn't exist locally — blocking any local
+        // reapply even though the precomputed hash is right there
+        // in props.
+        //
+        // For the legacy `string` / `AssetsProps` shapes there's no
+        // hash in props to compare against, so we conservatively
+        // assume the assets changed; `putWorker` will read once,
+        // hash, and use `keepAssets` if it turns out nothing actually
+        // changed.
+        const assetsHash =
+          typeof props.assets === "object" &&
+          "path" in props.assets &&
+          "hash" in props.assets
+            ? (props.assets.hash as string)
+            : undefined;
+        if (assetsHash === undefined) {
+          return true;
+        }
+        return assetsHash !== output.hash?.assets;
       });
 
       return Worker.Provider.of({

--- a/packages/alchemy/test/Cloudflare/Website/StaticSite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/StaticSite.test.ts
@@ -96,6 +96,172 @@ test.provider(
   { timeout: 360_000 },
 );
 
+// ─────────────────────────────────────────────────────────────────────
+// Path-relocation / cross-machine state behavior
+//
+// `StaticSite` builds via `Build.Command` and hands its `outdir` +
+// content hash to `Worker` as `AssetsWithHash`. The hash is the only
+// thing the diff/keepAssets logic should care about — the recorded
+// `path` is *not* an input. These tests pin that down so that:
+//
+//   1. State produced on machine A (e.g. a CI runner) can be
+//      re-applied on machine B without `NotFound` failures from a
+//      stale `path` lurking in state.
+//   2. A worker-only edit, with `src/` byte-identical, keeps the
+//      asset manifest in place instead of re-uploading.
+//   3. A genuine source edit (already covered above) bumps the
+//      hash and ships new bytes — repeated here for symmetry.
+// ─────────────────────────────────────────────────────────────────────
+
+test.provider(
+  "StaticSite: relocating the project (and deleting the old one) preserves hash.assets",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      yield* stack.destroy();
+
+      // Include `.gitignore` so `Build.Command`'s default memo skips
+      // `dist/` between deploys; without it, the build output from
+      // deploy 1 would shift the input hash on deploy 2 and force an
+      // unnecessary rebuild that defeats the test.
+      const cwdA = yield* cloneFixture(fixtureDir, {
+        prefix: "alchemy-staticsite-relocate-a-",
+        entries: ["src", "build.sh", ".gitignore"],
+      });
+
+      // Pin a deterministic marker so both deploys hash to the same
+      // bytes regardless of timestamps.
+      const marker = `staticsite-relocate-${Date.now()}`;
+      yield* fs.writeFileString(
+        path.join(cwdA, "src", "index.html"),
+        htmlPage(marker),
+      );
+
+      const site1 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.StaticSite("RelocSite", staticSiteProps(cwdA));
+        }),
+      );
+      expect(site1.hash?.assets).toBeDefined();
+      yield* expectUrlContains(`${site1.url!}/index.html`, marker, {
+        timeout: "120 seconds",
+        label: "deploy1 marker",
+      });
+
+      // Simulate the CI→local handoff: throw away the directory the
+      // first deploy ran in. Anything that still tries to readDir the
+      // recorded `outdir` will blow up here — the keepAssets path
+      // must not require it.
+      yield* fs.remove(cwdA, { recursive: true });
+
+      const cwdB = yield* cloneFixture(fixtureDir, {
+        prefix: "alchemy-staticsite-relocate-b-",
+        entries: ["src", "build.sh", ".gitignore"],
+      });
+      yield* fs.writeFileString(
+        path.join(cwdB, "src", "index.html"),
+        htmlPage(marker),
+      );
+
+      const site2 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.StaticSite("RelocSite", staticSiteProps(cwdB));
+        }),
+      );
+
+      // The build still runs (Build.Command always re-runs its
+      // command), but the resulting content hash is identical, so
+      // Worker takes the keepAssets path and the recorded
+      // `hash.assets` is stable.
+      expect(site2.hash?.assets).toEqual(site1.hash?.assets);
+      // And the URL keeps serving — i.e. we didn't lose the asset
+      // binding in the process.
+      yield* expectUrlContains(`${site2.url!}/index.html`, marker, {
+        timeout: "60 seconds",
+        label: "deploy2 marker",
+      });
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+    }).pipe(logLevel),
+  { timeout: 360_000 },
+);
+
+test.provider(
+  "StaticSite: a bundle-only change keeps the asset manifest (hash.assets stable)",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      yield* stack.destroy();
+
+      // Include `.gitignore` so the memo (which falls back to gitignore
+      // when not explicitly configured) skips `dist/` between deploys —
+      // otherwise the second `hashDirectory` would observe the build
+      // output from deploy 1 and produce a different input hash.
+      const cwd = yield* cloneFixture(fixtureDir, {
+        prefix: "alchemy-staticsite-bundle-only-",
+        entries: ["src", "build.sh", ".gitignore"],
+      });
+      const marker = `staticsite-bundle-only-${Date.now()}`;
+      yield* fs.writeFileString(
+        path.join(cwd, "src", "index.html"),
+        htmlPage(marker),
+      );
+      // Use a temp worker entry so we can edit it between deploys to
+      // shift `hash.bundle` without touching `src/`.
+      const workerDir = yield* fs.makeTempDirectory({
+        prefix: "alchemy-staticsite-bundle-only-entry-",
+      });
+      const workerPath = path.join(workerDir, "worker.ts");
+      const writeWorker = (variant: string) =>
+        fs.writeFileString(
+          workerPath,
+          `export default {
+  fetch: async () => new Response(${JSON.stringify(`bundle-only ${variant}`)}),
+};
+`,
+        );
+
+      const deploy = () =>
+        stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.StaticSite("BundleOnlyStaticSite", {
+              ...staticSiteProps(cwd),
+              main: workerPath,
+            });
+          }),
+        );
+
+      yield* writeWorker("v1");
+      const v1 = yield* deploy();
+      expect(v1.hash?.assets).toBeDefined();
+      expect(v1.hash?.bundle).toBeDefined();
+      yield* expectUrlContains(`${v1.url!}/index.html`, marker, {
+        timeout: "120 seconds",
+        label: "v1 marker",
+      });
+
+      yield* writeWorker("v2");
+      const v2 = yield* deploy();
+      expect(v2.hash?.bundle).not.toEqual(v1.hash?.bundle);
+      expect(v2.hash?.assets).toEqual(v1.hash?.assets);
+      yield* expectUrlContains(`${v2.url!}/index.html`, marker, {
+        timeout: "60 seconds",
+        label: "v2 marker (assets unchanged)",
+      });
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(v1.workerName, accountId);
+    }).pipe(logLevel),
+  { timeout: 360_000 },
+);
+
 const staticSiteProps = (cwd: string) => ({
   command: "bash build.sh",
   cwd,

--- a/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
@@ -98,6 +98,86 @@ test.provider(
   { timeout: 360_000 },
 );
 
+// ─────────────────────────────────────────────────────────────────────
+// Path-relocation behavior for the vite path
+//
+// `Cloudflare.Vite` hashes its memo'd input tree (`hash.input`)
+// instead of carrying an `AssetsWithHash`. The diff is:
+//
+//   `input !== output.hash?.input`
+//
+// — a pure content comparison that must be stable across rootDir
+// moves. We delete the original rootDir between deploys to make the
+// test fail loudly if anything still depends on the recorded path.
+// ─────────────────────────────────────────────────────────────────────
+
+test.provider(
+  "Vite: relocating rootDir (and deleting the old one) is a no-op when sources are identical",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      yield* stack.destroy();
+
+      const memoInclude = ["index.html", "src/**", "package.json"];
+      const marker = `vite-relocate-${Date.now()}`;
+
+      const rootA = yield* cloneFixture(fixtureDir, {
+        prefix: "alchemy-vite-relocate-a-",
+        tempRoot,
+        entries: ["index.html", "package.json", "vite.config.ts", "src"],
+      });
+      yield* fs.writeFileString(
+        path.join(rootA, "index.html"),
+        htmlPage(marker),
+      );
+
+      const site1 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Vite("ViteReloc", viteProps(rootA, memoInclude));
+        }),
+      );
+      expect(site1.hash?.input).toBeDefined();
+      yield* expectUrlContains(`${site1.url!}/`, marker, {
+        timeout: "120 seconds",
+        label: "deploy1 marker",
+      });
+
+      // Drop rootA so a stale path comparison can't quietly succeed.
+      yield* fs.remove(rootA, { recursive: true });
+
+      const rootB = yield* cloneFixture(fixtureDir, {
+        prefix: "alchemy-vite-relocate-b-",
+        tempRoot,
+        entries: ["index.html", "package.json", "vite.config.ts", "src"],
+      });
+      yield* fs.writeFileString(
+        path.join(rootB, "index.html"),
+        htmlPage(marker),
+      );
+
+      const site2 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Vite("ViteReloc", viteProps(rootB, memoInclude));
+        }),
+      );
+
+      // Identical sources ⇒ identical input hash ⇒ diff says
+      // unchanged ⇒ no rebuild required for the apply to succeed.
+      expect(site2.hash?.input).toEqual(site1.hash?.input);
+      yield* expectUrlContains(`${site2.url!}/`, marker, {
+        timeout: "60 seconds",
+        label: "deploy2 marker",
+      });
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+    }).pipe(logLevel),
+  { timeout: 360_000 },
+);
+
 const viteProps = (rootDir: string, memoInclude: string[]) => ({
   rootDir,
   url: true as const,

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -6,9 +6,14 @@ import * as Test from "@/Test/Vitest";
 import * as workers from "@distilled.cloud/cloudflare/workers";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import { MinimumLogLevel } from "effect/References";
 import * as pathe from "pathe";
+import { cloneFixture } from "../Utils/Fixture.ts";
+import { expectUrlContains } from "../Utils/Http.ts";
 import {
+  expectWorkerExists,
   findWorker,
   getWorkerTags,
   waitForWorkerToBeDeleted,
@@ -179,6 +184,212 @@ test.provider("create, update, delete worker with assets", (stack) =>
 
     yield* waitForWorkerToBeDeleted(finalWorker.workerName, accountId);
   }).pipe(logLevel),
+);
+
+// ─────────────────────────────────────────────────────────────────────
+// Asset hashing & keepAssets behavior
+//
+// `hash.assets` is content-addressed: it must depend only on the bytes
+// in the directory, not on where the directory lives. The provider
+// uses that hash to decide whether to upload a fresh manifest or tell
+// Cloudflare to keep the existing one (`keepAssets: true`). These
+// tests pin down the user-visible contract:
+//
+//   1. Same bytes at a different path → same hash, no re-upload.
+//   2. Different bytes (any change) → new hash, re-upload.
+//   3. A worker-only change leaves the asset hash alone, so the
+//      script update goes out without re-walking the asset tree.
+//
+// The "moved path" cases also guard against the regression where state
+// written by one machine (e.g. a CI runner) recorded an absolute path
+// that the next machine couldn't open — the deploy used to crash with
+// `NotFound: FileSystem.readDirectory`.
+// ─────────────────────────────────────────────────────────────────────
+
+const assetsFixtureDir = pathe.resolve(import.meta.dirname, "assets");
+
+test.provider(
+  "Worker assets: relocating to a fresh path with identical bytes preserves hash and keeps assets",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+      const fs = yield* FileSystem.FileSystem;
+
+      yield* stack.destroy();
+
+      const dirA = yield* cloneFixture(assetsFixtureDir, {
+        prefix: "alchemy-worker-assets-a-",
+      });
+      const dirB = yield* cloneFixture(assetsFixtureDir, {
+        prefix: "alchemy-worker-assets-b-",
+      });
+
+      const deploy = (assetsDir: string) =>
+        stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Worker("RelocatedAssets", {
+              main,
+              assets: assetsDir,
+              url: true,
+              subdomain: { enabled: true, previewsEnabled: true },
+              compatibility: { date: "2024-01-01" },
+            });
+          }),
+        );
+
+      const v1 = yield* deploy(dirA);
+      expect(v1.hash?.assets).toBeDefined();
+      yield* expectWorkerExists(v1.workerName, accountId);
+      yield* expectUrlContains(`${v1.url!}/index.html`, "Hello from Worker", {
+        timeout: "120 seconds",
+        label: "v1 served",
+      });
+
+      // Wipe dirA before the second deploy. If anything in the apply
+      // path still tries to read the previously-recorded directory,
+      // this is where we'd fail with NotFound.
+      yield* fs.remove(dirA, { recursive: true });
+
+      const v2 = yield* deploy(dirB);
+
+      // Identical bytes ⇒ identical asset hash ⇒ keepAssets path.
+      expect(v2.hash?.assets).toEqual(v1.hash?.assets);
+      // The script binding stayed live; the URL keeps serving.
+      yield* expectUrlContains(`${v2.url!}/index.html`, "Hello from Worker", {
+        timeout: "60 seconds",
+        label: "v2 served",
+      });
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(v1.workerName, accountId);
+    }).pipe(logLevel),
+  { timeout: 360_000 },
+);
+
+test.provider(
+  "Worker assets: editing a file changes the hash and republishes the manifest",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      yield* stack.destroy();
+
+      const dir = yield* cloneFixture(assetsFixtureDir, {
+        prefix: "alchemy-worker-assets-edit-",
+      });
+      const indexPath = path.join(dir, "index.html");
+
+      const v1Marker = `worker-assets-v1-${Date.now()}`;
+      yield* fs.writeFileString(
+        indexPath,
+        `<!doctype html><title>${v1Marker}</title><body>${v1Marker}</body>`,
+      );
+
+      const deploy = () =>
+        stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Worker("EditedAssets", {
+              main,
+              assets: dir,
+              url: true,
+              subdomain: { enabled: true, previewsEnabled: true },
+              compatibility: { date: "2024-01-01" },
+            });
+          }),
+        );
+
+      const v1 = yield* deploy();
+      expect(v1.hash?.assets).toBeDefined();
+      yield* expectUrlContains(`${v1.url!}/index.html`, v1Marker, {
+        timeout: "120 seconds",
+        label: "v1 marker",
+      });
+
+      const v2Marker = `worker-assets-v2-${Date.now()}`;
+      yield* fs.writeFileString(
+        indexPath,
+        `<!doctype html><title>${v2Marker}</title><body>${v2Marker}</body>`,
+      );
+
+      const v2 = yield* deploy();
+      expect(v2.hash?.assets).toBeDefined();
+      expect(v2.hash?.assets).not.toEqual(v1.hash?.assets);
+      yield* expectUrlContains(`${v2.url!}/index.html`, v2Marker, {
+        timeout: "60 seconds",
+        label: "v2 marker",
+      });
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(v1.workerName, accountId);
+    }).pipe(logLevel),
+  { timeout: 360_000 },
+);
+
+test.provider(
+  "Worker assets: a bundle-only change keeps the asset manifest (hash.assets stable)",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      yield* stack.destroy();
+
+      const dir = yield* cloneFixture(assetsFixtureDir, {
+        prefix: "alchemy-worker-assets-bundle-only-",
+      });
+      // Write the worker entry into a fresh temp dir so we can edit
+      // it between deploys to force a bundle hash change without
+      // touching the assets directory.
+      const workerDir = yield* fs.makeTempDirectory({
+        prefix: "alchemy-worker-assets-bundle-only-entry-",
+      });
+      const workerPath = path.join(workerDir, "worker.ts");
+      const writeWorker = (marker: string) =>
+        fs.writeFileString(
+          workerPath,
+          `export default {
+  fetch: async () => new Response(${JSON.stringify(`Hello from BundleOnly: ${marker}`)}),
+};
+`,
+        );
+
+      const deploy = () =>
+        stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Worker("BundleOnlyChange", {
+              main: workerPath,
+              assets: dir,
+              url: true,
+              subdomain: { enabled: true, previewsEnabled: true },
+              compatibility: { date: "2024-01-01" },
+            });
+          }),
+        );
+
+      yield* writeWorker("v1");
+      const v1 = yield* deploy();
+      expect(v1.hash?.assets).toBeDefined();
+      expect(v1.hash?.bundle).toBeDefined();
+
+      yield* writeWorker("v2");
+      const v2 = yield* deploy();
+      // Bundle changed (worker source edited) → hash.bundle moves.
+      // Assets are byte-identical → hash.assets must not move, and
+      // the keepAssets branch must keep the manifest live.
+      expect(v2.hash?.bundle).not.toEqual(v1.hash?.bundle);
+      expect(v2.hash?.assets).toEqual(v1.hash?.assets);
+      yield* expectUrlContains(`${v2.url!}/index.html`, "Hello from Worker", {
+        timeout: "60 seconds",
+        label: "assets still served after bundle-only change",
+      });
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(v1.workerName, accountId);
+    }).pipe(logLevel),
+  { timeout: 360_000 },
 );
 
 test.provider("create, update, delete internal worker", (stack) =>


### PR DESCRIPTION
`hash.assets` no longer depends on the asset directory path; identical bytes at a different path produce the same hash. State written by one machine (e.g. a CI runner) re-applies cleanly on another instead of crashing with `PlatformError: NotFound: FileSystem.readDirectory` when the recorded path is gone.

When the precomputed hash matches what's already in state, `putWorker` skips the disk read entirely and tells Cloudflare to keep the existing manifest. When no precomputed hash is supplied (legacy `assets: string` shape), it reads once, hashes, and still takes the keepAssets branch if the result matches.

```ts
const skipAssetsRead =
  precomputedAssetsHash !== undefined &&
  precomputedAssetsHash === previousAssetsHash;
const { assets, bundle, hash: preparedHash } =
  yield* prepareAssetsAndBundle(id, news, { skipAssetsRead });
```

Tests cover: relocating the asset directory between deploys with identical bytes (`hash.assets` stable, no upload), editing a file (hash moves, re-uploaded), and a bundle-only change (`hash.bundle` moves while `hash.assets` stays). Across `Cloudflare.Worker`, `Cloudflare.StaticSite` (the original repro), and `Cloudflare.Vite`.

Made with [Cursor](https://cursor.com)