### PR TITLE
fix(cloudflare): disable builder.sharedConfigBuild for vite build

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1522,9 +1522,6 @@ ${[
                   },
                 },
               },
-              builder: {
-                sharedConfigBuild: true,
-              },
               plugins: [
                 cloudflareVite({
                   compatibilityDate,


### PR DESCRIPTION
This was causing Vite builds to fail for static websites.

I'm a little wary of breaking something else by removing this. If we pin down why this was added, maybe we can figure out the root reason.