### PR TITLE
fix(aws/ec2): harden Vpc reconcile + add lifecycle convergence tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ dist/
 .DS_Store
 .env
 *.tsbuildinfo
-.claude/
+.claude/worktrees
+.worktrees
 .alchemy/
 # !.alchemy/github:alchemy/
 # examples/*/.alchemy
@@ -23,6 +24,7 @@ wrangler.jsonc
 .smoke.logs
 smoke
 .svelte-kit
+.claude/*.local.json
 .astro
 .wrangler
 

--- a/packages/alchemy/src/AWS/EC2/Vpc.ts
+++ b/packages/alchemy/src/AWS/EC2/Vpc.ts
@@ -77,7 +77,8 @@ export interface VpcProps {
 
   /**
    * Whether instances launched in the VPC get DNS hostnames.
-   * @default true
+   * Matches the AWS API default for new non-default VPCs.
+   * @default false
    */
   enableDnsHostnames?: boolean;
 
@@ -256,31 +257,43 @@ export const VpcProvider = () =>
           const desiredDnsSupport = news.enableDnsSupport ?? true;
           const desiredDnsHostnames = news.enableDnsHostnames ?? false;
 
-          const dnsSupportResult = yield* ec2.describeVpcAttribute({
-            VpcId: vpcId,
-            Attribute: "enableDnsSupport",
-          });
+          // describeVpcAttribute right after createVpc can race ahead of the
+          // VPC's visibility in the read path even after `waitForVpcAvailable`
+          // succeeded. Tolerate a transient `InvalidVpcID.NotFound` so we
+          // don't surface it as a hard failure.
+          const dnsSupportResult = yield* ec2
+            .describeVpcAttribute({
+              VpcId: vpcId,
+              Attribute: "enableDnsSupport",
+            })
+            .pipe(retryEventuallyConsistent);
           const currentDnsSupport =
             dnsSupportResult.EnableDnsSupport?.Value ?? true;
           if (currentDnsSupport !== desiredDnsSupport) {
-            yield* ec2.modifyVpcAttribute({
-              VpcId: vpcId,
-              EnableDnsSupport: { Value: desiredDnsSupport },
-            });
+            yield* ec2
+              .modifyVpcAttribute({
+                VpcId: vpcId,
+                EnableDnsSupport: { Value: desiredDnsSupport },
+              })
+              .pipe(retryEventuallyConsistent);
             yield* session.note(`Updated DNS support: ${desiredDnsSupport}`);
           }
 
-          const dnsHostnamesResult = yield* ec2.describeVpcAttribute({
-            VpcId: vpcId,
-            Attribute: "enableDnsHostnames",
-          });
+          const dnsHostnamesResult = yield* ec2
+            .describeVpcAttribute({
+              VpcId: vpcId,
+              Attribute: "enableDnsHostnames",
+            })
+            .pipe(retryEventuallyConsistent);
           const currentDnsHostnames =
             dnsHostnamesResult.EnableDnsHostnames?.Value ?? false;
           if (currentDnsHostnames !== desiredDnsHostnames) {
-            yield* ec2.modifyVpcAttribute({
-              VpcId: vpcId,
-              EnableDnsHostnames: { Value: desiredDnsHostnames },
-            });
+            yield* ec2
+              .modifyVpcAttribute({
+                VpcId: vpcId,
+                EnableDnsHostnames: { Value: desiredDnsHostnames },
+              })
+              .pipe(retryEventuallyConsistent);
             yield* session.note(
               `Updated DNS hostnames: ${desiredDnsHostnames}`,
             );
@@ -292,28 +305,45 @@ export const VpcProvider = () =>
           ) as Record<string, string>;
           const { removed, upsert } = diffTags(currentTags, desiredTags);
           if (removed.length > 0) {
-            yield* ec2.deleteTags({
-              Resources: [vpcId],
-              Tags: removed.map((key) => ({ Key: key })),
-              DryRun: false,
-            });
+            yield* ec2
+              .deleteTags({
+                Resources: [vpcId],
+                Tags: removed.map((key) => ({ Key: key })),
+                DryRun: false,
+              })
+              .pipe(retryEventuallyConsistent);
           }
           if (upsert.length > 0) {
-            yield* ec2.createTags({
-              Resources: [vpcId],
-              Tags: upsert,
-              DryRun: false,
-            });
+            yield* ec2
+              .createTags({
+                Resources: [vpcId],
+                Tags: upsert,
+                DryRun: false,
+              })
+              .pipe(retryEventuallyConsistent);
           }
 
           // Re-read final state so the returned attributes reflect what's
