### PR TITLE
fix(aws/kinesis): harden Stream reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/Kinesis/Stream.ts
+++ b/packages/alchemy/src/AWS/Kinesis/Stream.ts
@@ -403,6 +403,28 @@ const waitForStreamActive = (streamName: string) =>
     }),
   );
 
+// Mutation operations (updateShardCount, startStreamEncryption,
+// increaseStreamRetentionPeriod, etc.) reject with `ResourceInUseException`
+// when the stream is mid-update from a previous mutation, and may bounce
+// `LimitExceededException` under throttling. Retry both for ~60s — long
+// enough to ride out a single in-flight mutation but bounded so a stuck
+// stream doesn't loop forever. `waitForStreamActive` already paces between
+// ops in the happy path; this handles the race where Kinesis briefly
+// reports ACTIVE before the next call sees UPDATING.
+const retryMutationConflicts = <A, E extends { _tag: string }, R>(
+  effect: Effect.Effect<A, E, R>,
+) =>
+  effect.pipe(
+    Effect.retry({
+      while: (e: { _tag: string }) =>
+        e._tag === "ResourceInUseException" ||
+        e._tag === "LimitExceededException",
+      schedule: Schedule.exponential(500).pipe(
+        Schedule.both(Schedule.recurs(60)),
+      ),
+    }),
+  );
+
 const waitForStreamDeleted = (streamName: string) =>
   Effect.gen(function* () {
     yield* kinesis.describeStreamSummary({
@@ -469,7 +491,10 @@ export const StreamProvider = () =>
           // Ensure — create the stream if it's missing. Tolerate
           // `ResourceInUseException` as a race with a peer reconciler:
           // re-read and continue with the sync path. Retry transient
-          // `LimitExceededException`.
+          // `LimitExceededException` — Kinesis throws it whenever
+          // five+ streams are in CREATING state at once. Cap the retry
+          // schedule so a persistently saturated account fails loud
+          // instead of looping forever.
           if (state === undefined) {
             yield* kinesis
               .createStream({
@@ -487,7 +512,9 @@ export const StreamProvider = () =>
                 Effect.catchTag("ResourceInUseException", () => Effect.void),
                 Effect.retry({
                   while: (e: any) => e._tag === "LimitExceededException",
-                  schedule: Schedule.exponential(1000),
+                  schedule: Schedule.exponential(1000).pipe(
+                    Schedule.both(Schedule.recurs(20)),
+                  ),
                 }),
               );
 
@@ -505,14 +532,16 @@ export const StreamProvider = () =>
           // Sync stream mode — observed ↔ desired.
           const desiredMode = news.streamMode ?? defaultStreamMode;
           if (state.streamMode !== desiredMode) {
-            yield* kinesis.updateStreamMode({
-              StreamARN: streamArn,
-              StreamModeDetails: getStreamMode(news),
-              WarmThroughputMiBps:
-                desiredMode === "ON_DEMAND"
-                  ? news.warmThroughputMiBps
-                  : undefined,
-            });
+            yield* retryMutationConflicts(
+              kinesis.updateStreamMode({
+                StreamARN: streamArn,
+                StreamModeDetails: getStreamMode(news),
+                WarmThroughputMiBps:
+                  desiredMode === "ON_DEMAND"
+                    ? news.warmThroughputMiBps
+                    : undefined,
+              }),
+            );
             yield* waitForStreamActive(streamName);
             yield* session.note(`Updated stream mode to ${desiredMode}`);
             state = yield* readStream({ streamName, streamArn });
@@ -529,11 +558,13 @@ export const StreamProvider = () =>
             news.shardCount !== undefined &&
             state.openShardCount !== news.shardCount
           ) {
-            yield* kinesis.updateShardCount({
-              StreamName: streamName,
-              TargetShardCount: news.shardCount,
-              ScalingType: "UNIFORM_SCALING",
-            });
+            yield* retryMutationConflicts(
+              kinesis.updateShardCount({
+                StreamName: streamName,
+                TargetShardCount: news.shardCount,
+                ScalingType: "UNIFORM_SCALING",
+              }),
+            );
             yield* waitForStreamActive(streamName);
             yield* session.note(`Updated shard count to ${news.shardCount}`);
           }
@@ -543,15 +574,19 @@ export const StreamProvider = () =>
             news.retentionPeriodHours ?? defaultRetentionPeriodHours;
           if (state.retentionPeriodHours !== desiredRetention) {
             if (desiredRetention > state.retentionPeriodHours) {
-              yield* kinesis.increaseStreamRetentionPeriod({
-                StreamName: streamName,
-                RetentionPeriodHours: desiredRetention,
-              });
+              yield* retryMutationConflicts(
+                kinesis.increaseStreamRetentionPeriod({
+                  StreamName: streamName,
+                  RetentionPeriodHours: desiredRetention,
+                }),
+              );
             } else {
-              yield* kinesis.decreaseStreamRetentionPeriod({
-                StreamName: streamName,
-                RetentionPeriodHours: desiredRetention,
-              });
+              yield* retryMutationConflicts(
+                kinesis.decreaseStreamRetentionPeriod({
+                  StreamName: streamName,
+                  RetentionPeriodHours: desiredRetention,
+                }),
+              );
             }
             yield* waitForStreamActive(streamName);
             yield* session.note(
@@ -564,19 +599,23 @@ export const StreamProvider = () =>
           const desiredKmsKey = news.kmsKeyId ?? "alias/aws/kinesis";
           const observedEncryption = state.encryptionType === "KMS";
           if (!observedEncryption && desiredEncryption) {
-            yield* kinesis.startStreamEncryption({
-              StreamName: streamName,
-              EncryptionType: "KMS",
-              KeyId: desiredKmsKey,
-            });
+            yield* retryMutationConflicts(
+              kinesis.startStreamEncryption({
+                StreamName: streamName,
+                EncryptionType: "KMS",
+                KeyId: desiredKmsKey,
+              }),
+            );
             yield* waitForStreamActive(streamName);
             yield* session.note("Enabled encryption");
           } else if (observedEncryption && !desiredEncryption) {
-            yield* kinesis.stopStreamEncryption({
-              StreamName: streamName,
-              EncryptionType: "KMS",
-              KeyId: state.kmsKeyId ?? desiredKmsKey,
-            });
+            yield* retryMutationConflicts(
+              kinesis.stopStreamEncryption({
+                StreamName: streamName,
+                EncryptionType: "KMS",
+                KeyId: state.kmsKeyId ?? desiredKmsKey,
+              }),
+            );
             yield* waitForStreamActive(streamName);
             yield* session.note("Disabled encryption");
           } else if (
@@ -585,11 +624,13 @@ export const StreamProvider = () =>
             news.kmsKeyId !== undefined &&
             state.kmsKeyId !== news.kmsKeyId
           ) {
-            yield* kinesis.startStreamEncryption({
-              StreamName: streamName,
-              EncryptionType: "KMS",
-              KeyId: news.kmsKeyId,
-            });
+            yield* retryMutationConflicts(
+              kinesis.startStreamEncryption({
+                StreamName: streamName,
+                EncryptionType: "KMS",
+                KeyId: news.kmsKeyId,
+              }),
+            );
             yield* waitForStreamActive(streamName);
             yield* session.note("Updated KMS key");
           }
@@ -605,10 +646,12 @@ export const StreamProvider = () =>
           );
 
           if (metricsToDisable.length > 0) {
-            yield* kinesis.disableEnhancedMonitoring({
-              StreamName: streamName,
-              ShardLevelMetrics: metricsToDisable,
-            });
+            yield* retryMutationConflicts(
+              kinesis.disableEnhancedMonitoring({
+                StreamName: streamName,
+                ShardLevelMetrics: metricsToDisable,
+              }),
+            );
             yield* waitForStreamActive(streamName);
             yield* session.note(
               `Disabled metrics: ${metricsToDisable.join(", ")}`,
@@ -616,10 +659,12 @@ export const StreamProvider = () =>
           }
 
           if (metricsToEnable.length > 0) {
-            yield* kinesis.enableEnhancedMonitoring({
-              StreamName: streamName,
-              ShardLevelMetrics: metricsToEnable,
-            });
+            yield* retryMutationConflicts(
+              kinesis.enableEnhancedMonitoring({
+                StreamName: streamName,
+                ShardLevelMetrics: metricsToEnable,
+              }),
+            );
             yield* waitForStreamActive(streamName);
             yield* session.note(
               `Enabled metrics: ${metricsToEnable.join(", ")}`,
@@ -632,10 +677,12 @@ export const StreamProvider = () =>
             news.warmThroughputMiBps !== undefined &&
             state.warmThroughput?.targetMiBps !== news.warmThroughputMiBps
           ) {
-            yield* kinesis.updateStreamWarmThroughput({
-              StreamARN: streamArn,
-              WarmThroughputMiBps: news.warmThroughputMiBps,
-            });
+            yield* retryMutationConflicts(
+              kinesis.updateStreamWarmThroughput({
+                StreamARN: streamArn,
+                WarmThroughputMiBps: news.warmThroughputMiBps,
+              }),
+            );
             yield* waitForStreamActive(streamName);
             yield* session.note(
               `Updated warm throughput to ${news.warmThroughputMiBps} MiBps`,
@@ -647,10 +694,12 @@ export const StreamProvider = () =>
             news.maxRecordSizeInKiB !== undefined &&
             state.maxRecordSizeInKiB !== news.maxRecordSizeInKiB
           ) {
-            yield* kinesis.updateMaxRecordSize({
-              StreamARN: streamArn,
-              MaxRecordSizeInKiB: news.maxRecordSizeInKiB,
-            });
+            yield* retryMutationConflicts(
+              kinesis.updateMaxRecordSize({
+                StreamARN: streamArn,
+                MaxRecordSizeInKiB: news.maxRecordSizeInKiB,
+              }),
+            );
             yield* waitForStreamActive(streamName);
             yield* session.note(
               `Updated max record size to ${news.maxRecordSizeInKiB} KiB`,
@@ -718,14 +767,20 @@ export const StreamProvider = () =>
           return final;
         }),
         delete: Effect.fn(function* ({ output }) {
-          yield* kinesis
-            .deleteStream({
+          // `deleteStream` rejects with `ResourceInUseException` if the
+          // stream is mid-update (e.g. shard reshape from a prior reconcile)
+          // and `LimitExceededException` if 5+ streams are already in
+          // DELETING state. Both are transient — retry on the same bounded
+          // schedule we use for mutation conflicts. `ResourceNotFoundException`
+          // means somebody beat us to it; that's success for delete.
+          yield* retryMutationConflicts(
+            kinesis.deleteStream({
               StreamName: output.streamName,
               EnforceConsumerDeletion: true,
-            })
-            .pipe(
-              Effect.catchTag("ResourceNotFoundException", () => Effect.void),
-            );
+            }),
+          ).pipe(
+            Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+          );
 
           yield* waitForStreamDeleted(output.streamName);
         }),

--- a/packages/alchemy/test/AWS/Kinesis/Stream.test.ts
+++ b/packages/alchemy/test/AWS/Kinesis/Stream.test.ts
@@ -646,6 +646,422 @@ describe("AWS.Kinesis.Stream", () => {
     { timeout: 240_000 },
   );
 
+  test.provider(
+    "redeploy with same props is a no-op (reconcile is idempotent)",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("IdempotentRedeployStream", {
+              retentionPeriodHours: 36,
+            });
+          }),
+        );
+
+        const second = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("IdempotentRedeployStream", {
+              retentionPeriodHours: 36,
+            });
+          }),
+        );
+        expect(second.streamArn).toEqual(initial.streamArn);
+        expect(second.streamName).toEqual(initial.streamName);
+        expect(second.retentionPeriodHours).toEqual(36);
+
+        const summary = yield* Kinesis.describeStreamSummary({
+          StreamName: second.streamName,
+        });
+        expect(summary.StreamDescriptionSummary.RetentionPeriodHours).toEqual(
+          36,
+        );
+
+        yield* stack.destroy();
+        yield* assertStreamDeleted(initial.streamName);
+      }),
+    { timeout: 180_000 },
+  );
+
+  test.provider(
+    "reconcile resets shard count drift",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("ShardDriftStream", {
+              streamMode: "PROVISIONED",
+              shardCount: 1,
+            });
+          }),
+        );
+        expect(initial.openShardCount).toEqual(1);
+
+        // Mutate shard count out of band.
+        yield* Kinesis.updateShardCount({
+          StreamName: initial.streamName,
+          TargetShardCount: 2,
+          ScalingType: "UNIFORM_SCALING",
+        });
+        yield* waitForShardCount(initial.streamName, 2);
+
+        // Re-deploy with the original shard count — reconcile must converge.
+        const redeployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("ShardDriftStream", {
+              streamMode: "PROVISIONED",
+              shardCount: 1,
+            });
+          }),
+        );
+        expect(redeployed.streamArn).toEqual(initial.streamArn);
+        yield* waitForShardCount(initial.streamName, 1);
+
+        yield* stack.destroy();
+        yield* assertStreamDeleted(initial.streamName);
+      }),
+    { timeout: 360_000 },
+  );
+
+  test.provider(
+    "reconcile resets retention period drift",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("RetentionDriftStream", {
+              retentionPeriodHours: 24,
+            });
+          }),
+        );
+
+        // Drift retention out of band.
+        yield* Kinesis.increaseStreamRetentionPeriod({
+          StreamName: initial.streamName,
+          RetentionPeriodHours: 72,
+        });
+        yield* waitForRetentionHours(initial.streamName, 72);
+
+        // Re-deploy with the original retention — reconcile must reset it.
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("RetentionDriftStream", {
+              retentionPeriodHours: 24,
+            });
+          }),
+        );
+        yield* waitForRetentionHours(initial.streamName, 24);
+
+        yield* stack.destroy();
+        yield* assertStreamDeleted(initial.streamName);
+      }),
+    { timeout: 240_000 },
+  );
+
+  test.provider(
+    "reconcile resets shard-level metrics drift",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("MetricsDriftStream", {
+              shardLevelMetrics: ["IncomingBytes"],
+            });
+          }),
+        );
+
+        // Enable an extra metric out of band.
+        yield* Kinesis.enableEnhancedMonitoring({
+          StreamName: initial.streamName,
+          ShardLevelMetrics: ["OutgoingBytes"],
+        });
+
+        // Re-deploy with the original metrics — reconcile must remove
+        // the drifted metric.
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("MetricsDriftStream", {
+              shardLevelMetrics: ["IncomingBytes"],
+            });
+          }),
+        );
+
+        const summary = yield* Kinesis.describeStreamSummary({
+          StreamName: initial.streamName,
+        });
+        const metrics =
+          summary.StreamDescriptionSummary.EnhancedMonitoring?.[0]
+            ?.ShardLevelMetrics ?? [];
+        expect(metrics).toContain("IncomingBytes");
+        expect(metrics).not.toContain("OutgoingBytes");
+
+        yield* stack.destroy();
+        yield* assertStreamDeleted(initial.streamName);
+      }),
+    { timeout: 240_000 },
+  );
+
+  test.provider(
+    "reconcile re-creates a stream that was deleted out-of-band",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const streamName = `alchemy-test-kinesis-recreate-${Math.random()
+          .toString(36)
+          .slice(2, 8)}`;
+
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("RecreateStream", { streamName });
+          }),
+        );
+
+        // Delete the stream out of band and wait for AWS to fully drop it.
+        yield* Kinesis.deleteStream({
+          StreamName: initial.streamName,
+          EnforceConsumerDeletion: true,
+        });
+        yield* assertStreamDeleted(streamName);
+
+        // Re-deploying must converge by re-creating.
+        const recreated = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("RecreateStream", { streamName });
+          }),
+        );
+
+        expect(recreated.streamName).toEqual(streamName);
+        expect(recreated.streamStatus).toEqual("ACTIVE");
+
+        const summary = yield* Kinesis.describeStreamSummary({
+          StreamName: streamName,
+        });
+        expect(summary.StreamDescriptionSummary.StreamStatus).toEqual("ACTIVE");
+
+        yield* stack.destroy();
+        yield* assertStreamDeleted(streamName);
+      }),
+    { timeout: 360_000 },
+  );
+
+  test.provider(
+    "changing streamName triggers replace, old stream is deleted",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const suffix = Math.random().toString(36).slice(2, 8);
+        const nameA = `alchemy-test-kinesis-replace-a-${suffix}`;
+        const nameB = `alchemy-test-kinesis-replace-b-${suffix}`;
+
+        const a = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("RenameStream", { streamName: nameA });
+          }),
+        );
+        expect(a.streamName).toEqual(nameA);
+
+        const b = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("RenameStream", { streamName: nameB });
+          }),
+        );
+        expect(b.streamName).toEqual(nameB);
+        expect(b.streamArn).not.toEqual(a.streamArn);
+
+        // The old stream must be gone after replace.
+        yield* assertStreamDeleted(nameA);
+
+        yield* stack.destroy();
+        yield* assertStreamDeleted(nameB);
+      }),
+    { timeout: 360_000 },
+  );
+
+  test.provider(
+    "scale provisioned shard count up and back down",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("ShardScaleStream", {
+              streamMode: "PROVISIONED",
+              shardCount: 1,
+            });
+          }),
+        );
+        expect(initial.openShardCount).toEqual(1);
+
+        const scaledUp = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("ShardScaleStream", {
+              streamMode: "PROVISIONED",
+              shardCount: 2,
+            });
+          }),
+        );
+        expect(scaledUp.streamArn).toEqual(initial.streamArn);
+        yield* waitForShardCount(initial.streamName, 2);
+
+        const scaledDown = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("ShardScaleStream", {
+              streamMode: "PROVISIONED",
+              shardCount: 1,
+            });
+          }),
+        );
+        expect(scaledDown.streamArn).toEqual(initial.streamArn);
+        yield* waitForShardCount(initial.streamName, 1);
+
+        yield* stack.destroy();
+        yield* assertStreamDeleted(initial.streamName);
+      }),
+    { timeout: 480_000 },
+  );
+
+  test.provider(
+    "toggle stream mode on-demand <-> provisioned",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const onDemand = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("ModeToggleStream", {
+              streamMode: "ON_DEMAND",
+            });
+          }),
+        );
+        expect(onDemand.streamMode).toEqual("ON_DEMAND");
+
+        const provisioned = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("ModeToggleStream", {
+              streamMode: "PROVISIONED",
+              shardCount: 1,
+            });
+          }),
+        );
+        expect(provisioned.streamArn).toEqual(onDemand.streamArn);
+
+        const summary = yield* Kinesis.describeStreamSummary({
+          StreamName: provisioned.streamName,
+        });
+        expect(
+          summary.StreamDescriptionSummary.StreamModeDetails?.StreamMode,
+        ).toEqual("PROVISIONED");
+
+        const backToOnDemand = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("ModeToggleStream", {
+              streamMode: "ON_DEMAND",
+            });
+          }),
+        );
+        expect(backToOnDemand.streamArn).toEqual(onDemand.streamArn);
+
+        const finalSummary = yield* Kinesis.describeStreamSummary({
+          StreamName: backToOnDemand.streamName,
+        });
+        expect(
+          finalSummary.StreamDescriptionSummary.StreamModeDetails?.StreamMode,
+        ).toEqual("ON_DEMAND");
+
+        yield* stack.destroy();
+        yield* assertStreamDeleted(onDemand.streamName);
+      }),
+    { timeout: 480_000 },
+  );
+
+  test.provider(
+    "destroying an already-deleted stream is a no-op",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const stream = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Stream("DoubleDestroyStream");
+          }),
+        );
+
+        // Delete the stream out of band, then ask the engine to destroy it.
+        // Provider's `delete` must catch ResourceNotFoundException and
+        // complete cleanly.
+        yield* Kinesis.deleteStream({
+          StreamName: stream.streamName,
+          EnforceConsumerDeletion: true,
+        });
+        yield* assertStreamDeleted(stream.streamName);
+
+        yield* stack.destroy();
+      }),
+    { timeout: 240_000 },
+  );
+
+  class ShardCountMismatch extends Data.TaggedError("ShardCountMismatch") {}
+  class RetentionMismatch extends Data.TaggedError("RetentionMismatch") {}
+
+  /** Poll DescribeStreamSummary until the stream reports the expected shard count. */
+  const waitForShardCount = Effect.fn(function* (
+    streamName: string,
+    expected: number,
+  ) {
+    yield* Effect.gen(function* () {
+      const { StreamDescriptionSummary } = yield* Kinesis.describeStreamSummary(
+        { StreamName: streamName },
+      );
+      if (
+        StreamDescriptionSummary.StreamStatus !== "ACTIVE" ||
+        StreamDescriptionSummary.OpenShardCount !== expected
+      ) {
+        return yield* Effect.fail(new ShardCountMismatch());
+      }
+    }).pipe(
+      Effect.retry({
+        while: (e: { _tag: string }) =>
+          e._tag === "ShardCountMismatch" || e._tag === "ParseError",
+        schedule: Schedule.exponential(500).pipe(
+          Schedule.both(Schedule.recurs(60)),
+        ),
+      }),
+    );
+  });
+
+  /** Poll DescribeStreamSummary until the stream reports the expected retention period. */
+  const waitForRetentionHours = Effect.fn(function* (
+    streamName: string,
+    expected: number,
+  ) {
+    yield* Effect.gen(function* () {
+      const { StreamDescriptionSummary } = yield* Kinesis.describeStreamSummary(
+        { StreamName: streamName },
+      );
+      if (StreamDescriptionSummary.RetentionPeriodHours !== expected) {
+        return yield* Effect.fail(new RetentionMismatch());
+      }
+    }).pipe(
+      Effect.retry({
+        while: (e: { _tag: string }) =>
+          e._tag === "RetentionMismatch" || e._tag === "ParseError",
+        schedule: Schedule.fixed("500 millis").pipe(
+          Schedule.both(Schedule.recurs(40)),
+        ),
+      }),
+    );
+  });
+
   class StreamStillExists extends Data.TaggedError("StreamStillExists") {}
 
   const assertStreamDeleted = Effect.fn(function* (streamName: string) {


### PR DESCRIPTION
Per-resource hardening sweep on top of #179 for `AWS.Kinesis.Stream`.

### Reconciler changes

Bounded the `createStream` `LimitExceededException` retry — it was unbounded.

```diff
 .pipe(
   Effect.catchTag("ResourceInUseException", () => Effect.void),
   Effect.retry({
     while: (e: any) => e._tag === "LimitExceededException",
-    schedule: Schedule.exponential(1000),
+    schedule: Schedule.exponential(1000).pipe(
+      Schedule.both(Schedule.recurs(20)),
+    ),
   }),
 );
```

Added a `retryMutationConflicts` helper and wrapped every mutation call (`updateStreamMode`, `updateShardCount`, `increase`/`decreaseStreamRetentionPeriod`, `start`/`stopStreamEncryption`, `enable`/`disableEnhancedMonitoring`, `updateStreamWarmThroughput`, `updateMaxRecordSize`, `deleteStream`).

```ts
// Mutation operations reject with ResourceInUseException when the stream
// is mid-update from a previous mutation, and LimitExceededException
// under throttling. Retry both for ~60s.
const retryMutationConflicts = <A, E extends { _tag: string }, R>(
  effect: Effect.Effect<A, E, R>,
) =>
  effect.pipe(
    Effect.retry({
      while: (e) =>
        e._tag === "ResourceInUseException" ||
        e._tag === "LimitExceededException",
      schedule: Schedule.exponential(500).pipe(
        Schedule.both(Schedule.recurs(60)),
      ),
    }),
  );
```

`waitForStreamActive` paces the happy path between sync steps, but Kinesis briefly reports `ACTIVE` between mutations before the next call sees `UPDATING`, so each mutation needs its own bounded retry on the conflict tags.

### New lifecycle tests

Each runs `destroy -> deploy -> ... -> destroy` on a `ScratchStack`.

- redeploy with same props is a no-op
- reconcile resets shard count drift mutated out-of-band
- reconcile resets retention period drift mutated out-of-band
- reconcile resets shard-level metrics drift mutated out-of-band
- reconcile re-creates a stream that was deleted out-of-band
- changing `streamName` triggers replace; old stream is deleted
- scale provisioned shard count up and back down
- toggle stream mode `ON_DEMAND` <-> `PROVISIONED` (round trip)
- destroying an already-deleted stream is a no-op

### Distilled patch

Error category fixes at https://github.com/alchemy-run/distilled/pull/240 — needed so `ResourceInUseException`, `LimitExceededException`, `ProvisionedThroughputExceededException`, `KMSThrottlingException`, `InternalFailureException` participate in the AWS retry layer instead of surfacing as terminal.

`test.resources.ts` carries a one-line baseline fix for `stableId` / `stableArn` fallbacks on the update branch (same as the SQS hardening PR).
