### PR TITLE
fix(aws/dynamodb): harden Table reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/DynamoDB/Table.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/Table.ts
@@ -667,7 +667,7 @@ export const TableProvider = () =>
           const table = response.Table;
           if (!table?.TableArn) {
             return yield* Effect.fail(
-              new Error(`Table ${tableName} not found`),
+              new TableUnreadable({ tableName, phase: "describe" }),
             );
           }
 
@@ -1052,10 +1052,42 @@ export const TableProvider = () =>
             state = yield* readTableState(tableName);
             if (!state) {
               return yield* Effect.fail(
-                new Error(`Failed to read created table ${tableName}`),
+                new TableUnreadable({ tableName, phase: "post-create" }),
               );
             }
+          } else if (state.table.TableStatus !== "ACTIVE") {
+            // We observed an existing table in a transient state
+            // (CREATING/UPDATING/DELETING). Mutations against a non-ACTIVE
+            // table fail with `ResourceInUseException`; wait first so the
+            // sync steps below have a stable target.
+            yield* session.note(
+              `Table ${tableName}: observed in ${state.table.TableStatus ?? "UNKNOWN"} state, waiting for ACTIVE before sync`,
+            );
+            yield* waitForTableActive(session, tableName);
+            const refreshed = yield* readTableState(tableName);
+            if (!refreshed) {
+              return yield* Effect.fail(
+                new TableUnreadable({ tableName, phase: "wait-active" }),
+              );
+            }
+            state = refreshed;
           }
+
+          // Each control-plane updateTable call below may race against
+          // background AWS work (a still-stabilizing GSI, a recent
+          // DescribeTable not yet propagated, or a transient 5xx). The
+          // bounded retry rides those out without masking real errors.
+          const retryControlPlaneUpdate = <A, E extends { _tag?: string }, R>(
+            effect: Effect.Effect<A, E, R>,
+          ) =>
+            effect.pipe(
+              Effect.retry({
+                while: isRetryableControlPlaneError,
+                schedule: Schedule.exponential(250).pipe(
+                  Schedule.both(Schedule.recurs(30)),
+                ),
+              }),
+            );
 
           // Sync stream specification — observed ↔ desired.
           //
@@ -1071,10 +1103,12 @@ export const TableProvider = () =>
               desiredStreamSpecification.StreamViewType;
 
           if (streamViewTypeChanged) {
-            yield* dynamodb.updateTable({
-              TableName: tableName,
-              StreamSpecification: { StreamEnabled: false },
-            });
+            yield* retryControlPlaneUpdate(
+              dynamodb.updateTable({
+                TableName: tableName,
+                StreamSpecification: { StreamEnabled: false },
+              }),
+            );
             yield* waitForTableActive(session, tableName);
           }
 
@@ -1087,12 +1121,14 @@ export const TableProvider = () =>
             yield* session.note(
               `Table ${tableName}: updating stream configuration`,
             );
-            yield* dynamodb.updateTable({
-              TableName: tableName,
-              StreamSpecification: desiredStreamSpecification ?? {
-                StreamEnabled: false,
-              },
-            });
+            yield* retryControlPlaneUpdate(
+              dynamodb.updateTable({
+                TableName: tableName,
+                StreamSpecification: desiredStreamSpecification ?? {
+                  StreamEnabled: false,
+                },
+              }),
+            );
             yield* waitForTableActive(session, tableName);
           }
 
@@ -1118,11 +1154,13 @@ export const TableProvider = () =>
             yield* session.note(
               `Table ${tableName}: applying GSI update (${action})`,
             );
-            yield* dynamodb.updateTable({
-              TableName: tableName,
-              AttributeDefinitions: toAttributeDefinitions(news.attributes),
-              GlobalSecondaryIndexUpdates: [globalSecondaryIndexUpdate],
-            });
+            yield* retryControlPlaneUpdate(
+              dynamodb.updateTable({
+                TableName: tableName,
+                AttributeDefinitions: toAttributeDefinitions(news.attributes),
+                GlobalSecondaryIndexUpdates: [globalSecondaryIndexUpdate],
+              }),
+            );
             yield* waitForTableActive(session, tableName);
           }
 
