### PR TITLE
fix(aws/lambda): harden Function reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -771,6 +771,30 @@ export default await Effect.runPromise(handlerEffect)
         };
       };
 
+      // Lambda's update-vs-update race: each update mutates the function and
+      // surfaces `LastUpdateStatus = InProgress` for several seconds. Issuing
+      // another `updateFunction*` before `Successful` returns
+      // `ResourceConflictException` ("update in progress"). Poll the status
+      // every second until it leaves `InProgress`, capped at 90s — well past
+      // the typical sub-30s convergence window on VPC-attached functions —
+      // then surface so we don't loop forever if Lambda stays in this state.
+      const waitForFunctionUpdateSuccessful = (functionName: string) =>
+        Lambda.getFunctionConfiguration({ FunctionName: functionName }).pipe(
+          Effect.flatMap((cfg) =>
+            cfg.LastUpdateStatus === "InProgress"
+              ? Effect.fail({ _tag: "FunctionUpdateInProgress" } as const)
+              : Effect.succeed(cfg),
+          ),
+          Effect.retry({
+            while: (e: { _tag: string }) =>
+              e._tag === "FunctionUpdateInProgress",
+            schedule: Schedule.fixed(1000).pipe(
+              Schedule.both(Schedule.recurs(90)),
+            ),
+          }),
+          Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+        );
+
       const createOrUpdateFunction = Effect.fnUntraced(function* ({
         id,
         news,
@@ -870,6 +894,12 @@ export default await Effect.runPromise(handlerEffect)
           Effect.flatMap(() =>
             Effect.gen(function* () {
               yield* Effect.logDebug(`updating function code ${id}`);
+              // Wait for any in-flight update to converge so the next
+              // updateFunctionCode call doesn't surface
+              // `ResourceConflictException` ("update in progress").
+              yield* waitForFunctionUpdateSuccessful(
+                createFunctionRequest.FunctionName,
+              );
               yield* Lambda.updateFunctionCode({
                 FunctionName: createFunctionRequest.FunctionName,
                 Architectures: createFunctionRequest.Architectures,
@@ -886,14 +916,27 @@ export default await Effect.runPromise(handlerEffect)
                     ? noteRolePropagationWait()
                     : Effect.void,
                 ),
+                // Cap at 60 retries (~12 minutes max with exponential backoff
+                // from 100ms). `ResourceConflictException` here means another
+                // update is in progress — we already wait for it above, but
+                // a peer reconciler could race in between. Role propagation
+                // can take 30-60s on first deploy.
                 Effect.retry({
                   while: (e) =>
                     e._tag === "ResourceConflictException" ||
                     isRolePropagationError(e),
-                  schedule: Schedule.exponential(100),
+                  schedule: Schedule.exponential(100).pipe(
+                    Schedule.both(Schedule.recurs(60)),
+                  ),
                 }),
               );
               yield* Effect.logDebug(`updated function code ${id}`);
+              // updateFunctionCode -> InProgress -> Successful again. Wait
+              // before issuing updateFunctionConfiguration so we don't bounce
+              // back-to-back through `ResourceConflictException`.
+              yield* waitForFunctionUpdateSuccessful(
+                createFunctionRequest.FunctionName,
+              );
               yield* Lambda.updateFunctionConfiguration({
                 FunctionName: createFunctionRequest.FunctionName,
                 DeadLetterConfig: createFunctionRequest.DeadLetterConfig,
@@ -924,10 +967,18 @@ export default await Effect.runPromise(handlerEffect)
                   while: (e) =>
                     e._tag === "ResourceConflictException" ||
                     isRolePropagationError(e),
-                  schedule: Schedule.exponential(100),
+                  schedule: Schedule.exponential(100).pipe(
+                    Schedule.both(Schedule.recurs(60)),
+                  ),
                 }),
               );
               yield* Effect.logDebug(`updated function configuration ${id}`);
+              // Final wait so callers (e.g. createOrUpdateFunctionUrl,
+              // attachBindings on a downstream resource) don't immediately
+              // race the in-flight update.
+              yield* waitForFunctionUpdateSuccessful(
+                createFunctionRequest.FunctionName,
+              );
             }),
           ),
         );
@@ -938,10 +989,15 @@ export default await Effect.runPromise(handlerEffect)
               yield* Effect.logDebug(e);
             }),
           ),
