### PR TITLE
chore(deploy): provide GitHub credentials to cleanup destroy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,6 +103,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Generate bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ALCHEMY_VERSION_BOT_ID }}
+          private-key: ${{ secrets.ALCHEMY_VERSION_BOT_PRIVATE_KEY }}
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
@@ -124,3 +131,4 @@ jobs:
           CLOUDFLARE_EMAIL: ${{ secrets.ADMIN_CLOUDFLARE_EMAIL }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
           PULL_REQUEST: ${{ github.event.number }}
+          GITHUB_TOKEN: ${{ steps.bot-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Mint an alchemy-version-bot token in the cleanup job and pass it as \`GITHUB_TOKEN\` to \`bun alchemy destroy\`, mirroring the deploy job.
- Fixes \`AuthError: Failed to resolve GitHub credentials for profile 'default'\` when destroying PR preview stages on PR close.

## Test plan
- [ ] Close a PR and verify the cleanup job's destroy step succeeds.

Made with [Cursor](https://cursor.com)