### PR TITLE
feat(cloudflare): expose raw durable object sql storage

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectStorage.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectStorage.ts
@@ -23,6 +23,13 @@ export interface SqlCursor<
 }
 
 export interface SqlStorage {
+  /**
+   * The raw underlying Cloudflare SqlStorage binding.
+   *
+   * Use this when you need direct access for libraries that already support
+   * Cloudflare Durable Object SQLite storage.
+   */
+  readonly raw: cf.SqlStorage;
   exec<T extends Record<string, SqlStorageValue>>(
     query: string,
     ...bindings: any[]
@@ -49,6 +56,7 @@ const fromSqlCursor = <T extends Record<string, SqlStorageValue>>(
 };
 
 const fromSqlStorage = (sql: cf.SqlStorage): SqlStorage => ({
+  raw: sql,
   exec: <T extends Record<string, SqlStorageValue>>(
     query: string,
     ...bindings: any[]


### PR DESCRIPTION
Expose the native Cloudflare `SqlStorage` alongside Alchemy's Effect wrapper so libraries that already support Durable Object SQLite can use the underlying binding directly.

```ts
const sql = durableObjectState.storage.sql.raw;
```

The existing `storage.sql.exec(...)` Effect wrapper remains unchanged.

Made with [Cursor](https://cursor.com)