### PR TITLE
docs(cloudflare/artifacts): add Git repo API tutorial and example

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -137,6 +137,16 @@
         "effect": "catalog:",
       },
     },
+    "examples/cloudflare-git-artifacts": {
+      "name": "cloudflare-git-artifacts",
+      "version": "0.0.0",
+      "dependencies": {
+        "@effect/platform-bun": "catalog:",
+        "@effect/platform-node": "catalog:",
+        "alchemy": "workspace:*",
+        "effect": "catalog:",
+      },
+    },
     "examples/cloudflare-secrets-store": {
       "name": "cloudflare-secrets-store",
       "version": "0.0.0",
@@ -261,7 +271,7 @@
     },
     "packages/alchemy": {
       "name": "alchemy",
-      "version": "2.0.0-beta.28",
+      "version": "2.0.0-beta.30",
       "bin": {
         "alchemy": "./bin/cli.js",
       },
@@ -345,7 +355,7 @@
     },
     "packages/better-auth": {
       "name": "@alchemy.run/better-auth",
-      "version": "2.0.0-beta.28",
+      "version": "2.0.0-beta.30",
       "dependencies": {
         "alchemy": "workspace:*",
         "better-auth": "catalog:",
@@ -354,7 +364,7 @@
     },
     "packages/pr-package": {
       "name": "@alchemy.run/pr-package",
-      "version": "2.0.0-beta.28",
+      "version": "2.0.0-beta.30",
       "dependencies": {
         "alchemy": "workspace:*",
         "effect": "catalog:",
@@ -1991,6 +2001,8 @@
     "cloudflare": ["cloudflare@5.2.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-dVzqDpPFYR9ApEC9e+JJshFJZXcw4HzM8W+3DHzO5oy9+8rLC53G7x6fEf9A7/gSuSCxuvndzui5qJKftfIM9A=="],
 
     "cloudflare-dev": ["cloudflare-dev@workspace:examples/cloudflare-dev"],
+
+    "cloudflare-git-artifacts": ["cloudflare-git-artifacts@workspace:examples/cloudflare-git-artifacts"],
 
     "cloudflare-secrets-store": ["cloudflare-secrets-store@workspace:examples/cloudflare-secrets-store"],
 

--- a/examples/cloudflare-git-artifacts/alchemy.run.ts
+++ b/examples/cloudflare-git-artifacts/alchemy.run.ts
@@ -2,7 +2,7 @@ import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 
-import Api from "./src/Api.ts";
+import Api from "./src/Worker.ts";
 
 export default Alchemy.Stack(
   "CloudflareGitArtifacts",

--- a/examples/cloudflare-git-artifacts/alchemy.run.ts
+++ b/examples/cloudflare-git-artifacts/alchemy.run.ts
@@ -1,0 +1,20 @@
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+
+import Api from "./src/Api.ts";
+
+export default Alchemy.Stack(
+  "CloudflareGitArtifacts",
+  {
+    providers: Cloudflare.providers(),
+    state: Cloudflare.state(),
+  },
+  Effect.gen(function* () {
+    const api = yield* Api;
+
+    return {
+      url: api.url.as<string>(),
+    };
+  }),
+);

--- a/examples/cloudflare-git-artifacts/package.json
+++ b/examples/cloudflare-git-artifacts/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "cloudflare-git-artifacts",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alchemy-run/alchemy-effect"
+  },
+  "type": "module",
+  "scripts": {
+    "deploy": "alchemy deploy",
+    "dev": "alchemy dev",
+    "destroy": "alchemy destroy",
+    "logs": "alchemy logs",
+    "tail": "alchemy tail",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@effect/platform-bun": "catalog:",
+    "@effect/platform-node": "catalog:",
+    "alchemy": "workspace:*",
+    "effect": "catalog:"
+  }
+}

--- a/examples/cloudflare-git-artifacts/src/Api.ts
+++ b/examples/cloudflare-git-artifacts/src/Api.ts
@@ -1,209 +1,129 @@
-import * as Cloudflare from "alchemy/Cloudflare";
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
-import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
-import RepoMetadata from "./RepoMetadata.ts";
-import { Repos } from "./Repos.ts";
+import * as Schema from "effect/Schema";
+import * as HttpApi from "effect/unstable/httpapi/HttpApi";
+import * as HttpApiEndpoint from "effect/unstable/httpapi/HttpApiEndpoint";
+import * as HttpApiGroup from "effect/unstable/httpapi/HttpApiGroup";
+import * as HttpApiSchema from "effect/unstable/httpapi/HttpApiSchema";
 
-export default class Api extends Cloudflare.Worker<Api>()(
-  "Api",
-  {
-    main: import.meta.path,
-    observability: { enabled: true },
-  },
-  Effect.gen(function* () {
-    const repos = yield* Cloudflare.Artifacts.bind(Repos);
-    const metadata = yield* RepoMetadata;
+// ─── Domain types ────────────────────────────────────────────────────
 
-    return {
-      fetch: Effect.gen(function* () {
-        const request = yield* HttpServerRequest;
-        const url = new URL(request.url, "http://x");
-        const parts = url.pathname.split("/").filter(Boolean);
+export class Metadata extends Schema.Class<Metadata>("Metadata")({
+  description: Schema.String,
+  topics: Schema.Array(Schema.String),
+  stars: Schema.Number,
+  createdAt: Schema.Number,
+}) {}
 
-        // POST /repos — create a repo + init metadata
-        if (
-          parts[0] === "repos" &&
-          parts.length === 1 &&
-          request.method === "POST"
-        ) {
-          const body = JSON.parse((yield* request.text) || "{}") as {
-            name?: string;
-            description?: string;
-          };
-          const name = body.name?.trim();
-          if (!name) {
-            return yield* HttpServerResponse.json(
-              { error: "name is required" },
-              { status: 400 },
-            );
-          }
-          return yield* repos
-            .create(name, {
-              description: body.description,
-              setDefaultBranch: "main",
-            })
-            .pipe(
-              Effect.tap((created) =>
-                metadata
-                  .getByName(created.name)
-                  .init(body.description ?? "")
-                  .pipe(Effect.orDie),
-              ),
-              Effect.flatMap((created) =>
-                HttpServerResponse.json({
-                  name: created.name,
-                  remote: created.remote,
-                  token: created.token,
-                  tokenExpiresAt: created.tokenExpiresAt,
-                  defaultBranch: created.defaultBranch,
-                }),
-              ),
-              Effect.catchTag("ArtifactsError", (err) =>
-                HttpServerResponse.json(
-                  { error: err.message },
-                  { status: 409 },
-                ),
-              ),
-            );
-        }
+export class RepoInfo extends Schema.Class<RepoInfo>("RepoInfo")({
+  id: Schema.String,
+  name: Schema.String,
+  description: Schema.NullOr(Schema.String),
+  defaultBranch: Schema.String,
+  remote: Schema.String,
+  status: Schema.String,
+  readOnly: Schema.Boolean,
+  createdAt: Schema.String,
+  updatedAt: Schema.String,
+  lastPushAt: Schema.NullOr(Schema.String),
+  metadata: Schema.NullOr(Metadata),
+}) {}
 
-        // GET /repos — list repos
-        if (
-          parts[0] === "repos" &&
-          parts.length === 1 &&
-          request.method === "GET"
-        ) {
-          return yield* repos.list({ limit: 50 }).pipe(
-            Effect.flatMap((list) => HttpServerResponse.json(list)),
-            Effect.catchTag("ArtifactsError", (err) =>
-              HttpServerResponse.json(
-                { error: err.message },
-                { status: 500 },
-              ),
-            ),
-          );
-        }
+export class CreateRepoResponse extends Schema.Class<CreateRepoResponse>(
+  "CreateRepoResponse",
+)({
+  name: Schema.String,
+  remote: Schema.String,
+  token: Schema.String,
+  defaultBranch: Schema.String,
+}) {}
 
-        // GET /repos/:name — combined Artifacts info (from list) + DO metadata.
-        // `repos.get(name).raw` is an opaque RPC stub (no enumerable fields), so
-        // we look the repo up via `list()` to get a serialisable POJO.
-        if (
-          parts[0] === "repos" &&
-          parts.length === 2 &&
-          request.method === "GET"
-        ) {
-          const name = parts[1]!;
-          return yield* repos.list({ limit: 100 }).pipe(
-            Effect.flatMap((list) => {
-              const found = list.repos.find((r) => r.name === name);
-              if (!found) {
-                return HttpServerResponse.json(
-                  { name, error: "not found" },
-                  { status: 404 },
-                );
-              }
-              return metadata
-                .getByName(name)
-                .get()
-                .pipe(
-                  Effect.catch(() => Effect.succeed(null)),
-                  Effect.flatMap((meta) =>
-                    HttpServerResponse.json({ ...found, metadata: meta }),
-                  ),
-                );
-            }),
-            Effect.catchTag("ArtifactsError", (err) =>
-              HttpServerResponse.json(
-                { name, error: err.message },
-                { status: 500 },
-              ),
-            ),
-          );
-        }
+export class CloneToken extends Schema.Class<CloneToken>("CloneToken")({
+  id: Schema.String,
+  plaintext: Schema.String,
+  scope: Schema.Literals(["read", "write"]),
+  expiresAt: Schema.String,
+}) {}
 
-        // PATCH /repos/:name — update description / topics on the DO
-        if (
-          parts[0] === "repos" &&
-          parts.length === 2 &&
-          request.method === "PATCH"
-        ) {
-          const name = parts[1]!;
-          const patch = JSON.parse((yield* request.text) || "{}") as {
-            description?: string;
-            topics?: string[];
-          };
-          const meta = yield* metadata
-            .getByName(name)
-            .update(patch)
-            .pipe(Effect.orDie);
-          return yield* HttpServerResponse.json(meta);
-        }
+// ─── Errors ─────────────────────────────────────────────────────────
 
-        // DELETE /repos/:name — delete repo
-        if (
-          parts[0] === "repos" &&
-          parts.length === 2 &&
-          request.method === "DELETE"
-        ) {
-          const name = parts[1]!;
-          return yield* repos.delete(name).pipe(
-            Effect.map(() => HttpServerResponse.empty({ status: 204 })),
-            Effect.catchTag("ArtifactsError", (err) =>
-              HttpServerResponse.json(
-                { name, error: err.message },
-                { status: 404 },
-              ),
-            ),
-          );
-        }
-
-        // POST /repos/:name/star — bump star count on the DO
-        if (
-          parts[0] === "repos" &&
-          parts[2] === "star" &&
-          request.method === "POST"
-        ) {
-          const meta = yield* metadata
-            .getByName(parts[1]!)
-            .star()
-            .pipe(Effect.orDie);
-          return yield* HttpServerResponse.json(meta);
-        }
-
-        // POST /repos/:name/clone-token — mint a short-lived token
-        if (
-          parts[0] === "repos" &&
-          parts[2] === "clone-token" &&
-          request.method === "POST"
-        ) {
-          const body = JSON.parse((yield* request.text) || "{}") as {
-            scope?: "read" | "write";
-            ttl?: number;
-          };
-          return yield* repos.get(parts[1]!).pipe(
-            Effect.flatMap((repo) =>
-              repo.createToken(body.scope ?? "read", body.ttl ?? 3600),
-            ),
-            Effect.flatMap((token) => HttpServerResponse.json(token)),
-            Effect.catchTag("ArtifactsError", (err) =>
-              HttpServerResponse.json(
-                { error: err.message },
-                { status: 404 },
-              ),
-            ),
-          );
-        }
-
-        return HttpServerResponse.text("Not Found", { status: 404 });
-      }).pipe(
-        Effect.catch(() =>
-          Effect.succeed(
-            HttpServerResponse.text("Internal Server Error", { status: 500 }),
-          ),
-        ),
-      ),
-    };
-  }).pipe(Effect.provide(Layer.mergeAll(Cloudflare.ArtifactsBindingLive))),
+export class RepoNotFound extends Schema.TaggedErrorClass<RepoNotFound>()(
+  "RepoNotFound",
+  { name: Schema.String },
 ) {}
+
+export class RepoConflict extends Schema.TaggedErrorClass<RepoConflict>()(
+  "RepoConflict",
+  { message: Schema.String },
+) {}
+
+// ─── Path / payload schemas ──────────────────────────────────────────
+
+const RepoNameParam = Schema.Struct({ name: Schema.String });
+
+const CreateRepoPayload = Schema.Struct({
+  name: Schema.String,
+  description: Schema.optional(Schema.String),
+});
+
+const UpdateRepoPayload = Schema.Struct({
+  description: Schema.optional(Schema.String),
+  topics: Schema.optional(Schema.Array(Schema.String)),
+});
+
+const CloneTokenPayload = Schema.Struct({
+  scope: Schema.optional(Schema.Literals(["read", "write"])),
+  ttl: Schema.optional(Schema.Number),
+});
+
+// ─── Endpoints ──────────────────────────────────────────────────────
+
+export const createRepo = HttpApiEndpoint.post("createRepo", "/repos", {
+  payload: CreateRepoPayload,
+  success: CreateRepoResponse,
+  error: RepoConflict,
+});
+
+export const getRepo = HttpApiEndpoint.get("getRepo", "/repos/:name", {
+  params: RepoNameParam,
+  success: RepoInfo,
+  error: RepoNotFound,
+});
+
+export const updateRepo = HttpApiEndpoint.patch("updateRepo", "/repos/:name", {
+  params: RepoNameParam,
+  payload: UpdateRepoPayload,
+  success: Metadata,
+  error: RepoNotFound,
+});
+
+export const deleteRepo = HttpApiEndpoint.delete("deleteRepo", "/repos/:name", {
+  params: RepoNameParam,
+  success: HttpApiSchema.NoContent,
+  error: RepoNotFound,
+});
+
+export const starRepo = HttpApiEndpoint.post("starRepo", "/repos/:name/star", {
+  params: RepoNameParam,
+  success: Metadata,
+  error: RepoNotFound,
+});
+
+export const cloneToken = HttpApiEndpoint.post(
+  "cloneToken",
+  "/repos/:name/clone-token",
+  {
+    params: RepoNameParam,
+    payload: CloneTokenPayload,
+    success: CloneToken,
+    error: RepoNotFound,
+  },
+);
+
+export class ReposGroup extends HttpApiGroup.make("repos")
+  .add(createRepo)
+  .add(getRepo)
+  .add(updateRepo)
+  .add(deleteRepo)
+  .add(starRepo)
+  .add(cloneToken) {}
+
+export class RepoApi extends HttpApi.make("RepoApi").add(ReposGroup) {}

--- a/examples/cloudflare-git-artifacts/src/Api.ts
+++ b/examples/cloudflare-git-artifacts/src/Api.ts
@@ -1,0 +1,206 @@
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import RepoMetadata from "./RepoMetadata.ts";
+import { Repos } from "./Repos.ts";
+
+export default class Api extends Cloudflare.Worker<Api>()(
+  "Api",
+  {
+    main: import.meta.path,
+    observability: { enabled: true },
+  },
+  Effect.gen(function* () {
+    const repos = yield* Cloudflare.Artifacts.bind(Repos);
+    const metadata = yield* RepoMetadata;
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://x");
+        const parts = url.pathname.split("/").filter(Boolean);
+
+        // POST /repos — create a repo + init metadata
+        if (
+          parts[0] === "repos" &&
+          parts.length === 1 &&
+          request.method === "POST"
+        ) {
+          const body = JSON.parse((yield* request.text) || "{}") as {
+            name?: string;
+            description?: string;
+          };
+          const name = body.name?.trim();
+          if (!name) {
+            return yield* HttpServerResponse.json(
+              { error: "name is required" },
+              { status: 400 },
+            );
+          }
+          return yield* repos
+            .create(name, {
+              description: body.description,
+              setDefaultBranch: "main",
+            })
+            .pipe(
+              Effect.tap((created) =>
+                metadata
+                  .getByName(created.name)
+                  .init(body.description ?? "")
+                  .pipe(Effect.orDie),
+              ),
+              Effect.flatMap((created) =>
+                HttpServerResponse.json({
+                  name: created.name,
+                  remote: created.remote,
+                  token: created.token,
+                  tokenExpiresAt: created.tokenExpiresAt,
+                  defaultBranch: created.defaultBranch,
+                }),
+              ),
+              Effect.catchTag("ArtifactsError", (err) =>
+                HttpServerResponse.json(
+                  { error: err.message },
+                  { status: 409 },
+                ),
+              ),
+            );
+        }
+
+        // GET /repos — list repos
+        if (
+          parts[0] === "repos" &&
+          parts.length === 1 &&
+          request.method === "GET"
+        ) {
+          return yield* repos.list({ limit: 50 }).pipe(
+            Effect.flatMap((list) => HttpServerResponse.json(list)),
+            Effect.catchTag("ArtifactsError", (err) =>
+              HttpServerResponse.json(
+                { error: err.message },
+                { status: 500 },
+              ),
+            ),
+          );
+        }
+
+        // GET /repos/:name — combined Artifacts + DO info
+        if (
+          parts[0] === "repos" &&
+          parts.length === 2 &&
+          request.method === "GET"
+        ) {
+          const name = parts[1]!;
+          return yield* repos.get(name).pipe(
+            Effect.flatMap((repo) =>
+              metadata
+                .getByName(name)
+                .get()
+                .pipe(
+                  Effect.catch(() => Effect.succeed(null)),
+                  Effect.flatMap((meta) =>
+                    HttpServerResponse.json({
+                      name: repo.raw.name,
+                      remote: repo.raw.remote,
+                      defaultBranch: repo.raw.defaultBranch,
+                      lastPushAt: repo.raw.lastPushAt,
+                      metadata: meta,
+                    }),
+                  ),
+                ),
+            ),
+            Effect.catchTag("ArtifactsError", (err) =>
+              HttpServerResponse.json(
+                { name, error: err.message },
+                { status: 404 },
+              ),
+            ),
+          );
+        }
+
+        // PATCH /repos/:name — update description / topics on the DO
+        if (
+          parts[0] === "repos" &&
+          parts.length === 2 &&
+          request.method === "PATCH"
+        ) {
+          const name = parts[1]!;
+          const patch = JSON.parse((yield* request.text) || "{}") as {
+            description?: string;
+            topics?: string[];
+          };
+          const meta = yield* metadata
+            .getByName(name)
+            .update(patch)
+            .pipe(Effect.orDie);
+          return yield* HttpServerResponse.json(meta);
+        }
+
+        // DELETE /repos/:name — delete repo
+        if (
+          parts[0] === "repos" &&
+          parts.length === 2 &&
+          request.method === "DELETE"
+        ) {
+          const name = parts[1]!;
+          return yield* repos.delete(name).pipe(
+            Effect.map(() => HttpServerResponse.empty({ status: 204 })),
+            Effect.catchTag("ArtifactsError", (err) =>
+              HttpServerResponse.json(
+                { name, error: err.message },
+                { status: 404 },
+              ),
+            ),
+          );
+        }
+
+        // POST /repos/:name/star — bump star count on the DO
+        if (
+          parts[0] === "repos" &&
+          parts[2] === "star" &&
+          request.method === "POST"
+        ) {
+          const meta = yield* metadata
+            .getByName(parts[1]!)
+            .star()
+            .pipe(Effect.orDie);
+          return yield* HttpServerResponse.json(meta);
+        }
+
+        // POST /repos/:name/clone-token — mint a short-lived token
+        if (
+          parts[0] === "repos" &&
+          parts[2] === "clone-token" &&
+          request.method === "POST"
+        ) {
+          const body = JSON.parse((yield* request.text) || "{}") as {
+            scope?: "read" | "write";
+            ttl?: number;
+          };
+          return yield* repos.get(parts[1]!).pipe(
+            Effect.flatMap((repo) =>
+              repo.createToken(body.scope ?? "read", body.ttl ?? 3600),
+            ),
+            Effect.flatMap((token) => HttpServerResponse.json(token)),
+            Effect.catchTag("ArtifactsError", (err) =>
+              HttpServerResponse.json(
+                { error: err.message },
+                { status: 404 },
+              ),
+            ),
+          );
+        }
+
+        return HttpServerResponse.text("Not Found", { status: 404 });
+      }).pipe(
+        Effect.catch(() =>
+          Effect.succeed(
+            HttpServerResponse.text("Internal Server Error", { status: 500 }),
+          ),
+        ),
+      ),
+    };
+  }).pipe(Effect.provide(Layer.mergeAll(Cloudflare.ArtifactsBindingLive))),
+) {}

