### PR TITLE
feat(test): add dev flag to test harness, toggleable via ALCHEMY_DEV

### DIFF
--- a/packages/alchemy/src/Deploy.ts
+++ b/packages/alchemy/src/Deploy.ts
@@ -9,9 +9,11 @@ import { Stage } from "./Stage.ts";
 export const deploy = <A>({
   stack,
   stage,
+  dev,
 }: {
   stack: StackEffect<CompiledStack<A>, Stage | AlchemyContext>;
   stage: string;
+  dev?: boolean;
 }) =>
   evalStack(
     stack,
@@ -21,5 +23,5 @@ export const deploy = <A>({
         const output = yield* Apply.apply(plan);
         return output as Input.Resolve<A>;
       }),
-    { stage },
+    { stage, dev },
   );

--- a/packages/alchemy/src/Destroy.ts
+++ b/packages/alchemy/src/Destroy.ts
@@ -9,9 +9,11 @@ import type { Stage } from "./Stage.ts";
 export const destroy = ({
   stack,
   stage,
+  dev,
 }: {
   stack: StackEffect<CompiledStack, Stage | AlchemyContext>;
   stage: string;
+  dev?: boolean;
 }) =>
   evalStack(
     stack,
@@ -24,5 +26,5 @@ export const destroy = ({
         bindings: {},
         output: {},
       }).pipe(Effect.flatMap(Apply.apply)),
-    { stage },
+    { stage, dev },
   );

--- a/packages/alchemy/src/Stack.ts
+++ b/packages/alchemy/src/Stack.ts
@@ -252,17 +252,29 @@ const platform = Layer.mergeAll(
   Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
 );
 // override alchemy state store, CLI/reporting, state, and Config
-const alchemy = Layer.mergeAll(
-  // CLI.inkCLI(),
-  // optional
-  AlchemyContextLive,
-);
+const alchemy = (overrides?: { dev?: boolean }) =>
+  Layer.mergeAll(
+    // CLI.inkCLI(),
+    // optional
+    overrides?.dev
+      ? Layer.provide(
+          Layer.effect(
+            AlchemyContext,
+            AlchemyContext.asEffect().pipe(
+              Effect.map((ctx) => ({ ...ctx, dev: overrides.dev! })),
+            ),
+          ),
+          AlchemyContextLive,
+        )
+      : AlchemyContextLive,
+  );
 
 export const evalStack = <A, B, Err, Req>(
   effect: StackEffect<CompiledStack<A>, Stage | AlchemyContext>,
   fn: (stack: CompiledStack<A>) => Effect.Effect<B, Err, Req>,
   options: {
     stage: string;
+    dev?: boolean;
   },
 ) =>
   Effect.gen(function* () {
@@ -284,6 +296,6 @@ export const evalStack = <A, B, Err, Req>(
       ),
     ),
     Effect.provide(Layer.succeed(Stage, options.stage)),
-    Effect.provide(Layer.provideMerge(alchemy, platform)),
+    Effect.provide(Layer.provideMerge(alchemy({ dev: options.dev }), platform)),
     Effect.scoped,
   );

--- a/packages/alchemy/src/Test/Core.ts
+++ b/packages/alchemy/src/Test/Core.ts
@@ -5,8 +5,7 @@ import * as Option from "effect/Option";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 
 import { AdoptPolicy } from "../AdoptPolicy.ts";
-import type { AlchemyContext } from "../AlchemyContext.ts";
-import { AlchemyContextLive } from "../AlchemyContext.ts";
+import { AlchemyContext, AlchemyContextLive } from "../AlchemyContext.ts";
 import { apply } from "../Apply.ts";
 import { provideFreshArtifactStore } from "../Artifacts.ts";
 import { AuthProviders } from "../Auth/AuthProvider.ts";
