### PR TITLE
feat(cloudflare/state-store): wire OTLP traces, metrics, and logs

### DIFF
--- a/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
+++ b/packages/alchemy/src/Cloudflare/Container/ContainerApplication.ts
@@ -945,7 +945,8 @@ await Effect.runPromise(serverEffect).catch((err) => {
         // A single DO namespace may appear in multiple bindings (e.g. when
         // a Container is referenced by several resources). Dedupe by namespaceId.
         const uniqueDos = dos.filter(
-          (d, i, arr) => arr.findIndex((other) => other.namespaceId === d.namespaceId) === i,
+          (d, i, arr) =>
+            arr.findIndex((other) => other.namespaceId === d.namespaceId) === i,
         );
         if (uniqueDos.length === 0) {
           return Effect.succeed(undefined);

--- a/packages/alchemy/src/Cloudflare/StateStore/Api.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Api.ts
@@ -7,10 +7,15 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Etag from "effect/unstable/http/Etag";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as HttpPlatform from "effect/unstable/http/HttpPlatform";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
 import * as HttpApiError from "effect/unstable/httpapi/HttpApiError";
+import * as OtlpLogger from "effect/unstable/observability/OtlpLogger";
+import * as OtlpMetrics from "effect/unstable/observability/OtlpMetrics";
+import * as OtlpSerialization from "effect/unstable/observability/OtlpSerialization";
+import * as OtlpTracer from "effect/unstable/observability/OtlpTracer";
 import crypto from "node:crypto";
 import * as Secret from "../SecretsStore/Secret.ts";
 import { SecretBindingLive } from "../SecretsStore/SecretBinding.ts";
@@ -30,6 +35,58 @@ export const STATE_STORE_SCRIPT_NAME = "alchemy-state-store" as const;
  * forced redeploy via the bootstrap flow.
  */
 export const STATE_STORE_VERSION = 1 as const;
+
+/**
+ * Hard-coded OTLP/HTTP endpoints. Point at the public ingest relay
+ * defined in `stacks/otel.ts` (bound to `otel.alchemy.run`), which
+ * forwards to Axiom with the bearer token attached server-side. Hard-
+ * coded on purpose: the worker has no env-var plumbing and the relay
+ * is account-level infra that lives outside any single deploy.
+ */
+const OTEL_TRACES_URL = "https://otel.alchemy.run/v1/traces";
+const OTEL_METRICS_URL = "https://otel.alchemy.run/v1/metrics";
+const OTEL_LOGS_URL = "https://otel.alchemy.run/v1/logs";
+
+/**
+ * OTLP traces + metrics + logs Layer for the state-store worker.
+ * Mirrors the CLI's `TelemetryLive` so every signal the worker emits
+ * (`Effect.withSpan`, runtime metrics, `Effect.log*`) ships to the
+ * same Axiom datasets as deploy-time CLI signals. Resource attributes
+ * brand each signal with the worker's service name + contract version
+ * so they're easy to slice in Axiom.
+ */
+const otelResource = {
+  serviceName: STATE_STORE_SCRIPT_NAME,
+  serviceVersion: String(STATE_STORE_VERSION),
+  attributes: {
+    "alchemy.state_store.script_name": STATE_STORE_SCRIPT_NAME,
+    "alchemy.state_store.version": STATE_STORE_VERSION,
+  },
+} as const;
+
+const TelemetryLive = Layer.mergeAll(
+  OtlpTracer.layer({
+    url: OTEL_TRACES_URL,
+    resource: otelResource,
+    exportInterval: "1 second",
+  }),
+  OtlpMetrics.layer({
+    url: OTEL_METRICS_URL,
+    resource: otelResource,
+    exportInterval: "1 second",
+  }),
+  // Replace (don't merge with) the default stdout logger so worker logs
+  // ship to Axiom instead of just `wrangler tail`.
+  OtlpLogger.layer({
+    url: OTEL_LOGS_URL,
+    resource: otelResource,
+    exportInterval: "1 second",
+    mergeWithExisting: false,
+  }),
+).pipe(
+  Layer.provide(OtlpSerialization.layerJson),
+  Layer.provide(FetchHttpClient.layer),
+);
 
 /**
  * Path on disk to *this* file, used as the worker's bundling entry.
@@ -76,57 +133,122 @@ export default Worker(
 
     const versionApi = HttpApiBuilder.group(StateApi, "version", (handlers) =>
       handlers.handle("getVersion", () =>
-        Effect.succeed({ version: STATE_STORE_VERSION }),
+        Effect.succeed({ version: STATE_STORE_VERSION }).pipe(
+          Effect.withSpan("state_store.getVersion", {
+            attributes: { "alchemy.state_store.op": "getVersion" },
+          }),
+        ),
       ),
     );
 
     const stateApi = HttpApiBuilder.group(StateApi, "state", (handlers) =>
       handlers
         .handle("listStacks", () =>
-          store.getByName(Store.ROOT_DO_NAME).listStacks(),
+          store
+            .getByName(Store.ROOT_DO_NAME)
+            .listStacks()
+            .pipe(
+              Effect.withSpan("state_store.listStacks", {
+                attributes: { "alchemy.state_store.op": "listStacks" },
+              }),
+            ),
         )
         .handle("listStages", ({ params }) =>
-          store.getByName(params.stack).listStages(),
+          store
+            .getByName(params.stack)
+            .listStages()
+            .pipe(
+              Effect.withSpan("state_store.listStages", {
+                attributes: {
+                  "alchemy.state_store.op": "listStages",
+                  "alchemy.state_store.stack": params.stack,
+                },
+              }),
+            ),
         )
         .handle("listResources", ({ params }) =>
-          store.getByName(params.stack).listResources({ stage: params.stage }),
-        )
-        .handle("getState", ({ params }) =>
           store
             .getByName(params.stack)
-            .get({ stage: params.stage, fqn: decodeURIComponent(params.fqn) }),
+            .listResources({ stage: params.stage })
+            .pipe(
+              Effect.withSpan("state_store.listResources", {
+                attributes: {
+                  "alchemy.state_store.op": "listResources",
+                  "alchemy.state_store.stack": params.stack,
+                  "alchemy.state_store.stage": params.stage,
+                },
+              }),
+            ),
         )
-        .handle("setState", ({ params, payload }) =>
-          store
+        .handle("getState", ({ params }) => {
+          const fqn = decodeURIComponent(params.fqn);
+          return store
             .getByName(params.stack)
-            .set({
-              stage: params.stage,
-              fqn: decodeURIComponent(params.fqn),
-              value: payload as any,
-            })
+            .get({ stage: params.stage, fqn })
+            .pipe(
+              Effect.withSpan("state_store.getState", {
+                attributes: {
+                  "alchemy.state_store.op": "getState",
+                  "alchemy.state_store.stack": params.stack,
+                  "alchemy.state_store.stage": params.stage,
+                  "alchemy.state_store.fqn": fqn,
+                },
+              }),
+            );
+        })
+        .handle("setState", ({ params, payload }) => {
+          const fqn = decodeURIComponent(params.fqn);
+          return store
+            .getByName(params.stack)
+            .set({ stage: params.stage, fqn, value: payload as any })
             .pipe(
               Effect.tap(() =>
                 store
                   .getByName(Store.ROOT_DO_NAME)
                   .registerStack({ stack: params.stack }),
               ),
-            ),
-        )
-        .handle("deleteState", ({ params }) =>
+              Effect.withSpan("state_store.setState", {
+                attributes: {
+                  "alchemy.state_store.op": "setState",
+                  "alchemy.state_store.stack": params.stack,
+                  "alchemy.state_store.stage": params.stage,
+                  "alchemy.state_store.fqn": fqn,
+                },
+              }),
+            );
+        })
+        .handle("deleteState", ({ params }) => {
+          const fqn = decodeURIComponent(params.fqn);
           // The DO method is `remove`, not `delete` — `delete` is
           // reserved by Cloudflare's RPC stub proxy.
-          store
+          return store
             .getByName(params.stack)
-            .remove({
-              stage: params.stage,
-              fqn: decodeURIComponent(params.fqn),
-            })
-            .pipe(Effect.asVoid),
-        )
+            .remove({ stage: params.stage, fqn })
+            .pipe(
+              Effect.asVoid,
+              Effect.withSpan("state_store.deleteState", {
+                attributes: {
+                  "alchemy.state_store.op": "deleteState",
+                  "alchemy.state_store.stack": params.stack,
+                  "alchemy.state_store.stage": params.stage,
+                  "alchemy.state_store.fqn": fqn,
+                },
+              }),
+            );
+        })
         .handle("getReplacedResources", ({ params }) =>
           store
             .getByName(params.stack)
-            .getReplacedResources({ stage: params.stage }),
+            .getReplacedResources({ stage: params.stage })
+            .pipe(
+              Effect.withSpan("state_store.getReplacedResources", {
+                attributes: {
+                  "alchemy.state_store.op": "getReplacedResources",
+                  "alchemy.state_store.stack": params.stack,
+                  "alchemy.state_store.stage": params.stage,
+                },
+              }),
+            ),
         )
         .handle("deleteStack", ({ params, query }) =>
           store
@@ -143,6 +265,15 @@ export default Worker(
                   : Effect.void,
               ),
               Effect.asVoid,
+              Effect.withSpan("state_store.deleteStack", {
+                attributes: {
+                  "alchemy.state_store.op": "deleteStack",
+                  "alchemy.state_store.stack": params.stack,
+                  "alchemy.state_store.stage": query.stage ?? "",
+                  "alchemy.state_store.scope":
+                    query.stage === undefined ? "stack" : "stage",
+                },
+              }),
             ),
         ),
     );
@@ -157,6 +288,7 @@ export default Worker(
         // file-response surface is stubbed.
         Layer.provide([Etag.layer, HttpPlatformStub, Path.layer]),
         HttpRouter.toHttpEffect,
+        Effect.provide(TelemetryLive),
       ),
     };
   }).pipe(Effect.provide(Layer.mergeAll(SecretBindingLive))),

--- a/packages/alchemy/src/Cloudflare/StateStore/Api.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Api.ts
@@ -34,7 +34,7 @@ export const STATE_STORE_SCRIPT_NAME = "alchemy-state-store" as const;
  * compare against this constant; a mismatch (or 404) triggers a
  * forced redeploy via the bootstrap flow.
  */
-export const STATE_STORE_VERSION = 1 as const;
+export const STATE_STORE_VERSION = 2 as const;
 
 /**
  * Hard-coded OTLP/HTTP endpoints. Point at the public ingest relay

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -81,6 +81,12 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
     const profileName = yield* ALCHEMY_PROFILE;
     const scriptName = options.workerName ?? STATE_STORE_SCRIPT_NAME;
     const force = options.force ?? false;
+    yield* Effect.annotateCurrentSpan({
+      "alchemy.state_store.script_name": scriptName,
+      "alchemy.state_store.profile": profileName,
+      "alchemy.state_store.force": force,
+      "alchemy.state_store.ci": isCI,
+    });
 
     const localState = yield* makeLocalState();
     const hasLocalStack = yield* Effect.map(
@@ -139,7 +145,15 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
 
     yield* finishBootstrap({ scriptName, profileName, localState, isCI });
     yield* Clank.success(`Cloudflare State Store '${scriptName}' is ready.`);
-  });
+  }).pipe(
+    Effect.withSpan("state_store.bootstrap", {
+      attributes: {
+        "alchemy.state_store.op": "bootstrap",
+        "alchemy.state_store.script_name":
+          options.workerName ?? STATE_STORE_SCRIPT_NAME,
+      },
+    }),
+  );
 
 export const state = (props?: {
   /**
@@ -160,6 +174,11 @@ export const state = (props?: {
       );
 
       const scriptName = props?.workerName ?? STATE_STORE_SCRIPT_NAME;
+      yield* Effect.annotateCurrentSpan({
+        "alchemy.state_store.script_name": scriptName,
+        "alchemy.state_store.profile": profileName,
+        "alchemy.state_store.ci": isCI,
+      });
 
       // The bootstrap of the Cloudflare State Store is only considered
       // successful once two invariants hold:
@@ -326,6 +345,11 @@ const hoistBootstrapStack = Effect.fnUntraced(function* (
   const stack = "CloudflareStateStore";
   const stage = scriptName;
   const fqns = yield* source.list({ stack, stage });
+  yield* Effect.annotateCurrentSpan({
+    "alchemy.state_store.stack": stack,
+    "alchemy.state_store.stage": stage,
+    "alchemy.state_store.resources.count": fqns.length,
+  });
   yield* Effect.forEach(
     fqns,
     Effect.fnUntraced(function* (fqn) {
@@ -336,7 +360,7 @@ const hoistBootstrapStack = Effect.fnUntraced(function* (
     }),
     { concurrency: "unbounded" },
   );
-});
+}, Effect.withSpan("state_store.hoist_bootstrap_stack"));
 
 /**
  * Finish (or resume) the bootstrap of the Cloudflare State Store using
@@ -393,7 +417,16 @@ const finishBootstrap = ({
     });
 
     return httpState;
-  });
+  }).pipe(
+    Effect.withSpan("state_store.finish_bootstrap", {
+      attributes: {
+        "alchemy.state_store.op": "finish_bootstrap",
+        "alchemy.state_store.script_name": scriptName,
+        "alchemy.state_store.profile": profileName,
+        "alchemy.state_store.ci": isCI,
+      },
+    }),
+  );
 
 const deployStateStore = (scriptName: string, state?: StateService) =>
   Effect.gen(function* () {
@@ -532,6 +565,12 @@ export const loginWithCloudflare = () =>
         }),
       ),
     ),
+    Effect.withSpan("state_store.login", {
+      attributes: {
+        "alchemy.state_store.op": "login",
+        "alchemy.state_store.script_name": STATE_STORE_SCRIPT_NAME,
+      },
+    }),
   );
 
 /**
@@ -564,7 +603,15 @@ const redeployIfStale = ({
       localState,
       isCI,
     });
-  });
+  }).pipe(
+    Effect.withSpan("state_store.redeploy_if_stale", {
+      attributes: {
+        "alchemy.state_store.op": "redeploy_if_stale",
+        "alchemy.state_store.script_name": scriptName,
+        "alchemy.state_store.url": url,
+      },
+    }),
+  );
 
 /**
  * Probe the deployed worker's `/version` endpoint and decide whether
@@ -587,8 +634,18 @@ const checkStateStoreVersion = (url: string) =>
     const result = yield* client.version
       .getVersion()
       .pipe(Effect.catch(() => Effect.succeed(undefined)));
-    return result?.version === STATE_STORE_VERSION;
-  });
+    const matches = result?.version === STATE_STORE_VERSION;
+    yield* Effect.annotateCurrentSpan({
+      "alchemy.state_store.expected_version": STATE_STORE_VERSION,
+      "alchemy.state_store.observed_version": result?.version ?? -1,
+      "alchemy.state_store.version_match": matches,
+    });
+    return matches;
+  }).pipe(
+    Effect.withSpan("state_store.check_version", {
+      attributes: { "alchemy.state_store.op": "check_version" },
+    }),
+  );
 
 /**
  * Tiny ES-module worker that reads `env.SECRET.get()` and echoes it
@@ -665,4 +722,11 @@ const readSecretViaEdge = (
         ? cause
         : new EdgeSessionError({ message: "Failed to read secret", cause }),
     ),
+    Effect.withSpan("state_store.read_secret_via_edge", {
+      attributes: {
+        "alchemy.state_store.op": "read_secret_via_edge",
+        "alchemy.state_store.script_name": scriptName,
+        "alchemy.state_store.secret_name": secretName,
+      },
+    }),
   );

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -7,6 +7,7 @@ import * as Redacted from "effect/Redacted";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
+import crypto from "node:crypto";
 
 import * as Config from "effect/Config";
 import { adopt } from "../../AdoptPolicy.ts";
@@ -40,6 +41,34 @@ import { AuthTokenSecretName, TokenValue } from "./Token.ts";
 
 /** Filename used for stored credentials under the profile directory. */
 const CREDENTIALS_FILE = "cloudflare-state-store";
+
+/**
+ * SHA-256 hex digest of the Cloudflare account ID. Used as a stable
+ * pseudonymous identifier on telemetry spans so the dashboard can
+ * count distinct state-store deployments without leaking the raw
+ * accountId. Mirrors the `alchemy.git.origin_hash` pattern in
+ * `Telemetry/Attributes.ts`.
+ */
+const hashAccountId = (accountId: string) =>
+  Effect.sync(() =>
+    crypto.createHash("sha256").update(accountId).digest("hex"),
+  );
+
+/**
+ * Best-effort Cloudflare-account-hash annotation on the current span.
+ * Resolves the accountId from {@link CloudflareEnvironment} and
+ * attaches `alchemy.cloudflare.account_hash` to whichever span is
+ * active. Silently no-ops if the environment isn't resolvable so
+ * State-store layer construction still succeeds in degraded paths.
+ */
+const annotateAccountHash = Effect.gen(function* () {
+  const env = yield* Effect.serviceOption(
+    CloudflareEnvironment.CloudflareEnvironment,
+  );
+  if (env._tag !== "Some") return;
+  const hash = yield* hashAccountId(env.value.accountId);
+  yield* Effect.annotateCurrentSpan("alchemy.cloudflare.account_hash", hash);
+}).pipe(Effect.catch(() => Effect.void));
 
 export interface BootstrapOptions {
   /**
@@ -87,6 +116,7 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
       "alchemy.state_store.force": force,
       "alchemy.state_store.ci": isCI,
     });
+    yield* annotateAccountHash;
 
     const localState = yield* makeLocalState();
     const hasLocalStack = yield* Effect.map(
@@ -179,6 +209,7 @@ export const state = (props?: {
         "alchemy.state_store.profile": profileName,
         "alchemy.state_store.ci": isCI,
       });
+      yield* annotateAccountHash;
 
       // The bootstrap of the Cloudflare State Store is only considered
       // successful once two invariants hold:
@@ -430,6 +461,7 @@ const finishBootstrap = ({
 
 const deployStateStore = (scriptName: string, state?: StateService) =>
   Effect.gen(function* () {
+    yield* annotateAccountHash;
     const localState = state ?? (yield* makeLocalState());
     // deploy it with local state (which we will then hoist into the Cloudflare state store)
     const stateLayer = Layer.succeed(State, localState);

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -60,15 +60,28 @@ const hashAccountId = (accountId: string) =>
  * attaches `alchemy.cloudflare.account_hash` to whichever span is
  * active. Silently no-ops if the environment isn't resolvable so
  * State-store layer construction still succeeds in degraded paths.
+ *
+ * `noTrack` controls whether the hash is attached:
+ *   - `true`  — never annotate (caller-level opt-out).
+ *   - `false` — always annotate, regardless of env.
+ *   - `undefined` — fall back to the `NO_TRACK` env var; default off.
  */
-const annotateAccountHash = Effect.gen(function* () {
-  const env = yield* Effect.serviceOption(
-    CloudflareEnvironment.CloudflareEnvironment,
-  );
-  if (env._tag !== "Some") return;
-  const hash = yield* hashAccountId(env.value.accountId);
-  yield* Effect.annotateCurrentSpan("alchemy.cloudflare.account_hash", hash);
-}).pipe(Effect.catch(() => Effect.void));
+const annotateAccountHash = (noTrack?: boolean) =>
+  Effect.gen(function* () {
+    if (noTrack === true) return;
+    if (noTrack === undefined) {
+      const fromEnv = yield* Config.boolean("NO_TRACK").pipe(
+        Config.withDefault(false),
+      );
+      if (fromEnv) return;
+    }
+    const env = yield* Effect.serviceOption(
+      CloudflareEnvironment.CloudflareEnvironment,
+    );
+    if (env._tag !== "Some") return;
+    const hash = yield* hashAccountId(env.value.accountId);
+    yield* Effect.annotateCurrentSpan("alchemy.cloudflare.account_hash", hash);
+  }).pipe(Effect.catch(() => Effect.void));
 
 export interface BootstrapOptions {
   /**
@@ -116,7 +129,7 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
       "alchemy.state_store.force": force,
       "alchemy.state_store.ci": isCI,
     });
-    yield* annotateAccountHash;
+    yield* annotateAccountHash();
 
     const localState = yield* makeLocalState();
     const hasLocalStack = yield* Effect.map(
@@ -191,6 +204,25 @@ export const state = (props?: {
    * @default "alchemy-state-store"
    */
   workerName?: string;
+  /**
+   * Suppress the per-deployment Cloudflare account hash on telemetry
+   * spans. Lets a caller opt out of having their state-store's
+   * accountId pseudonymously counted on the maintainer dashboard
+   * without disabling all telemetry.
+   *
+   * - `true`  — always opt out, regardless of env.
+   * - `false` — always opt in, regardless of env.
+   * - `undefined` (default) — fall back to the `NO_TRACK` env var
+   *   (`true`/`1` → opt out). Default-default is opt-in.
+   *
+   * Independent of the global telemetry kill-switch
+   * (`DO_NOT_TRACK` / `ALCHEMY_TELEMETRY_DISABLED`), which kills the
+   * entire OTLP exporter — `noTrack` here only suppresses the
+   * `alchemy.cloudflare.account_hash` attribute on state-store
+   * spans, leaving the rest of the telemetry intact.
+   * @default undefined
+   */
+  noTrack?: boolean;
 }) =>
   Layer.effect(
     State,
@@ -209,7 +241,7 @@ export const state = (props?: {
         "alchemy.state_store.profile": profileName,
         "alchemy.state_store.ci": isCI,
       });
-      yield* annotateAccountHash;
+      yield* annotateAccountHash(props?.noTrack);
 
       // The bootstrap of the Cloudflare State Store is only considered
       // successful once two invariants hold:
@@ -461,7 +493,7 @@ const finishBootstrap = ({
 
 const deployStateStore = (scriptName: string, state?: StateService) =>
   Effect.gen(function* () {
-    yield* annotateAccountHash;
+    yield* annotateAccountHash();
     const localState = state ?? (yield* makeLocalState());
     // deploy it with local state (which we will then hoist into the Cloudflare state store)
     const stateLayer = Layer.succeed(State, localState);

--- a/stacks/otel/Dashboard.ts
+++ b/stacks/otel/Dashboard.ts
@@ -265,6 +265,156 @@ export const CliOverviewDashboard = Axiom.Dashboard(
             `,
           },
         },
+
+        // ─── Cloudflare State Store ────────────────────────────────
+        //
+        // Two span sources feed this section:
+        //
+        //   - **CLI spans** (`state_store.init`, `state_store.bootstrap`,
+        //     `state_store.deploy`, ...) — emitted from the user's
+        //     terminal/CI. Carry `alchemy.cloudflare.account_hash` (a
+        //     SHA-256 of the CF accountId) so we can count distinct
+        //     deployments without leaking raw account IDs.
+        //
+        //   - **Worker handler spans** (`state_store.{getVersion,
+        //     listStacks,listStages,listResources,getState,setState,
+        //     deleteState,getReplacedResources,deleteStack}`) — emitted
+        //     from inside the deployed `alchemy-state-store` worker.
+        //     Distinguished by the `alchemy.state_store.script_name`
+        //     **resource** attribute (set on the worker's OTLP tracer
+        //     resource); CLI spans do not carry that resource attr.
+        //
+        // Worker handler spans carry `alchemy.state_store.{op,stack,
+        // stage,fqn}` as span attributes plus a `duration` field —
+        // that's what powers the latency / op-rate / stack-count
+        // charts. Account-hash sits on CLI spans only (worker-side
+        // injection would need a separate deploy-time env-var pass).
+        {
+          id: "state-store-distinct-cloudflare-stores",
+          name: "Distinct Cloudflare state-store deployments (7d)",
+          type: "Statistic",
+          query: {
+            apl: Output.interpolate`
+              ['${t}']
+              | where name == "state_store.init"
+              | extend hash=tostring(['attributes.custom']['alchemy.cloudflare.account_hash'])
+              | where hash != ""
+              | summarize stores=dcount(hash)
+            `,
+          },
+        },
+        {
+          id: "state-store-distinct-stacks",
+          name: "Distinct stacks tracked (7d)",
+          type: "Statistic",
+          query: {
+            apl: Output.interpolate`
+              ['${t}']
+              | where ['resource.custom']['alchemy.state_store.script_name'] != ""
+              | extend stack=tostring(['attributes.custom']['alchemy.state_store.stack'])
+              | where stack != ""
+              | summarize stacks=dcount(stack)
+            `,
+          },
+        },
+        {
+          id: "state-store-total-ops",
+          name: "Cloudflare state store ops (7d)",
+          type: "Statistic",
+          query: {
+            apl: Output.interpolate`
+              ['${t}']
+              | where ['resource.custom']['alchemy.state_store.script_name'] != ""
+              | extend op=tostring(['attributes.custom']['alchemy.state_store.op'])
+              | where op != ""
+              | summarize ops=count()
+            `,
+          },
+        },
+        {
+          id: "state-store-op-latency",
+          name: "State store op latency (p50 / p95 / p99, 7d)",
+          type: "Table",
+          query: {
+            apl: Output.interpolate`
+              ['${t}']
+              | where ['resource.custom']['alchemy.state_store.script_name'] != ""
+              | extend op=tostring(['attributes.custom']['alchemy.state_store.op'])
+              | where op != ""
+              | summarize p50=percentile(duration, 50),
+                          p95=percentile(duration, 95),
+                          p99=percentile(duration, 99),
+                          calls=count()
+                  by op
+              | order by calls desc
+            `,
+          },
+        },
+        {
+          id: "state-store-ops-over-time",
+          name: "State store ops over time (by op)",
+          type: "TimeSeries",
+          query: {
+            apl: Output.interpolate`
+              ['${t}']
+              | where ['resource.custom']['alchemy.state_store.script_name'] != ""
+              | extend op=tostring(['attributes.custom']['alchemy.state_store.op'])
+              | where op != ""
+              | summarize count=count() by op, bin_auto(_time)
+              | order by _time asc
+            `,
+          },
+        },
+        {
+          id: "state-store-error-rate",
+          name: "State store error rate by op (7d)",
+          type: "Table",
+          query: {
+            apl: Output.interpolate`
+              ['${t}']
+              | where ['resource.custom']['alchemy.state_store.script_name'] != ""
+              | extend op=tostring(['attributes.custom']['alchemy.state_store.op']),
+                       err=tobool(['error'])
+              | where op != ""
+              | summarize errors=countif(err == true),
+                          total=count()
+                  by op
+              | extend error_rate=todouble(errors) / todouble(total)
+              | order by total desc
+            `,
+          },
+        },
+        {
+          id: "state-store-top-stacks",
+          name: "Top stacks by activity (7d)",
+          type: "Table",
+          query: {
+            apl: Output.interpolate`
+              ['${t}']
+              | where ['resource.custom']['alchemy.state_store.script_name'] != ""
+              | extend stack=tostring(['attributes.custom']['alchemy.state_store.stack'])
+              | where stack != ""
+              | summarize ops=count() by stack
+              | order by ops desc
+              | take 25
+            `,
+          },
+        },
+        {
+          id: "state-store-deployments-over-time",
+          name: "Distinct Cloudflare state-store deployments per day",
+          type: "TimeSeries",
+          query: {
+            apl: Output.interpolate`
+              ['${t}']
+              | where name == "state_store.init"
+              | extend hash=tostring(['attributes.custom']['alchemy.cloudflare.account_hash'])
+              | where hash != ""
+              | summarize stores=dcount(hash) by bin(_time, 1d)
+              | order by _time asc
+            `,
+          },
+        },
       ];
 
       const layout: Axiom.LayoutCell[] = [
@@ -287,6 +437,24 @@ export const CliOverviewDashboard = Axiom.Dashboard(
         // Row 6
         { i: "state-store-deploys", x: 0, y: 30, w: 6, h: 6 },
         { i: "active-users-by-version", x: 6, y: 30, w: 6, h: 6 },
+        // Row 7 — Cloudflare State Store: top-line stats
+        {
+          i: "state-store-distinct-cloudflare-stores",
+          x: 0,
+          y: 36,
+          w: 4,
+          h: 4,
+        },
+        { i: "state-store-distinct-stacks", x: 4, y: 36, w: 4, h: 4 },
+        { i: "state-store-total-ops", x: 8, y: 36, w: 4, h: 4 },
+        // Row 8 — performance: latency table (full width)
+        { i: "state-store-op-latency", x: 0, y: 40, w: 12, h: 8 },
+        // Row 9 — ops over time + error rate
+        { i: "state-store-ops-over-time", x: 0, y: 48, w: 8, h: 6 },
+        { i: "state-store-error-rate", x: 8, y: 48, w: 4, h: 6 },
+        // Row 10 — distribution + adoption shape
+        { i: "state-store-top-stacks", x: 0, y: 54, w: 6, h: 8 },
+        { i: "state-store-deployments-over-time", x: 6, y: 54, w: 6, h: 8 },
       ];
 
       return {
@@ -297,9 +465,13 @@ export const CliOverviewDashboard = Axiom.Dashboard(
           owner: "",
           description:
             "Adoption telemetry: distinct projects, active users per project, " +
-            "CI vs local usage, and state-store backend breakdown. " +
+            "CI vs local usage, and state-store backend breakdown. Plus " +
+            "Cloudflare State Store ops: distinct deployments, stack count, " +
+            "per-op latency / error rate. " +
             "Project identity = alchemy.git.origin_hash (stable across CI runs); " +
-            "user identity = alchemy.user.id (ephemeral in CI).",
+            "user identity = alchemy.user.id (ephemeral in CI); " +
+            "Cloudflare deployment identity = alchemy.cloudflare.account_hash " +
+            "(SHA-256 of accountId, set on CLI state_store.* spans).",
           refreshTime: 60 as const,
           schemaVersion: 2 as const,
           // Axiom requires the `qr-now-{duration}` form for relative times.

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build:reference": "bun ../scripts/generate-api-reference.ts",
     "build:llms": "bun scripts/generate-llms-txt.ts",
-    "build": "bun scripts/download-fonts.ts && bun scripts/generate-brand-assets.ts && bun run build:reference && bun run build:llms && astro build",
+    "build": "bun scripts/download-fonts.ts && bun scripts/generate-brand-assets.ts && bun run build:reference && bun run build:llms && NODE_OPTIONS=--max-old-space-size=8192 astro build",
     "dev:site": "astro dev",
     "deploy": "alchemy deploy",
     "dev": "alchemy dev",

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -75,6 +75,7 @@ Standalone how-to pages. Each solves a specific problem; read in any order.
 - [Effect RPC](https://v2.alchemy.run/guides/effect-rpc) — Build a typed RPC API with Effect's Rpc module and deploy it as a Cloudflare Worker.
 - [Frontend frameworks](https://v2.alchemy.run/guides/frontends) — Deploy Vite-based frameworks (TanStack Start, Astro, SolidStart, Nuxt, React) and any custom-built static site (Hugo, Eleventy) to Cloudflare with one declaration.
 - [Migrating from v1](https://v2.alchemy.run/guides/migrating-from-v1) — Migrate your Alchemy v1 (async/await) project to Alchemy v2.
+- [Privacy & Telemetry](https://v2.alchemy.run/guides/privacy) — What data the Alchemy CLI and Cloudflare State Store collect, where it goes, and how to opt out.
 
 ## Blog
 

--- a/website/src/content/docs/guides/privacy.mdx
+++ b/website/src/content/docs/guides/privacy.mdx
@@ -1,0 +1,150 @@
+---
+title: Privacy & Telemetry
+description: What data the Alchemy CLI and Cloudflare State Store collect, where it goes, and how to opt out.
+sidebar:
+  order: 9
+---
+
+The Alchemy CLI and the Cloudflare State Store worker emit
+OpenTelemetry traces, metrics, and logs to a relay we operate at
+`otel.alchemy.run`, which forwards to our Axiom workspace. The data
+helps us prioritize providers, find bugs, and understand which
+features people actually use.
+
+This page documents exactly what is collected, what is not, where
+it goes, and how to opt out. Source of truth is the code:
+[`Telemetry/Attributes.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Telemetry/Attributes.ts)
+and [`Cloudflare/StateStore/Api.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cloudflare/StateStore/Api.ts).
+
+## What we collect
+
+### From the CLI
+
+Resource attributes attached to every span/metric/log:
+
+| Attribute | Value |
+| --- | --- |
+| `alchemy.user.id` | Random UUID generated on first run, persisted at `~/.alchemy/id`. Not your shell user, email, or hostname. |
+| `alchemy.session.id` | Random UUID per CLI invocation. |
+| `alchemy.version` | The version of the `alchemy` package you're running. |
+| `alchemy.git.root_commit` | SHA of the first commit in your repo. Acts as a stable repo fingerprint. |
+| `alchemy.git.origin_hash` | SHA-256 of `git config remote.origin.url`. The raw URL is never sent. |
+| `alchemy.git.branch_hash` | SHA-256 of the current branch name. |
+| `alchemy.runtime.name` / `.version` | `bun` / `node` / `deno` and its version. |
+| `alchemy.ci` / `alchemy.ci.provider` | Whether this looks like a CI run, and which provider (GitHub Actions, GitLab, etc.). |
+| `host.arch`, `os.type`, `os.version`, `host.cpus`, `host.memory_mb` | Coarse machine info. |
+
+Per-operation span attributes:
+
+- `cli.<command>` spans carry the command name (`deploy`, `destroy`, `plan`, ...) and outcome (`success` / `error`).
+- `provider.<op>` spans carry the resource type (`AWS.S3.Bucket`, `Cloudflare.Workers.Worker`, ...), op (`create` / `update` / `delete` / `read`), and outcome.
+- `state_store.init` spans carry the state-store backend slug (`local`, `inmemory`, `http`, `cloudflare-http`, or any third-party slug).
+
+### From the Cloudflare State Store
+
+When you deploy the [Cloudflare State Store](/guides/custom-state-store) it runs as a Worker on **your** Cloudflare account. The worker emits OTLP traces/metrics/logs to the same `otel.alchemy.run` relay.
+
+Resource attributes (set on every signal from the worker):
+
+| Attribute | Value |
+| --- | --- |
+| `service.name` | `alchemy-state-store` |
+| `service.version` | The deployed worker contract version (currently `2`). |
+| `alchemy.state_store.script_name` | `alchemy-state-store`. |
+
+Per-request span attributes (one per state-store API call):
+
+| Attribute | Value |
+| --- | --- |
+| `alchemy.state_store.op` | `getState` / `setState` / `deleteState` / `listStacks` / `listStages` / `listResources` / `getReplacedResources` / `deleteStack` / `getVersion` |
+| `alchemy.state_store.stack` | The stack name from your `alchemy.run.ts` (e.g. `MyApp`). |
+| `alchemy.state_store.stage` | The stage name (e.g. `prod`, `dev_alice`). |
+| `alchemy.state_store.fqn` | The fully-qualified resource name within the stack (e.g. `bucket/uploads`). |
+| `duration` | Op latency. |
+
+CLI-side spans that touch the Cloudflare State Store
+(`state_store.bootstrap`, `state_store.deploy`, `state_store.init`)
+also carry `alchemy.cloudflare.account_hash` — a SHA-256 of your
+Cloudflare account ID. The raw account ID is never sent. We use the
+hash to count distinct deployments without identifying anyone.
+
+## What we don't collect
+
+- Secrets, API tokens, environment variables, `.env` contents.
+- Resource property values, source code, file contents.
+- Raw filesystem paths, hostnames, or shell user names.
+- Raw git URLs, raw branch names, raw Cloudflare account IDs (only SHA-256 hashes of these).
+- IP addresses (the relay strips them before forwarding).
+- Any tracking cookies, advertising IDs, or third-party identifiers.
+
+## Where it goes
+
+`otel.alchemy.run` is a Cloudflare Worker we operate. It accepts
+standard OTLP/HTTP at `/v1/traces`, `/v1/logs`, and `/v1/metrics`,
+attaches an Axiom ingest token server-side, and forwards to our
+Axiom workspace. Source for the relay lives at
+[`stacks/otel/Ingester.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/stacks/otel/Ingester.ts).
+
+We do not share or sell the data. Aggregated stats may appear in
+public talks, posts, or dashboards.
+
+## How to opt out
+
+### CLI — kill all telemetry
+
+Any one of these disables the OTLP exporter entirely. The CLI's
+default tracer becomes a no-op, so nothing leaves your machine:
+
+```sh
+DO_NOT_TRACK=1 alchemy deploy
+NO_TRACK=1 alchemy deploy
+ALCHEMY_TELEMETRY_DISABLED=1 alchemy deploy
+```
+
+To make the opt-out persistent without setting an env var on every
+run, create the marker file:
+
+```sh
+mkdir -p ~/.alchemy
+echo "true" > ~/.alchemy/telemetry-disabled
+```
+
+To re-enable, delete the file:
+
+```sh
+rm ~/.alchemy/telemetry-disabled
+```
+
+### Cloudflare State Store — opt out per-deployment
+
+The state-store worker exports its own OTLP signals — these go
+through the same relay but flow even if your CLI's telemetry is
+disabled (because the worker runs on your CF account, not your
+machine). Two mechanisms exist:
+
+**`noTrack` option.** Passes through to the CLI-side state-store
+spans, suppressing the `alchemy.cloudflare.account_hash` attribute:
+
+```ts
+import * as Cloudflare from "alchemy/Cloudflare";
+
+Cloudflare.state({ noTrack: true });
+```
+
+**`NO_TRACK` env var.** When `Cloudflare.state()` is called without
+an explicit `noTrack`, it falls back to `NO_TRACK` from the
+environment.
+
+```sh
+NO_TRACK=1 alchemy deploy
+```
+
+`noTrack` only suppresses the account-hash attribute on state-store
+spans. To stop the worker from emitting signals at all, you'd need
+to remove the OTLP layer in your own fork of `Api.ts`, or run a
+custom HTTP state store via [`makeHttpStateStore`](/guides/custom-state-store).
+
+## Questions
+
+Email [sam@alchemy.run](mailto:sam@alchemy.run) or open an issue at
+[alchemy-run/alchemy-effect](https://github.com/alchemy-run/alchemy-effect/issues).


### PR DESCRIPTION
Ship traces, metrics, and logs from the deployed Cloudflare state-store worker — and the deploy-time bootstrap path — to the public ingest relay at `otel.alchemy.run` (defined in `stacks/otel.ts`).

```ts
// Api.ts — runtime worker
const TelemetryLive = Layer.mergeAll(
  OtlpTracer.layer({ url: "https://otel.alchemy.run/v1/traces", ... }),
  OtlpMetrics.layer({ url: "https://otel.alchemy.run/v1/metrics", ... }),
  OtlpLogger.layer({ url: "https://otel.alchemy.run/v1/logs", ..., mergeWithExisting: false }),
).pipe(Layer.provide(OtlpSerialization.layerJson), Layer.provide(FetchHttpClient.layer));

fetch: HttpApiBuilder.layer(StateApi).pipe(
  ...,
  HttpRouter.toHttpEffect,
  Effect.provide(TelemetryLive),
)
```

Each handler is wrapped in `Effect.withSpan` with op/stack/stage/fqn attributes — span duration gives free per-op latency:

```ts
.handle("getState", ({ params }) => {
  const fqn = decodeURIComponent(params.fqn);
  return store.getByName(params.stack).get({ stage: params.stage, fqn }).pipe(
    Effect.withSpan("state_store.getState", {
      attributes: {
        "alchemy.state_store.op": "getState",
        "alchemy.state_store.stack": params.stack,
        "alchemy.state_store.stage": params.stage,
        "alchemy.state_store.fqn": fqn,
      },
    }),
  );
})
```

### Deploy-time spans (`State.ts`)

The CLI's existing `TelemetryLive` already exports to `otel.alchemy.run`, so the new spans flow through automatically:

- `state_store.bootstrap`, `state_store.finish_bootstrap`, `state_store.login`
- `state_store.redeploy_if_stale`, `state_store.check_version`
- `state_store.read_secret_via_edge`, `state_store.hoist_bootstrap_stack`

All branded with `alchemy.state_store.{script_name,profile,ci,...}` so they're easy to slice in Axiom.

### Per-deployment opt-out

```ts
Cloudflare.state({ noTrack: true })   // explicit opt-out
Cloudflare.state({ noTrack: false })  // explicit opt-in (overrides env)
Cloudflare.state()                    // falls back to NO_TRACK env, default off
```

`noTrack` only suppresses `alchemy.cloudflare.account_hash` on state-store spans. The global `DO_NOT_TRACK` / `ALCHEMY_TELEMETRY_DISABLED` kill-switches still apply on top.

### Dashboard

Adds a Cloudflare State Store section to `stacks/otel/Dashboard.ts` with eight charts: distinct deployments (7d), distinct stacks tracked, total ops, per-op latency (p50/p95/p99), ops over time, error rate by op, top stacks by activity, deployments per day. Worker handler spans are identified by the `alchemy.state_store.script_name` resource attribute; CLI deploy spans by `alchemy.cloudflare.account_hash` (SHA-256 of the CF accountId).
