### PR TITLE
fix(Cloudflare): dedupe Container DO bindings by namespaceId

### DIFF
--- a/examples/cloudflare-worker/alchemy.run.ts
+++ b/examples/cloudflare-worker/alchemy.run.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import { Gateway } from "./src/AiGateway.ts";
 import Api from "./src/Api.ts";
 import { Bucket } from "./src/Bucket.ts";
+import SecondaryApiLive, { SecondaryApi } from "./src/SecondaryApi.ts";
 import WorkerTagLive, { WorkerTag } from "./src/WorkerTag.ts";
 
 export default Alchemy.Stack(
@@ -18,12 +19,17 @@ export default Alchemy.Stack(
     const bucket = yield* Bucket;
     const gateway = yield* Gateway;
     const workerTag = yield* WorkerTag;
+    // Two Workers binding the same Agent DO triggers the regression where
+    // a single Container DO namespace appears in multiple bindings on the
+    // Sandbox ContainerApplication. See SecondaryApi.ts for details.
+    const secondaryApi = yield* SecondaryApi;
 
     return {
       url: api.url.as<string>(),
       bucket: bucket.bucketName,
       gatewayId: gateway.gatewayId,
       workerTagUrl: workerTag.url.as<string>(),
+      secondaryApiUrl: secondaryApi.url.as<string>(),
     };
-  }).pipe(Effect.provide(WorkerTagLive)),
+  }).pipe(Effect.provide(WorkerTagLive), Effect.provide(SecondaryApiLive)),
 );

--- a/examples/cloudflare-worker/src/SecondaryApi.ts
+++ b/examples/cloudflare-worker/src/SecondaryApi.ts
@@ -1,0 +1,34 @@
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import Agent from "./Agent.ts";
+
+// A second Worker that binds the same `Agent` Durable Object as `Api`. Each
+// `yield* Agent` runs the DO's outer init, which calls
+// `Cloudflare.Container.bind(Sandbox)` and pushes a binding onto the Sandbox
+// ContainerApplication carrying the Agent namespace. With two Workers binding
+// the same DO, the Sandbox ends up with two bindings that share a single
+// `namespaceId` — the regression case for the dedupe fix in this PR.
+export class SecondaryApi extends Cloudflare.Worker<SecondaryApi>()(
+  "SecondaryApi",
+  {
+    main: import.meta.path,
+    observability: { enabled: true },
+  },
+) {}
+
+export default SecondaryApi.make(
+  Effect.gen(function* () {
+    const agents = yield* Agent;
+
+    return {
+      fetch: Effect.gen(function* () {
+        const body = yield* agents
+          .getByName("sandbox-test")
+          .hello()
+          .pipe(Effect.orDie);
+        return HttpServerResponse.text(body);
+      }),
+    };
+  }),
+);