@@ -47,7 +46,29 @@ export interface MakeOptions<ROut = any> {
    * (matching the CLI's `--adopt` flag). Defaults to `false`.
    */
   adopt?: boolean;
+  /**
+   * Run providers in local-dev mode (matching the CLI's `alchemy dev` flag).
+   * When `true`, resources like Cloudflare Workers run locally via workerd
+   * instead of being deployed to the cloud. When omitted, falls back to the
+   * `ALCHEMY_DEV` environment variable (`"1"` / `"true"` enable it).
+   */
+  dev?: boolean;
 }
+
+/** Resolve the effective `dev` flag from explicit options or `ALCHEMY_DEV`. */
+export const resolveDev = (options: { dev?: boolean }): boolean => {
+  if (options.dev !== undefined) return options.dev;
+  const env = process.env.ALCHEMY_DEV;
+  return env === "1" || env?.toLowerCase() === "true";
+};
+
+const overrideAlchemyContext = (overrides: { dev: boolean }) =>
+  Layer.effect(
+    AlchemyContext,
+    AlchemyContext.asEffect().pipe(
+      Effect.map((ctx) => ({ ...ctx, ...overrides })),
+    ),
+  );
 
 export type TestEffect<A, Req = never> = StackEffect<A, any, Req>;
 
@@ -77,6 +98,7 @@ export const toEffect = <A>(
     );
   }).pipe(
     Effect.provideService(AdoptPolicy, options.adopt ?? false),
+    Effect.provide(overrideAlchemyContext({ dev: resolveDev(options) })),
     // `options.state` (e.g. `Cloudflare.state()`) itself requires
     // `AuthProviders` to read credentials, so AuthProviders must be provided
     // AFTER the state layer or the state layer's requirement is never
@@ -129,6 +151,7 @@ export const deploy = <A>(
   _deploy({
     stack: stack as Effect.Effect<CompiledStack<A>, never, any>,
     stage: callOptions?.stage ?? options.stage ?? "test",
+    dev: resolveDev(options),
   }).pipe(Effect.provide(TelemetryLive));
 
 export const destroy = (
@@ -139,6 +162,7 @@ export const destroy = (
   _destroy({
     stack: stack as Effect.Effect<CompiledStack, never, any>,
     stage: callOptions?.stage ?? options.stage ?? "test",
+    dev: resolveDev(options),
   }).pipe(Effect.provide(TelemetryLive));
 
 /**

--- a/website/src/content/docs/tutorial/part-4.mdx
+++ b/website/src/content/docs/tutorial/part-4.mdx
@@ -58,21 +58,48 @@ export default Cloudflare.Worker(
 );
 ```
 
-## Run tests against dev
+## Run tests in dev mode
 
-Since your Worker runs on localhost in dev mode, you can point your
-integration tests at it for an even faster feedback loop:
+You don't need to run `alchemy dev` in a separate terminal to test
+against locally-emulated resources. The test harness has its own
+`dev` flag that flips every Worker over to workerd inside the test
+process — same wiring as `alchemy dev`, no extra terminal.
 
-```sh
-# Terminal 1: start dev mode
-alchemy dev
-
-# Terminal 2: run tests against local
-bun test test/integ.test.ts
+```diff lang="typescript"
+// test/integ.test.ts
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+  state: Cloudflare.state(),
++ dev: true,
+});
 ```
 
-The tests deploy the stack and run HTTP assertions against your
-local Worker.
+`beforeAll(deploy(Stack))` now boots the Workers locally; HTTP
+assertions hit `http://localhost:1337` and roundtrip into your code
+with full stack traces.
+
+## Toggle dev mode from CI
+
+Hardcoding `dev: true` would force CI runs to local emulation too.
+Read it from the environment instead so the same test file runs
+against real cloud resources in CI and locally-emulated ones on your
+laptop.
+
+```diff lang="typescript"
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+  state: Cloudflare.state(),
+- dev: true,
+});
+```
+
+Drop the explicit flag and the harness falls back to the
+`ALCHEMY_DEV` env var — set `ALCHEMY_DEV=1` in your shell to flip
+to local mode, leave it unset in CI.
+
+```sh
+ALCHEMY_DEV=1 bun test test/integ.test.ts
+```
 
 ## Recap
 

--- a/website/src/content/docs/tutorial/part-5.mdx
+++ b/website/src/content/docs/tutorial/part-5.mdx
@@ -83,12 +83,12 @@ You'll also be prompted for a GitHub credential. Pick `gh-cli` if
 you have the GitHub CLI installed, otherwise paste a Personal
 Access Token with the `repo` scope.
 
-## Create the GitHub stack
+## Scaffold the GitHub stack
 
-Create `stacks/github.ts`. This is a one-shot stack you'll deploy
-from your laptop (under the `admin` profile) to provision the
-Cloudflare API token CI will use, and to push it into your repo as
-an encrypted GitHub Actions secret.
+Create `stacks/github.ts` with an empty stack that loads both
+provider layers and reuses your remote state store. This is a
+one-shot stack you'll deploy from your laptop (under the `admin`
+profile) to provision the Cloudflare API token CI will use.
 
 ```typescript
 // stacks/github.ts
@@ -111,61 +111,93 @@ export default Alchemy.Stack(
   },
   Effect.gen(function* () {
     const accountId = yield* Config.string("CLOUDFLARE_ACCOUNT_ID");
-
-    const apiToken = yield* Cloudflare.AccountApiToken("CIToken", {
-      accountId,
-      policies: [
-        {
-          effect: "allow",
-          permissionGroups: [
-            "Workers Scripts Write",
-            "Workers KV Storage Write",
-            "Workers R2 Storage Write",
-            "D1 Write",
-            "Queues Write",
-            "Pages Write",
-            "Account Settings Write",
-            "Workers Tail Read",
-          ],
-          resources: {
-            [`com.cloudflare.api.account.${accountId}`]: "*",
-          },
-        },
-      ],
-    });
-
-    yield* GitHub.Secret("cf-api-token", {
-      owner: "your-org",
-      repository: "your-repo",
-      name: "CLOUDFLARE_API_TOKEN",
-      value: apiToken.value,
-    });
-
-    yield* GitHub.Secret("cf-account-id", {
-      owner: "your-org",
-      repository: "your-repo",
-      name: "CLOUDFLARE_ACCOUNT_ID",
-      value: Redacted.make(accountId),
-    });
   }),
 );
 ```
 
-A few things worth pointing out:
+Reusing the same `Cloudflare.state()` you set up in Part 1 means the
+token's ID is tracked alongside the rest of your infrastructure, so
+any future edit (rename, policy change) produces a clean diff.
 
-- `Cloudflare.AccountApiToken` calls
-  `POST /accounts/{account_id}/tokens` and returns the freshly minted
-  secret. Cloudflare only reveals that value once, so Alchemy stores
-  it in state and pipes it straight into `GitHub.Secret` — the raw
-  token never touches your terminal.
-- The token is **scoped down** to exactly the permissions your app
-  needs. If you don't use D1 or R2, drop those entries.
-- The same stack reuses your remote `Cloudflare.state()`, so the
-  token's ID is tracked and any future edit (rename, policy change)
-  produces a clean diff.
+## Mint a scoped Cloudflare API token
+
+Add an `AccountApiToken` resource. Under the hood it calls
+`POST /accounts/{account_id}/tokens` and returns the freshly minted
+secret. Cloudflare only reveals that value once, so Alchemy stores it
+in state — the raw token never touches your terminal.
+
+```diff lang="typescript"
+  Effect.gen(function* () {
+    const accountId = yield* Config.string("CLOUDFLARE_ACCOUNT_ID");
++
++   const apiToken = yield* Cloudflare.AccountApiToken("CIToken", {
++     accountId,
++     policies: [
++       {
++         effect: "allow",
++         permissionGroups: [
++           "Workers Scripts Write",
++           "Workers KV Storage Write",
++           "Workers R2 Storage Write",
++           "D1 Write",
++           "Queues Write",
++           "Pages Write",
++           "Account Settings Write",
++           "Workers Tail Read",
++         ],
++         resources: {
++           [`com.cloudflare.api.account.${accountId}`]: "*",
++         },
++       },
++     ],
++   });
+  }),
+```
+
+The `permissionGroups` list scopes the token down to exactly what
+your app needs. If you don't use D1 or R2, drop those entries.
+
+## Push the token into GitHub
+
+Pipe `apiToken.value` straight into a `GitHub.Secret` so CI can read
+it without the secret ever round-tripping through your shell.
+
+```diff lang="typescript"
+    });
++
++   yield* GitHub.Secret("cf-api-token", {
++     owner: "your-org",
++     repository: "your-repo",
++     name: "CLOUDFLARE_API_TOKEN",
++     value: apiToken.value,
++   });
+  }),
+```
 
 Replace `your-org` and `your-repo` with your GitHub org and repo
 slug.
+
+## Expose the account ID to CI
+
+The workflow also needs `CLOUDFLARE_ACCOUNT_ID`. It isn't a secret in
+the cryptographic sense, but storing it as a GitHub Actions secret
+keeps all CI configuration in one place and out of your workflow YAML.
+
+```diff lang="typescript"
+      value: apiToken.value,
+    });
++
++   yield* GitHub.Secret("cf-account-id", {
++     owner: "your-org",
++     repository: "your-repo",
++     name: "CLOUDFLARE_ACCOUNT_ID",
++     value: Redacted.make(accountId),
++   });
+  }),
+```
+
+`Redacted.make` wraps the plain string so it gets the same masking
+treatment as the API token.
 
 ## Deploy the GitHub stack
 


### PR DESCRIPTION
Test.make({ ..., dev: true }) now flips Cloudflare Workers (and any
other resource that branches on AlchemyContext.dev) to local workerd
mode, matching `alchemy dev` — without spawning a separate process.
Falls back to the ALCHEMY_DEV env var so the same test file can run
against local emulation locally and real cloud in CI.

Threads `dev` through evalStack -> Deploy/Destroy so the override
reaches resource providers (which read it via AlchemyContext).

Tutorial:
- part-4: replace the "two terminals + alchemy dev" recipe with the
  new harness flag + ALCHEMY_DEV pattern.
- part-5: split the GitHub stack snippet into per-step sections so
  each new resource has its own heading + diff + explanation,
  matching the tutorial standard.