### PR TITLE
docs(tutorial): add GitHub.providers() to part-5 PR comment diff

### DIFF
--- a/website/src/content/docs/tutorial/part-5.mdx
+++ b/website/src/content/docs/tutorial/part-5.mdx
@@ -270,13 +270,18 @@ import * as Cloudflare from "alchemy/Cloudflare";
 +import * as GitHub from "alchemy/GitHub";
 +import * as Output from "alchemy/Output";
 import * as Effect from "effect/Effect";
++import * as Layer from "effect/Layer";
 import { Bucket } from "./src/bucket.ts";
 import Worker from "./src/worker.ts";
 
 export default Alchemy.Stack(
   "MyApp",
   {
-    providers: Cloudflare.providers(),
+-   providers: Cloudflare.providers(),
++   providers: Layer.mergeAll(
++     Cloudflare.providers(),
++     GitHub.providers(),
++   ),
     state: Cloudflare.state(),
   },
   Effect.gen(function* () {


### PR DESCRIPTION
The diff for adding PR preview comments in `tutorial/part-5` imports `GitHub` but never wires it into the providers layer, so following the tutorial verbatim leaves a broken stack.

```diff lang="typescript"
 import * as Cloudflare from "alchemy/Cloudflare";
+import * as GitHub from "alchemy/GitHub";
+import * as Output from "alchemy/Output";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";

 export default Alchemy.Stack(
   "MyApp",
   {
-    providers: Cloudflare.providers(),
+    providers: Layer.mergeAll(
+      Cloudflare.providers(),
+      GitHub.providers(),
+    ),
     state: Cloudflare.state(),
   },
```