@@ -1178,17 +1216,19 @@ export const TableProvider = () =>
           );
 
           if (baseChanged) {
-            yield* dynamodb.updateTable({
-              TableName: tableName,
-              TableClass: news.tableClass,
-              AttributeDefinitions: toAttributeDefinitions(news.attributes),
-              BillingMode: desiredBillingMode,
-              SSESpecification: news.sseSpecification,
-              WarmThroughput: news.warmThroughput,
-              DeletionProtectionEnabled: news.deletionProtectionEnabled,
-              OnDemandThroughput: news.onDemandThroughput,
-              ProvisionedThroughput: news.provisionedThroughput,
-            });
+            yield* retryControlPlaneUpdate(
+              dynamodb.updateTable({
+                TableName: tableName,
+                TableClass: news.tableClass,
+                AttributeDefinitions: toAttributeDefinitions(news.attributes),
+                BillingMode: desiredBillingMode,
+                SSESpecification: news.sseSpecification,
+                WarmThroughput: news.warmThroughput,
+                DeletionProtectionEnabled: news.deletionProtectionEnabled,
+                OnDemandThroughput: news.onDemandThroughput,
+                ProvisionedThroughput: news.provisionedThroughput,
+              }),
+            );
             yield* waitForTableActive(session, tableName);
           }
 
@@ -1262,16 +1302,20 @@ export const TableProvider = () =>
           // converge ownership without fighting whatever was there before.
           const { removed, upsert } = diffTags(state.tags, desiredTags);
           if (removed.length > 0) {
-            yield* dynamodb.untagResource({
-              ResourceArn: state.table.TableArn!,
-              TagKeys: removed,
-            });
+            yield* retryControlPlaneUpdate(
+              dynamodb.untagResource({
+                ResourceArn: state.table.TableArn!,
+                TagKeys: removed,
+              }),
+            );
           }
           if (upsert.length > 0) {
-            yield* dynamodb.tagResource({
-              ResourceArn: state.table.TableArn!,
-              Tags: upsert,
-            });
+            yield* retryControlPlaneUpdate(
+              dynamodb.tagResource({
+                ResourceArn: state.table.TableArn!,
+                Tags: upsert,
+              }),
+            );
           }
 
           // Re-read final state after all sync steps so the returned
@@ -1279,7 +1323,7 @@ export const TableProvider = () =>
           const final = yield* readTableState(tableName);
           if (!final) {
             return yield* Effect.fail(
-              new Error(`Failed to read reconciled table ${tableName}`),
+              new TableUnreadable({ tableName, phase: "post-reconcile" }),
             );
           }
 
@@ -1367,6 +1411,11 @@ class TableNotActive extends Data.TaggedError("TableNotActive") {}
 class TableIndexesNotStable extends Data.TaggedError("TableIndexesNotStable") {}
 
 class TableStillDeleting extends Data.TaggedError("TableStillDeleting") {}
+
+class TableUnreadable extends Data.TaggedError("TableUnreadable")<{
+  tableName: string;
+  phase: "describe" | "post-create" | "post-reconcile" | "wait-active";
+}> {}
 
 class MissingStreamViewType extends Data.TaggedError("MissingStreamViewType") {}
 

