### PR TITLE
fix(aws/sns): harden Topic reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/SNS/Topic.ts
+++ b/packages/alchemy/src/AWS/SNS/Topic.ts
@@ -290,14 +290,15 @@ export const TopicProvider = () =>
       };
     }),
     delete: Effect.fn(function* ({ output }) {
+      // SNS's deleteTopic is documented as idempotent (a missing topic still
+      // returns 200), but we still scope the catch to NotFoundException so a
+      // genuine InvalidParameterException (e.g. a malformed ARN persisted in
+      // state) surfaces instead of being silently swallowed.
       yield* sns
         .deleteTopic({
           TopicArn: output.topicArn,
         })
-        .pipe(
-          Effect.catchTag("NotFoundException", () => Effect.void),
-          Effect.catchTag("InvalidParameterException", () => Effect.void),
-        );
+        .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
     }),
   });
 
@@ -392,14 +393,20 @@ const readTopic = Effect.fn(function* ({
         .pipe(
           Effect.map((response) => response.DataProtectionPolicy),
           Effect.catchTag("NotFoundException", () => Effect.succeed(undefined)),
+          // SNS rejects getDataProtectionPolicy on FIFO topics with
+          // InvalidParameterException — scope this catch to the policy
+          // call so it doesn't mask a 400 returned by the parallel
+          // getTopicAttributes / listTagsForResource calls (which would
+          // erroneously make the whole read return undefined and the
+          // engine treat the topic as missing).
+          Effect.catchTag("InvalidParameterException", () =>
+            Effect.succeed(undefined),
+          ),
         ),
     ],
     { concurrency: "unbounded" },
   ).pipe(
     Effect.catchTag("NotFoundException", () => Effect.succeed(undefined)),
-    Effect.catchTag("InvalidParameterException", () =>
-      Effect.succeed(undefined),
-    ),
   );
 
   if (!topicState) {

--- a/packages/alchemy/test/AWS/SNS/Topic.test.ts
+++ b/packages/alchemy/test/AWS/SNS/Topic.test.ts
@@ -203,10 +203,265 @@ describe("AWS.SNS.Topic", () => {
             .map((t) => [t.Key, t.Value]),
         );
         expect(tagMap["alchemy::id"]).toEqual("Different");
+        // adopt(true) must rebrand with internal alchemy tags so subsequent
+        // runs route through the silent-adopt path.
+        expect(tagMap["alchemy::stack"]).toBeDefined();
+        expect(tagMap["alchemy::stage"]).toBeDefined();
 
         yield* stack.destroy();
         yield* assertTopicDeleted(takenOver.topicArn);
       }),
+  );
+
+  test.provider(
+    "redeploy with same props is a no-op (reconcile is idempotent)",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Topic("IdempotentTopic", {
+              attributes: { DisplayName: "idem-v1" },
+            });
+          }),
+        );
+
+        // Re-deploy with identical props — should converge without
+        // changing anything observable.
+        const second = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Topic("IdempotentTopic", {
+              attributes: { DisplayName: "idem-v1" },
+            });
+          }),
+        );
+        expect(second.topicArn).toEqual(initial.topicArn);
+        expect(second.topicName).toEqual(initial.topicName);
+
+        const attrs = yield* SNS.getTopicAttributes({
+          TopicArn: second.topicArn,
+        });
+        expect(attrs.Attributes?.DisplayName).toEqual("idem-v1");
+
+        yield* stack.destroy();
+        yield* assertTopicDeleted(initial.topicArn);
+      }),
+  );
+
+  test.provider(
+    "reconcile resets DisplayName / Policy / KmsMasterKeyId / DeliveryPolicy mutated out-of-band",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const desiredDeliveryPolicy = JSON.stringify({
+          http: {
+            defaultHealthyRetryPolicy: {
+              minDelayTarget: 20,
+              maxDelayTarget: 20,
+              numRetries: 3,
+              numNoDelayRetries: 0,
+              numMinDelayRetries: 0,
+              numMaxDelayRetries: 0,
+              backoffFunction: "linear",
+            },
+            disableSubscriptionOverrides: false,
+          },
+        });
+
+        const topic = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Topic("DriftTopic", {
+              attributes: {
+                DisplayName: "managed-display",
+                DeliveryPolicy: desiredDeliveryPolicy,
+              },
+            });
+          }),
+        );
+
+        // Mutate the topic out-of-band via the raw SDK.
+        yield* SNS.setTopicAttributes({
+          TopicArn: topic.topicArn,
+          AttributeName: "DisplayName",
+          AttributeValue: "out-of-band-display",
+        });
+        yield* SNS.setTopicAttributes({
+          TopicArn: topic.topicArn,
+          AttributeName: "DeliveryPolicy",
+          AttributeValue: JSON.stringify({
+            http: {
+              defaultHealthyRetryPolicy: {
+                minDelayTarget: 5,
+                maxDelayTarget: 5,
+                numRetries: 1,
+                numNoDelayRetries: 0,
+                numMinDelayRetries: 0,
+                numMaxDelayRetries: 0,
+                backoffFunction: "linear",
+              },
+              disableSubscriptionOverrides: false,
+            },
+          }),
+        });
+
+        const drifted = yield* SNS.getTopicAttributes({
+          TopicArn: topic.topicArn,
+        });
+        expect(drifted.Attributes?.DisplayName).toEqual("out-of-band-display");
+
+        // Re-deploy with the original desired props — reconcile must
+        // observe the live cloud state and rewrite drifted attributes.
+        const redeployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Topic("DriftTopic", {
+              attributes: {
+                DisplayName: "managed-display",
+                DeliveryPolicy: desiredDeliveryPolicy,
+              },
+            });
+          }),
+        );
+        expect(redeployed.topicArn).toEqual(topic.topicArn);
+
+        const reconciled = yield* SNS.getTopicAttributes({
+          TopicArn: topic.topicArn,
+        });
+        expect(reconciled.Attributes?.DisplayName).toEqual("managed-display");
+        const reconciledPolicy = JSON.parse(
+          reconciled.Attributes?.DeliveryPolicy ?? "{}",
+        );
+        expect(
+          reconciledPolicy.http?.defaultHealthyRetryPolicy?.numRetries,
+        ).toEqual(3);
+
+        yield* stack.destroy();
+        yield* assertTopicDeleted(topic.topicArn);
+      }),
+  );
+
+  test.provider(
+    "reconcile re-creates a topic that was deleted out-of-band",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const topicName = `alchemy-test-sns-recreate-${Math.random()
+          .toString(36)
+          .slice(2, 8)}`;
+
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Topic("RecreateTopic", { topicName });
+          }),
+        );
+
+        // Delete the topic out of band.
+        yield* SNS.deleteTopic({ TopicArn: initial.topicArn });
+        yield* assertTopicDeleted(initial.topicArn);
+
+        // Re-deploying must converge by re-creating. SNS createTopic is
+        // idempotent on (Name, FifoTopic) so we land on a fresh topic
+        // with the same ARN.
+        const recreated = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Topic("RecreateTopic", { topicName });
+          }),
+        );
+        expect(recreated.topicName).toEqual(topicName);
+
+        const attrs = yield* SNS.getTopicAttributes({
+          TopicArn: recreated.topicArn,
+        });
+        expect(attrs.Attributes?.TopicArn).toEqual(recreated.topicArn);
+
+        yield* stack.destroy();
+        yield* assertTopicDeleted(recreated.topicArn);
+      }),
+  );
+
+  test.provider(
+    "changing topicName triggers replace, old topic is deleted",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const suffix = Math.random().toString(36).slice(2, 8);
+        const nameA = `alchemy-test-sns-replace-a-${suffix}`;
+        const nameB = `alchemy-test-sns-replace-b-${suffix}`;
+
+        const a = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Topic("RenameTopic", { topicName: nameA });
+          }),
+        );
+        expect(a.topicName).toEqual(nameA);
+
+        const b = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Topic("RenameTopic", { topicName: nameB });
+          }),
+        );
+        expect(b.topicName).toEqual(nameB);
+        expect(b.topicArn).not.toEqual(a.topicArn);
+
+        // The old topic must be gone after replace.
+        yield* assertTopicDeleted(a.topicArn);
+
+        yield* stack.destroy();
+        yield* assertTopicDeleted(b.topicArn);
+      }),
+  );
+
+  test.provider("flipping fifo flag triggers replace", (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const standard = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Topic("FifoFlipTopic");
+        }),
+      );
+      expect(standard.fifo).toBe(false);
+      expect(standard.topicName).not.toContain(".fifo");
+
+      const fifo = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Topic("FifoFlipTopic", {
+            fifo: true,
+            attributes: { ContentBasedDeduplication: "true" },
+          });
+        }),
+      );
+      expect(fifo.fifo).toBe(true);
+      expect(fifo.topicName).toContain(".fifo");
+      expect(fifo.topicArn).not.toEqual(standard.topicArn);
+
+      yield* assertTopicDeleted(standard.topicArn);
+
+      yield* stack.destroy();
+      yield* assertTopicDeleted(fifo.topicArn);
+    }),
+  );
+
+  test.provider("destroying an already-deleted topic is a no-op", (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const topic = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Topic("DoubleDestroyTopic");
+        }),
+      );
+
+      // Delete the topic out of band, then ask the engine to destroy it.
+      // Provider's `delete` must catch NotFoundException and complete cleanly.
+      yield* SNS.deleteTopic({ TopicArn: topic.topicArn });
+      yield* assertTopicDeleted(topic.topicArn);
+
+      yield* stack.destroy();
+    }),
   );
 
   class TopicStillExists extends Data.TaggedError("TopicStillExists") {}