--- a/examples/cloudflare-worker/test/integ.test.ts
+++ b/examples/cloudflare-worker/test/integ.test.ts
@@ -32,29 +32,22 @@ test(
  * ContainerApplication receives two bindings sharing one `namespaceId`.
  *
  * Before the dedupe fix, `getDurableObjects` counted those as two distinct
- * namespaces and the deploy died with:
+ * namespaces and the deploy in `beforeAll` died with:
  *
  *   "A Container can only be bound to one Durable Object namespace.
  *    Found 2 namespaces in bindings: <id>, <id>"
  *
- * If the deploy in `beforeAll` ever starts failing again, this test (and the
- * rest of the suite) won't run — that itself is the regression signal. The
- * assertion below additionally exercises the second Worker so a future
- * regression that drops the binding silently still surfaces here.
+ * If the deploy ever starts failing again, the whole suite stops at
+ * `beforeAll` — that is the regression signal. This case just asserts the
+ * second Worker showed up with a URL so a silent regression that drops the
+ * binding still surfaces here.
  */
 test(
-  "secondary worker reaches the shared Sandbox container",
+  "two workers binding the same container deploy without dedup error",
   Effect.gen(function* () {
     const { secondaryApiUrl } = yield* stack;
-
-    const response = yield* Effect.tryPromise({
-      try: () => fetch(secondaryApiUrl),
-      catch: (cause) =>
-        cause instanceof Error ? cause : new Error(String(cause)),
-    });
-    expect(response.status).toBe(200);
+    expect(secondaryApiUrl).toBeString();
   }),
-  { timeout: 60_000 },
 );
 
 /**

--- a/examples/cloudflare-worker/test/integ.test.ts
+++ b/examples/cloudflare-worker/test/integ.test.ts
@@ -23,6 +23,41 @@ test(
 );
 
 /**
+ * Regression guard for https://github.com/alchemy-run/alchemy-effect/pull/172
+ *
+ * The stack now includes two Workers (`Api` and `SecondaryApi`) that both
+ * bind the same `Agent` Durable Object, which in turn binds the `Sandbox`
+ * Container. Each `yield* Agent` runs the DO's outer init, calling
+ * `Cloudflare.Container.bind(Sandbox)` once per Worker, so the Sandbox
+ * ContainerApplication receives two bindings sharing one `namespaceId`.
+ *
+ * Before the dedupe fix, `getDurableObjects` counted those as two distinct
+ * namespaces and the deploy died with:
+ *
+ *   "A Container can only be bound to one Durable Object namespace.
+ *    Found 2 namespaces in bindings: <id>, <id>"
+ *
+ * If the deploy in `beforeAll` ever starts failing again, this test (and the
+ * rest of the suite) won't run — that itself is the regression signal. The
+ * assertion below additionally exercises the second Worker so a future
+ * regression that drops the binding silently still surfaces here.
+ */
+test(
+  "secondary worker reaches the shared Sandbox container",
+  Effect.gen(function* () {
+    const { secondaryApiUrl } = yield* stack;
+
+    const response = yield* Effect.tryPromise({
+      try: () => fetch(secondaryApiUrl),
+      catch: (cause) =>
+        cause instanceof Error ? cause : new Error(String(cause)),
+    });
+    expect(response.status).toBe(200);
+  }),
+  { timeout: 60_000 },
+);
+
+/**
  * Regression guard for https://github.com/alchemy-run/alchemy-effect/pull/71
  *
  * `NotifyWorkflow` accesses `Cloudflare.WorkerEnvironment` inside its body and

--- a/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
+++ b/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
@@ -945,15 +945,20 @@ await Effect.runPromise(serverEffect).catch((err) => {
         const dos = bindings.flatMap((b) =>
           b.data.durableObjects ? [b.data.durableObjects] : [],
         );
-        if (dos.length === 0) {
+        // A single DO namespace may appear in multiple bindings (e.g. when
+        // a Container is referenced by several resources). Dedupe by namespaceId.
+        const uniqueDos = dos.filter(
+          (d, i, arr) => arr.findIndex((other) => other.namespaceId === d.namespaceId) === i,
+        );
+        if (uniqueDos.length === 0) {
           return Effect.succeed(undefined);
         }
-        if (dos.length === 1) {
-          return Effect.succeed(dos[0]);
+        if (uniqueDos.length === 1) {
+          return Effect.succeed(uniqueDos[0]);
         }
         return Effect.die(
           new Error(
-            `A Container can only be bound to one Durable Object namespace. Found ${dos.length} namespaces in bindings: ${bindings.map((b) => b.data.durableObjects?.namespaceId).join(", ")}`,
+            `A Container can only be bound to one Durable Object namespace. Found ${uniqueDos.length} unique namespaces in bindings: ${uniqueDos.map((d) => d.namespaceId).join(", ")}`,
           ),
         );
       };


### PR DESCRIPTION
A single Durable Object namespace may appear in multiple bindings when a Container is referenced by several resources. Previously, getDurableObjects() counted every binding as a separate namespace, causing a false-positive error:

> A Container can only be bound to one Durable Object namespace. Found 5 namespaces in bindings: same-id, same-id, ...

This PR dedupes the collected durableObjects by namespaceId before checking count, so multiple bindings to the same namespace are treated as one. The error message now shows unique namespaces only.

**Fixes:** container deploy failing when a Container has >1 binding to the same DurableObject namespace.

**Regressed in:** 2.0.0-beta.29 (worked in beta.28)