### PR TITLE
fix(aws/s3): harden Bucket reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/S3/Bucket.ts
+++ b/packages/alchemy/src/AWS/S3/Bucket.ts
@@ -265,12 +265,16 @@ export const BucketProvider = () =>
         );
 
         // For us-east-1, BucketAlreadyOwnedByYou is not thrown, so we need to
-        // pre-emptively check if the bucket exists for idempotency
+        // pre-emptively check if the bucket exists for idempotency.
+        //
+        // Only swallow `NotFound` (the documented "no such bucket" signal).
+        // Auth/throttling/parse errors must surface so we don't blindly try
+        // to recreate a bucket that we don't own — which would race with the
+        // real owner and bounce off `BucketAlreadyExists`.
         if (region === "us-east-1") {
           const exists = yield* s3.headBucket({ Bucket: bucketName }).pipe(
             Effect.map(() => true),
             Effect.catchTag("NotFound", () => Effect.succeed(false)),
-            Effect.catch(() => Effect.succeed(false)),
           );
 
           yield* Effect.logInfo(
@@ -287,11 +291,18 @@ export const BucketProvider = () =>
                 ObjectLockEnabledForBucket: news.objectLockEnabled ?? false,
               })
               .pipe(
+                // `OperationAborted` is S3's "another conflicting request is
+                // in flight" race (e.g. policy thrash); `ServiceUnavailable`
+                // is a 503. Both are transient — bound the retry at ~30s
+                // (~ 8 attempts of 100ms exponential) so we don't spin
+                // forever if the service stays in this state.
                 Effect.retry({
                   while: (e) =>
                     e._tag === "OperationAborted" ||
                     e._tag === "ServiceUnavailable",
-                  schedule: Schedule.exponential(100),
+                  schedule: Schedule.exponential(100).pipe(
+                    Schedule.both(Schedule.recurs(8)),
+                  ),
                 }),
               );
           }
@@ -314,7 +325,9 @@ export const BucketProvider = () =>
                 while: (e) =>
                   e._tag === "OperationAborted" ||
                   e._tag === "ServiceUnavailable",
-                schedule: Schedule.exponential(100),
+                schedule: Schedule.exponential(100).pipe(
+                  Schedule.both(Schedule.recurs(8)),
+                ),
               }),
             );
         }
@@ -339,9 +352,11 @@ export const BucketProvider = () =>
         };
       });
 