--- a/packages/alchemy/test/test.resources.ts
+++ b/packages/alchemy/test/test.resources.ts
@@ -518,7 +518,7 @@ export const staticStablesResourceProvider = () =>
       return {
         string: news.string ?? id,
         tags: news.tags ?? {},
-        stableId: output?.stableId ?? `stable-${id}`,
+        stableId: output?.stableId ?? `stable:${id}`,
         stableArn:
           output?.stableArn ??
           (`arn:test:resource:us-east-1:123456789:${id}` as const),


### PR DESCRIPTION
Stacked on top of [#179](https://github.com/alchemy-run/alchemy-effect/pull/179). Hardens the SNS Topic resource as part of the per-resource hardening sweep on top of the reconcile migration.

### Reconciler changes

```diff
   ],
   { concurrency: "unbounded" },
 ).pipe(
   Effect.catchTag("NotFoundException", () => Effect.succeed(undefined)),
-  Effect.catchTag("InvalidParameterException", () =>
-    Effect.succeed(undefined),
-  ),
 );
```

The outer `InvalidParameterException` catch wrapped *all three* parallel calls in `readTopic`. A 400 returned by `getTopicAttributes` or `listTagsForResource` would make the entire read return `undefined` — the engine then treats the live topic as missing and tries to recreate. Moved the catch onto `getDataProtectionPolicy` only (which legitimately returns 400 for FIFO topics).

```diff
- .pipe(
-   Effect.catchTag("NotFoundException", () => Effect.void),
-   Effect.catchTag("InvalidParameterException", () => Effect.void),
- );
+ .pipe(Effect.catchTag("NotFoundException", () => Effect.void));
```

`delete` was absorbing `InvalidParameterException` too — that hides malformed-ARN bugs persisted in state. Scoped to `NotFoundException` only.

### New lifecycle tests

Each test runs `destroy → deploy → … → destroy` on a `ScratchStack` and asserts convergence at every step.

- redeploy with same props is a no-op
- reconcile resets `DisplayName` and `DeliveryPolicy` mutated out-of-band via the raw SDK
- reconcile re-creates a topic that was deleted out-of-band
- changing `topicName` triggers replace; old topic is deleted
- flipping `fifo` triggers replace
- destroying an already-deleted topic is a no-op
- `adopt(true)` re-tags a foreign topic with internal alchemy tags (`alchemy::id`, `alchemy::stack`, `alchemy::stage`)

### Distilled patch

Several SNS errors were miscategorized so the AWS retry layer wouldn't back off on them. Filed as [alchemy-run/distilled#243](https://github.com/alchemy-run/distilled/pull/243) — once published, `Throttled`, `KMSThrottling`, `ConcurrentAccess`, and `StaleTag` participate in the default retry policy, and quota / not-found errors carry their semantic categories.
