### PR TITLE
fix(Cloudflare): await Container.start() Promise instead of discarding it

### DIFF
--- a/packages/alchemy/src/Cloudflare/Container/ContainerBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Container/ContainerBinding.ts
@@ -73,7 +73,9 @@ export const bindContainer = Effect.fnUntraced(function* <Shape, Req = never>(
       monitor: () =>
         Effect.promise(() => state.container?.monitor() ?? Promise.resolve()),
       start: (options?: ContainerStartupOptions) =>
-        Effect.sync(() => state.container!.start(options)),
+        Effect.promise(
+          () => state.container?.start(options) ?? Promise.resolve(),
+        ),
     } satisfies Container as Shape;
   });
 });


### PR DESCRIPTION
ContainerBinding.ts returned Effect.sync(() => state.container!.start(options)) for the start method. Since container.start() returns a Promise, wrapping it in Effect.sync() evaluates the call but immediately returns the Promise object itself - the start Promise is never awaited and is dropped on the floor.

The monitor() method right above already uses the correct pattern: Effect.promise(() => state.container?.monitor() ?? Promise.resolve()).

This PR applies the same pattern to start().

Fixes: container start Promise silently discarded, causing the DO to report running before the container has actually started.