### PR TITLE
feat(core): factory-form Platform/Resource for parametric default exports

### DIFF
--- a/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
+++ b/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
@@ -945,7 +945,8 @@ await Effect.runPromise(serverEffect).catch((err) => {
         // A single DO namespace may appear in multiple bindings (e.g. when
         // a Container is referenced by several resources). Dedupe by namespaceId.
         const uniqueDos = dos.filter(
-          (d, i, arr) => arr.findIndex((other) => other.namespaceId === d.namespaceId) === i,
+          (d, i, arr) =>
+            arr.findIndex((other) => other.namespaceId === d.namespaceId) === i,
         );
         if (uniqueDos.length === 0) {
           return Effect.succeed(undefined);

--- a/packages/alchemy/src/Cloudflare/StateStore/Api.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Api.ts
@@ -48,7 +48,7 @@ export const STATE_STORE_VERSION = 1 as const;
  * stores per account by overriding the worker name (default
  * {@link STATE_STORE_SCRIPT_NAME}).
  */
-const Api = (scriptName: string = STATE_STORE_SCRIPT_NAME) => Worker(
+const Api = Worker((scriptName: string = STATE_STORE_SCRIPT_NAME) => Worker(
   "Api",
   {
     name: scriptName,
@@ -164,7 +164,7 @@ const Api = (scriptName: string = STATE_STORE_SCRIPT_NAME) => Worker(
       ),
     };
   }).pipe(Effect.provide(Layer.mergeAll(SecretBindingLive))),
-);
+));
 
 export default Api;
 

--- a/packages/alchemy/src/Cloudflare/StateStore/Api.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Api.ts
@@ -43,11 +43,15 @@ export const STATE_STORE_VERSION = 1 as const;
  *
  * In the bundled case, fall back to the published source file shipped
  * alongside the CLI under `../src/Cloudflare/StateStore/Api.ts`.
+ *
+ * Parameterised on `scriptName` so callers can deploy multiple state
+ * stores per account by overriding the worker name (default
+ * {@link STATE_STORE_SCRIPT_NAME}).
  */
-export default Worker(
+const Api = (scriptName: string = STATE_STORE_SCRIPT_NAME) => Worker(
   "Api",
   {
-    name: STATE_STORE_SCRIPT_NAME,
+    name: scriptName,
     main: import.meta.filename,
     url: true,
     compatibility: {
@@ -161,6 +165,8 @@ export default Worker(
     };
   }).pipe(Effect.provide(Layer.mergeAll(SecretBindingLive))),
 );
+
+export default Api;
 
 /**
  * Stub `HttpPlatform` for the worker. The state-store API never

--- a/packages/alchemy/src/Cloudflare/StateStore/Api.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Api.ts
@@ -48,7 +48,7 @@ export const STATE_STORE_VERSION = 1 as const;
  * stores per account by overriding the worker name (default
  * {@link STATE_STORE_SCRIPT_NAME}).
  */
-const Api = Worker((scriptName: string = STATE_STORE_SCRIPT_NAME) => Worker(
+const Api = Worker((scriptName: string = STATE_STORE_SCRIPT_NAME) => [
   "Api",
   {
     name: scriptName,
@@ -164,7 +164,7 @@ const Api = Worker((scriptName: string = STATE_STORE_SCRIPT_NAME) => Worker(
       ),
     };
   }).pipe(Effect.provide(Layer.mergeAll(SecretBindingLive))),
-));
+]);
 
 export default Api;
 

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -110,7 +110,7 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
         `Worker '${scriptName}' already exists; adopting and refreshing credentials. ` +
           `Use --force to redeploy.`,
       );