+          // Role propagation through IAM is eventually consistent and
+          // typically completes in 10-30s. Cap at 120s so a misconfigured
+          // role (e.g. bad assume-role policy) eventually surfaces instead
+          // of looping forever.
           Effect.retry({
             while: (e) => isRolePropagationError(e),
             schedule: Schedule.fixed(1000).pipe(
               Schedule.tapOutput(() => noteRolePropagationWait()),
+              Schedule.both(Schedule.recurs(120)),
             ),
           }),
           Effect.catchTags({
@@ -1122,13 +1178,18 @@ export default await Effect.runPromise(handlerEffect)
               Effect.succeed({} as Record<string, string>),
             ),
           );
+          // `getFunctionUrlConfig` returns `ResourceConflictException` while
+          // a function URL is being created/updated. Bound the retry at 30s
+          // so a stuck URL config doesn't block read indefinitely.
           const functionUrl = yield* Lambda.getFunctionUrlConfig({
             FunctionName: fn.FunctionName,
           }).pipe(
             Effect.map((f) => f.FunctionUrl),
             Effect.retry({
               while: (e: any) => e._tag === "ResourceConflictException",
-              schedule: Schedule.exponential(100),
+              schedule: Schedule.exponential(100).pipe(
+                Schedule.both(Schedule.recurs(30)),
+              ),
             }),
             Effect.catchTag("ResourceNotFoundException", () =>
               Effect.succeed(undefined),
@@ -1249,6 +1310,9 @@ export default await Effect.runPromise(handlerEffect)
           };
         }),
         delete: Effect.fnUntraced(function* ({ output }) {
+          // The role may already be gone (out-of-band delete or partial
+          // earlier delete). Treat `NoSuchEntityException` from list calls
+          // as "no inline/attached policies to clean up" and continue.
           yield* iam
             .listRolePolicies({
               RoleName: output.roleName,
@@ -1257,13 +1321,21 @@ export default await Effect.runPromise(handlerEffect)
               Effect.flatMap((policies) =>
                 Effect.all(
                   (policies.PolicyNames ?? []).map((policyName) =>
-                    iam.deleteRolePolicy({
-                      RoleName: output.roleName,
-                      PolicyName: policyName,
-                    }),
+                    iam
+                      .deleteRolePolicy({
+                        RoleName: output.roleName,
+                        PolicyName: policyName,
+                      })
+                      .pipe(
+                        Effect.catchTag(
+                          "NoSuchEntityException",
+                          () => Effect.void,
+                        ),
+                      ),
                   ),
                 ),
               ),
+              Effect.catchTag("NoSuchEntityException", () => Effect.void),
             );
 
           yield* iam
@@ -1288,11 +1360,20 @@ export default await Effect.runPromise(handlerEffect)
                   ),
                 ),
               ),
+              Effect.catchTag("NoSuchEntityException", () => Effect.void),
             );
 
+          // `ResourceConflictException` from `deleteFunction` means the
+          // function is mid-update. Wait for it to finish, then retry.
           yield* Lambda.deleteFunction({
             FunctionName: output.functionName,
           }).pipe(
+            Effect.retry({
+              while: (e) => e._tag === "ResourceConflictException",
+              schedule: Schedule.exponential(500).pipe(
+                Schedule.both(Schedule.recurs(30)),
+              ),
+            }),
             Effect.catchTag("ResourceNotFoundException", () => Effect.void),
           );
 

--- a/packages/alchemy/test/AWS/Lambda/Function.test.ts
+++ b/packages/alchemy/test/AWS/Lambda/Function.test.ts
@@ -1,10 +1,19 @@
+import { adopt } from "@/AdoptPolicy";
 import * as AWS from "@/AWS";
+import { State } from "@/State";
 import * as Test from "@/Test/Vitest";