-      const fetchBucketTags = (
-        bucketName: string,
-      ): Effect.Effect<Record<string, string>, never, any> =>
+      const fetchBucketTags = (bucketName: string) =>
+        // Only swallow the documented "no tags / no bucket" signals so real
+        // failures (auth, throttling, parse errors) surface instead of being
+        // silently coerced into "bucket has no tags" — which would make us
+        // wipe and re-write the tagset on every reconcile.
         s3.getBucketTagging({ Bucket: bucketName }).pipe(
           Effect.map(
             (r) =>
@@ -352,39 +367,37 @@ export const BucketProvider = () =>
           Effect.catchTag("NoSuchTagSet", () =>
             Effect.succeed({} as Record<string, string>),
           ),
-          Effect.catch(() => Effect.succeed({} as Record<string, string>)),
+          Effect.catchTag("NoSuchBucket", () =>
+            Effect.succeed({} as Record<string, string>),
+          ),
         );
 
       const syncBucketTags = Effect.fnUntraced(function* ({
         bucketName,
-        oldTags,
         newTags,
         session,
         operation,
       }: {
         bucketName: string;
-        oldTags?: Record<string, string>;
         newTags?: Record<string, string>;
         session: ScopedPlanStatusSession;
         operation: "create" | "update";
       }) {
         // Compare against the cloud's actual tags so drift surfaces
         // correctly even after a cold-start adoption (where olds.tags
-        // equals news.tags and would otherwise look like a no-op).
-        const previousTags = oldTags ?? (yield* fetchBucketTags(bucketName));
+        // would equal news.tags and otherwise look like a no-op).
+        const previousTags = yield* fetchBucketTags(bucketName);
         const desiredTags = newTags ?? {};
         const { removed, upsert } = diffTags(previousTags, desiredTags);
-        const canSkip = oldTags !== undefined;
 
         yield* Effect.logInfo(
           `S3 Bucket ${operation}: bucket=${bucketName} removedTags=${removed.length} upsertTags=${Object.keys(upsert).length}`,
         );
 
-        if (
-          canSkip &&
-          removed.length === 0 &&
-          Object.keys(upsert).length === 0
-        ) {
+        // Already in sync — every later step is unnecessary. Skipping here
+        // also avoids issuing `deleteBucketTagging` on a bucket that already
+        // has no tags (which would be a no-op API write on every reconcile).
+        if (removed.length === 0 && Object.keys(upsert).length === 0) {
           return;
         }
 
@@ -486,10 +499,14 @@ export const BucketProvider = () =>
             output?.bucketName ?? (yield* createBucketName(id, olds ?? {}));
           const region = yield* Region;
           const { accountId } = yield* AWSEnvironment;
+          // Only swallow `NotFound` — that is the documented "no such
+          // bucket in this account" signal. Throttling, parse, network and
+          // permission errors must surface so callers get a real failure
+          // instead of a silent "bucket missing" misdiagnosis.
           const exists = yield* s3.headBucket({ Bucket: bucketName }).pipe(
             Effect.map(() => true),
             Effect.catchTag("NotFound", () => Effect.succeed(false)),
-            Effect.catch(() => Effect.succeed(false)),
+            Effect.catchTag("NoSuchBucket", () => Effect.succeed(false)),
           );
           if (!exists) return undefined;
           return {
@@ -539,9 +556,6 @@ export const BucketProvider = () =>
 
           yield* syncBucketTags({
             bucketName: resolved.bucketName,
-            // Omit `oldTags` so syncBucketTags fetches the cloud's actual
-            // current tags. This makes drift detection correct even after
-            // a cold-start adoption where olds.tags would equal news.tags.
             newTags: news.tags,
             session,
             operation,

--- a/packages/alchemy/test/AWS/S3/Bucket.test.ts
+++ b/packages/alchemy/test/AWS/S3/Bucket.test.ts
@@ -1,3 +1,4 @@
+import { adopt } from "@/AdoptPolicy";
 import * as AWS from "@/AWS";
 import { Bucket } from "@/AWS/S3";
 import { State } from "@/State";
@@ -366,6 +367,402 @@ test.provider(
       );
 
       expect(adopted.bucketArn).toEqual(initial.bucketArn);
+
+      yield* stack.destroy();
+      yield* assertBucketDeleted(bucketName);
+    }),
+);
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Bucket("IdempotentReconcileBucket", {
+            tags: { Environment: "test" },
+            forceDestroy: true,
+          });
+        }),
+      );
+
+      // Deploy again with identical props — reconcile must converge
+      // without changing the bucket.
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Bucket("IdempotentReconcileBucket", {
+            tags: { Environment: "test" },
+            forceDestroy: true,
+          });
+        }),
+      );
+
+      expect(second.bucketName).toEqual(initial.bucketName);
+      expect(second.bucketArn).toEqual(initial.bucketArn);
+
+      const tagging = yield* S3.getBucketTagging({
+        Bucket: second.bucketName,
+      });
+      expect(tagging.TagSet).toContainEqual({
+        Key: "Environment",
+        Value: "test",
+      });
+
+      yield* stack.destroy();
+      yield* assertBucketDeleted(initial.bucketName);
+    }),
+);
+
+test.provider(
+  "reconcile resets tags mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const bucket = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Bucket("DriftTagsBucket", {
+            tags: { Environment: "test" },
+            forceDestroy: true,
+          });
+        }),
+      );
+
+      // Mutate tags out-of-band via the raw SDK.
+      yield* S3.putBucketTagging({
+        Bucket: bucket.bucketName,
+        Tagging: {
+          TagSet: [
+            { Key: "Drifted", Value: "yes" },
+            { Key: "Environment", Value: "WRONG" },
+          ],
+        },
+      });
+
+      // Re-deploy with the original desired props — reconcile should
+      // observe the drifted cloud tags and reset them.
+      const redeployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Bucket("DriftTagsBucket", {
+            tags: { Environment: "test" },
+            forceDestroy: true,
+          });
+        }),
+      );
+      expect(redeployed.bucketName).toEqual(bucket.bucketName);
+
+      const tagging = yield* S3.getBucketTagging({
+        Bucket: bucket.bucketName,
+      });
+      const tagMap = Object.fromEntries(
+        (tagging.TagSet ?? []).map((t) => [t.Key, t.Value]),
+      );
+      expect(tagMap["Environment"]).toEqual("test");
+      expect(tagMap["Drifted"]).toBeUndefined();
+
+      yield* stack.destroy();
+      yield* assertBucketDeleted(bucket.bucketName);
+    }),
+);
+
+test.provider(
+  "reconcile resets a bucket policy mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const distributionArn =
+        "arn:aws:cloudfront::123456789012:distribution/DRIFTDIST";
+      const bucketName = `alchemy-test-s3-policy-drift-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+      const bucketArn = `arn:aws:s3:::${bucketName}` as const;
+
+      const bucket = yield* stack.deploy(
+        Effect.gen(function* () {
+          const bucket = yield* Bucket("DriftPolicyBucket", {
+            bucketName,
+            forceDestroy: true,
+          });
+          yield* bucket.bind("AWS.S3.Policy(DriftDist, DriftPolicyBucket)", {
+            policyStatements: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "cloudfront.amazonaws.com" },
+                Action: ["s3:GetObject"],
+                Resource: [`${bucketArn}/*`],
+                Condition: {
+                  StringEquals: { "AWS:SourceArn": distributionArn },
+                },
+              },
+            ],
+          });
+          return bucket;
+        }),
+      );
+
+      // Replace the bucket's policy out-of-band with something foreign.
+      yield* S3.putBucketPolicy({
+        Bucket: bucket.bucketName,
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Sid: "ForeignDrifted",
+              Effect: "Allow",
+              Principal: "*",
+              Action: ["s3:GetObject"],
+              Resource: [`${bucketArn}/*`],
+            },
+          ],
+        }),
+      });
+
+      // Re-deploy — reconcile must reset the policy back to what bindings
+      // describe.
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          const bucket = yield* Bucket("DriftPolicyBucket", {
+            bucketName,
+            forceDestroy: true,
+          });
+          yield* bucket.bind("AWS.S3.Policy(DriftDist, DriftPolicyBucket)", {
+            policyStatements: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "cloudfront.amazonaws.com" },
+                Action: ["s3:GetObject"],
+                Resource: [`${bucketArn}/*`],
+                Condition: {
+                  StringEquals: { "AWS:SourceArn": distributionArn },
+                },
+              },
+            ],
+          });
+          return bucket;
+        }),
+      );
+
+      const policy = yield* S3.getBucketPolicy({
+        Bucket: bucket.bucketName,
+      }).pipe(Effect.map((r) => JSON.parse(r.Policy!)));
+      expect(policy.Statement).toHaveLength(1);
+      expect(policy.Statement[0].Principal).toEqual({
+        Service: "cloudfront.amazonaws.com",
+      });
+      expect(policy.Statement[0].Sid).toBeUndefined();
+
+      yield* stack.destroy();
+      yield* assertBucketDeleted(bucket.bucketName);
+    }),
+);
+
+test.provider(
+  "reconcile re-creates a bucket that was deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const bucketName = `alchemy-test-s3-recreate-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Bucket("RecreateBucket", {
+            bucketName,
+            forceDestroy: true,
+          });
+        }),
+      );
+
+      // Delete the bucket out-of-band. S3 forbids reusing the same name
+      // for a brief window — the reconciler's bounded retries on
+      // `OperationAborted` / `ServiceUnavailable` ride this out.
+      yield* S3.deleteBucket({ Bucket: initial.bucketName });
+      yield* assertBucketDeleted(initial.bucketName);
+
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Bucket("RecreateBucket", {
+            bucketName,
+            forceDestroy: true,
+          });
+        }),
+      );
+      expect(recreated.bucketName).toEqual(bucketName);
+      yield* S3.headBucket({ Bucket: recreated.bucketName });
+
+      yield* stack.destroy();
+      yield* assertBucketDeleted(recreated.bucketName);
+    }),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "changing bucketName triggers replace; old bucket is deleted",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const nameA = `alchemy-test-s3-rename-a-${suffix}`;
+      const nameB = `alchemy-test-s3-rename-b-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Bucket("RenameBucket", {
+            bucketName: nameA,
+            forceDestroy: true,
+          });
+        }),
+      );
+      expect(a.bucketName).toEqual(nameA);
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Bucket("RenameBucket", {
+            bucketName: nameB,
+            forceDestroy: true,
+          });
+        }),
+      );
+      expect(b.bucketName).toEqual(nameB);
+      expect(b.bucketArn).not.toEqual(a.bucketArn);
+
+      yield* assertBucketDeleted(a.bucketName);
+
+      yield* stack.destroy();
+      yield* assertBucketDeleted(b.bucketName);
+    }),
+);
+
+test.provider(
+  "flipping objectLockEnabled triggers replace",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Bucket("ObjectLockFlipBucket", {
+            bucketName: `alchemy-test-s3-objlock-${Math.random()
+              .toString(36)
+              .slice(2, 8)}`,
+            forceDestroy: true,
+          });
+        }),
+      );
+
+      const replaced = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Bucket("ObjectLockFlipBucket", {
+            bucketName: `alchemy-test-s3-objlock-${Math.random()
+              .toString(36)
+              .slice(2, 8)}`,
+            objectLockEnabled: true,
+            forceDestroy: true,
+          });
+        }),
+      );
+      expect(replaced.bucketArn).not.toEqual(initial.bucketArn);
+
+      const lockConfig = yield* S3.getObjectLockConfiguration({
+        Bucket: replaced.bucketName,
+      });
+      expect(
+        lockConfig.ObjectLockConfiguration?.ObjectLockEnabled,
+      ).toEqual("Enabled");
+
+      yield* assertBucketDeleted(initial.bucketName);
+
+      yield* stack.destroy();
+      yield* assertBucketDeleted(replaced.bucketName);
+    }),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "destroying an already-deleted bucket is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const bucket = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Bucket("DoubleDestroyBucket", {
+            forceDestroy: true,
+          });
+        }),
+      );
+
+      // Delete the bucket out-of-band, then ask the engine to destroy it.
+      // `delete` must catch `NoSuchBucket` and complete cleanly.
+      yield* S3.deleteBucket({ Bucket: bucket.bucketName });
+      yield* assertBucketDeleted(bucket.bucketName);
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider(
+  "adopt(true) re-syncs tags on a foreign-tagged bucket",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const bucketName = `alchemy-test-s3-adopt-tags-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      // Pre-deploy with foreign tags, then wipe the state file so the
+      // next deploy must adopt — adopt(true) is required because we
+      // simulate a stack rename (logical id changes from "Original" to
+      // "Different").
+      const original = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Bucket("Original", {
+            bucketName,
+            tags: { OwnedBy: "someone-else", Stage: "stale" },
+            forceDestroy: true,
+          });
+        }),
+      );
+
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "Original",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      const adopted = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* Bucket("Different", {
+              bucketName,
+              tags: { OwnedBy: "alchemy", Stage: "fresh" },
+              forceDestroy: true,
+            });
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(adopted.bucketName).toEqual(bucketName);
+      expect(adopted.bucketArn).toEqual(original.bucketArn);
+
+      const tagging = yield* S3.getBucketTagging({
+        Bucket: adopted.bucketName,
+      });
+      const tagMap = Object.fromEntries(
+        (tagging.TagSet ?? []).map((t) => [t.Key, t.Value]),
+      );
+      expect(tagMap["OwnedBy"]).toEqual("alchemy");
+      expect(tagMap["Stage"]).toEqual("fresh");
 
       yield* stack.destroy();
       yield* assertBucketDeleted(bucketName);


### PR DESCRIPTION
Audits the S3 Bucket reconciler for the same classes of issues SQS had, and adds lifecycle convergence tests on top of #179.

### Reconciler changes

Scope blanket catches to documented signals so real failures surface:

```diff
- const exists = yield* s3.headBucket({ Bucket: bucketName }).pipe(
-   Effect.map(() => true),
-   Effect.catchTag("NotFound", () => Effect.succeed(false)),
-   Effect.catch(() => Effect.succeed(false)),
- );
+ const exists = yield* s3.headBucket({ Bucket: bucketName }).pipe(
+   Effect.map(() => true),
+   Effect.catchTag("NotFound", () => Effect.succeed(false)),
+ );
```

```diff
- Effect.catchTag("NoSuchTagSet", () => Effect.succeed({} as Record<string, string>)),
- Effect.catch(() => Effect.succeed({} as Record<string, string>)),
+ Effect.catchTag("NoSuchTagSet", () => Effect.succeed({} as Record<string, string>)),
+ Effect.catchTag("NoSuchBucket", () => Effect.succeed({} as Record<string, string>)),
```

Bound the `OperationAborted` / `ServiceUnavailable` retry on `createBucket` so we don't spin forever when the service stays in that state:

```diff
  Effect.retry({
    while: (e) => e._tag === "OperationAborted" || e._tag === "ServiceUnavailable",
-   schedule: Schedule.exponential(100),
+   schedule: Schedule.exponential(100).pipe(Schedule.both(Schedule.recurs(8))),
  }),
```

`syncBucketTags` always diffs against observed cloud tags and skips the API call when the diff is empty — avoids a spurious `deleteBucketTagging` on every reconcile of a bucket that already has no tags.

### New lifecycle tests

Each test runs `destroy -> deploy -> ... -> destroy` on a `ScratchStack` and asserts at every step:

- redeploy with same props is a no-op (idempotent)
- reconcile resets bucket tags mutated out-of-band
- reconcile resets a bucket policy mutated out-of-band
- reconcile re-creates a bucket that was deleted out-of-band (rides the `OperationAborted` window)
- changing `bucketName` triggers replace; old bucket is deleted
- flipping `objectLockEnabled` triggers replace
- destroying an already-deleted bucket is a no-op
- `adopt(true)` re-syncs tags on a foreign-tagged bucket

`test.resources.ts` picks up the same `output?.stableId` fix from the SQS PR so this branch type-checks in isolation.

### Distilled patch

S3 error category fixes at https://github.com/alchemy-run/distilled/pull/241.