-      const credentials = yield* loginWithCloudflare();
+      const credentials = yield* loginWithCloudflare(scriptName);
       if (!isCI) {
         yield* writeCredentials<HttpStateStoreCredentials>(
           profileName,
@@ -231,7 +231,7 @@ export const state = (props?: {
 
       if (workerExists) {
         // it exists, so fetch the secret token
-        const credentials = yield* loginWithCloudflare();
+        const credentials = yield* loginWithCloudflare(scriptName);
         if (!isCI) {
           yield* writeCredentials<HttpStateStoreCredentials>(
             profileName,
@@ -370,7 +370,7 @@ const finishBootstrap = ({
     // actually deployed. `loginWithCloudflare` also persists the
     // credentials file (skipping the write in CI), so we don't need
     // to do that explicitly here.
-    const { url, authToken } = yield* loginWithCloudflare();
+    const { url, authToken } = yield* loginWithCloudflare(scriptName);
     const httpState = yield* makeCloudflareStateStore({ url, authToken });
     // `profileName` is intentionally unused here — `loginWithCloudflare`
     // resolves it itself. Reference it to keep the surrounding API
@@ -411,7 +411,7 @@ const deployStateStore = (scriptName: string, state?: StateService) =>
         },
         Effect.gen(function* () {
           const token = yield* TokenValue;
-          const api = yield* Api;
+          const api = yield* Api(scriptName);
 
           // Surface the bearer token so tests and clients can authenticate
           // after deploy. The underlying value lives in the Cloudflare
@@ -449,9 +449,8 @@ const deployStateStore = (scriptName: string, state?: StateService) =>
  * 1. Find the single account-wide Secrets Store.
  * 2. Upload a short-lived edge-preview worker that binds the
  *    auth-token secret and returns its value.
- * 3. Derive the state-store worker URL from
- *    {@link STATE_STORE_SCRIPT_NAME} and the account's workers.dev
- *    subdomain.
+ * 3. Derive the state-store worker URL from `scriptName` and the
+ *    account's workers.dev subdomain.
  * 4. Persist `{ url, token }` under the `http-state-store`
  *    credentials file.
  *
@@ -459,7 +458,9 @@ const deployStateStore = (scriptName: string, state?: StateService) =>
  * `CloudflareEnvironment`, `Credentials`, `HttpClient`, and
  * `FileSystem`.
  */
-export const loginWithCloudflare = () =>
+export const loginWithCloudflare = (
+  scriptName: string = STATE_STORE_SCRIPT_NAME,
+) =>
   Effect.gen(function* () {
     const isCI = yield* Config.boolean("CI").pipe(Config.withDefault(false));
     const profileName = yield* ALCHEMY_PROFILE;
@@ -487,14 +488,14 @@ export const loginWithCloudflare = () =>
     //    resolve and Cloudflare's edge serves a 400 HTML error page
     //    instead of routing to the preview.
     const authToken = yield* readSecretViaEdge(
-      STATE_STORE_SCRIPT_NAME,
+      scriptName,
       store.id,
       AuthTokenSecretName,
     );
 
     // 3. Derive the deployed worker URL.
     const { subdomain } = yield* workers.getSubdomain({ accountId });
-    const url = `https://${STATE_STORE_SCRIPT_NAME}.${subdomain}.workers.dev`;
+    const url = `https://${scriptName}.${subdomain}.workers.dev`;
 
     if (!isCI) {
       // 4. Persist credentials. The profile entry is managed by

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1404,11 +1404,24 @@ import { WorkerEnvironment, makeDurableObjectBridge${hasWfClasses ? ", makeWorkf
 
 import entry from "${importPath}";
 
+// If \`entry\` is a factory-form default export (Worker((args) => Worker(...))),
+// re-apply the args persisted at deploy time before treating the
+// result as a Layer/Effect. The factory marker and reserved env-var
+// name are duplicated here verbatim because this script is emitted
+// as a string and bundled in the worker; importing the constants
+// directly from \`alchemy/Factory\` would force-bundle the rest of the
+// package.
+const __alchemyFactoryArgs = env.__ALCHEMY_FACTORY_ARGS__;
+const resolved =
+  entry && typeof entry === "function" && entry.__alchemyFactory
+    ? entry(...JSON.parse(__alchemyFactoryArgs ?? "[]"))
+    : entry;
+
 const tag = Context.Service("${Self.key}")
 const layer =
-  typeof entry?.build === "function"
-    ? entry
-    : Layer.effect(tag, typeof entry?.asEffect === "function" ? entry.asEffect() : entry);
+  typeof resolved?.build === "function"
+    ? resolved
+    : Layer.effect(tag, typeof resolved?.asEffect === "function" ? resolved.asEffect() : resolved);
 
 const platform = Layer.mergeAll(
   NodeServices.layer,

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1395,6 +1395,7 @@ import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
 import * as Context from "effect/Context";
 import * as Stream from "effect/Stream";
+import * as Redacted from "effect/Redacted";
 
 import { env, DurableObject${hasWfClasses ? ", WorkflowEntrypoint" : ""} } from "cloudflare:workers";
 import { MinimumLogLevel } from "effect/References";
@@ -1406,15 +1407,43 @@ import entry from "${importPath}";
 
 // If \`entry\` is a factory-form default export (Worker((args) => Worker(...))),
 // re-apply the args persisted at deploy time before treating the
-// result as a Layer/Effect. The factory marker and reserved env-var
-// name are duplicated here verbatim because this script is emitted
-// as a string and bundled in the worker; importing the constants
-// directly from \`alchemy/Factory\` would force-bundle the rest of the
-// package.
-const __alchemyFactoryArgs = env.__ALCHEMY_FACTORY_ARGS__;
+// result as a Layer/Effect. Each arg lives in its own env binding —
+// \`secret_text\` for top-level Redacted args, \`plain_text\` for
+// everything else — encoded as JSON with a \`_tag: "Redacted"\`
+// marker so the wrapper can be rebuilt here. The marker name and
+// env-key shape are duplicated verbatim from \`alchemy/Factory\`
+// because this file is emitted as a string and bundled into the
+// worker; importing the constants directly would force-bundle the
+// rest of the package.
+const __decodeFactoryArg = (raw) => {
+  if (raw === undefined || raw === null) return raw;
+  const text = typeof raw === "string" ? raw : String(raw);
+  try {
+    const parsed = JSON.parse(text);
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      parsed._tag === "Redacted" &&
+      "value" in parsed
+    ) {
+      return Redacted.make(parsed.value);
+    }
+    return parsed;
+  } catch {
+    return text;
+  }
+};
+const __alchemyFactoryArgsCount = parseInt(
+  env.__ALCHEMY_FACTORY_ARG_COUNT__ ?? "0",
+  10,
+);
+const __alchemyFactoryArgs = Array.from(
+  { length: Number.isFinite(__alchemyFactoryArgsCount) ? __alchemyFactoryArgsCount : 0 },
+  (_, i) => __decodeFactoryArg(env["__ALCHEMY_FACTORY_ARG_" + i + "__"]),
+);
 const resolved =
   entry && typeof entry === "function" && entry.__alchemyFactory
-    ? entry(...JSON.parse(__alchemyFactoryArgs ?? "[]"))
+    ? entry(...__alchemyFactoryArgs)
     : entry;
 
 const tag = Context.Service("${Self.key}")

--- a/packages/alchemy/src/Factory.ts
+++ b/packages/alchemy/src/Factory.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared support for the factory-form of a Platform/Resource — a
+ * default export of the shape `(args) => Worker(id, props, body)`.
+ *
+ * ```ts
+ * export default Worker((scriptName: string) =>
+ *   Worker("Api", { name: scriptName, main: import.meta.filename, ... }, body));
+ * ```
+ *
+ * At deploy time, calling `yield* MyWorker(...args)` runs the inner
+ * Effect and stamps `args` into `Props.env` under
+ * {@link FACTORY_ARGS_KEY}, so the standard env-binding lifecycle
+ * persists them as a `plain_text` binding on the deployed resource.
+ * At runtime, the generated entrypoint detects the
+ * {@link FACTORY_MARKER} marker on the imported default export,
+ * JSON-decodes the args from `env`, and calls the factory before
+ * treating the result as a Layer/Effect.
+ *
+ * v1 limitation: factory args must be JSON-serializable. `Output` /
+ * `Redacted` args are not yet supported — they would need per-arg
+ * bindings (so secrets can use `secret_text`) and a matching
+ * marker-aware decode on the runtime side.
+ */
+
+import * as Effect from "effect/Effect";
+
+export const FACTORY_ARGS_KEY = "__ALCHEMY_FACTORY_ARGS__";
+export const FACTORY_MARKER = "__alchemyFactory" as const;
+
+export const makeFactory = (
+  fn: (...args: any[]) => Effect.Effect<any>,
+): ((...args: any[]) => Effect.Effect<any>) & {
+  readonly [FACTORY_MARKER]: true;
+} => {
+  const factory = (...args: any[]) =>
+    Effect.gen(function* () {
+      const resource = yield* fn(...args);
+      if (resource && typeof resource === "object") {
+        const props = (resource as any).Props ?? {};
+        (resource as any).Props = {
+          ...props,
+          env: {
+            ...(props.env ?? {}),
+            [FACTORY_ARGS_KEY]: JSON.stringify(args),
+          },
+        };
+      }
+      return resource;
+    });
+  return Object.assign(factory, { [FACTORY_MARKER]: true as const });
+};

--- a/packages/alchemy/src/Factory.ts
+++ b/packages/alchemy/src/Factory.ts
@@ -8,24 +8,47 @@
  * ```
  *
  * At deploy time, calling `yield* MyWorker(...args)` runs the inner
- * Effect and stamps `args` into `Props.env` under
- * {@link FACTORY_ARGS_KEY}, so the standard env-binding lifecycle
- * persists them as a `plain_text` binding on the deployed resource.
- * At runtime, the generated entrypoint detects the
- * {@link FACTORY_MARKER} marker on the imported default export,
- * JSON-decodes the args from `env`, and calls the factory before
- * treating the result as a Layer/Effect.
+ * Effect and stamps each arg into `Props.env` as its own binding under
+ * keys `__ALCHEMY_FACTORY_ARG_<i>__` (plus a count under
+ * `__ALCHEMY_FACTORY_ARG_COUNT__`). Top-level `Redacted` args ride the
+ * existing `secret_text` binding lifecycle; everything else rides
+ * `plain_text`. `Output` args are unwrapped at deploy time by the
+ * engine's resolver, so an `Output<Redacted<string>>` lands as a
+ * `secret_text` binding too.
  *
- * v1 limitation: factory args must be JSON-serializable. `Output` /
- * `Redacted` args are not yet supported — they would need per-arg
- * bindings (so secrets can use `secret_text`) and a matching
- * marker-aware decode on the runtime side.
+ * At runtime, the generated entrypoint detects the
+ * {@link FACTORY_MARKER} marker, reads the count, decodes each arg
+ * (rebuilding `Redacted` from the JSON marker), and calls the factory
+ * before treating the result as a Layer/Effect.
  */
 
 import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import * as Output from "./Output.ts";
 
-export const FACTORY_ARGS_KEY = "__ALCHEMY_FACTORY_ARGS__";
+export const FACTORY_ARG_COUNT_KEY = "__ALCHEMY_FACTORY_ARG_COUNT__";
+export const FACTORY_ARG_PREFIX = "__ALCHEMY_FACTORY_ARG_";
+export const factoryArgKey = (i: number) => `${FACTORY_ARG_PREFIX}${i}__`;
+
 export const FACTORY_MARKER = "__alchemyFactory" as const;
+
+const encodeOne = (value: unknown): unknown =>
+  Redacted.isRedacted(value)
+    ? // Preserve `Redacted`-ness across the env-binding boundary so the
+      // create/update lifecycle deploys this arg via `secret_text`. The
+      // JSON payload still carries the `_tag` marker so the runtime
+      // decode below can rebuild the wrapper after Cloudflare hands the
+      // binding back as a plain string.
+      Redacted.make(
+        JSON.stringify({
+          _tag: "Redacted",
+          value: Redacted.value(value),
+        }),
+      )
+    : JSON.stringify(value);
+
+const encodeArg = (arg: unknown): unknown =>
+  Output.isOutput(arg) ? arg.pipe(Output.map(encodeOne)) : encodeOne(arg);
 
 export const makeFactory = (
   fn: (...args: any[]) => Effect.Effect<any>,
@@ -37,13 +60,12 @@ export const makeFactory = (
       const resource = yield* fn(...args);
       if (resource && typeof resource === "object") {
         const props = (resource as any).Props ?? {};
-        (resource as any).Props = {
-          ...props,
-          env: {
-            ...(props.env ?? {}),
-            [FACTORY_ARGS_KEY]: JSON.stringify(args),
-          },
-        };
+        const env: Record<string, unknown> = { ...(props.env ?? {}) };
+        env[FACTORY_ARG_COUNT_KEY] = String(args.length);
+        for (let i = 0; i < args.length; i++) {
+          env[factoryArgKey(i)] = encodeArg(args[i]);
+        }
+        (resource as any).Props = { ...props, env };
       }
       return resource;
     });

--- a/packages/alchemy/src/Factory.ts
+++ b/packages/alchemy/src/Factory.ts
@@ -51,8 +51,8 @@ const encodeArg = (arg: unknown): unknown =>
   Output.isOutput(arg) ? arg.pipe(Output.map(encodeOne)) : encodeOne(arg);
 
 export const makeFactory = (
-  fn: (...args: any[]) => Effect.Effect<any>,
-): ((...args: any[]) => Effect.Effect<any>) & {
+  fn: (...args: any[]) => Effect.Effect<any, any, any>,
+): ((...args: any[]) => Effect.Effect<any, any, any>) & {
   readonly [FACTORY_MARKER]: true;
 } => {
   const factory = (...args: any[]) =>

--- a/packages/alchemy/src/Platform.ts
+++ b/packages/alchemy/src/Platform.ts
@@ -194,7 +194,9 @@ export interface Platform<
     PropsReq = never,
     InitReq extends Services | PlatformServices = never,
   >(
-    factory: (...args: Args) => readonly [
+    factory: (
+      ...args: Args
+    ) => readonly [
       id: string,
       props:
         | InputProps<Resource["Props"]>

--- a/packages/alchemy/src/Platform.ts
+++ b/packages/alchemy/src/Platform.ts
@@ -11,6 +11,7 @@ import {
   ExecutionContext,
   type BaseExecutionContext,
 } from "./ExecutionContext.ts";
+import { FACTORY_MARKER, makeFactory } from "./Factory.ts";
 import type { HttpEffect } from "./Http.ts";
 import type { InputProps } from "./Input.ts";
 import type { Provider, ProviderCollectionLike } from "./Provider.ts";
@@ -169,6 +170,18 @@ export interface Platform<
     | PropsReq
     | Exclude<InitReq, Services | PlatformServices>
   >;
+  /**
+   * Factory form. The user's `export default Worker((args) => Worker(...))`
+   * is the wrapped function; deploy-side calls invoke the inner
+   * Effect and persist `args` into the Worker's env, and the runtime
+   * entrypoint re-applies them after import.
+   */
+  <Args extends readonly unknown[], R, Req = never>(
+    factory: (...args: Args) => Effect.Effect<R, never, Req>,
+  ): ((...args: Args) => Effect.Effect<R, never, Req>) & {
+    readonly [FACTORY_MARKER]: true;
+    readonly Type: Resource["Type"];
+  };
 }
 
 type MakeShape<Shape, BaseShape> = Shape extends never | undefined | void
@@ -199,12 +212,32 @@ export const Platform = <
   const PlatformContext = ExecutionContext(type);
 
   const constructor = (
-    id?: string,
+    id?: string | ((...args: any[]) => Effect.Effect<any>),
     props?: any,
     impl?: Impl,
     isTag = false,
   ): any => {
-    if (!id) {
+    if (typeof id === "function") {
+      // Factory form, e.g.
+      //   export default Worker((scriptName: string) =>
+      //     Worker("Api", { name: scriptName, main: import.meta.filename, ... }, body));
+      //
+      // The user's default export is the wrapped function. At deploy
+      // time `yield* MyWorker(...args)` runs the inner Effect and
+      // stamps the args under a reserved key in `Props.env` so the
+      // existing env-binding lifecycle persists them as a `plain_text`
+      // binding on the deployed worker. At runtime, the generated
+      // entrypoint detects the `__alchemyFactory` marker, reads the
+      // serialized args back from `env`, and calls the function before
+      // treating the result as a Layer/Effect.
+      //
+      // v1 limitation: args must be JSON-serializable. `Output` /
+      // `Redacted` args are not yet supported — they would need
+      // per-arg bindings (so secrets can use `secret_text`) and a
+      // matching marker-aware decode on the runtime side.
+      // TODO(sam): support Output/Redacted factory args.
+      return Object.assign(makeFactory(id), { Type: type });
+    } else if (!id) {
       // impl was not provided inline, this is a tagged instance
       // e.g.
       // export class Sandbox extends Cloudflare.Container<Sandbox>()(..) {}

--- a/packages/alchemy/src/Platform.ts
+++ b/packages/alchemy/src/Platform.ts
@@ -224,18 +224,11 @@ export const Platform = <
       //
       // The user's default export is the wrapped function. At deploy
       // time `yield* MyWorker(...args)` runs the inner Effect and
-      // stamps the args under a reserved key in `Props.env` so the
-      // existing env-binding lifecycle persists them as a `plain_text`
-      // binding on the deployed worker. At runtime, the generated
-      // entrypoint detects the `__alchemyFactory` marker, reads the
-      // serialized args back from `env`, and calls the function before
-      // treating the result as a Layer/Effect.
-      //
-      // v1 limitation: args must be JSON-serializable. `Output` /
-      // `Redacted` args are not yet supported — they would need
-      // per-arg bindings (so secrets can use `secret_text`) and a
-      // matching marker-aware decode on the runtime side.
-      // TODO(sam): support Output/Redacted factory args.
+      // stamps each arg as its own env binding. At runtime, the
+      // generated entrypoint detects the `__alchemyFactory` marker,
+      // reads the args back from `env`, and calls the function before
+      // treating the result as a Layer/Effect. See `Factory.ts` for
+      // the encoding details (Redacted args ride `secret_text`).
       return Object.assign(makeFactory(id), { Type: type });
     } else if (!id) {
       // impl was not provided inline, this is a tagged instance

--- a/packages/alchemy/src/Platform.ts
+++ b/packages/alchemy/src/Platform.ts
@@ -171,14 +171,45 @@ export interface Platform<
     | Exclude<InitReq, Services | PlatformServices>
   >;
   /**
-   * Factory form. The user's `export default Worker((args) => Worker(...))`
-   * is the wrapped function; deploy-side calls invoke the inner
-   * Effect and persist `args` into the Worker's env, and the runtime
-   * entrypoint re-applies them after import.
+   * Factory form. The user writes:
+   *
+   * ```ts
+   * export default Worker((scriptName: string) => [
+   *   "Api",
+   *   { name: scriptName, main: import.meta.filename, ... },
+   *   Effect.gen(function* () { ... }),
+   * ]);
+   * ```
+   *
+   * The function returns the same `[id, props, impl]` tuple that
+   * positional `Worker(id, props, impl)` accepts. Deploy-side
+   * `yield* MyWorker(...args)` invokes the function, applies the
+   * tuple to the platform constructor, and persists `args` into the
+   * resource's env so the runtime entrypoint can re-apply them after
+   * import.
    */
-  <Args extends readonly unknown[], R, Req = never>(
-    factory: (...args: Args) => Effect.Effect<R, never, Req>,
-  ): ((...args: Args) => Effect.Effect<R, never, Req>) & {
+  <
+    Args extends readonly unknown[],
+    Shape extends MainShape,
+    PropsReq = never,
+    InitReq extends Services | PlatformServices = never,
+  >(
+    factory: (...args: Args) => readonly [
+      id: string,
+      props:
+        | InputProps<Resource["Props"]>
+        | Effect.Effect<InputProps<Resource["Props"]>, never, PropsReq>,
+      impl: Effect.Effect<Shape, never, InitReq>,
+    ],
+  ): ((
+    ...args: Args
+  ) => Effect.Effect<
+    Resource & Rpc<Shape>,
+    never,
+    | Resource["Providers"]
+    | PropsReq
+    | Exclude<InitReq, Services | PlatformServices>
+  >) & {
     readonly [FACTORY_MARKER]: true;
     readonly Type: Resource["Type"];
   };
@@ -212,24 +243,32 @@ export const Platform = <
   const PlatformContext = ExecutionContext(type);
 
   const constructor = (
-    id?: string | ((...args: any[]) => Effect.Effect<any>),
+    id?: string | ((...args: any[]) => readonly [string, any, Impl]),
     props?: any,
     impl?: Impl,
     isTag = false,
   ): any => {
     if (typeof id === "function") {
       // Factory form, e.g.
-      //   export default Worker((scriptName: string) =>
-      //     Worker("Api", { name: scriptName, main: import.meta.filename, ... }, body));
+      //   export default Worker((scriptName: string) => [
+      //     "Api",
+      //     { name: scriptName, main: import.meta.filename, ... },
+      //     Effect.gen(function* () { ... }),
+      //   ]);
       //
-      // The user's default export is the wrapped function. At deploy
-      // time `yield* MyWorker(...args)` runs the inner Effect and
-      // stamps each arg as its own env binding. At runtime, the
-      // generated entrypoint detects the `__alchemyFactory` marker,
-      // reads the args back from `env`, and calls the function before
-      // treating the result as a Layer/Effect. See `Factory.ts` for
-      // the encoding details (Redacted args ride `secret_text`).
-      return Object.assign(makeFactory(id), { Type: type });
+      // The user's default export is the wrapped function. The inner
+      // function returns the same `[id, props, impl]` tuple the
+      // positional `Worker(id, props, impl)` form accepts. At deploy
+      // time `yield* MyWorker(...args)` calls the function, applies
+      // the tuple to this constructor, and stamps each arg as its own
+      // env binding so the runtime entrypoint can re-apply them after
+      // import (see `Factory.ts` — Redacted args ride `secret_text`).
+      const tupleFactory = id as (...a: any[]) => readonly [string, any, Impl];
+      const inner = (...args: any[]) => {
+        const tuple = tupleFactory(...args);
+        return constructor(tuple[0], tuple[1], tuple[2]);
+      };
+      return Object.assign(makeFactory(inner), { Type: type });
     } else if (!id) {
       // impl was not provided inline, this is a tagged instance
       // e.g.

--- a/packages/alchemy/src/Resource.ts
+++ b/packages/alchemy/src/Resource.ts
@@ -6,6 +6,7 @@ import { toFqn } from "./FQN.ts";
 import type { Input, InputProps } from "./Input.ts";
 import { CurrentNamespace, type NamespaceNode } from "./Namespace.ts";
 import * as Output from "./Output.ts";
+import { makeFactory } from "./Factory.ts";
 import { Provider } from "./Provider.ts";
 import { RemovalPolicy } from "./RemovalPolicy.ts";
 import { Self } from "./Self.ts";
@@ -292,10 +293,17 @@ export function Resource<R extends ResourceLike>(
   };
 
   const ResourceClass = Object.assign(
-    (...args: [id: string, props: R["Props"]] | [methods: object]) =>
-      typeof args[0] === "object"
-        ? Object.assign(ResourceClass, args[0])
-        : constructor(...(args as [string, R["Props"]])),
+    (
+      ...args:
+        | [id: string, props: R["Props"]]
+        | [methods: object]
+        | [factory: (...args: any[]) => Effect.Effect<any>]
+    ) =>
+      typeof args[0] === "function"
+        ? makeFactory(args[0] as (...args: any[]) => Effect.Effect<any>)
+        : typeof args[0] === "object"
+          ? Object.assign(ResourceClass, args[0])
+          : constructor(...(args as [string, R["Props"]])),
     Service,
   ) as any;
 

--- a/packages/alchemy/src/Resource.ts
+++ b/packages/alchemy/src/Resource.ts
@@ -41,15 +41,15 @@ export type ResourceConstructor<R extends ResourceLike, Req = never> = {
    * tuple the positional `Resource(id, props)` form accepts.
    */
   <Args extends readonly unknown[], PropsReq = never>(
-    factory: (...args: Args) => readonly [
+    factory: (
+      ...args: Args
+    ) => readonly [
       id: string,
       props:
         | InputProps<R["Props"]>
         | Effect.Effect<InputProps<R["Props"]>, never, PropsReq>,
     ],
-  ): ((
-    ...args: Args
-  ) => Effect.Effect<R, never, Req | PropsReq>) & {
+  ): ((...args: Args) => Effect.Effect<R, never, Req | PropsReq>) & {
     readonly [FACTORY_MARKER]: true;
   };
 };
@@ -319,9 +319,7 @@ export function Resource<R extends ResourceLike>(
         // Factory form: the user's function returns `[id, props]`,
         // which we apply to the resource constructor. See `Factory.ts`
         // for how the factory args are persisted into Props.env.
-        const tupleFactory = args[0] as (
-          ...a: any[]
-        ) => readonly [string, any];
+        const tupleFactory = args[0] as (...a: any[]) => readonly [string, any];
         const inner = (...factoryArgs: any[]) => {
           const [id, props] = tupleFactory(...factoryArgs);
           return constructor(id, props);

--- a/packages/alchemy/src/Resource.ts
+++ b/packages/alchemy/src/Resource.ts
@@ -6,7 +6,7 @@ import { toFqn } from "./FQN.ts";
 import type { Input, InputProps } from "./Input.ts";
 import { CurrentNamespace, type NamespaceNode } from "./Namespace.ts";
 import * as Output from "./Output.ts";
-import { makeFactory } from "./Factory.ts";
+import { FACTORY_MARKER, makeFactory } from "./Factory.ts";
 import { Provider } from "./Provider.ts";
 import { RemovalPolicy } from "./RemovalPolicy.ts";
 import { Self } from "./Self.ts";
@@ -36,6 +36,22 @@ export type ResourceConstructor<R extends ResourceLike, Req = never> = {
     id: string,
     props: Effect.Effect<InputProps<R["Props"]>, never, PropsReq>,
   ): Effect.Effect<R, never, PropsReq | Req>;
+  /**
+   * Factory form. The inner function returns the same `[id, props]`
+   * tuple the positional `Resource(id, props)` form accepts.
+   */
+  <Args extends readonly unknown[], PropsReq = never>(
+    factory: (...args: Args) => readonly [
+      id: string,
+      props:
+        | InputProps<R["Props"]>
+        | Effect.Effect<InputProps<R["Props"]>, never, PropsReq>,
+    ],
+  ): ((
+    ...args: Args
+  ) => Effect.Effect<R, never, Req | PropsReq>) & {
+    readonly [FACTORY_MARKER]: true;
+  };
 };
 
 export type ResourceClassWithMethods<
@@ -297,13 +313,26 @@ export function Resource<R extends ResourceLike>(
       ...args:
         | [id: string, props: R["Props"]]
         | [methods: object]
-        | [factory: (...args: any[]) => Effect.Effect<any>]
-    ) =>
-      typeof args[0] === "function"
-        ? makeFactory(args[0] as (...args: any[]) => Effect.Effect<any>)
-        : typeof args[0] === "object"
-          ? Object.assign(ResourceClass, args[0])
-          : constructor(...(args as [string, R["Props"]])),
+        | [factory: (...args: any[]) => readonly [string, any]]
+    ) => {
+      if (typeof args[0] === "function") {
+        // Factory form: the user's function returns `[id, props]`,
+        // which we apply to the resource constructor. See `Factory.ts`
+        // for how the factory args are persisted into Props.env.
+        const tupleFactory = args[0] as (
+          ...a: any[]
+        ) => readonly [string, any];
+        const inner = (...factoryArgs: any[]) => {
+          const [id, props] = tupleFactory(...factoryArgs);
+          return constructor(id, props);
+        };
+        return makeFactory(inner);
+      }
+      if (typeof args[0] === "object") {
+        return Object.assign(ResourceClass, args[0]);
+      }
+      return constructor(...(args as [string, R["Props"]]));
+    },
     Service,
   ) as any;
 

--- a/packages/alchemy/src/Resource.ts
+++ b/packages/alchemy/src/Resource.ts
@@ -15,6 +15,25 @@ import { Stack } from "./Stack.ts";
 export type ResourceConstructor<R extends ResourceLike, Req = never> = {
   Type: R["Type"];
   Props: R["Props"];
+  /**
+   * Factory form. The inner function returns the same `[id, props]`
+   * tuple the positional `Resource(id, props)` form accepts. Listed
+   * before the methods overload because a function value also
+   * satisfies `{ [key: string]: any }`, and TS overload resolution
+   * picks the first match.
+   */
+  <Args extends readonly unknown[], PropsReq = never>(
+    factory: (
+      ...args: Args
+    ) => readonly [
+      id: string,
+      props:
+        | InputProps<R["Props"]>
+        | Effect.Effect<InputProps<R["Props"]>, never, PropsReq>,
+    ],
+  ): ((...args: Args) => Effect.Effect<R, never, Req | PropsReq>) & {
+    readonly [FACTORY_MARKER]: true;
+  };
   <const Methods extends { [key: string]: any }>(
     methods: Methods,
   ): ResourceClassWithMethods<R, Methods>;
@@ -36,22 +55,6 @@ export type ResourceConstructor<R extends ResourceLike, Req = never> = {
     id: string,
     props: Effect.Effect<InputProps<R["Props"]>, never, PropsReq>,
   ): Effect.Effect<R, never, PropsReq | Req>;
-  /**
-   * Factory form. The inner function returns the same `[id, props]`
-   * tuple the positional `Resource(id, props)` form accepts.
-   */
-  <Args extends readonly unknown[], PropsReq = never>(
-    factory: (
-      ...args: Args
-    ) => readonly [
-      id: string,
-      props:
-        | InputProps<R["Props"]>
-        | Effect.Effect<InputProps<R["Props"]>, never, PropsReq>,
-    ],
-  ): ((...args: Args) => Effect.Effect<R, never, Req | PropsReq>) & {
-    readonly [FACTORY_MARKER]: true;
-  };
 };
 
 export type ResourceClassWithMethods<

--- a/packages/alchemy/test/Factory.test.ts
+++ b/packages/alchemy/test/Factory.test.ts
@@ -1,0 +1,197 @@
+import {
+  FACTORY_ARG_COUNT_KEY,
+  FACTORY_MARKER,
+  factoryArgKey,
+  makeFactory,
+} from "@/Factory.ts";
+import * as Output from "@/Output.ts";
+import { Resource } from "@/Resource.ts";
+import * as Stack from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import { InMemoryService, inMemoryState, State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import { describe, expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+import { Bucket, TestLayers } from "./test.resources.ts";
+
+const freshState = Layer.effect(
+  State,
+  Effect.sync(() => InMemoryService({})),
+);
+
+const { test } = Test.make({
+  providers: TestLayers(),
+  state: freshState,
+});
+
+// Inline test resource with an open-ended `env: Record<string, unknown>`
+// so we can inspect what the factory writes into Props.env without
+// fighting the typed env shapes on the production resources.
+interface FactoryProbe
+  extends Resource<
+    "Test.FactoryProbe",
+    { env?: Record<string, unknown> },
+    { name: string }
+  > {}
+const FactoryProbe = Resource<FactoryProbe>("Test.FactoryProbe");
+
+const runInStack = <A>(eff: Effect.Effect<A, any, any>): Effect.Effect<A> =>
+  eff.pipe(
+    Stack.make({
+      name: "test-factory",
+      providers: Layer.empty as any,
+      state: inMemoryState() as any,
+    }) as any,
+    Effect.provideService(Stage, "test"),
+    Effect.map((compiled: any) => compiled.output as A),
+    Effect.provide(TestLayers()),
+    Effect.scoped,
+  ) as Effect.Effect<A>;
+
+describe("factory form", () => {
+  test(
+    "marker and Type are exposed on the wrapper",
+    Effect.gen(function* () {
+      const Factory = Bucket((name: string) => ["Probe", { name }]);
+      expect((Factory as any)[FACTORY_MARKER]).toBe(true);
+      // Resource (non-Platform) wrappers don't carry Type — only the
+      // Platform overload pins it. Sanity-check we don't accidentally
+      // leak undefined onto the function.
+      expect(typeof Factory).toBe("function");
+    }),
+  );
+
+  test(
+    "plain args are JSON-encoded into Props.env",
+    Effect.gen(function* () {
+      const Factory: (...args: any[]) => Effect.Effect<unknown> = FactoryProbe(
+        (_region: string, _count: number, _opts: { strict: boolean }) => [
+          "Probe",
+          {},
+        ] as const,
+      );
+      const probe = yield* Factory("us-east-1", 3, { strict: true }).pipe(
+        runInStack,
+      );
+      const env = (probe as any).Props.env as Record<string, unknown>;
+      expect(env[FACTORY_ARG_COUNT_KEY]).toBe("3");
+      expect(env[factoryArgKey(0)]).toBe(JSON.stringify("us-east-1"));
+      expect(env[factoryArgKey(1)]).toBe(JSON.stringify(3));
+      expect(env[factoryArgKey(2)]).toBe(JSON.stringify({ strict: true }));
+    }),
+  );
+
+  test(
+    "Redacted args are wrapped with the _tag marker so the lifecycle binds them as secret_text",
+    Effect.gen(function* () {
+      const Factory: (...args: any[]) => Effect.Effect<unknown> = FactoryProbe(
+        (_token: Redacted.Redacted<string>) => ["Probe", {}] as const,
+      );
+      const secret = Redacted.make("super-secret");
+      const probe = yield* Factory(secret).pipe(runInStack);
+      const env = (probe as any).Props.env as Record<string, unknown>;
+      const encoded = env[factoryArgKey(0)];
+      // Stays Redacted — the env-binding lifecycle (Worker.ts) checks
+      // Redacted.isRedacted to choose secret_text vs plain_text.
+      expect(Redacted.isRedacted(encoded)).toBe(true);
+      // The inner string is the JSON-with-marker the runtime decodes.
+      expect(JSON.parse(Redacted.value(encoded as Redacted.Redacted<string>))).toEqual({
+        _tag: "Redacted",
+        value: "super-secret",
+      });
+    }),
+  );
+
+  test(
+    "Output args are passed through as Output so the engine resolves them at deploy time",
+    Effect.gen(function* () {
+      const Factory: (...args: any[]) => Effect.Effect<unknown> = FactoryProbe(
+        (_upstream: Output.Output<string>) => ["Probe", {}] as const,
+      );
+      const probe = yield* Factory(Output.literal("from-upstream")).pipe(
+        runInStack,
+      );
+      const env = (probe as any).Props.env as Record<string, unknown>;
+      // The engine hasn't resolved Outputs at this layer yet (we
+      // bypassed Plan/Apply), so the slot still holds an Output. The
+      // important invariant is just that the factory didn't pre-stringify
+      // the Output itself — the resolver will JSON-stringify the
+      // resolved string when it runs.
+      expect(Output.isOutput(env[factoryArgKey(0)])).toBe(true);
+    }),
+  );
+
+  test(
+    "decode round-trip rebuilds Redacted and primitives",
+    Effect.gen(function* () {
+      // Mirrors the decode block emitted into the generated worker
+      // entrypoint — a regression here means the runtime decode and
+      // the deploy-time encode have drifted.
+      const decode = (raw: unknown) => {
+        if (raw == null) return raw;
+        const text = typeof raw === "string" ? raw : String(raw);
+        try {
+          const parsed = JSON.parse(text);
+          if (
+            parsed !== null &&
+            typeof parsed === "object" &&
+            parsed._tag === "Redacted" &&
+            "value" in parsed
+          ) {
+            return Redacted.make(parsed.value);
+          }
+          return parsed;
+        } catch {
+          return text;
+        }
+      };
+
+      const Factory: (...args: any[]) => Effect.Effect<unknown> = FactoryProbe(
+        (_a: string, _b: Redacted.Redacted<string>, _c: { n: number }) => [
+          "Probe",
+          {},
+        ] as const,
+      );
+      const probe = yield* Factory("hello", Redacted.make("hide-me"), {
+        n: 7,
+      }).pipe(runInStack);
+      const env = (probe as any).Props.env as Record<string, unknown>;
+
+      // Cloudflare hands plain_text bindings back as strings and
+      // secret_text bindings back as strings too — both arrive as
+      // strings at runtime regardless of how they were tagged. Mimic
+      // that by unwrapping any Redacted wrapper before decoding.
+      const flatten = (raw: unknown): unknown =>
+        Redacted.isRedacted(raw)
+          ? Redacted.value(raw as Redacted.Redacted<string>)
+          : raw;
+
+      expect(decode(flatten(env[factoryArgKey(0)]))).toBe("hello");
+      const rebuiltSecret = decode(flatten(env[factoryArgKey(1)]));
+      expect(Redacted.isRedacted(rebuiltSecret)).toBe(true);
+      expect(Redacted.value(rebuiltSecret as Redacted.Redacted<string>)).toBe(
+        "hide-me",
+      );
+      expect(decode(flatten(env[factoryArgKey(2)]))).toEqual({ n: 7 });
+    }),
+  );
+
+  test(
+    "makeFactory wraps a custom function with the marker",
+    Effect.gen(function* () {
+      const inner = (x: string) =>
+        Effect.gen(function* () {
+          return { Props: { env: {} } } as any;
+        });
+      const wrapped = makeFactory(inner);
+      expect((wrapped as any)[FACTORY_MARKER]).toBe(true);
+      const result = yield* wrapped("hi");
+      expect((result as any).Props.env[FACTORY_ARG_COUNT_KEY]).toBe("1");
+      expect((result as any).Props.env[factoryArgKey(0)]).toBe(
+        JSON.stringify("hi"),
+      );
+    }),
+  );
+});


### PR DESCRIPTION
Adds a factory overload for Platform/Resource so a default-exported worker can be parametric, and uses it to fix `Cloudflare.state({ workerName })` end-to-end.

```ts
// User-facing: parametric default export
export default Worker((scriptName: string) => [
  "Api",
  {
    name: scriptName,
    main: import.meta.filename,
    ...
  },
  Effect.gen(function* () { ... }),
]);
```

The factory function returns the same `[id, props, body]` tuple the positional `Worker(id, props, body)` form accepts — no nested `Worker(...Worker(...))`. `Resource` (non-Platform) takes a `[id, props]` 2-tuple.

At deploy time, `yield* MyWorker(...args)` applies the tuple to the constructor and stamps each arg into `Props.env` as its own binding (`__ALCHEMY_FACTORY_ARG_<i>__`, plus `__ALCHEMY_FACTORY_ARG_COUNT__`). Top-level `Redacted` args ride the `secret_text` lifecycle; everything else rides `plain_text`. `Output` args resolve at deploy time via the engine's normal Output resolver, so `Output<Redacted<string>>` lands on `secret_text` too — same encoding as the existing `ctx.set`/`ctx.get` pair.

```diff
+import * as Redacted from "effect/Redacted";

+const __decodeFactoryArg = (raw) => {
+  if (raw == null) return raw;
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed?._tag === "Redacted" && "value" in parsed) {
+      return Redacted.make(parsed.value);
+    }
+    return parsed;
+  } catch { return raw; }
+};
+const __alchemyFactoryArgs = Array.from(
+  { length: parseInt(env.__ALCHEMY_FACTORY_ARG_COUNT__ ?? "0", 10) },
+  (_, i) => __decodeFactoryArg(env["__ALCHEMY_FACTORY_ARG_" + i + "__"]),
+);
+const resolved = entry?.__alchemyFactory ? entry(...__alchemyFactoryArgs) : entry;

 const tag = Context.Service("...")
 const layer =
-  typeof entry?.build === "function"
-    ? entry
-    : Layer.effect(tag, typeof entry?.asEffect === "function" ? entry.asEffect() : entry);
+  typeof resolved?.build === "function"
+    ? resolved
+    : Layer.effect(tag, typeof resolved?.asEffect === "function" ? resolved.asEffect() : resolved);
```

`Cloudflare/StateStore/Api.ts` switches to the factory form. Combined with the existing `loginWithCloudflare(scriptName)` change, `Cloudflare.state({ workerName: "custom-state" })` now deploys and looks up `custom-state` — the bug that motivated this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