+import * as IAM from "@distilled.cloud/aws/iam";
 import * as Lambda from "@distilled.cloud/aws/lambda";
 import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import {
+  LifecycleFunction,
+  LifecycleFunctionLive,
+} from "./lifecycle-handler.ts";
 import { TestFunction, TestFunctionLive } from "./handler.ts";
 
 const { test } = Test.make({ providers: AWS.providers() });
@@ -87,3 +96,359 @@ const getPolicyStatement = Effect.fn(function* (
     }),
   );
 });
+
+// ---------------------------------------------------------------------------
+// Lifecycle convergence tests
+// ---------------------------------------------------------------------------
+
+class FunctionStillExists extends Data.TaggedError("FunctionStillExists") {}
+class FunctionEnvNotReady extends Data.TaggedError("FunctionEnvNotReady") {}
+
+const lifecycleHandlerPath = new URL(
+  "./lifecycle-handler.ts",
+  import.meta.url,
+).pathname;
+
+// Inline `impl` for `Function(id, props, impl)` — same minimal handler as
+// the fixture file, used when a test needs to vary props (functionName, url,
+// env) without authoring a new tagged class per variation.
+const okImpl = Effect.gen(function* () {
+  return {
+    fetch: Effect.succeed(HttpServerResponse.text("ok")),
+  };
+});
+
+const assertFunctionDeleted = Effect.fn(function* (functionName: string) {
+  yield* Lambda.getFunction({ FunctionName: functionName }).pipe(
+    Effect.flatMap(() => Effect.fail(new FunctionStillExists())),
+    Effect.retry({
+      while: (e) => e._tag === "FunctionStillExists",
+      schedule: Schedule.exponential(200).pipe(
+        Schedule.both(Schedule.recurs(20)),
+      ),
+    }),
+    Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+  );
+});
+
+/**
+ * Wait until the function's `Environment.Variables` matches each
+ * key/value pair in `expected`. Lambda returns the last persisted state
+ * but `LastUpdateStatus` may briefly trail `updateFunctionConfiguration`.
+ */
+const waitForFunctionEnvMatch = Effect.fn(function* (
+  functionName: string,
+  expected: Record<string, string>,
+) {
+  yield* Lambda.getFunctionConfiguration({ FunctionName: functionName }).pipe(
+    Effect.flatMap((cfg) => {
+      const actual = cfg.Environment?.Variables ?? {};
+      for (const [k, v] of Object.entries(expected)) {
+        if (actual[k] !== v) return Effect.fail(new FunctionEnvNotReady());
+      }
+      if (cfg.LastUpdateStatus === "InProgress") {
+        return Effect.fail(new FunctionEnvNotReady());
+      }
+      return Effect.void;
+    }),
+    Effect.retry({
+      while: (e) => e._tag === "FunctionEnvNotReady",
+      schedule: Schedule.fixed(1000).pipe(
+        Schedule.both(Schedule.recurs(60)),
+      ),
+    }),
+  );
+});
+
+const waitForFunctionUrlConfig = Effect.fn(function* (functionName: string) {
+  return yield* Lambda.getFunctionUrlConfig({ FunctionName: functionName });
+});
+
+test.provider(
+  "redeploy with same props is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        LifecycleFunction.asEffect().pipe(Effect.provide(LifecycleFunctionLive)),
+      );
+      expect(initial.functionName).toBeDefined();
+
+      const second = yield* stack.deploy(
+        LifecycleFunction.asEffect().pipe(Effect.provide(LifecycleFunctionLive)),
+      );
+      expect(second.functionArn).toEqual(initial.functionArn);
+      expect(second.functionName).toEqual(initial.functionName);
+      expect(second.code.hash).toEqual(initial.code.hash);
+
+      yield* stack.destroy();
+      yield* assertFunctionDeleted(initial.functionName);
+    }),
+  { timeout: 240_000 },
+);
+
+test.provider(
+  "reconcile resets environment variables mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        AWS.Lambda.Function(
+          "DriftFunction",
+          {
+            main: lifecycleHandlerPath,
+            env: { FOO: "alchemy", BAR: "hello" },
+          },
+          okImpl,
+        ),
+      );
+      yield* waitForFunctionEnvMatch(initial.functionName, {
+        FOO: "alchemy",
+        BAR: "hello",
+      });
+
+      // Mutate env vars out-of-band.
+      yield* Lambda.updateFunctionConfiguration({
+        FunctionName: initial.functionName,
+        Environment: {
+          Variables: { FOO: "drifted", BAR: "drifted" },
+        },
+      });
+      yield* waitForFunctionEnvMatch(initial.functionName, {
+        FOO: "drifted",
+        BAR: "drifted",
+      });
+
+      // Re-deploy with the same desired props — reconcile should reset
+      // the drifted env vars back to the desired values.
+      const redeployed = yield* stack.deploy(
+        AWS.Lambda.Function(
+          "DriftFunction",
+          {
+            main: lifecycleHandlerPath,
+            env: { FOO: "alchemy", BAR: "hello" },
+          },
+          okImpl,
+        ),
+      );
+      expect(redeployed.functionArn).toEqual(initial.functionArn);
+      yield* waitForFunctionEnvMatch(redeployed.functionName, {
+        FOO: "alchemy",
+        BAR: "hello",
+      });
+
+      yield* stack.destroy();
+      yield* assertFunctionDeleted(initial.functionName);
+    }),
+  { timeout: 300_000 },
+);
+
+test.provider(
+  "reconcile re-creates a function deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        LifecycleFunction.asEffect().pipe(Effect.provide(LifecycleFunctionLive)),
+      );
+
+      // Delete the function out of band.
+      yield* Lambda.deleteFunction({ FunctionName: initial.functionName });
+      yield* assertFunctionDeleted(initial.functionName);
+
+      // Reconcile should re-create the function and surface the same
+      // deterministic name.
+      const recreated = yield* stack.deploy(
+        LifecycleFunction.asEffect().pipe(Effect.provide(LifecycleFunctionLive)),
+      );
+      expect(recreated.functionName).toEqual(initial.functionName);
+
+      const cfg = yield* Lambda.getFunctionConfiguration({
+        FunctionName: recreated.functionName,
+      });
+      expect(cfg.FunctionName).toEqual(recreated.functionName);
+
+      yield* stack.destroy();
+      yield* assertFunctionDeleted(recreated.functionName);
+    }),
+  { timeout: 240_000 },
+);
+
+test.provider(
+  "changing functionName triggers replace, old function is deleted",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const nameA = `alchemy-test-lambda-rename-a-${suffix}`;
+      const nameB = `alchemy-test-lambda-rename-b-${suffix}`;
+
+      const a = yield* stack.deploy(
+        AWS.Lambda.Function(
+          "RenameFunction",
+          {
+            main: lifecycleHandlerPath,
+            functionName: nameA,
+          },
+          okImpl,
+        ),
+      );
+      expect(a.functionName).toEqual(nameA);
+
+      const b = yield* stack.deploy(
+        AWS.Lambda.Function(
+          "RenameFunction",
+          {
+            main: lifecycleHandlerPath,
+            functionName: nameB,
+          },
+          okImpl,
+        ),
+      );
+      expect(b.functionName).toEqual(nameB);
+      expect(b.functionArn).not.toEqual(a.functionArn);
+
+      // The old function must be gone after replace.
+      yield* assertFunctionDeleted(a.functionName);
+
+      yield* stack.destroy();
+      yield* assertFunctionDeleted(b.functionName);
+    }),
+  { timeout: 300_000 },
+);
+
+test.provider(
+  "function URL: enable, then disable",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const noUrl = yield* stack.deploy(
+        AWS.Lambda.Function(
+          "UrlFunction",
+          {
+            main: lifecycleHandlerPath,
+            url: false,
+          },
+          okImpl,
+        ),
+      );
+      expect(noUrl.functionUrl).toBeUndefined();
+
+      const withUrl = yield* stack.deploy(
+        AWS.Lambda.Function(
+          "UrlFunction",
+          {
+            main: lifecycleHandlerPath,
+            url: true,
+          },
+          okImpl,
+        ),
+      );
+      // Toggling `url` triggers replace per the diff function, so the
+      // function name is identical (deterministic) but functionUrl is now set.
+      expect(withUrl.functionUrl).toBeDefined();
+      const cfg = yield* waitForFunctionUrlConfig(withUrl.functionName);
+      expect(cfg.FunctionUrl).toEqual(withUrl.functionUrl);
+
+      yield* stack.destroy();
+      yield* assertFunctionDeleted(withUrl.functionName);
+    }),
+  { timeout: 360_000 },
+);
+
+test.provider(
+  "destroying an already-deleted function is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const fn = yield* stack.deploy(
+        LifecycleFunction.asEffect().pipe(Effect.provide(LifecycleFunctionLive)),
+      );
+
+      // Delete the function out of band, then ask the engine to destroy it.
+      // Provider's `delete` must catch ResourceNotFoundException + the
+      // role's NoSuchEntityException and complete cleanly.
+      yield* Lambda.deleteFunction({ FunctionName: fn.functionName });
+      yield* assertFunctionDeleted(fn.functionName);
+
+      yield* IAM.deleteRolePolicy({
+        RoleName: fn.roleName,
+        PolicyName: fn.roleName, // policyName == createPhysicalName(id, 128)
+      }).pipe(Effect.catchTag("NoSuchEntityException", () => Effect.void));
+      yield* IAM.detachRolePolicy({
+        RoleName: fn.roleName,
+        PolicyArn:
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+      }).pipe(Effect.catchTag("NoSuchEntityException", () => Effect.void));
+      yield* IAM.deleteRole({ RoleName: fn.roleName }).pipe(
+        Effect.catchTag("NoSuchEntityException", () => Effect.void),
+      );
+
+      yield* stack.destroy();
+    }),
+  { timeout: 240_000 },
+);
+
+test.provider(
+  "adopt(true) re-tags a foreign function with internal alchemy tags",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const functionName = `alchemy-test-lambda-adopt-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const original = yield* stack.deploy(
+        AWS.Lambda.Function(
+          "Original",
+          {
+            main: lifecycleHandlerPath,
+            functionName,
+          },
+          okImpl,
+        ),
+      );
+
+      // Wipe state — function stays in Lambda.
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "Original",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      const takenOver = yield* stack
+        .deploy(
+          AWS.Lambda.Function(
+            "Different",
+            {
+              main: lifecycleHandlerPath,
+              functionName,
+            },
+            okImpl,
+          ),
+        )
+        .pipe(adopt(true));
+      expect(takenOver.functionName).toEqual(functionName);
+      expect(takenOver.functionArn).toEqual(original.functionArn);
+
+      // adopt(true) re-tags the function with the new logical id ("Different")
+      // so subsequent runs use silent adoption.
+      const tags = yield* Lambda.listTags({ Resource: takenOver.functionArn });
+      expect(tags.Tags?.["alchemy:fqn"]).toBeDefined();
+      expect(tags.Tags?.["alchemy:stage"]).toBeDefined();
+
+      yield* stack.destroy();
+      yield* assertFunctionDeleted(takenOver.functionName);
+    }),
+  { timeout: 300_000 },
+);

--- a/packages/alchemy/test/AWS/Lambda/lifecycle-handler.ts
+++ b/packages/alchemy/test/AWS/Lambda/lifecycle-handler.ts
@@ -1,0 +1,30 @@
+import * as AWS from "@/AWS";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+const main = import.meta.filename;
+
+/**
+ * Bare-bones Lambda fixture used by the lifecycle convergence tests.
+ *
+ * The tests vary `functionName`, `url`, `env`, `vpc`, etc. via the
+ * `LifecycleFunction(...)` props at deploy time — this file just supplies
+ * a reusable bundleable handler so the convergence tests can be expressed
+ * as plain prop diffs.
+ */
+export class LifecycleFunction extends AWS.Lambda.Function<LifecycleFunction>()(
+  "LifecycleFunction",
+  { main, url: false },
+) {}
+
+export const LifecycleFunctionLive = LifecycleFunction.make(
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.gen(function* () {
+        return HttpServerResponse.text("ok");
+      }),
+    };
+  }),
+);
+
+export default LifecycleFunctionLive;


### PR DESCRIPTION
Stacked on top of [#179](https://github.com/alchemy-run/alchemy-effect/pull/179). Continues the per-resource hardening sweep started in [#184](https://github.com/alchemy-run/alchemy-effect/pull/184) (SQS) / [#185](https://github.com/alchemy-run/alchemy-effect/pull/185) (DynamoDB) / [#186](https://github.com/alchemy-run/alchemy-effect/pull/186) (Kinesis) / [#187](https://github.com/alchemy-run/alchemy-effect/pull/187) (S3).

### Reconciler changes

```diff
+ // Wait for any in-flight update to converge so the next
+ // updateFunctionCode call doesn't surface
+ // `ResourceConflictException` ("update in progress").
+ yield* waitForFunctionUpdateSuccessful(createFunctionRequest.FunctionName);
  yield* Lambda.updateFunctionCode({ ... }).pipe(
    Effect.retry({
      while: (e) => e._tag === "ResourceConflictException" || isRolePropagationError(e),
-     schedule: Schedule.exponential(100),
+     schedule: Schedule.exponential(100).pipe(Schedule.both(Schedule.recurs(60))),
    }),
  );
```

`updateFunctionCode` and `updateFunctionConfiguration` retried `ResourceConflictException` ("update in progress") on an unbounded `Schedule.exponential(100)` — a function stuck in `LastUpdateStatus = InProgress` would loop forever. Added an explicit `LastUpdateStatus` poll between mutations and capped the retry budget.

```diff
  Effect.retry({
    while: (e) => isRolePropagationError(e),
    schedule: Schedule.fixed(1000).pipe(
      Schedule.tapOutput(() => noteRolePropagationWait()),
+     Schedule.both(Schedule.recurs(120)),
    ),
  })
```

`createFunction`'s role-propagation retry was unbounded — a misconfigured assume-role policy would never surface. Capped at 120s.

```diff
- Effect.flatMap((policies) => Effect.all((policies.PolicyNames ?? []).map((p) =>
-   iam.deleteRolePolicy({ RoleName: output.roleName, PolicyName: p }),
- ))),
+ Effect.flatMap((policies) => Effect.all((policies.PolicyNames ?? []).map((p) =>
+   iam.deleteRolePolicy({ RoleName: output.roleName, PolicyName: p }).pipe(
+     Effect.catchTag("NoSuchEntityException", () => Effect.void),
+   ),
+ ))),
+ Effect.catchTag("NoSuchEntityException", () => Effect.void),
```

`delete` blew up if the IAM role was already gone (out-of-band delete). Tolerate `NoSuchEntityException` on the list calls + per-policy delete. Also added a bounded `ResourceConflictException` retry on `deleteFunction` for the "delete during update" race.

### New lifecycle tests

Each runs `destroy → deploy → … → destroy` on a `ScratchStack` and asserts at every step.

- redeploy with same props is a no-op (no replace, no rename)
- reconcile resets environment variables mutated out-of-band via the raw SDK
- reconcile re-creates a function deleted out-of-band
- changing `functionName` triggers replace; old function is deleted
- function URL: enable, then disable
- destroying an already-deleted function is a no-op (also exercises the role-already-gone path)
- `adopt(true)` re-tags a foreign function with internal alchemy tags

A `lifecycle-handler.ts` fixture supplies a minimal bundleable handler so the variant tests can express themselves as plain prop diffs (`functionName`, `url`, `env`).

### Distilled patch

No patch needed. Lambda's error categories already include `withConflictError` (`ResourceConflictException`, `DurableExecutionAlreadyStartedException`, `SnapStartNotReadyException`), `withThrottlingError` (`TooManyRequestsException`, `RequestLimitExceeded`), and `withServerError` for the known transient VPC/ENI codes (`EC2ThrottledException`, `ENILimitReachedException`, `ResourceNotReadyException`) — all already participate in the AWS retry layer's `isTransientError` check.