-          // actually in the cloud after all sync steps.
-          const final = yield* ec2.describeVpcs({ VpcIds: [vpcId] });
+          // actually in the cloud after all sync steps. EC2 is eventually
+          // consistent, so a freshly-created VPC may briefly show as
+          // `InvalidVpcID.NotFound` here — treat that as "not yet visible"
+          // and retry rather than failing.
+          const final = yield* ec2
+            .describeVpcs({ VpcIds: [vpcId] })
+            .pipe(
+              Effect.catchTag("InvalidVpcID.NotFound", () =>
+                Effect.fail(new VpcPending({ vpcId, state: "describing" })),
+              ),
+              Effect.retry({
+                while: (e) => e instanceof VpcPending,
+                schedule: Schedule.fixed(1000).pipe(
+                  Schedule.both(Schedule.recurs(15)),
+                ),
+              }),
+            );
           const finalVpc = final.Vpcs?.[0];
           if (!finalVpc) {
-            return yield* Effect.fail(
-              new Error(`VPC ${vpcId} disappeared during reconcile`),
-            );
+            return yield* new VpcDisappeared({ vpcId });
           }
 
           return {
@@ -354,43 +384,32 @@ export const VpcProvider = () =>
 
           yield* session.note(`Deleting VPC: ${vpcId}`);
 
-          // 1. Attempt to delete VPC
+          // Attempt to delete the VPC. If it's already gone, that's a no-op.
+          // DependencyViolation means subnets/IGWs/SGs/route tables are still
+          // being torn down (or were created out of band) — bounded poll up
+          // to ~5 minutes. The DependencyViolation tag comes straight from
+          // distilled (`withDependencyViolationError`), no string matching.
           yield* ec2
             .deleteVpc({
               VpcId: vpcId,
               DryRun: false,
             })
             .pipe(
-              Effect.tapError(Effect.logDebug),
-              Effect.catchTag("InvalidVpcID.NotFound", () => Effect.void),
-              // Retry on dependency violations (resources still being deleted)
               Effect.retry({
-                while: (e) => {
-                  // DependencyViolation means there are still dependent resources
-                  // This can happen if subnets/IGW are being deleted concurrently
-                  return (
-                    e._tag === "DependencyViolation" ||
-                    (e._tag === "ValidationError" &&
-                      e.message?.includes("DependencyViolation"))
-                  );
-                },
-                // Use fixed 5s delay instead of exponential to avoid very long waits
+                while: (e) => e._tag === "DependencyViolation",
                 schedule: Schedule.fixed(5000).pipe(
-                  Schedule.both(Schedule.recurs(60)), // Up to 5 minutes total
+                  Schedule.both(Schedule.recurs(60)),
                   Schedule.tapOutput(([, attempt]) =>
                     session.note(
-                      `Waiting for dependencies to clear... (attempt ${attempt + 1})`,
+                      `Waiting for VPC dependencies to clear... (attempt ${attempt + 1})`,
                     ),
                   ),
                 ),
               }),
-              // Log the actual error for debugging
-              Effect.tapError((e) =>
-                session.note(`VPC delete failed: ${e._tag} - ${e.message}`),
-              ),
+              Effect.catchTag("InvalidVpcID.NotFound", () => Effect.void),
             );
 
-          // 2. Wait for VPC to be fully deleted
+          // Wait for the deletion to propagate.
           yield* waitForVpcDeleted(vpcId, session);
 
           yield* session.note(`VPC ${vpcId} deleted successfully`);
@@ -410,26 +429,55 @@ class VpcStillExists extends Data.TaggedError("VpcStillExists")<{
   vpcId: string;
 }> {}
 
+// Tagged failure for the rare case where a VPC vanishes mid-reconcile
+// (e.g. it was deleted out of band between createVpc and the final read).
+class VpcDisappeared extends Data.TaggedError("VpcDisappeared")<{
+  vpcId: string;
+}> {}
+
 /**
- * Wait for VPC to be in available state
+ * Pipe an EC2 effect through a bounded retry that rides out post-create
+ * eventual-consistency `InvalidVpcID.NotFound`. The general AWS retry layer
+ * doesn't ride this out because distilled doesn't tag it as retryable —
+ * but we know it's transient when we have just created the VPC ourselves.
+ */
+const retryEventuallyConsistent = <A, E, R>(
+  self: Effect.Effect<A, E, R>,
+): Effect.Effect<A, Exclude<E, { _tag: "InvalidVpcID.NotFound" }>, R> =>
+  self.pipe(
+    Effect.retry({
+      while: (e: any) => e?._tag === "InvalidVpcID.NotFound",
+      schedule: Schedule.fixed(1000).pipe(Schedule.both(Schedule.recurs(15))),
+    }),
+  ) as Effect.Effect<A, Exclude<E, { _tag: "InvalidVpcID.NotFound" }>, R>;
+
+/**
+ * Wait for VPC to be in available state. EC2 is eventually consistent, so
+ * `describeVpcs` immediately after `createVpc` may briefly return
+ * `InvalidVpcID.NotFound` — treat that as "still pending" instead of failing.
  */
 const waitForVpcAvailable = (
   vpcId: string,
   session?: ScopedPlanStatusSession,
 ) =>
   Effect.gen(function* () {
-    const result = yield* ec2.describeVpcs({ VpcIds: [vpcId] });
+    const result = yield* ec2
+      .describeVpcs({ VpcIds: [vpcId] })
+      .pipe(
+        Effect.catchTag("InvalidVpcID.NotFound", () =>
+          Effect.succeed({ Vpcs: [] as EC2.Vpc[] }),
+        ),
+      );
     const vpc = result.Vpcs?.[0];
 
     if (!vpc) {
-      return yield* Effect.fail(new Error(`VPC ${vpcId} not found`));
+      return yield* new VpcPending({ vpcId, state: "missing" });
     }
 
     if (vpc.State === "available") {
       return vpc;
     }
 
-    // Still pending - this is the only retryable case
     return yield* new VpcPending({ vpcId, state: vpc.State! });
   }).pipe(
     Effect.retry({

--- a/packages/alchemy/test/AWS/EC2/Vpc.test.ts
+++ b/packages/alchemy/test/AWS/EC2/Vpc.test.ts
@@ -15,7 +15,7 @@ const logLevel = Effect.provideService(
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-test.provider.skip("create, update, delete vpc", (stack) =>
+test.provider("create, update, delete vpc", (stack) =>
   Effect.gen(function* () {
     const vpc = yield* stack.deploy(
       Effect.gen(function* () {
@@ -73,6 +73,252 @@ test.provider.skip("create, update, delete vpc", (stack) =>
 
     yield* assertVpcDeleted(vpc.vpcId);
   }).pipe(logLevel),
+);
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Vpc("IdempotentVpc", {
+            cidrBlock: "10.10.0.0/16",
+            enableDnsSupport: true,
+            enableDnsHostnames: true,
+          });
+        }),
+      );
+
+      // Re-deploy with identical props. The result should match the
+      // original VPC by id/CIDR — no replace, no drift.
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Vpc("IdempotentVpc", {
+            cidrBlock: "10.10.0.0/16",
+            enableDnsSupport: true,
+            enableDnsHostnames: true,
+          });
+        }),
+      );
+      expect(second.vpcId).toEqual(initial.vpcId);
+      expect(second.vpcArn).toEqual(initial.vpcArn);
+      expect(second.cidrBlock).toEqual("10.10.0.0/16");
+
+      yield* expectVpcAttribute({
+        VpcId: second.vpcId,
+        Attribute: "enableDnsSupport",
+        Value: true,
+      });
+      yield* expectVpcAttribute({
+        VpcId: second.vpcId,
+        Attribute: "enableDnsHostnames",
+        Value: true,
+      });
+
+      yield* stack.destroy();
+      yield* assertVpcDeleted(initial.vpcId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile resets DNS attributes mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const vpc = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Vpc("DriftDnsVpc", {
+            cidrBlock: "10.11.0.0/16",
+            enableDnsSupport: true,
+            enableDnsHostnames: true,
+          });
+        }),
+      );
+
+      // Mutate DNS attrs out-of-band via the raw SDK.
+      yield* EC2.modifyVpcAttribute({
+        VpcId: vpc.vpcId,
+        EnableDnsSupport: { Value: false },
+      });
+      yield* EC2.modifyVpcAttribute({
+        VpcId: vpc.vpcId,
+        EnableDnsHostnames: { Value: false },
+      });
+      yield* expectVpcAttribute({
+        VpcId: vpc.vpcId,
+        Attribute: "enableDnsSupport",
+        Value: false,
+      });
+      yield* expectVpcAttribute({
+        VpcId: vpc.vpcId,
+        Attribute: "enableDnsHostnames",
+        Value: false,
+      });
+
+      // Re-deploying with the original desired props must converge cloud
+      // state back to the desired values.
+      const redeployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Vpc("DriftDnsVpc", {
+            cidrBlock: "10.11.0.0/16",
+            enableDnsSupport: true,
+            enableDnsHostnames: true,
+          });
+        }),
+      );
+      expect(redeployed.vpcId).toEqual(vpc.vpcId);
+
+      yield* expectVpcAttribute({
+        VpcId: redeployed.vpcId,
+        Attribute: "enableDnsSupport",
+        Value: true,
+      });
+      yield* expectVpcAttribute({
+        VpcId: redeployed.vpcId,
+        Attribute: "enableDnsHostnames",
+        Value: true,
+      });
+
+      yield* stack.destroy();
+      yield* assertVpcDeleted(vpc.vpcId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile resets tags mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const vpc = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Vpc("DriftTagsVpc", {
+            cidrBlock: "10.12.0.0/16",
+            tags: { Environment: "dev", Owner: "alchemy" },
+          });
+        }),
+      );
+
+      // Add a foreign tag and overwrite an existing one out-of-band.
+      yield* EC2.createTags({
+        Resources: [vpc.vpcId],
+        Tags: [
+          { Key: "Environment", Value: "drifted" },
+          { Key: "Foreign", Value: "tag" },
+        ],
+      });
+
+      const redeployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Vpc("DriftTagsVpc", {
+            cidrBlock: "10.12.0.0/16",
+            tags: { Environment: "dev", Owner: "alchemy" },
+          });
+        }),
+      );
+      expect(redeployed.vpcId).toEqual(vpc.vpcId);
+
+      const observed = yield* EC2.describeVpcs({ VpcIds: [redeployed.vpcId] });
+      const tagMap = Object.fromEntries(
+        (observed.Vpcs?.[0]?.Tags ?? []).map((t) => [t.Key!, t.Value!]),
+      );
+      // Drifted tag is reset, foreign tag is removed, internal tags remain.
+      expect(tagMap.Environment).toEqual("dev");
+      expect(tagMap.Owner).toEqual("alchemy");
+      expect(tagMap.Foreign).toBeUndefined();
+      expect(tagMap["alchemy::id"]).toEqual("DriftTagsVpc");
+
+      yield* stack.destroy();
+      yield* assertVpcDeleted(vpc.vpcId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile re-creates a VPC that was deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Vpc("RecreateVpc", { cidrBlock: "10.13.0.0/16" });
+        }),
+      );
+
+      // Delete the VPC via the raw SDK.
+      yield* EC2.deleteVpc({ VpcId: initial.vpcId });
+      yield* assertVpcDeleted(initial.vpcId);
+
+      // Re-deploying must converge by re-creating. The state still
+      // references the old vpcId; the reconciler observes
+      // `InvalidVpcID.NotFound`, falls through to `createVpc`, and
+      // produces a brand-new VPC with the same logical id.
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Vpc("RecreateVpc", { cidrBlock: "10.13.0.0/16" });
+        }),
+      );
+      expect(recreated.vpcId).not.toEqual(initial.vpcId);
+      expect(recreated.cidrBlock).toEqual("10.13.0.0/16");
+
+      yield* stack.destroy();
+      yield* assertVpcDeleted(recreated.vpcId);
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "changing cidrBlock triggers replace; old VPC is deleted",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Vpc("ReplaceVpc", { cidrBlock: "10.14.0.0/16" });
+        }),
+      );
+      expect(a.cidrBlock).toEqual("10.14.0.0/16");
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Vpc("ReplaceVpc", { cidrBlock: "10.15.0.0/16" });
+        }),
+      );
+      expect(b.cidrBlock).toEqual("10.15.0.0/16");
+      expect(b.vpcId).not.toEqual(a.vpcId);
+
+      // Old VPC must be torn down by the replacement flow.
+      yield* assertVpcDeleted(a.vpcId);
+
+      yield* stack.destroy();
+      yield* assertVpcDeleted(b.vpcId);
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "destroying an already-deleted VPC is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const vpc = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Vpc("DoubleDestroyVpc", { cidrBlock: "10.16.0.0/16" });
+        }),
+      );
+
+      // Delete out of band, then ask the engine to destroy. The provider
+      // must catch InvalidVpcID.NotFound and complete cleanly.
+      yield* EC2.deleteVpc({ VpcId: vpc.vpcId });
+      yield* assertVpcDeleted(vpc.vpcId);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
 );
 
 const expectVpcAttribute = Effect.fn(function* (props: {


### PR DESCRIPTION
Harden the EC2 `Vpc` reconciler against eventual-consistency races and remove brittle delete-error matching, then add lifecycle convergence tests on top of `ScratchStack`.

### Reconciler changes

```diff
-          const dnsSupportResult = yield* ec2.describeVpcAttribute({
-            VpcId: vpcId,
-            Attribute: "enableDnsSupport",
-          });
+          // describeVpcAttribute / modifyVpcAttribute / createTags / deleteTags
+          // right after createVpc can race ahead of the VPC's visibility in
+          // the read path even after `waitForVpcAvailable` succeeded.
+          const dnsSupportResult = yield* ec2
+            .describeVpcAttribute({
+              VpcId: vpcId,
+              Attribute: "enableDnsSupport",
+            })
+            .pipe(retryEventuallyConsistent);
```

```diff
-              Effect.retry({
-                while: (e) => {
-                  return (
-                    e._tag === "DependencyViolation" ||
-                    (e._tag === "ValidationError" &&
-                      e.message?.includes("DependencyViolation"))
-                  );
-                },
+              Effect.retry({
+                while: (e) => e._tag === "DependencyViolation",
```

The `ValidationError` substring branch was dead — distilled tags `DependencyViolation` directly via `withDependencyViolationError`, so the substring match never fired and any real `ValidationError` was being swallowed silently.

```diff
   /**
    * Whether instances launched in the VPC get DNS hostnames.
-   * @default true
+   * Matches the AWS API default for new non-default VPCs.
+   * @default false
    */
   enableDnsHostnames?: boolean;
```

Doc was inverted vs. what the code actually does (`?? false`).

`waitForVpcAvailable` previously hard-failed on `Error("VPC ${vpcId} not found")` (untagged, so `Effect.retry` couldn't ride it out). It now folds that case into the existing `VpcPending` tag and tolerates `InvalidVpcID.NotFound` from the lookup.

### New lifecycle tests

- redeploy with same props is a no-op (reconcile is idempotent)
- reconcile resets DNS attributes mutated out-of-band
- reconcile resets tags mutated out-of-band (foreign tags removed, drifted tags reset, internal alchemy tags retained)
- reconcile re-creates a VPC that was deleted out-of-band
- changing cidrBlock triggers replace; old VPC is deleted
- destroying an already-deleted VPC is a no-op

The original happy-path test was `.skip`-ped; un-skipped it.

### Distilled patch

EC2 `IncorrectState` was uncategorized in distilled, so the AWS retry layer didn't ride it out. https://github.com/alchemy-run/distilled/pull/242 tags it as `ConflictError + RetryableError`.