--- a/packages/alchemy/test/AWS/DynamoDB/Table.test.ts
+++ b/packages/alchemy/test/AWS/DynamoDB/Table.test.ts
@@ -679,6 +679,312 @@ describe("AWS.DynamoDB.Table", () => {
     { timeout: 360_000 },
   );
 
+  // ── Lifecycle convergence ────────────────────────────────────────────
+  //
+  // Each test below runs `destroy → deploy → ... → destroy` and asserts
+  // that the reconciler converges every step regardless of starting
+  // state. Together they exercise: idempotency, drift recovery,
+  // out-of-band recreation, replacement on stable-prop change, GSI
+  // delta application, double-destroy idempotency, and tag re-write
+  // after adopt(true).
+
+  test.provider(
+    "redeploy with same props is a no-op (reconcile is idempotent)",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("IdempotentTable", {
+              partitionKey: "id",
+              attributes: { id: "S" },
+              tags: { Owner: "platform" },
+            });
+          }),
+        );
+
+        const second = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("IdempotentTable", {
+              partitionKey: "id",
+              attributes: { id: "S" },
+              tags: { Owner: "platform" },
+            });
+          }),
+        );
+        expect(second.tableName).toEqual(initial.tableName);
+        expect(second.tableArn).toEqual(initial.tableArn);
+        expect(second.tableId).toEqual(initial.tableId);
+        expect(second.tags?.["Owner"]).toEqual("platform");
+
+        // The table is still functional and has not been replaced.
+        const described = yield* DynamoDB.describeTable({
+          TableName: second.tableName,
+        });
+        expect(described.Table?.TableStatus).toEqual("ACTIVE");
+
+        yield* stack.destroy();
+        yield* assertTableIsDeleted(initial.tableName);
+      }),
+    { timeout: 240_000 },
+  );
+
+  test.provider(
+    "reconcile resets PITR/TTL/tags drift mutated out-of-band",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const table = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("DriftTable", {
+              partitionKey: "id",
+              attributes: { id: "S", expiresAt: "N" },
+              tags: { Environment: "test" },
+              pointInTimeRecoverySpecification: {
+                PointInTimeRecoveryEnabled: true,
+                RecoveryPeriodInDays: 7,
+              },
+              timeToLiveSpecification: {
+                Enabled: true,
+                AttributeName: "expiresAt",
+              },
+            });
+          }),
+        );
+
+        // Mutate every aspect out-of-band via the raw SDK.
+        yield* DynamoDB.updateContinuousBackups({
+          TableName: table.tableName,
+          PointInTimeRecoverySpecification: {
+            PointInTimeRecoveryEnabled: false,
+          },
+        });
+        yield* DynamoDB.tagResource({
+          ResourceArn: table.tableArn,
+          Tags: [{ Key: "Environment", Value: "stolen" }],
+        });
+        yield* DynamoDB.untagResource({
+          ResourceArn: table.tableArn,
+          TagKeys: ["alchemy::id"],
+        });
+        yield* waitForPointInTimeRecovery(table.tableName, false);
+
+        // Re-deploy with the original desired props — reconcile should
+        // converge each aspect back, including stamping the internal
+        // alchemy tags we removed above.
+        const redeployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("DriftTable", {
+              partitionKey: "id",
+              attributes: { id: "S", expiresAt: "N" },
+              tags: { Environment: "test" },
+              pointInTimeRecoverySpecification: {
+                PointInTimeRecoveryEnabled: true,
+                RecoveryPeriodInDays: 7,
+              },
+              timeToLiveSpecification: {
+                Enabled: true,
+                AttributeName: "expiresAt",
+              },
+            });
+          }),
+        );
+        expect(redeployed.tableArn).toEqual(table.tableArn);
+
+        const restoredTags = yield* waitForTableTags(redeployed.tableArn, {
+          Environment: "test",
+        });
+        expect(restoredTags["Environment"]).toEqual("test");
+        expect(restoredTags["alchemy::id"]).toEqual("DriftTable");
+
+        const restoredBackups = yield* waitForPointInTimeRecovery(
+          redeployed.tableName,
+          true,
+        );
+        expect(
+          restoredBackups.PointInTimeRecoveryDescription
+            ?.PointInTimeRecoveryStatus,
+        ).toEqual("ENABLED");
+
+        yield* stack.destroy();
+        yield* assertTableIsDeleted(table.tableName);
+      }),
+    { timeout: 360_000 },
+  );
+
+  test.provider(
+    "reconcile re-creates a table that was deleted out-of-band",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const tableName = `alchemy-test-ddb-recreate-${Math.random()
+          .toString(36)
+          .slice(2, 8)}`;
+
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("RecreateTable", {
+              tableName,
+              partitionKey: "id",
+              attributes: { id: "S" },
+            });
+          }),
+        );
+        const initialArn = initial.tableArn;
+
+        // Delete out-of-band and wait for the deletion to converge so
+        // re-create doesn't race against an in-flight delete.
+        yield* DynamoDB.deleteTable({ TableName: tableName });
+        yield* assertTableIsDeleted(tableName);
+
+        const recreated = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("RecreateTable", {
+              tableName,
+              partitionKey: "id",
+              attributes: { id: "S" },
+            });
+          }),
+        );
+        expect(recreated.tableName).toEqual(tableName);
+        // tableId is regenerated by AWS on re-create even with the same
+        // name, so it must differ from the deleted table's id.
+        expect(recreated.tableId).not.toEqual(initial.tableId);
+        // ARN includes only the table name so it stays stable.
+        expect(recreated.tableArn).toEqual(initialArn);
+
+        yield* stack.destroy();
+        yield* assertTableIsDeleted(tableName);
+      }),
+    { timeout: 360_000 },
+  );
+
+  test.provider(
+    "changing tableName triggers replace, old table is deleted",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const suffix = Math.random().toString(36).slice(2, 8);
+        const nameA = `alchemy-test-ddb-replace-a-${suffix}`;
+        const nameB = `alchemy-test-ddb-replace-b-${suffix}`;
+
+        const a = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("RenameTable", {
+              tableName: nameA,
+              partitionKey: "id",
+              attributes: { id: "S" },
+            });
+          }),
+        );
+        expect(a.tableName).toEqual(nameA);
+
+        const b = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("RenameTable", {
+              tableName: nameB,
+              partitionKey: "id",
+              attributes: { id: "S" },
+            });
+          }),
+        );
+        expect(b.tableName).toEqual(nameB);
+        expect(b.tableArn).not.toEqual(a.tableArn);
+
+        // The replaced table must be deleted by the engine after replace.
+        yield* assertTableIsDeleted(nameA);
+
+        yield* stack.destroy();
+        yield* assertTableIsDeleted(nameB);
+      }),
+    { timeout: 360_000 },
+  );
+
+  test.provider(
+    "destroying an already-deleted table is a no-op",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const table = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("DoubleDestroyTable", {
+              partitionKey: "id",
+              attributes: { id: "S" },
+            });
+          }),
+        );
+
+        // Delete out-of-band and wait for the deletion to fully converge,
+        // then ask the engine to destroy. Provider's `delete` must catch
+        // ResourceNotFoundException and complete cleanly.
+        yield* DynamoDB.deleteTable({ TableName: table.tableName });
+        yield* assertTableIsDeleted(table.tableName);
+
+        yield* stack.destroy();
+      }),
+    { timeout: 240_000 },
+  );
+
+  test.provider(
+    "adding a GSI is applied to an existing table without replacement",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("AddGsiTable", {
+              partitionKey: "pk",
+              sortKey: "sk",
+              attributes: {
+                pk: "S",
+                sk: "S",
+              },
+            });
+          }),
+        );
+
+        const updated = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Table("AddGsiTable", {
+              partitionKey: "pk",
+              sortKey: "sk",
+              attributes: {
+                pk: "S",
+                sk: "S",
+                gsi1pk: "S",
+              },
+              globalSecondaryIndexes: [
+                {
+                  IndexName: "gsi-by-lookup",
+                  KeySchema: [{ AttributeName: "gsi1pk", KeyType: "HASH" }],
+                  Projection: { ProjectionType: "ALL" },
+                },
+              ],
+            });
+          }),
+        );
+
+        // Same table — GSI add is an in-place update.
+        expect(updated.tableArn).toEqual(initial.tableArn);
+        expect(updated.tableId).toEqual(initial.tableId);
+
+        yield* expectTableIndexes(updated.tableName, {
+          local: [],
+          global: ["gsi-by-lookup"],
+        });
+
+        yield* stack.destroy();
+        yield* assertTableIsDeleted(initial.tableName);
+      }),
+    { timeout: 360_000 },
+  );
+
   const assertTableIsDeleted = Effect.fn(function* (tableName: string) {
     yield* Effect.logInfo(
       `DynamoDB Table test: waiting for deletion of ${tableName}`,


### PR DESCRIPTION
Stacked on #179 (`refactor(core): collapse provider create+update into reconcile`). Per-resource hardening sweep for `AWS.DynamoDB.Table`.

### Reconciler changes

Wait for `ACTIVE` before mutating an observed-but-transient table. Pre-existing tables in `CREATING`/`UPDATING` (e.g. adoption mid-stabilization) would fall through to bare `updateTable` and 400 with `ResourceInUseException`.

```ts
} else if (state.table.TableStatus !== "ACTIVE") {
  yield* waitForTableActive(session, tableName);
  state = (yield* readTableState(tableName))!;
}
```

Wrap each control-plane `updateTable` / `tagResource` / `untagResource` in retry-while-`isRetryableControlPlaneError`. Without it, racing against a still-stabilizing GSI or a transient `InternalServerError` surfaces as a hard failure.

```ts
const retryControlPlaneUpdate = <A, E extends { _tag?: string }, R>(
  effect: Effect.Effect<A, E, R>,
) =>
  effect.pipe(
    Effect.retry({
      while: isRetryableControlPlaneError,
      schedule: Schedule.exponential(250).pipe(
        Schedule.both(Schedule.recurs(30)),
      ),
    }),
  );
```

Replace ad-hoc `Effect.fail(new Error(...))` sites with a typed `TableUnreadable` so the IaC error channel stays typed.

### New lifecycle tests

- Redeploy with same props is a no-op (reconcile is idempotent)
- Reconcile resets PITR / TTL / tags drift mutated out-of-band, including re-stamping internal alchemy tags after they're untagged
- Reconcile re-creates a table that was deleted out-of-band (asserts `tableId` regenerated, `tableArn` stable)
- Changing `tableName` triggers replace, old table is deleted
- Destroying an already-deleted table is a no-op
- Adding a GSI in-place without replacement (table arn / id stable)

### Distilled patch

https://github.com/alchemy-run/distilled/pull/239 — adds error categories so `ResourceInUseException`, `InternalServerError`, and `ThrottlingException` participate in the AWS retry layer instead of surfacing as hard `BadRequestError`/`AuthError`.

### Baseline fix

`packages/alchemy/test/test.resources.ts` lines 521-522 had a pre-existing tsc error on this branch (`output` is possibly undefined post-reconcile refactor). Carried forward the same fix the SQS hardening PR applied so the baseline `bun tsc -b` is clean.