--- a/examples/cloudflare-git-artifacts/src/Api.ts
+++ b/examples/cloudflare-git-artifacts/src/Api.ts
@@ -86,35 +86,38 @@ export default class Api extends Cloudflare.Worker<Api>()(
           );
         }
 
-        // GET /repos/:name — combined Artifacts + DO info
+        // GET /repos/:name — combined Artifacts info (from list) + DO metadata.
+        // `repos.get(name).raw` is an opaque RPC stub (no enumerable fields), so
+        // we look the repo up via `list()` to get a serialisable POJO.
         if (
           parts[0] === "repos" &&
           parts.length === 2 &&
           request.method === "GET"
         ) {
           const name = parts[1]!;
-          return yield* repos.get(name).pipe(
-            Effect.flatMap((repo) =>
-              metadata
+          return yield* repos.list({ limit: 100 }).pipe(
+            Effect.flatMap((list) => {
+              const found = list.repos.find((r) => r.name === name);
+              if (!found) {
+                return HttpServerResponse.json(
+                  { name, error: "not found" },
+                  { status: 404 },
+                );
+              }
+              return metadata
                 .getByName(name)
                 .get()
                 .pipe(
                   Effect.catch(() => Effect.succeed(null)),
                   Effect.flatMap((meta) =>
-                    HttpServerResponse.json({
-                      name: repo.raw.name,
-                      remote: repo.raw.remote,
-                      defaultBranch: repo.raw.defaultBranch,
-                      lastPushAt: repo.raw.lastPushAt,
-                      metadata: meta,
-                    }),
+                    HttpServerResponse.json({ ...found, metadata: meta }),
                   ),
-                ),
-            ),
+                );
+            }),
             Effect.catchTag("ArtifactsError", (err) =>
               HttpServerResponse.json(
                 { name, error: err.message },
-                { status: 404 },
+                { status: 500 },
               ),
             ),
           );

--- a/examples/cloudflare-git-artifacts/src/Repo.ts
+++ b/examples/cloudflare-git-artifacts/src/Repo.ts
@@ -8,8 +8,8 @@ export type Metadata = {
   createdAt: number;
 };
 
-export default class RepoMetadata extends Cloudflare.DurableObjectNamespace<RepoMetadata>()(
-  "RepoMetadata",
+export default class Repo extends Cloudflare.DurableObjectNamespace<Repo>()(
+  "Repo",
   Effect.gen(function* () {
     return Effect.gen(function* () {
       const state = yield* Cloudflare.DurableObjectState;

--- a/examples/cloudflare-git-artifacts/src/RepoMetadata.ts
+++ b/examples/cloudflare-git-artifacts/src/RepoMetadata.ts
@@ -1,0 +1,56 @@
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+
+export type Metadata = {
+  description: string;
+  topics: string[];
+  stars: number;
+  createdAt: number;
+};
+
+export default class RepoMetadata extends Cloudflare.DurableObjectNamespace<RepoMetadata>()(
+  "RepoMetadata",
+  Effect.gen(function* () {
+    return Effect.gen(function* () {
+      const state = yield* Cloudflare.DurableObjectState;
+      let meta = (yield* state.storage.get<Metadata>("meta")) ?? null;
+
+      const ensure = Effect.gen(function* () {
+        if (meta === null) {
+          return yield* Effect.fail(new Error("repo not initialized"));
+        }
+        return meta;
+      });
+
+      return {
+        init: (description: string) =>
+          Effect.gen(function* () {
+            if (meta !== null) return meta;
+            meta = {
+              description,
+              topics: [],
+              stars: 0,
+              createdAt: Date.now(),
+            };
+            yield* state.storage.put("meta", meta);
+            return meta;
+          }),
+        get: () => ensure,
+        update: (patch: Partial<Pick<Metadata, "description" | "topics">>) =>
+          Effect.gen(function* () {
+            const current = yield* ensure;
+            meta = { ...current, ...patch };
+            yield* state.storage.put("meta", meta);
+            return meta;
+          }),
+        star: () =>
+          Effect.gen(function* () {
+            const current = yield* ensure;
+            meta = { ...current, stars: current.stars + 1 };
+            yield* state.storage.put("meta", meta);
+            return meta;
+          }),
+      };
+    });
+  }),
+) {}

--- a/examples/cloudflare-git-artifacts/src/Repos.ts
+++ b/examples/cloudflare-git-artifacts/src/Repos.ts
@@ -1,0 +1,3 @@
+import * as Cloudflare from "alchemy/Cloudflare";
+
+export const Repos = Cloudflare.Artifacts("Repos");

--- a/examples/cloudflare-git-artifacts/src/Worker.ts
+++ b/examples/cloudflare-git-artifacts/src/Worker.ts
@@ -6,14 +6,6 @@ import * as Etag from "effect/unstable/http/Etag";
 import * as HttpPlatform from "effect/unstable/http/HttpPlatform";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
-
-// Workers don't have a FileSystem, so HttpPlatform's file-response surface
-// is stubbed. The repo API never serves files.
-const HttpPlatformStub = Layer.succeed(HttpPlatform.HttpPlatform, {
-  fileResponse: () => Effect.die("HttpPlatform.fileResponse not supported"),
-  fileWebResponse: () =>
-    Effect.die("HttpPlatform.fileWebResponse not supported"),
-});
 import {
   CloneToken,
   CreateRepoResponse,
@@ -23,8 +15,16 @@ import {
   RepoInfo,
   RepoNotFound,
 } from "./Api.ts";
-import RepoMetadata from "./RepoMetadata.ts";
+import Repo from "./Repo.ts";
 import { Repos } from "./Repos.ts";
+
+// Workers don't have a FileSystem, so HttpPlatform's file-response surface
+// is stubbed. The repo API never serves files.
+const HttpPlatformStub = Layer.succeed(HttpPlatform.HttpPlatform, {
+  fileResponse: () => Effect.die("HttpPlatform.fileResponse not supported"),
+  fileWebResponse: () =>
+    Effect.die("HttpPlatform.fileWebResponse not supported"),
+});
 
 export default class Worker extends Cloudflare.Worker<Worker>()(
   "Api",
@@ -37,13 +37,15 @@ export default class Worker extends Cloudflare.Worker<Worker>()(
     },
   },
   Effect.gen(function* () {
-    const repos = yield* Cloudflare.Artifacts.bind(Repos);
-    const metadata = yield* RepoMetadata;
+    const artifacts = yield* Cloudflare.Artifacts.bind(Repos);
+    const repos = yield* Repo;
 
     const findRepo = (name: string) =>
-      repos.list({ limit: 100 }).pipe(
+      artifacts.list({ limit: 100 }).pipe(
         Effect.flatMap((res) => {
-          const found = res.repos.find((r: { name: string }) => r.name === name);
+          const found = res.repos.find(
+            (r: { name: string }) => r.name === name,
+          );
           return found
             ? Effect.succeed(found)
             : Effect.fail(new RepoNotFound({ name }));
@@ -56,14 +58,14 @@ export default class Worker extends Cloudflare.Worker<Worker>()(
     const handlers = HttpApiBuilder.group(RepoApi, "repos", (h) =>
       h
         .handle("createRepo", ({ payload }) =>
-          repos
+          artifacts
             .create(payload.name, {
               description: payload.description,
               setDefaultBranch: "main",
             })
             .pipe(
               Effect.tap(() =>
-                metadata
+                repos
                   .getByName(payload.name)
                   .init(payload.description ?? "")
                   .pipe(Effect.orDie),
@@ -85,7 +87,7 @@ export default class Worker extends Cloudflare.Worker<Worker>()(
         .handle("getRepo", ({ params }) =>
           findRepo(params.name).pipe(
             Effect.flatMap((found) =>
-              metadata
+              repos
                 .getByName(params.name)
                 .get()
                 .pipe(
@@ -113,7 +115,7 @@ export default class Worker extends Cloudflare.Worker<Worker>()(
         .handle("updateRepo", ({ params, payload }) =>
           findRepo(params.name).pipe(
             Effect.flatMap(() =>
-              metadata
+              repos
                 .getByName(params.name)
                 .update({
                   description: payload.description,
@@ -125,7 +127,7 @@ export default class Worker extends Cloudflare.Worker<Worker>()(
           ),
         )
         .handle("deleteRepo", ({ params }) =>
-          repos.delete(params.name).pipe(
+          artifacts.delete(params.name).pipe(
             Effect.asVoid,
             Effect.catchTag("ArtifactsError", () =>
               Effect.fail(new RepoNotFound({ name: params.name })),
@@ -135,15 +137,15 @@ export default class Worker extends Cloudflare.Worker<Worker>()(
         .handle("starRepo", ({ params }) =>
           findRepo(params.name).pipe(
             Effect.flatMap(() =>
-              metadata.getByName(params.name).star().pipe(Effect.orDie),
+              repos.getByName(params.name).star().pipe(Effect.orDie),
             ),
             Effect.map((m) => new Metadata(m)),
           ),
         )
         .handle("cloneToken", ({ params, payload }) =>
-          repos.get(params.name).pipe(
-            Effect.flatMap((repo) =>
-              repo.createToken(payload.scope ?? "read", payload.ttl ?? 3600),
+          artifacts.get(params.name).pipe(
+            Effect.flatMap((handle) =>
+              handle.createToken(payload.scope ?? "read", payload.ttl ?? 3600),
             ),
             Effect.map(
               (t) =>

--- a/examples/cloudflare-git-artifacts/src/Worker.ts
+++ b/examples/cloudflare-git-artifacts/src/Worker.ts
@@ -1,0 +1,172 @@
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Etag from "effect/unstable/http/Etag";
+import * as HttpPlatform from "effect/unstable/http/HttpPlatform";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
+
+// Workers don't have a FileSystem, so HttpPlatform's file-response surface
+// is stubbed. The repo API never serves files.
+const HttpPlatformStub = Layer.succeed(HttpPlatform.HttpPlatform, {
+  fileResponse: () => Effect.die("HttpPlatform.fileResponse not supported"),
+  fileWebResponse: () =>
+    Effect.die("HttpPlatform.fileWebResponse not supported"),
+});
+import {
+  CloneToken,
+  CreateRepoResponse,
+  Metadata,
+  RepoApi,
+  RepoConflict,
+  RepoInfo,
+  RepoNotFound,
+} from "./Api.ts";
+import RepoMetadata from "./RepoMetadata.ts";
+import { Repos } from "./Repos.ts";
+
+export default class Worker extends Cloudflare.Worker<Worker>()(
+  "Api",
+  {
+    main: import.meta.path,
+    observability: { enabled: true },
+    compatibility: {
+      flags: ["nodejs_compat"],
+      date: "2026-03-17",
+    },
+  },
+  Effect.gen(function* () {
+    const repos = yield* Cloudflare.Artifacts.bind(Repos);
+    const metadata = yield* RepoMetadata;
+
+    const findRepo = (name: string) =>
+      repos.list({ limit: 100 }).pipe(
+        Effect.flatMap((res) => {
+          const found = res.repos.find((r: { name: string }) => r.name === name);
+          return found
+            ? Effect.succeed(found)
+            : Effect.fail(new RepoNotFound({ name }));
+        }),
+        Effect.catchTag("ArtifactsError", () =>
+          Effect.fail(new RepoNotFound({ name })),
+        ),
+      );
+
+    const handlers = HttpApiBuilder.group(RepoApi, "repos", (h) =>
+      h
+        .handle("createRepo", ({ payload }) =>
+          repos
+            .create(payload.name, {
+              description: payload.description,
+              setDefaultBranch: "main",
+            })
+            .pipe(
+              Effect.tap(() =>
+                metadata
+                  .getByName(payload.name)
+                  .init(payload.description ?? "")
+                  .pipe(Effect.orDie),
+              ),
+              Effect.map(
+                (c) =>
+                  new CreateRepoResponse({
+                    name: c.name,
+                    remote: c.remote,
+                    token: c.token,
+                    defaultBranch: c.defaultBranch,
+                  }),
+              ),
+              Effect.catchTag("ArtifactsError", (err) =>
+                Effect.fail(new RepoConflict({ message: err.message })),
+              ),
+            ),
+        )
+        .handle("getRepo", ({ params }) =>
+          findRepo(params.name).pipe(
+            Effect.flatMap((found) =>
+              metadata
+                .getByName(params.name)
+                .get()
+                .pipe(
+                  Effect.catch(() => Effect.succeed(null)),
+                  Effect.map(
+                    (meta) =>
+                      new RepoInfo({
+                        id: found.id,
+                        name: found.name,
+                        description: found.description ?? null,
+                        defaultBranch: found.defaultBranch,
+                        remote: found.remote,
+                        status: found.status,
+                        readOnly: found.readOnly,
+                        createdAt: found.createdAt,
+                        updatedAt: found.updatedAt,
+                        lastPushAt: found.lastPushAt ?? null,
+                        metadata: meta ? new Metadata(meta) : null,
+                      }),
+                  ),
+                ),
+            ),
+          ),
+        )
+        .handle("updateRepo", ({ params, payload }) =>
+          findRepo(params.name).pipe(
+            Effect.flatMap(() =>
+              metadata
+                .getByName(params.name)
+                .update({
+                  description: payload.description,
+                  topics: payload.topics ? [...payload.topics] : undefined,
+                })
+                .pipe(Effect.orDie),
+            ),
+            Effect.map((m) => new Metadata(m)),
+          ),
+        )
+        .handle("deleteRepo", ({ params }) =>
+          repos.delete(params.name).pipe(
+            Effect.asVoid,
+            Effect.catchTag("ArtifactsError", () =>
+              Effect.fail(new RepoNotFound({ name: params.name })),
+            ),
+          ),
+        )
+        .handle("starRepo", ({ params }) =>
+          findRepo(params.name).pipe(
+            Effect.flatMap(() =>
+              metadata.getByName(params.name).star().pipe(Effect.orDie),
+            ),
+            Effect.map((m) => new Metadata(m)),
+          ),
+        )
+        .handle("cloneToken", ({ params, payload }) =>
+          repos.get(params.name).pipe(
+            Effect.flatMap((repo) =>
+              repo.createToken(payload.scope ?? "read", payload.ttl ?? 3600),
+            ),
+            Effect.map(
+              (t) =>
+                new CloneToken({
+                  id: t.id,
+                  plaintext: t.plaintext,
+                  scope: t.scope as "read" | "write",
+                  expiresAt: t.expiresAt,
+                }),
+            ),
+            Effect.catchTag("ArtifactsError", () =>
+              Effect.fail(new RepoNotFound({ name: params.name })),
+            ),
+          ),
+        ),
+    );
+
+    return {
+      fetch: HttpApiBuilder.layer(RepoApi).pipe(
+        Layer.provide(handlers),
+        Layer.provide([Etag.layer, HttpPlatformStub, Path.layer]),
+        HttpRouter.toHttpEffect,
+      ),
+    };
+  }).pipe(Effect.provide(Layer.mergeAll(Cloudflare.ArtifactsBindingLive))),
+) {}

--- a/examples/cloudflare-git-artifacts/test/integ.test.ts
+++ b/examples/cloudflare-git-artifacts/test/integ.test.ts
@@ -2,8 +2,8 @@ import * as Cloudflare from "alchemy/Cloudflare";
 import * as Test from "alchemy/Test/Bun";
 import { expect } from "bun:test";
 import * as Effect from "effect/Effect";
-import * as HttpBody from "effect/unstable/http/HttpBody";
-import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
+import { RepoApi } from "../src/Api.ts";
 import Stack from "../alchemy.run.ts";
 
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
@@ -12,56 +12,49 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
 });
 
 const stack = beforeAll(deploy(Stack));
-
 afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
 
 const repoName = `tutorial-${Date.now().toString(36)}`;
 
 test(
-  "create + star + patch + read combined",
+  "repo lifecycle",
   Effect.gen(function* () {
     const { url } = yield* stack;
+    const client = yield* HttpApiClient.make(RepoApi, { baseUrl: url });
 
-    const created = yield* HttpClient.post(`${url}/repos`, {
-      body: yield* HttpBody.json({
-        name: repoName,
-        description: "tutorial repo",
-      }),
-    }).pipe(Effect.flatMap((res) => res.json));
-    expect((created as any).name).toBe(repoName);
-    expect((created as any).remote).toBeString();
-    expect((created as any).token).toBeString();
-
-    const starred = yield* HttpClient.post(
-      `${url}/repos/${repoName}/star`,
-    ).pipe(Effect.flatMap((res) => res.json));
-    expect((starred as any).stars).toBe(1);
-
-    yield* HttpClient.patch(`${url}/repos/${repoName}`, {
-      body: yield* HttpBody.json({
-        description: "now with stars",
-        topics: ["demo", "alchemy"],
-      }),
+    const created = yield* client.repos.createRepo({
+      payload: { name: repoName, description: "tutorial repo" },
     });
+    expect(created.name).toBe(repoName);
+    expect(created.remote).toBeString();
+    expect(created.token).toBeString();
 
-    const info = yield* HttpClient.get(`${url}/repos/${repoName}`).pipe(
-      Effect.flatMap((res) => res.json),
-    );
-    expect((info as any).name).toBe(repoName);
-    expect((info as any).metadata.description).toBe("now with stars");
-    expect((info as any).metadata.topics).toEqual(["demo", "alchemy"]);
-    expect((info as any).metadata.stars).toBe(1);
+    const info = yield* client.repos.getRepo({ params: { name: repoName } });
+    expect(info.name).toBe(repoName);
+    expect(info.defaultBranch).toBe("main");
+    expect(info.metadata?.description).toBe("tutorial repo");
+    expect(info.metadata?.stars).toBe(0);
 
-    const token = yield* HttpClient.post(
-      `${url}/repos/${repoName}/clone-token`,
-      {
-        body: yield* HttpBody.json({ scope: "read", ttl: 600 }),
-      },
-    ).pipe(Effect.flatMap((res) => res.json));
-    expect((token as any).plaintext).toBeString();
-    expect((token as any).scope).toBe("read");
+    const token = yield* client.repos.cloneToken({
+      params: { name: repoName },
+      payload: { scope: "read", ttl: 600 },
+    });
+    expect(token.plaintext).toBeString();
+    expect(token.scope).toBe("read");
 
-    yield* HttpClient.del(`${url}/repos/${repoName}`);
+    const updated = yield* client.repos.updateRepo({
+      params: { name: repoName },
+      payload: { description: "now with stars", topics: ["demo", "alchemy"] },
+    });
+    expect(updated.description).toBe("now with stars");
+    expect(updated.topics).toEqual(["demo", "alchemy"]);
+
+    const starred = yield* client.repos.starRepo({
+      params: { name: repoName },
+    });
+    expect(starred.stars).toBe(1);
+
+    yield* client.repos.deleteRepo({ params: { name: repoName } });
   }),
   { timeout: 120_000 },
 );

--- a/examples/cloudflare-git-artifacts/test/integ.test.ts
+++ b/examples/cloudflare-git-artifacts/test/integ.test.ts
@@ -2,6 +2,8 @@ import * as Cloudflare from "alchemy/Cloudflare";
 import * as Test from "alchemy/Test/Bun";
 import { expect } from "bun:test";
 import * as Effect from "effect/Effect";
+import * as HttpBody from "effect/unstable/http/HttpBody";
+import * as HttpClient from "effect/unstable/http/HttpClient";
 import Stack from "../alchemy.run.ts";
 
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
@@ -20,58 +22,46 @@ test(
   Effect.gen(function* () {
     const { url } = yield* stack;
 
-    const created = yield* Effect.tryPromise(() =>
-      fetch(`${url}/repos`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          name: repoName,
-          description: "tutorial repo",
-        }),
-      }).then((r) => r.json()),
-    );
-    expect(created.name).toBe(repoName);
-    expect(created.remote).toBeString();
-    expect(created.token).toBeString();
-
-    const starred = yield* Effect.tryPromise(() =>
-      fetch(`${url}/repos/${repoName}/star`, { method: "POST" }).then((r) =>
-        r.json(),
-      ),
-    );
-    expect(starred.stars).toBe(1);
-
-    yield* Effect.tryPromise(() =>
-      fetch(`${url}/repos/${repoName}`, {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          description: "now with stars",
-          topics: ["demo", "alchemy"],
-        }),
+    const created = yield* HttpClient.post(`${url}/repos`, {
+      body: yield* HttpBody.json({
+        name: repoName,
+        description: "tutorial repo",
       }),
-    );
+    }).pipe(Effect.flatMap((res) => res.json));
+    expect((created as any).name).toBe(repoName);
+    expect((created as any).remote).toBeString();
+    expect((created as any).token).toBeString();
 
-    const info = yield* Effect.tryPromise(() =>
-      fetch(`${url}/repos/${repoName}`).then((r) => r.json()),
-    );
-    expect(info.name).toBe(repoName);
-    expect(info.metadata.description).toBe("now with stars");
-    expect(info.metadata.topics).toEqual(["demo", "alchemy"]);
-    expect(info.metadata.stars).toBe(1);
+    const starred = yield* HttpClient.post(
+      `${url}/repos/${repoName}/star`,
+    ).pipe(Effect.flatMap((res) => res.json));
+    expect((starred as any).stars).toBe(1);
 
-    const token = yield* Effect.tryPromise(() =>
-      fetch(`${url}/repos/${repoName}/clone-token`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ scope: "read", ttl: 600 }),
-      }).then((r) => r.json()),
-    );
-    expect(token.token).toBeString();
+    yield* HttpClient.patch(`${url}/repos/${repoName}`, {
+      body: yield* HttpBody.json({
+        description: "now with stars",
+        topics: ["demo", "alchemy"],
+      }),
+    });
 
-    yield* Effect.tryPromise(() =>
-      fetch(`${url}/repos/${repoName}`, { method: "DELETE" }),
+    const info = yield* HttpClient.get(`${url}/repos/${repoName}`).pipe(
+      Effect.flatMap((res) => res.json),
     );
+    expect((info as any).name).toBe(repoName);
+    expect((info as any).metadata.description).toBe("now with stars");
+    expect((info as any).metadata.topics).toEqual(["demo", "alchemy"]);
+    expect((info as any).metadata.stars).toBe(1);
+
+    const token = yield* HttpClient.post(
+      `${url}/repos/${repoName}/clone-token`,
+      {
+        body: yield* HttpBody.json({ scope: "read", ttl: 600 }),
+      },
+    ).pipe(Effect.flatMap((res) => res.json));
+    expect((token as any).plaintext).toBeString();
+    expect((token as any).scope).toBe("read");
+
+    yield* HttpClient.del(`${url}/repos/${repoName}`);
   }),
   { timeout: 120_000 },
 );

--- a/examples/cloudflare-git-artifacts/test/integ.test.ts
+++ b/examples/cloudflare-git-artifacts/test/integ.test.ts
@@ -1,0 +1,77 @@
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Test from "alchemy/Test/Bun";
+import { expect } from "bun:test";
+import * as Effect from "effect/Effect";
+import Stack from "../alchemy.run.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+  state: Cloudflare.state(),
+});
+
+const stack = beforeAll(deploy(Stack));
+
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
+
+const repoName = `tutorial-${Date.now().toString(36)}`;
+
+test(
+  "create + star + patch + read combined",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+
+    const created = yield* Effect.tryPromise(() =>
+      fetch(`${url}/repos`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: repoName,
+          description: "tutorial repo",
+        }),
+      }).then((r) => r.json()),
+    );
+    expect(created.name).toBe(repoName);
+    expect(created.remote).toBeString();
+    expect(created.token).toBeString();
+
+    const starred = yield* Effect.tryPromise(() =>
+      fetch(`${url}/repos/${repoName}/star`, { method: "POST" }).then((r) =>
+        r.json(),
+      ),
+    );
+    expect(starred.stars).toBe(1);
+
+    yield* Effect.tryPromise(() =>
+      fetch(`${url}/repos/${repoName}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          description: "now with stars",
+          topics: ["demo", "alchemy"],
+        }),
+      }),
+    );
+
+    const info = yield* Effect.tryPromise(() =>
+      fetch(`${url}/repos/${repoName}`).then((r) => r.json()),
+    );
+    expect(info.name).toBe(repoName);
+    expect(info.metadata.description).toBe("now with stars");
+    expect(info.metadata.topics).toEqual(["demo", "alchemy"]);
+    expect(info.metadata.stars).toBe(1);
+
+    const token = yield* Effect.tryPromise(() =>
+      fetch(`${url}/repos/${repoName}/clone-token`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ scope: "read", ttl: 600 }),
+      }).then((r) => r.json()),
+    );
+    expect(token.token).toBeString();
+
+    yield* Effect.tryPromise(() =>
+      fetch(`${url}/repos/${repoName}`, { method: "DELETE" }),
+    );
+  }),
+  { timeout: 120_000 },
+);

--- a/examples/cloudflare-git-artifacts/tsconfig.json
+++ b/examples/cloudflare-git-artifacts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["alchemy.run.ts", "src/**/*.ts", "test/**/*.ts"],
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "target": "ESNext"
+  },
+  "references": [
+    {
+      "path": "../../packages/alchemy/tsconfig.json"
+    }
+  ]
+}

--- a/packages/alchemy/src/Test/Core.ts
+++ b/packages/alchemy/src/Test/Core.ts
@@ -74,8 +74,12 @@ export const toEffect = <A>(
       Effect.provide(Layer.succeed(ConfigProvider, configProvider)),
     );
   }).pipe(
-    Effect.provideService(AuthProviders, {}),
+    // `options.state` (e.g. `Cloudflare.state()`) itself requires
+    // `AuthProviders` to read credentials, so AuthProviders must be provided
+    // AFTER the state layer or the state layer's requirement is never
+    // satisfied — which surfaces as `Service not found: AuthProviders`.
     Effect.provide(options.state ?? State.localState()),
+    Effect.provideService(AuthProviders, {}),
     Effect.provide(Layer.provideMerge(alchemyLayer, platformLayer)),
     Effect.scoped,
   ) as Effect.Effect<A, any, never>;

--- a/website/src/content/docs/tutorial/cloudflare/artifacts.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/artifacts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Build a Git Repo API
-description: Build a mini-GitHub on Cloudflare — Artifacts for Git storage, a Durable Object per repo for metadata, all wired into a Worker.
+description: Build a mini-GitHub on Cloudflare — Artifacts for Git storage, a Durable Object per repo for metadata, fronted by a schema-typed HttpApi.
 sidebar:
   order: 7
 ---
@@ -11,6 +11,11 @@ recognizable: a tiny GitHub. **Cloudflare Artifacts** stores the
 actual Git history (clone, push, pull all work against it), and a
 **Durable Object per repo** holds the metadata you don't want
 inside the repo itself — description, topics, star count.
+
+We'll front the whole thing with Effect's
+[HttpApi](/guides/effect-http-api) so every route is
+schema-validated end-to-end and the integration test can call the
+worker through the same typed client a real consumer would use.
 
 By the end you'll have a Worker that lets a client create a repo,
 `git clone` against it, read combined info, star it, and update
@@ -34,166 +39,419 @@ export const Repos = Cloudflare.Artifacts("Repos");
 ```
 
 That's the whole declaration. The Worker provider will see this
-the moment you `.bind(...)` it.
+the moment we `.bind(...)` it.
 
-## Bind it to the Worker
+## Define the API
 
-`Cloudflare.Artifacts.bind(Repos)` returns an Effect-native client
-whose methods are tagged with `ArtifactsError`. Bind it in the
-Worker's init phase, and provide `ArtifactsBindingLive` so the
-runtime can resolve the underlying binding from `env`:
+The schema and endpoint declarations live outside the Worker so
+the same file can be imported by clients and tests without
+pulling in any runtime code. Start with one endpoint —
+`POST /repos`:
 
-```diff lang="typescript"
+```typescript twoslash
 // src/Api.ts
+import * as Schema from "effect/Schema";
+import * as HttpApi from "effect/unstable/httpapi/HttpApi";
+import * as HttpApiEndpoint from "effect/unstable/httpapi/HttpApiEndpoint";
+import * as HttpApiGroup from "effect/unstable/httpapi/HttpApiGroup";
+
+export class CreateRepoResponse extends Schema.Class<CreateRepoResponse>(
+  "CreateRepoResponse",
+)({
+  name: Schema.String,
+  remote: Schema.String,
+  token: Schema.String,
+  defaultBranch: Schema.String,
+}) {}
+
+export class RepoConflict extends Schema.TaggedErrorClass<RepoConflict>()(
+  "RepoConflict",
+  { message: Schema.String },
+) {}
+
+export const createRepo = HttpApiEndpoint.post("createRepo", "/repos", {
+  payload: Schema.Struct({
+    name: Schema.String,
+    description: Schema.optional(Schema.String),
+  }),
+  success: CreateRepoResponse,
+  error: RepoConflict,
+});
+
+export class ReposGroup extends HttpApiGroup.make("repos").add(createRepo) {}
+
+export class RepoApi extends HttpApi.make("RepoApi").add(ReposGroup) {}
+```
+
+`Schema.Class` gives you a runtime-validated class with an inferred
+TypeScript type. `Schema.TaggedErrorClass` gives you a typed error
+that becomes a discriminated union member on the client.
+
+## Implement the Worker
+
+Create `src/Worker.ts`. The handler group is *constructed* with
+`HttpApiBuilder.group` (pure — safe inside the Worker's Init
+phase), and the `fetch` field is the result of layering the API
+into an `HttpEffect`:
+
+```typescript twoslash
+// @noErrors
+// src/Worker.ts
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
-+import * as Layer from "effect/Layer";
-import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
-import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
-+import { Repos } from "./Repos.ts";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Etag from "effect/unstable/http/Etag";
+import * as HttpPlatform from "effect/unstable/http/HttpPlatform";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
+import { CreateRepoResponse, RepoApi, RepoConflict } from "./Api.ts";
+import { Repos } from "./Repos.ts";
 
-export default class Api extends Cloudflare.Worker<Api>()(
+// Workers don't have a FileSystem, so HttpPlatform's file-response
+// surface is stubbed. The repo API never serves files.
+const HttpPlatformStub = Layer.succeed(HttpPlatform.HttpPlatform, {
+  fileResponse: () => Effect.die("HttpPlatform.fileResponse not supported"),
+  fileWebResponse: () =>
+    Effect.die("HttpPlatform.fileWebResponse not supported"),
+});
+
+export default class Worker extends Cloudflare.Worker<Worker>()(
   "Api",
-  { main: import.meta.path },
+  {
+    main: import.meta.path,
+    compatibility: { flags: ["nodejs_compat"], date: "2026-03-17" },
+  },
   Effect.gen(function* () {
-+   const repos = yield* Cloudflare.Artifacts.bind(Repos);
+    const repos = yield* Cloudflare.Artifacts.bind(Repos);
+
+    const handlers = HttpApiBuilder.group(RepoApi, "repos", (h) =>
+      h.handle("createRepo", ({ payload }) =>
+        repos
+          .create(payload.name, {
+            description: payload.description,
+            setDefaultBranch: "main",
+          })
+          .pipe(
+            Effect.map(
+              (c) =>
+                new CreateRepoResponse({
+                  name: c.name,
+                  remote: c.remote,
+                  token: c.token,
+                  defaultBranch: c.defaultBranch,
+                }),
+            ),
+            Effect.catchTag("ArtifactsError", (err) =>
+              Effect.fail(new RepoConflict({ message: err.message })),
+            ),
+          ),
+      ),
+    );
 
     return {
-      fetch: Effect.gen(function* () {
-        return HttpServerResponse.text("Not Found", { status: 404 });
-      }),
+      fetch: HttpApiBuilder.layer(RepoApi).pipe(
+        Layer.provide(handlers),
+        Layer.provide([Etag.layer, HttpPlatformStub, Path.layer]),
+        HttpRouter.toHttpEffect,
+      ),
     };
-- })
-+ }).pipe(
-+   Effect.provide(Layer.mergeAll(Cloudflare.ArtifactsBindingLive)),
-+ ),
+  }).pipe(Effect.provide(Cloudflare.ArtifactsBindingLive)),
 ) {}
 ```
 
-`repos` is now a typed handle into the Artifacts namespace. Next,
-let's use it.
+The handler returns a `CreateRepoResponse` instance — `Schema.Class`
+expects an actual instance, not a plain object. Errors from
+`repos.create` (the only declared error path) are translated to
+`RepoConflict`; anything else dies and surfaces as a 500.
 
-## Create a repo
+## Set up the integration test
 
-Add a `POST /repos` route that calls `repos.create(name, ...)`.
-The result includes the Git remote URL and a short-lived token
-the client can use to `git clone`:
+Same `Test.make` shape as
+[Add a Durable Object](/tutorial/cloudflare/durable-objects), but
+this time the test calls the worker through `HttpApiClient.make` —
+the same `RepoApi` value drives the typed client:
+
+```typescript
+// test/integ.test.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Test from "alchemy/Test/Bun";
+import { expect } from "bun:test";
+import * as Effect from "effect/Effect";
+import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
+import { RepoApi } from "../src/Api.ts";
+import Stack from "../alchemy.run.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+  state: Cloudflare.state(),
+});
+
+const stack = beforeAll(deploy(Stack));
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
+
+const repoName = `tutorial-${Date.now().toString(36)}`;
+```
+
+Add the first assertion. `client.repos.createRepo` returns
+`Effect<CreateRepoResponse, RepoConflict | HttpClientError>` — fields
+are typed straight from the schema:
 
 ```diff lang="typescript"
-return {
-  fetch: Effect.gen(function* () {
-    const request = yield* HttpServerRequest;
-+   const url = new URL(request.url, "http://x");
-+   const parts = url.pathname.split("/").filter(Boolean);
+const repoName = `tutorial-${Date.now().toString(36)}`;
+
++test(
++  "repo lifecycle",
++  Effect.gen(function* () {
++    const { url } = yield* stack;
++    const client = yield* HttpApiClient.make(RepoApi, { baseUrl: url });
 +
-+   if (parts[0] === "repos" && parts.length === 1 && request.method === "POST") {
-+     const body = JSON.parse((yield* request.text) || "{}") as {
-+       name?: string;
-+       description?: string;
-+     };
-+     const name = body.name?.trim();
-+     if (!name) {
-+       return yield* HttpServerResponse.json(
-+         { error: "name is required" },
-+         { status: 400 },
-+       );
-+     }
-+     const created = yield* repos.create(name, {
-+       description: body.description,
-+       setDefaultBranch: "main",
-+     });
-+     return yield* HttpServerResponse.json({
-+       name: created.name,
-+       remote: created.remote,
-+       token: created.token,
-+       tokenExpiresAt: created.tokenExpiresAt,
-+     });
-+   }
-
-    return HttpServerResponse.text("Not Found", { status: 404 });
-  }),
-};
++    const created = yield* client.repos.createRepo({
++      payload: { name: repoName, description: "tutorial repo" },
++    });
++    expect(created.name).toBe(repoName);
++    expect(created.remote).toBeString();
++    expect(created.token).toBeString();
++  }),
++  { timeout: 120_000 },
++);
 ```
-
-Deploy and try it:
 
 ```sh
-URL=$(bun alchemy stack output url)
-curl -X POST "$URL/repos" \
-  -H "content-type: application/json" \
-  -d '{"name":"hello-world","description":"my first repo"}'
+bun test
 ```
 
-You'll get back a `remote` and a `token`. You can `git clone`
-against them right now.
+Alchemy deploys the Worker, the test posts to `/repos`, and you
+get back a `remote` and `token`. You could `git clone` against
+them right now.
 
 ## Look up an existing repo
 
-`repos.get(name)` returns an `ArtifactsRepoClient` whose `.raw`
-field is the runtime RPC stub — useful for `createToken`, `fork`,
-etc., but **not a serialisable POJO**. To return repo info as JSON,
-use `repos.list(...)` and find the entry by name; every record in
-the list is a plain object with `name`, `remote`, `defaultBranch`,
-`createdAt`, `lastPushAt`, etc.
+`repos.get(name)` returns an opaque RPC stub — useful for
+`createToken` later, but its fields aren't enumerable. To return
+repo info as JSON, use `repos.list(...)` and find the entry by
+name; every record in the list is a plain object.
 
-Add `GET /repos/:name`:
+Add a `RepoInfo` schema and a `getRepo` endpoint to the API:
 
 ```diff lang="typescript"
-+if (parts[0] === "repos" && parts.length === 2 && request.method === "GET") {
-+  const name = parts[1]!;
-+  const list = yield* repos.list({ limit: 100 });
-+  const found = list.repos.find((r) => r.name === name);
-+  if (!found) {
-+    return yield* HttpServerResponse.json(
-+      { name, error: "not found" },
-+      { status: 404 },
-+    );
-+  }
-+  return yield* HttpServerResponse.json(found);
-+}
+// src/Api.ts
+import * as Schema from "effect/Schema";
+import * as HttpApi from "effect/unstable/httpapi/HttpApi";
+import * as HttpApiEndpoint from "effect/unstable/httpapi/HttpApiEndpoint";
+import * as HttpApiGroup from "effect/unstable/httpapi/HttpApiGroup";
+
++export class RepoInfo extends Schema.Class<RepoInfo>("RepoInfo")({
++  id: Schema.String,
++  name: Schema.String,
++  description: Schema.NullOr(Schema.String),
++  defaultBranch: Schema.String,
++  remote: Schema.String,
++  status: Schema.String,
++  readOnly: Schema.Boolean,
++  createdAt: Schema.String,
++  updatedAt: Schema.String,
++  lastPushAt: Schema.NullOr(Schema.String),
++}) {}
+
+export class CreateRepoResponse extends Schema.Class<CreateRepoResponse>(
+  "CreateRepoResponse",
+)({ /* … */ }) {}
+
++export class RepoNotFound extends Schema.TaggedErrorClass<RepoNotFound>()(
++  "RepoNotFound",
++  { name: Schema.String },
++) {}
+
+export class RepoConflict extends Schema.TaggedErrorClass<RepoConflict>()(
+  "RepoConflict",
+  { message: Schema.String },
+) {}
+
+export const createRepo = HttpApiEndpoint.post("createRepo", "/repos", { /* … */ });
+
++export const getRepo = HttpApiEndpoint.get("getRepo", "/repos/:name", {
++  params: Schema.Struct({ name: Schema.String }),
++  success: RepoInfo,
++  error: RepoNotFound,
++});
+
+-export class ReposGroup extends HttpApiGroup.make("repos").add(createRepo) {}
++export class ReposGroup extends HttpApiGroup.make("repos")
++  .add(createRepo)
++  .add(getRepo) {}
+
+export class RepoApi extends HttpApi.make("RepoApi").add(ReposGroup) {}
 ```
 
-Catch `ArtifactsError` once at the bottom of the handler so any
-underlying API failure surfaces consistently:
+Implement the handler in the Worker, and factor out a `findRepo`
+helper since several handlers will need to look up a repo:
 
 ```diff lang="typescript"
-return {
-  fetch: Effect.gen(function* () {
-    // …routes
-- }),
-+ }).pipe(
-+   Effect.catchTag("ArtifactsError", (err) =>
-+     HttpServerResponse.json({ error: err.message }, { status: 500 }),
+// src/Worker.ts — inside Effect.gen
+const repos = yield* Cloudflare.Artifacts.bind(Repos);
+
++const findRepo = (name: string) =>
++  repos.list({ limit: 100 }).pipe(
++    Effect.flatMap((res) => {
++      const found = res.repos.find((r: { name: string }) => r.name === name);
++      return found
++        ? Effect.succeed(found)
++        : Effect.fail(new RepoNotFound({ name }));
++    }),
++    Effect.catchTag("ArtifactsError", () =>
++      Effect.fail(new RepoNotFound({ name })),
++    ),
++  );
+
+const handlers = HttpApiBuilder.group(RepoApi, "repos", (h) =>
+  h
+    .handle("createRepo", ({ payload }) =>
+      // …existing
+    )
++   .handle("getRepo", ({ params }) =>
++     findRepo(params.name).pipe(
++       Effect.map(
++         (found) =>
++           new RepoInfo({
++             id: found.id,
++             name: found.name,
++             description: found.description ?? null,
++             defaultBranch: found.defaultBranch,
++             remote: found.remote,
++             status: found.status,
++             readOnly: found.readOnly,
++             createdAt: found.createdAt,
++             updatedAt: found.updatedAt,
++             lastPushAt: found.lastPushAt ?? null,
++           }),
++       ),
++     ),
 +   ),
-+ ),
-};
+);
+```
+
+Extend the test:
+
+```diff lang="typescript"
+test(
+  "repo lifecycle",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    const client = yield* HttpApiClient.make(RepoApi, { baseUrl: url });
+
+    const created = yield* client.repos.createRepo({
+      payload: { name: repoName, description: "tutorial repo" },
+    });
+    expect(created.name).toBe(repoName);
+    expect(created.remote).toBeString();
+    expect(created.token).toBeString();
++
++   const info = yield* client.repos.getRepo({ params: { name: repoName } });
++   expect(info.name).toBe(repoName);
++   expect(info.defaultBranch).toBe("main");
++   expect(info.description).toBe("tutorial repo");
+  }),
+  { timeout: 120_000 },
+);
+```
+
+```sh
+bun test
 ```
 
 ## Mint a fresh clone token
 
 The token returned by `create` expires. Clients that already know
 a repo's name should be able to ask for a new one without
-recreating the repo. `repo.createToken(scope, ttl)` returns
-`{ id, plaintext, scope, expiresAt }` — the `plaintext` field is
-the actual bearer token used in the clone URL:
+recreating the repo. Add a `cloneToken` endpoint:
 
 ```diff lang="typescript"
-+if (
-+  parts[0] === "repos" &&
-+  parts[2] === "clone-token" &&
-+  request.method === "POST"
-+) {
-+  const body = JSON.parse((yield* request.text) || "{}") as {
-+    scope?: "read" | "write";
-+    ttl?: number;
-+  };
-+  const repo = yield* repos.get(parts[1]!);
-+  const token = yield* repo.createToken(
-+    body.scope ?? "read",
-+    body.ttl ?? 3600,
-+  );
-+  return yield* HttpServerResponse.json(token);
-+}
+// src/Api.ts
++export class CloneToken extends Schema.Class<CloneToken>("CloneToken")({
++  id: Schema.String,
++  plaintext: Schema.String,
++  scope: Schema.Literals(["read", "write"]),
++  expiresAt: Schema.String,
++}) {}
+
+export const getRepo = HttpApiEndpoint.get("getRepo", "/repos/:name", { /* … */ });
+
++export const cloneToken = HttpApiEndpoint.post(
++  "cloneToken",
++  "/repos/:name/clone-token",
++  {
++    params: Schema.Struct({ name: Schema.String }),
++    payload: Schema.Struct({
++      scope: Schema.optional(Schema.Literals(["read", "write"])),
++      ttl: Schema.optional(Schema.Number),
++    }),
++    success: CloneToken,
++    error: RepoNotFound,
++  },
++);
+
+export class ReposGroup extends HttpApiGroup.make("repos")
+  .add(createRepo)
+  .add(getRepo)
++ .add(cloneToken) {}
+```
+
+`repo.createToken(scope, ttl)` on the runtime stub returns
+`{ id, plaintext, scope, expiresAt }` — wrap it in a `CloneToken`
+instance:
+
+```diff lang="typescript"
+.handle("getRepo", ({ params }) => /* … */)
++.handle("cloneToken", ({ params, payload }) =>
++  repos.get(params.name).pipe(
++    Effect.flatMap((repo) =>
++      repo.createToken(payload.scope ?? "read", payload.ttl ?? 3600),
++    ),
++    Effect.map(
++      (t) =>
++        new CloneToken({
++          id: t.id,
++          plaintext: t.plaintext,
++          scope: t.scope as "read" | "write",
++          expiresAt: t.expiresAt,
++        }),
++    ),
++    Effect.catchTag("ArtifactsError", () =>
++      Effect.fail(new RepoNotFound({ name: params.name })),
++    ),
++  ),
++),
+```
+
+```diff lang="typescript"
+test(
+  "repo lifecycle",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    const client = yield* HttpApiClient.make(RepoApi, { baseUrl: url });
+
+    const created = yield* client.repos.createRepo({
+      payload: { name: repoName, description: "tutorial repo" },
+    });
+    expect(created.name).toBe(repoName);
+    expect(created.remote).toBeString();
+    expect(created.token).toBeString();
+
+    const info = yield* client.repos.getRepo({ params: { name: repoName } });
+    expect(info.name).toBe(repoName);
+    expect(info.defaultBranch).toBe("main");
+    expect(info.description).toBe("tutorial repo");
++
++   const token = yield* client.repos.cloneToken({
++     params: { name: repoName },
++     payload: { scope: "read", ttl: 600 },
++   });
++   expect(token.plaintext).toBeString();
++   expect(token.scope).toBe("read");
+  }),
+  { timeout: 120_000 },
+);
 ```
 
 That covers the Git half. Artifacts is now storing history and
@@ -232,7 +490,7 @@ the current metadata out of storage in the inner init so it
 survives restarts and hibernation:
 
 ```diff lang="typescript"
-+export type Metadata = {
++export type Meta = {
 +  description: string;
 +  topics: string[];
 +  stars: number;
@@ -244,15 +502,14 @@ export default class RepoMetadata extends Cloudflare.DurableObjectNamespace<Repo
   Effect.gen(function* () {
     return Effect.gen(function* () {
 +     const state = yield* Cloudflare.DurableObjectState;
-+     let meta = (yield* state.storage.get<Metadata>("meta")) ?? null;
++     let meta = (yield* state.storage.get<Meta>("meta")) ?? null;
       return {};
     });
   }),
 ) {}
 ```
 
-`meta` is `null` until the repo is initialized. The next step
-adds the methods that fill it in and read it back.
+`meta` is `null` until the repo is initialized.
 
 ## Add `init` and `get`
 
@@ -263,7 +520,7 @@ the first time a repo is created, and one to read it:
 ```diff lang="typescript"
 return Effect.gen(function* () {
   const state = yield* Cloudflare.DurableObjectState;
-  let meta = (yield* state.storage.get<Metadata>("meta")) ?? null;
+  let meta = (yield* state.storage.get<Meta>("meta")) ?? null;
 
 + const ensure = Effect.gen(function* () {
 +   if (meta === null) {
@@ -277,12 +534,7 @@ return Effect.gen(function* () {
 +   init: (description: string) =>
 +     Effect.gen(function* () {
 +       if (meta !== null) return meta;
-+       meta = {
-+         description,
-+         topics: [],
-+         stars: 0,
-+         createdAt: Date.now(),
-+       };
++       meta = { description, topics: [], stars: 0, createdAt: Date.now() };
 +       yield* state.storage.put("meta", meta);
 +       return meta;
 +     }),
@@ -291,100 +543,157 @@ return Effect.gen(function* () {
 });
 ```
 
-`init` is idempotent — calling it twice on the same repo doesn't
-overwrite existing metadata. We'll wire it into the create route
-next.
+## Wire the DO into the API
 
-## Wire the DO into the Worker
-
-Yield the `RepoMetadata` class in the Worker's init phase to get a
-namespace handle, then call `getByName(name)` inside `fetch` to
-obtain a typed stub for that repo's instance. Initialize metadata
-on create, and merge it into the GET response:
+Add a `Metadata` schema to `Api.ts` and extend `RepoInfo` with a
+nullable `metadata` field:
 
 ```diff lang="typescript"
 // src/Api.ts
-import * as Cloudflare from "alchemy/Cloudflare";
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
-import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
-+import RepoMetadata from "./RepoMetadata.ts";
-import { Repos } from "./Repos.ts";
++export class Metadata extends Schema.Class<Metadata>("Metadata")({
++  description: Schema.String,
++  topics: Schema.Array(Schema.String),
++  stars: Schema.Number,
++  createdAt: Schema.Number,
++}) {}
 
-export default class Api extends Cloudflare.Worker<Api>()(
-  "Api",
-  { main: import.meta.path },
+export class RepoInfo extends Schema.Class<RepoInfo>("RepoInfo")({
+  id: Schema.String,
+  name: Schema.String,
+  description: Schema.NullOr(Schema.String),
+  defaultBranch: Schema.String,
+  remote: Schema.String,
+  status: Schema.String,
+  readOnly: Schema.Boolean,
+  createdAt: Schema.String,
+  updatedAt: Schema.String,
+  lastPushAt: Schema.NullOr(Schema.String),
++ metadata: Schema.NullOr(Metadata),
+}) {}
+```
+
+Yield the `RepoMetadata` class in the Worker's init phase, then
+update `createRepo` to seed metadata and `getRepo` to merge it in:
+
+```diff lang="typescript"
+// src/Worker.ts
++import RepoMetadata from "./RepoMetadata.ts";
+import {
+  CloneToken,
+  CreateRepoResponse,
++ Metadata,
+  RepoApi,
+  RepoConflict,
+  RepoInfo,
+  RepoNotFound,
+} from "./Api.ts";
+
   Effect.gen(function* () {
     const repos = yield* Cloudflare.Artifacts.bind(Repos);
 +   const metadata = yield* RepoMetadata;
-
-    return {
-      fetch: Effect.gen(function* () {
-        // …
-        if (parts[0] === "repos" && parts.length === 1 && request.method === "POST") {
-          // …existing create
-          const created = yield* repos.create(name, { /* … */ });
-+         yield* metadata.getByName(name).init(body.description ?? "");
-          return yield* HttpServerResponse.json({ /* … */ });
-        }
-
-        if (parts[0] === "repos" && parts.length === 2 && request.method === "GET") {
-          const name = parts[1]!;
-          const repo = yield* repos.get(name);
-+         const meta = yield* metadata.getByName(name).get();
-          return yield* HttpServerResponse.json({
-            name: repo.raw.name,
-            remote: repo.raw.remote,
-            defaultBranch: repo.raw.defaultBranch,
-            lastPushAt: repo.raw.lastPushAt,
-+           ...meta,
-          });
-        }
-        // …
-      }),
-    };
-  }),
-) {}
+    // …findRepo helper
 ```
 
-Two things just happened:
-
-1. **`yield* RepoMetadata`** registers the DO with the Worker
-   (binding + class-migration metadata) and hands you the namespace.
-2. **`metadata.getByName(name)`** returns a typed stub: the Worker
-   sees `init(description: string): Effect<Metadata>` and
-   `get(): Effect<Metadata>` exactly as you defined them.
-
-Each repo name addresses its own durable instance, so writes never
-contend across repos. Combine the metadata into the GET response
-the same way:
+Now extend the handlers — `createRepo` calls `init` after the repo
+is created, `getRepo` reads metadata and merges it:
 
 ```diff lang="typescript"
-if (parts[0] === "repos" && parts.length === 2 && request.method === "GET") {
-  const name = parts[1]!;
-  const list = yield* repos.list({ limit: 100 });
-  const found = list.repos.find((r) => r.name === name);
-  if (!found) { /* 404 */ }
-+ const meta = yield* metadata
-+   .getByName(name)
-+   .get()
-+   .pipe(Effect.catch(() => Effect.succeed(null)));
-- return yield* HttpServerResponse.json(found);
-+ return yield* HttpServerResponse.json({ ...found, metadata: meta });
-}
+.handle("createRepo", ({ payload }) =>
+  repos
+    .create(payload.name, {
+      description: payload.description,
+      setDefaultBranch: "main",
+    })
+    .pipe(
++     Effect.tap(() =>
++       metadata
++         .getByName(payload.name)
++         .init(payload.description ?? "")
++         .pipe(Effect.orDie),
++     ),
+      Effect.map(
+        (c) =>
+          new CreateRepoResponse({
+            name: c.name,
+            remote: c.remote,
+            token: c.token,
+            defaultBranch: c.defaultBranch,
+          }),
+      ),
+      Effect.catchTag("ArtifactsError", (err) =>
+        Effect.fail(new RepoConflict({ message: err.message })),
+      ),
+    ),
+)
+.handle("getRepo", ({ params }) =>
+  findRepo(params.name).pipe(
++   Effect.flatMap((found) =>
++     metadata
++       .getByName(params.name)
++       .get()
++       .pipe(
++         Effect.catch(() => Effect.succeed(null)),
++         Effect.map((m) => ({ found, meta: m })),
++       ),
++   ),
+-   Effect.map(
+-     (found) =>
+-       new RepoInfo({
++   Effect.map(
++     ({ found, meta }) =>
++       new RepoInfo({
+          id: found.id,
+          name: found.name,
+          description: found.description ?? null,
+          defaultBranch: found.defaultBranch,
+          remote: found.remote,
+          status: found.status,
+          readOnly: found.readOnly,
+          createdAt: found.createdAt,
+          updatedAt: found.updatedAt,
+          lastPushAt: found.lastPushAt ?? null,
++         metadata: meta ? new Metadata(meta) : null,
+        }),
+    ),
+  ),
+),
+```
+
+The DO's `get()` fails with a plain `Error` when the repo wasn't
+initialised — recover with `Effect.catch` so the route still
+returns the Artifacts info even if the DO has no metadata yet.
+
+Update the test — `info.metadata` is now typed as
+`Metadata | null`:
+
+```diff lang="typescript"
+const info = yield* client.repos.getRepo({ params: { name: repoName } });
+expect(info.name).toBe(repoName);
+expect(info.defaultBranch).toBe("main");
+expect(info.description).toBe("tutorial repo");
++expect(info.metadata?.description).toBe("tutorial repo");
++expect(info.metadata?.stars).toBe(0);
+```
+
+```sh
+bun test
 ```
 
 ## Update description and topics
 
-Add an `update` method to the DO that merges a partial patch into
-the stored metadata:
+Add an `update` method to the DO:
 
 ```diff lang="typescript"
 return {
-  init: (description: string) => /* … */,
+  init: (description: string) =>
+    Effect.gen(function* () {
+      if (meta !== null) return meta;
+      meta = { description, topics: [], stars: 0, createdAt: Date.now() };
+      yield* state.storage.put("meta", meta);
+      return meta;
+    }),
   get: () => ensure,
-+ update: (patch: Partial<Pick<Metadata, "description" | "topics">>) =>
++ update: (patch: Partial<Pick<Meta, "description" | "topics">>) =>
 +   Effect.gen(function* () {
 +     const current = yield* ensure;
 +     meta = { ...current, ...patch };
@@ -394,25 +703,71 @@ return {
 };
 ```
 
-Expose it via `PATCH /repos/:name`:
+Add an `updateRepo` endpoint to the API:
 
 ```diff lang="typescript"
-+if (parts[0] === "repos" && parts.length === 2 && request.method === "PATCH") {
-+  const name = parts[1]!;
-+  const patch = JSON.parse((yield* request.text) || "{}") as {
-+    description?: string;
-+    topics?: string[];
-+  };
-+  const meta = yield* metadata.getByName(name).update(patch);
-+  return yield* HttpServerResponse.json(meta);
-+}
+// src/Api.ts
++export const updateRepo = HttpApiEndpoint.patch(
++  "updateRepo",
++  "/repos/:name",
++  {
++    params: Schema.Struct({ name: Schema.String }),
++    payload: Schema.Struct({
++      description: Schema.optional(Schema.String),
++      topics: Schema.optional(Schema.Array(Schema.String)),
++    }),
++    success: Metadata,
++    error: RepoNotFound,
++  },
++);
+
+export class ReposGroup extends HttpApiGroup.make("repos")
+  .add(createRepo)
+  .add(getRepo)
+  .add(cloneToken)
++ .add(updateRepo) {}
+```
+
+And the handler:
+
+```diff lang="typescript"
+.handle("cloneToken", ({ params, payload }) => /* … */)
++.handle("updateRepo", ({ params, payload }) =>
++  findRepo(params.name).pipe(
++    Effect.flatMap(() =>
++      metadata
++        .getByName(params.name)
++        .update({
++          description: payload.description,
++          topics: payload.topics ? [...payload.topics] : undefined,
++        })
++        .pipe(Effect.orDie),
++    ),
++    Effect.map((m) => new Metadata(m)),
++  ),
++),
+```
+
+Test it:
+
+```diff lang="typescript"
+expect(token.scope).toBe("read");
+
++const updated = yield* client.repos.updateRepo({
++  params: { name: repoName },
++  payload: { description: "now with stars", topics: ["demo", "alchemy"] },
++});
++expect(updated.description).toBe("now with stars");
++expect(updated.topics).toEqual(["demo", "alchemy"]);
 ```
 
 ## Star a repo
 
-Same pattern, one more method:
+Same pattern — add `star` to the DO, `starRepo` to the API, and
+the handler:
 
 ```diff lang="typescript"
+// src/RepoMetadata.ts
 return {
   // …
   update: (patch) => /* … */,
@@ -426,48 +781,59 @@ return {
 };
 ```
 
-And the route:
+```diff lang="typescript"
+// src/Api.ts
++export const starRepo = HttpApiEndpoint.post(
++  "starRepo",
++  "/repos/:name/star",
++  {
++    params: Schema.Struct({ name: Schema.String }),
++    success: Metadata,
++    error: RepoNotFound,
++  },
++);
+
+export class ReposGroup extends HttpApiGroup.make("repos")
+  .add(createRepo)
+  .add(getRepo)
+  .add(cloneToken)
+  .add(updateRepo)
++ .add(starRepo) {}
+```
 
 ```diff lang="typescript"
-+if (
-+  parts[0] === "repos" &&
-+  parts[2] === "star" &&
-+  request.method === "POST"
-+) {
-+  const meta = yield* metadata.getByName(parts[1]!).star();
-+  return yield* HttpServerResponse.json(meta);
-+}
+// src/Worker.ts
+.handle("updateRepo", ({ params, payload }) => /* … */)
++.handle("starRepo", ({ params }) =>
++  findRepo(params.name).pipe(
++    Effect.flatMap(() =>
++      metadata.getByName(params.name).star().pipe(Effect.orDie),
++    ),
++    Effect.map((m) => new Metadata(m)),
++  ),
++),
 ```
 
-## Deploy and try the whole thing
+```diff lang="typescript"
+expect(updated.topics).toEqual(["demo", "alchemy"]);
+
++const starred = yield* client.repos.starRepo({
++  params: { name: repoName },
++});
++expect(starred.stars).toBe(1);
+```
+
+## Run the full suite
 
 ```sh
-bun alchemy deploy
+bun test
 ```
 
-Create a repo, star it, update the description, and read everything
-back — each call round-trips through Artifacts, the DO, or both:
-
-```sh
-URL=$(bun alchemy stack output url)
-
-curl -X POST "$URL/repos" \
-  -H "content-type: application/json" \
-  -d '{"name":"hello-world","description":"my first repo"}'
-
-curl -X POST "$URL/repos/hello-world/star"
-
-curl -X PATCH "$URL/repos/hello-world" \
-  -H "content-type: application/json" \
-  -d '{"description":"now with stars","topics":["demo","alchemy"]}'
-
-curl "$URL/repos/hello-world"
-# { name, remote, defaultBranch, description, topics, stars: 1, ... }
-
-curl -X POST "$URL/repos/hello-world/clone-token" \
-  -H "content-type: application/json" \
-  -d '{"scope":"read","ttl":3600}'
-```
+Each call round-trips through Artifacts, the Durable Object, or
+both — created via `repos.create`, looked up via `repos.list`,
+mutated via the DO's `init`/`update`/`star` RPC methods. The whole
+flow is type-checked end-to-end through the same `RepoApi` schema,
+on both the server and the client.
 
 ## Why this shape
 
@@ -479,8 +845,12 @@ Artifacts and the per-repo DO each do one thing well:
 - **The DO** is the source of truth for everything that lives
   *around* the repo. Each repo gets its own instance, so a hot
   repo's writes never contend with another's.
+- **HttpApi** ties the two together. The same `RepoApi` value
+  drives the Worker, the integration test, and any external
+  client — so contract drift between server and consumer is
+  caught at compile time, not in production.
 
 Combine more primitives the same way: a Workflow that runs CI on
 push, a Container that builds and publishes artifacts, an AI
-Gateway that summarizes diffs. The Worker stays a thin router;
+Gateway that summarizes diffs. The Worker stays a thin handler;
 each primitive owns its own state.

--- a/website/src/content/docs/tutorial/cloudflare/artifacts.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/artifacts.mdx
@@ -130,29 +130,31 @@ against them right now.
 ## Look up an existing repo
 
 `repos.get(name)` returns an `ArtifactsRepoClient` whose `.raw`
-field holds the underlying Cloudflare repo. Add a `GET /repos/:name`
-route:
+field is the runtime RPC stub — useful for `createToken`, `fork`,
+etc., but **not a serialisable POJO**. To return repo info as JSON,
+use `repos.list(...)` and find the entry by name; every record in
+the list is a plain object with `name`, `remote`, `defaultBranch`,
+`createdAt`, `lastPushAt`, etc.
+
+Add `GET /repos/:name`:
 
 ```diff lang="typescript"
-if (parts[0] === "repos" && parts.length === 1 && request.method === "POST") {
-  // …create
-}
-
 +if (parts[0] === "repos" && parts.length === 2 && request.method === "GET") {
 +  const name = parts[1]!;
-+  const repo = yield* repos.get(name);
-+  return yield* HttpServerResponse.json({
-+    name: repo.raw.name,
-+    remote: repo.raw.remote,
-+    defaultBranch: repo.raw.defaultBranch,
-+    lastPushAt: repo.raw.lastPushAt,
-+  });
++  const list = yield* repos.list({ limit: 100 });
++  const found = list.repos.find((r) => r.name === name);
++  if (!found) {
++    return yield* HttpServerResponse.json(
++      { name, error: "not found" },
++      { status: 404 },
++    );
++  }
++  return yield* HttpServerResponse.json(found);
 +}
 ```
 
-If the repo doesn't exist, `get` fails with `ArtifactsError`. Catch
-it once at the bottom of the handler so every route gets the same
-404 behavior:
+Catch `ArtifactsError` once at the bottom of the handler so any
+underlying API failure surfaces consistently:
 
 ```diff lang="typescript"
 return {
@@ -161,7 +163,7 @@ return {
 - }),
 + }).pipe(
 +   Effect.catchTag("ArtifactsError", (err) =>
-+     HttpServerResponse.json({ error: err.message }, { status: 404 }),
++     HttpServerResponse.json({ error: err.message }, { status: 500 }),
 +   ),
 + ),
 };
@@ -171,8 +173,9 @@ return {
 
 The token returned by `create` expires. Clients that already know
 a repo's name should be able to ask for a new one without
-recreating the repo. `repo.createToken(scope, ttl)` does exactly
-that:
+recreating the repo. `repo.createToken(scope, ttl)` returns
+`{ id, plaintext, scope, expiresAt }` — the `plaintext` field is
+the actual bearer token used in the clone URL:
 
 ```diff lang="typescript"
 +if (
@@ -354,7 +357,23 @@ Two things just happened:
    `get(): Effect<Metadata>` exactly as you defined them.
 
 Each repo name addresses its own durable instance, so writes never
-contend across repos.
+contend across repos. Combine the metadata into the GET response
+the same way:
+
+```diff lang="typescript"
+if (parts[0] === "repos" && parts.length === 2 && request.method === "GET") {
+  const name = parts[1]!;
+  const list = yield* repos.list({ limit: 100 });
+  const found = list.repos.find((r) => r.name === name);
+  if (!found) { /* 404 */ }
++ const meta = yield* metadata
++   .getByName(name)
++   .get()
++   .pipe(Effect.catch(() => Effect.succeed(null)));
+- return yield* HttpServerResponse.json(found);
++ return yield* HttpServerResponse.json({ ...found, metadata: meta });
+}
+```
 
 ## Update description and topics
 

--- a/website/src/content/docs/tutorial/cloudflare/artifacts.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/artifacts.mdx
@@ -123,11 +123,11 @@ export default class Worker extends Cloudflare.Worker<Worker>()(
     compatibility: { flags: ["nodejs_compat"], date: "2026-03-17" },
   },
   Effect.gen(function* () {
-    const repos = yield* Cloudflare.Artifacts.bind(Repos);
+    const artifacts = yield* Cloudflare.Artifacts.bind(Repos);
 
     const handlers = HttpApiBuilder.group(RepoApi, "repos", (h) =>
       h.handle("createRepo", ({ payload }) =>
-        repos
+        artifacts
           .create(payload.name, {
             description: payload.description,
             setDefaultBranch: "main",
@@ -162,7 +162,7 @@ export default class Worker extends Cloudflare.Worker<Worker>()(
 
 The handler returns a `CreateRepoResponse` instance — `Schema.Class`
 expects an actual instance, not a plain object. Errors from
-`repos.create` (the only declared error path) are translated to
+`artifacts.create` (the only declared error path) are translated to
 `RepoConflict`; anything else dies and surfaces as a 500.
 
 ## Set up the integration test
@@ -227,9 +227,9 @@ them right now.
 
 ## Look up an existing repo
 
-`repos.get(name)` returns an opaque RPC stub — useful for
+`artifacts.get(name)` returns an opaque RPC stub — useful for
 `createToken` later, but its fields aren't enumerable. To return
-repo info as JSON, use `repos.list(...)` and find the entry by
+repo info as JSON, use `artifacts.list(...)` and find the entry by
 name; every record in the list is a plain object.
 
 Add a `RepoInfo` schema and a `getRepo` endpoint to the API:
@@ -289,10 +289,10 @@ helper since several handlers will need to look up a repo:
 
 ```diff lang="typescript"
 // src/Worker.ts — inside Effect.gen
-const repos = yield* Cloudflare.Artifacts.bind(Repos);
+const artifacts = yield* Cloudflare.Artifacts.bind(Repos);
 
 +const findRepo = (name: string) =>
-+  repos.list({ limit: 100 }).pipe(
++  artifacts.list({ limit: 100 }).pipe(
 +    Effect.flatMap((res) => {
 +      const found = res.repos.find((r: { name: string }) => r.name === name);
 +      return found
@@ -404,9 +404,9 @@ instance:
 ```diff lang="typescript"
 .handle("getRepo", ({ params }) => /* … */)
 +.handle("cloneToken", ({ params, payload }) =>
-+  repos.get(params.name).pipe(
-+    Effect.flatMap((repo) =>
-+      repo.createToken(payload.scope ?? "read", payload.ttl ?? 3600),
++  artifacts.get(params.name).pipe(
++    Effect.flatMap((handle) =>
++      handle.createToken(payload.scope ?? "read", payload.ttl ?? 3600),
 +    ),
 +    Effect.map(
 +      (t) =>
@@ -458,23 +458,23 @@ That covers the Git half. Artifacts is now storing history and
 handing out tokens. Next we'll add the metadata that lives
 *around* the repo.
 
-## Create the metadata Durable Object
+## Add the `Repo` Durable Object
 
 Artifacts owns commits, refs, and the clone protocol. It does not
 store the things a GitHub-like API needs alongside that —
-descriptions you can rename, topics, stars. We'll keep those in a
-Durable Object, one instance per repo (addressed by repo name),
-so each repo gets its own transactional storage.
+descriptions you can rename, topics, stars. The `Repo` Durable
+Object represents one repository: a single addressable instance
+per repo name with its own transactional storage.
 
 Start with the smallest possible DO — empty public API, no state:
 
 ```typescript twoslash
-// src/RepoMetadata.ts
+// src/Repo.ts
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 
-export default class RepoMetadata extends Cloudflare.DurableObjectNamespace<RepoMetadata>()(
-  "RepoMetadata",
+export default class Repo extends Cloudflare.DurableObjectNamespace<Repo>()(
+  "Repo",
   Effect.gen(function* () {
     return Effect.gen(function* () {
       return {};
@@ -497,8 +497,8 @@ survives restarts and hibernation:
 +  createdAt: number;
 +};
 
-export default class RepoMetadata extends Cloudflare.DurableObjectNamespace<RepoMetadata>()(
-  "RepoMetadata",
+export default class Repo extends Cloudflare.DurableObjectNamespace<Repo>()(
+  "Repo",
   Effect.gen(function* () {
     return Effect.gen(function* () {
 +     const state = yield* Cloudflare.DurableObjectState;
@@ -572,12 +572,13 @@ export class RepoInfo extends Schema.Class<RepoInfo>("RepoInfo")({
 }) {}
 ```
 
-Yield the `RepoMetadata` class in the Worker's init phase, then
-update `createRepo` to seed metadata and `getRepo` to merge it in:
+Yield the `Repo` class in the Worker's init phase. The handle is a
+DO namespace — `repos.getByName(name)` returns a typed RPC stub for
+that repo's instance:
 
 ```diff lang="typescript"
 // src/Worker.ts
-+import RepoMetadata from "./RepoMetadata.ts";
++import Repo from "./Repo.ts";
 import {
   CloneToken,
   CreateRepoResponse,
@@ -589,8 +590,8 @@ import {
 } from "./Api.ts";
 
   Effect.gen(function* () {
-    const repos = yield* Cloudflare.Artifacts.bind(Repos);
-+   const metadata = yield* RepoMetadata;
+    const artifacts = yield* Cloudflare.Artifacts.bind(Repos);
++   const repos = yield* Repo;
     // …findRepo helper
 ```
 
@@ -599,14 +600,14 @@ is created, `getRepo` reads metadata and merges it:
 
 ```diff lang="typescript"
 .handle("createRepo", ({ payload }) =>
-  repos
+  artifacts
     .create(payload.name, {
       description: payload.description,
       setDefaultBranch: "main",
     })
     .pipe(
 +     Effect.tap(() =>
-+       metadata
++       repos
 +         .getByName(payload.name)
 +         .init(payload.description ?? "")
 +         .pipe(Effect.orDie),
@@ -628,7 +629,7 @@ is created, `getRepo` reads metadata and merges it:
 .handle("getRepo", ({ params }) =>
   findRepo(params.name).pipe(
 +   Effect.flatMap((found) =>
-+     metadata
++     repos
 +       .getByName(params.name)
 +       .get()
 +       .pipe(
@@ -735,7 +736,7 @@ And the handler:
 +.handle("updateRepo", ({ params, payload }) =>
 +  findRepo(params.name).pipe(
 +    Effect.flatMap(() =>
-+      metadata
++      repos
 +        .getByName(params.name)
 +        .update({
 +          description: payload.description,
@@ -767,7 +768,7 @@ Same pattern — add `star` to the DO, `starRepo` to the API, and
 the handler:
 
 ```diff lang="typescript"
-// src/RepoMetadata.ts
+// src/Repo.ts
 return {
   // …
   update: (patch) => /* … */,
@@ -807,7 +808,7 @@ export class ReposGroup extends HttpApiGroup.make("repos")
 +.handle("starRepo", ({ params }) =>
 +  findRepo(params.name).pipe(
 +    Effect.flatMap(() =>
-+      metadata.getByName(params.name).star().pipe(Effect.orDie),
++      repos.getByName(params.name).star().pipe(Effect.orDie),
 +    ),
 +    Effect.map((m) => new Metadata(m)),
 +  ),
@@ -830,7 +831,7 @@ bun test
 ```
 
 Each call round-trips through Artifacts, the Durable Object, or
-both — created via `repos.create`, looked up via `repos.list`,
+both — created via `artifacts.create`, looked up via `artifacts.list`,
 mutated via the DO's `init`/`update`/`star` RPC methods. The whole
 flow is type-checked end-to-end through the same `RepoApi` schema,
 on both the server and the client.

--- a/website/src/content/docs/tutorial/cloudflare/artifacts.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/artifacts.mdx
@@ -1,0 +1,467 @@
+---
+title: Build a Git Repo API
+description: Build a mini-GitHub on Cloudflare — Artifacts for Git storage, a Durable Object per repo for metadata, all wired into a Worker.
+sidebar:
+  order: 7
+---
+
+So far the Cloudflare track has added stateful primitives one at a
+time. This tutorial pulls two of them together into something
+recognizable: a tiny GitHub. **Cloudflare Artifacts** stores the
+actual Git history (clone, push, pull all work against it), and a
+**Durable Object per repo** holds the metadata you don't want
+inside the repo itself — description, topics, star count.
+
+By the end you'll have a Worker that lets a client create a repo,
+`git clone` against it, read combined info, star it, and update
+its description.
+
+## Declare the namespace
+
+A Cloudflare Artifacts namespace is the top-level container for
+Git-compatible repos. Namespaces are *implicit* — there's nothing
+to provision at deploy time, so the resource is a thin binding
+marker. Repos themselves are created at runtime through the
+binding.
+
+Create `src/Repos.ts`:
+
+```typescript twoslash
+// src/Repos.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+
+export const Repos = Cloudflare.Artifacts("Repos");
+```
+
+That's the whole declaration. The Worker provider will see this
+the moment you `.bind(...)` it.
+
+## Bind it to the Worker
+
+`Cloudflare.Artifacts.bind(Repos)` returns an Effect-native client
+whose methods are tagged with `ArtifactsError`. Bind it in the
+Worker's init phase, and provide `ArtifactsBindingLive` so the
+runtime can resolve the underlying binding from `env`:
+
+```diff lang="typescript"
+// src/Api.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
++import * as Layer from "effect/Layer";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
++import { Repos } from "./Repos.ts";
+
+export default class Api extends Cloudflare.Worker<Api>()(
+  "Api",
+  { main: import.meta.path },
+  Effect.gen(function* () {
++   const repos = yield* Cloudflare.Artifacts.bind(Repos);
+
+    return {
+      fetch: Effect.gen(function* () {
+        return HttpServerResponse.text("Not Found", { status: 404 });
+      }),
+    };
+- })
++ }).pipe(
++   Effect.provide(Layer.mergeAll(Cloudflare.ArtifactsBindingLive)),
++ ),
+) {}
+```
+
+`repos` is now a typed handle into the Artifacts namespace. Next,
+let's use it.
+
+## Create a repo
+
+Add a `POST /repos` route that calls `repos.create(name, ...)`.
+The result includes the Git remote URL and a short-lived token
+the client can use to `git clone`:
+
+```diff lang="typescript"
+return {
+  fetch: Effect.gen(function* () {
+    const request = yield* HttpServerRequest;
++   const url = new URL(request.url, "http://x");
++   const parts = url.pathname.split("/").filter(Boolean);
++
++   if (parts[0] === "repos" && parts.length === 1 && request.method === "POST") {
++     const body = JSON.parse((yield* request.text) || "{}") as {
++       name?: string;
++       description?: string;
++     };
++     const name = body.name?.trim();
++     if (!name) {
++       return yield* HttpServerResponse.json(
++         { error: "name is required" },
++         { status: 400 },
++       );
++     }
++     const created = yield* repos.create(name, {
++       description: body.description,
++       setDefaultBranch: "main",
++     });
++     return yield* HttpServerResponse.json({
++       name: created.name,
++       remote: created.remote,
++       token: created.token,
++       tokenExpiresAt: created.tokenExpiresAt,
++     });
++   }
+
+    return HttpServerResponse.text("Not Found", { status: 404 });
+  }),
+};
+```
+
+Deploy and try it:
+
+```sh
+URL=$(bun alchemy stack output url)
+curl -X POST "$URL/repos" \
+  -H "content-type: application/json" \
+  -d '{"name":"hello-world","description":"my first repo"}'
+```
+
+You'll get back a `remote` and a `token`. You can `git clone`
+against them right now.
+
+## Look up an existing repo
+
+`repos.get(name)` returns an `ArtifactsRepoClient` whose `.raw`
+field holds the underlying Cloudflare repo. Add a `GET /repos/:name`
+route:
+
+```diff lang="typescript"
+if (parts[0] === "repos" && parts.length === 1 && request.method === "POST") {
+  // …create
+}
+
++if (parts[0] === "repos" && parts.length === 2 && request.method === "GET") {
++  const name = parts[1]!;
++  const repo = yield* repos.get(name);
++  return yield* HttpServerResponse.json({
++    name: repo.raw.name,
++    remote: repo.raw.remote,
++    defaultBranch: repo.raw.defaultBranch,
++    lastPushAt: repo.raw.lastPushAt,
++  });
++}
+```
+
+If the repo doesn't exist, `get` fails with `ArtifactsError`. Catch
+it once at the bottom of the handler so every route gets the same
+404 behavior:
+
+```diff lang="typescript"
+return {
+  fetch: Effect.gen(function* () {
+    // …routes
+- }),
++ }).pipe(
++   Effect.catchTag("ArtifactsError", (err) =>
++     HttpServerResponse.json({ error: err.message }, { status: 404 }),
++   ),
++ ),
+};
+```
+
+## Mint a fresh clone token
+
+The token returned by `create` expires. Clients that already know
+a repo's name should be able to ask for a new one without
+recreating the repo. `repo.createToken(scope, ttl)` does exactly
+that:
+
+```diff lang="typescript"
++if (
++  parts[0] === "repos" &&
++  parts[2] === "clone-token" &&
++  request.method === "POST"
++) {
++  const body = JSON.parse((yield* request.text) || "{}") as {
++    scope?: "read" | "write";
++    ttl?: number;
++  };
++  const repo = yield* repos.get(parts[1]!);
++  const token = yield* repo.createToken(
++    body.scope ?? "read",
++    body.ttl ?? 3600,
++  );
++  return yield* HttpServerResponse.json(token);
++}
+```
+
+That covers the Git half. Artifacts is now storing history and
+handing out tokens. Next we'll add the metadata that lives
+*around* the repo.
+
+## Create the metadata Durable Object
+
+Artifacts owns commits, refs, and the clone protocol. It does not
+store the things a GitHub-like API needs alongside that —
+descriptions you can rename, topics, stars. We'll keep those in a
+Durable Object, one instance per repo (addressed by repo name),
+so each repo gets its own transactional storage.
+
+Start with the smallest possible DO — empty public API, no state:
+
+```typescript twoslash
+// src/RepoMetadata.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+
+export default class RepoMetadata extends Cloudflare.DurableObjectNamespace<RepoMetadata>()(
+  "RepoMetadata",
+  Effect.gen(function* () {
+    return Effect.gen(function* () {
+      return {};
+    });
+  }),
+) {}
+```
+
+## Persist the metadata
+
+Each DO instance has its own SQLite-backed key/value storage. Pull
+the current metadata out of storage in the inner init so it
+survives restarts and hibernation:
+
+```diff lang="typescript"
++export type Metadata = {
++  description: string;
++  topics: string[];
++  stars: number;
++  createdAt: number;
++};
+
+export default class RepoMetadata extends Cloudflare.DurableObjectNamespace<RepoMetadata>()(
+  "RepoMetadata",
+  Effect.gen(function* () {
+    return Effect.gen(function* () {
++     const state = yield* Cloudflare.DurableObjectState;
++     let meta = (yield* state.storage.get<Metadata>("meta")) ?? null;
+      return {};
+    });
+  }),
+) {}
+```
+
+`meta` is `null` until the repo is initialized. The next step
+adds the methods that fill it in and read it back.
+
+## Add `init` and `get`
+
+Any function returned from the inner Effect that produces an
+`Effect` becomes a typed RPC method. Add one to seed the metadata
+the first time a repo is created, and one to read it:
+
+```diff lang="typescript"
+return Effect.gen(function* () {
+  const state = yield* Cloudflare.DurableObjectState;
+  let meta = (yield* state.storage.get<Metadata>("meta")) ?? null;
+
++ const ensure = Effect.gen(function* () {
++   if (meta === null) {
++     return yield* Effect.fail(new Error("repo not initialized"));
++   }
++   return meta;
++ });
+
+- return {};
++ return {
++   init: (description: string) =>
++     Effect.gen(function* () {
++       if (meta !== null) return meta;
++       meta = {
++         description,
++         topics: [],
++         stars: 0,
++         createdAt: Date.now(),
++       };
++       yield* state.storage.put("meta", meta);
++       return meta;
++     }),
++   get: () => ensure,
++ };
+});
+```
+
+`init` is idempotent — calling it twice on the same repo doesn't
+overwrite existing metadata. We'll wire it into the create route
+next.
+
+## Wire the DO into the Worker
+
+Yield the `RepoMetadata` class in the Worker's init phase to get a
+namespace handle, then call `getByName(name)` inside `fetch` to
+obtain a typed stub for that repo's instance. Initialize metadata
+on create, and merge it into the GET response:
+
+```diff lang="typescript"
+// src/Api.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
++import RepoMetadata from "./RepoMetadata.ts";
+import { Repos } from "./Repos.ts";
+
+export default class Api extends Cloudflare.Worker<Api>()(
+  "Api",
+  { main: import.meta.path },
+  Effect.gen(function* () {
+    const repos = yield* Cloudflare.Artifacts.bind(Repos);
++   const metadata = yield* RepoMetadata;
+
+    return {
+      fetch: Effect.gen(function* () {
+        // …
+        if (parts[0] === "repos" && parts.length === 1 && request.method === "POST") {
+          // …existing create
+          const created = yield* repos.create(name, { /* … */ });
++         yield* metadata.getByName(name).init(body.description ?? "");
+          return yield* HttpServerResponse.json({ /* … */ });
+        }
+
+        if (parts[0] === "repos" && parts.length === 2 && request.method === "GET") {
+          const name = parts[1]!;
+          const repo = yield* repos.get(name);
++         const meta = yield* metadata.getByName(name).get();
+          return yield* HttpServerResponse.json({
+            name: repo.raw.name,
+            remote: repo.raw.remote,
+            defaultBranch: repo.raw.defaultBranch,
+            lastPushAt: repo.raw.lastPushAt,
++           ...meta,
+          });
+        }
+        // …
+      }),
+    };
+  }),
+) {}
+```
+
+Two things just happened:
+
+1. **`yield* RepoMetadata`** registers the DO with the Worker
+   (binding + class-migration metadata) and hands you the namespace.
+2. **`metadata.getByName(name)`** returns a typed stub: the Worker
+   sees `init(description: string): Effect<Metadata>` and
+   `get(): Effect<Metadata>` exactly as you defined them.
+
+Each repo name addresses its own durable instance, so writes never
+contend across repos.
+
+## Update description and topics
+
+Add an `update` method to the DO that merges a partial patch into
+the stored metadata:
+
+```diff lang="typescript"
+return {
+  init: (description: string) => /* … */,
+  get: () => ensure,
++ update: (patch: Partial<Pick<Metadata, "description" | "topics">>) =>
++   Effect.gen(function* () {
++     const current = yield* ensure;
++     meta = { ...current, ...patch };
++     yield* state.storage.put("meta", meta);
++     return meta;
++   }),
+};
+```
+
+Expose it via `PATCH /repos/:name`:
+
+```diff lang="typescript"
++if (parts[0] === "repos" && parts.length === 2 && request.method === "PATCH") {
++  const name = parts[1]!;
++  const patch = JSON.parse((yield* request.text) || "{}") as {
++    description?: string;
++    topics?: string[];
++  };
++  const meta = yield* metadata.getByName(name).update(patch);
++  return yield* HttpServerResponse.json(meta);
++}
+```
+
+## Star a repo
+
+Same pattern, one more method:
+
+```diff lang="typescript"
+return {
+  // …
+  update: (patch) => /* … */,
++ star: () =>
++   Effect.gen(function* () {
++     const current = yield* ensure;
++     meta = { ...current, stars: current.stars + 1 };
++     yield* state.storage.put("meta", meta);
++     return meta;
++   }),
+};
+```
+
+And the route:
+
+```diff lang="typescript"
++if (
++  parts[0] === "repos" &&
++  parts[2] === "star" &&
++  request.method === "POST"
++) {
++  const meta = yield* metadata.getByName(parts[1]!).star();
++  return yield* HttpServerResponse.json(meta);
++}
+```
+
+## Deploy and try the whole thing
+
+```sh
+bun alchemy deploy
+```
+
+Create a repo, star it, update the description, and read everything
+back — each call round-trips through Artifacts, the DO, or both:
+
+```sh
+URL=$(bun alchemy stack output url)
+
+curl -X POST "$URL/repos" \
+  -H "content-type: application/json" \
+  -d '{"name":"hello-world","description":"my first repo"}'
+
+curl -X POST "$URL/repos/hello-world/star"
+
+curl -X PATCH "$URL/repos/hello-world" \
+  -H "content-type: application/json" \
+  -d '{"description":"now with stars","topics":["demo","alchemy"]}'
+
+curl "$URL/repos/hello-world"
+# { name, remote, defaultBranch, description, topics, stars: 1, ... }
+
+curl -X POST "$URL/repos/hello-world/clone-token" \
+  -H "content-type: application/json" \
+  -d '{"scope":"read","ttl":3600}'
+```
+
+## Why this shape
+
+Artifacts and the per-repo DO each do one thing well:
+
+- **Artifacts** is the Git server — it owns commits, refs, and the
+  clone/push protocol. Tokens are scoped and short-lived, so you
+  mint them on demand instead of handing out long-lived secrets.
+- **The DO** is the source of truth for everything that lives
+  *around* the repo. Each repo gets its own instance, so a hot
+  repo's writes never contend with another's.
+
+Combine more primitives the same way: a Workflow that runs CI on
+push, a Container that builds and publishes artifacts, an AI
+Gateway that summarizes diffs. The Worker stays a thin router;
+each primitive owns its own state.


### PR DESCRIPTION
Adds a mini-GitHub tutorial pairing **Cloudflare Artifacts** (Git storage + scoped clone tokens) with a per-repo **Durable Object** for metadata (description, topics, stars). Includes a runnable example mirroring the tutorial.

```ts
// src/Repos.ts
export const Repos = Cloudflare.Artifacts("Repos");

// src/RepoMetadata.ts — DO with init / get / update / star, persisted in state.storage
export default class RepoMetadata extends Cloudflare.DurableObjectNamespace<RepoMetadata>()(
  "RepoMetadata", /* ... */
) {}

// src/Api.ts
const repos = yield* Cloudflare.Artifacts.bind(Repos);
const metadata = yield* RepoMetadata;
// POST /repos, GET /repos, GET/PATCH/DELETE /repos/:name,
// POST /repos/:name/star, POST /repos/:name/clone-token
```

### Files

- `website/src/content/docs/tutorial/cloudflare/artifacts.mdx` (sidebar order 7) — incremental diff-style tutorial matching part-1/part-2 conventions.
- `examples/cloudflare-git-artifacts/` — runnable example with `alchemy.run.ts`, `src/{Repos,RepoMetadata,Api}.ts`, and `test/integ.test.ts`.

### Outstanding

`bun tsc -b` passes clean. Integ tests were not run against a real Cloudflare account — the worktree's auth environment fails identically on the existing `cloudflare-worker` example (`Service not found: AuthProviders`), so the failure isn't specific to this change. Needs a deploy + integ run on a wired-up profile before merge.