### PR TITLE
fix(aws/iam): harden Role reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/IAM/Role.ts
+++ b/packages/alchemy/src/AWS/IAM/Role.ts
@@ -1,5 +1,6 @@
 import * as iam from "@distilled.cloud/aws/iam";
 import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
 import { Unowned } from "../../AdoptPolicy.ts";
 import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
@@ -20,6 +21,53 @@ import {
   stringifyPolicyDocument,
   toTagRecord,
 } from "./common.ts";
+
+/**
+ * IAM control-plane errors that are safe to retry. `ConcurrentModification`
+ * is documented as transient — IAM serializes mutations to a role and
+ * surfaces this when two writes overlap. `EntityTemporarilyUnmodifiable`
+ * appears during cross-region propagation right after a `createRole`.
+ */
+const isRetryableIamControlPlaneError = (error: { _tag?: string }) =>
+  error._tag === "ConcurrentModificationException" ||
+  error._tag === "EntityTemporarilyUnmodifiableException";
+
+/**
+ * Retry an IAM mutation against `ConcurrentModification` /
+ * `EntityTemporarilyUnmodifiable`. Capped so a service that stays in this
+ * state surfaces instead of looping forever.
+ */
+const retryIamMutation = <A, E extends { _tag?: string }, R>(
+  effect: Effect.Effect<A, E, R>,
+) =>
+  effect.pipe(
+    Effect.retry({
+      while: isRetryableIamControlPlaneError,
+      schedule: Schedule.exponential(250).pipe(
+        Schedule.both(Schedule.recurs(20)),
+      ),
+    }),
+  );
+
+/**
+ * IAM is eventually consistent globally. Right after `createRole` the
+ * subsequent attach/put/tag calls can briefly hit `NoSuchEntity` because
+ * they land on an IAM host that hasn't seen the create yet. Retry that
+ * narrow window with a short bounded schedule.
+ */
+const retryNoSuchEntityAfterCreate = <A, E extends { _tag?: string }, R>(
+  effect: Effect.Effect<A, E, R>,
+) =>
+  effect.pipe(
+    Effect.retry({
+      while: (e) =>
+        e._tag === "NoSuchEntityException" ||
+        isRetryableIamControlPlaneError(e),
+      schedule: Schedule.exponential(500).pipe(
+        Schedule.both(Schedule.recurs(8)),
+      ),
+    }),
+  );
 
 export type RoleName = string;
 export type RoleArn = `arn:aws:iam::${AccountID}:role/${RoleName}`;
@@ -170,33 +218,38 @@ export const RoleProvider = () =>
         roleName,
         olds,
         news,
+        justCreated,
       }: {
         roleName: string;
         olds: string[];
         news: string[];
+        justCreated: boolean;
       }) {
         const oldSet = new Set(olds);
         const newSet = new Set(news);
 
         for (const policyArn of news) {
           if (!oldSet.has(policyArn)) {
-            yield* iam.attachRolePolicy({
+            const attach = iam.attachRolePolicy({
               RoleName: roleName,
               PolicyArn: policyArn,
             });
+            yield* justCreated
+              ? retryNoSuchEntityAfterCreate(attach)
+              : retryIamMutation(attach);
           }
         }
 
         for (const policyArn of olds) {
           if (!newSet.has(policyArn)) {
-            yield* iam
-              .detachRolePolicy({
+            yield* retryIamMutation(
+              iam.detachRolePolicy({
                 RoleName: roleName,
                 PolicyArn: policyArn,
-              })
-              .pipe(
-                Effect.catchTag("NoSuchEntityException", () => Effect.void),
-              );
+              }),
+            ).pipe(
+              Effect.catchTag("NoSuchEntityException", () => Effect.void),
+            );
           }
         }
       });
@@ -205,34 +258,39 @@ export const RoleProvider = () =>
         roleName,
         olds,
         news,
+        justCreated,
       }: {
         roleName: string;
         olds: Record<string, PolicyDocument>;
         news: Record<string, PolicyDocument>;
+        justCreated: boolean;
       }) {
         for (const [policyName, document] of Object.entries(news)) {
           if (
             JSON.stringify(olds[policyName] ?? null) !==
             JSON.stringify(document)
           ) {
-            yield* iam.putRolePolicy({
+            const put = iam.putRolePolicy({
               RoleName: roleName,
               PolicyName: policyName,
               PolicyDocument: stringifyPolicyDocument(document),
             });
+            yield* justCreated
+              ? retryNoSuchEntityAfterCreate(put)
+              : retryIamMutation(put);
           }
         }
 
         for (const policyName of Object.keys(olds)) {
           if (!(policyName in news)) {
-            yield* iam
-              .deleteRolePolicy({
+            yield* retryIamMutation(
+              iam.deleteRolePolicy({
                 RoleName: roleName,
                 PolicyName: policyName,
-              })
-              .pipe(
-                Effect.catchTag("NoSuchEntityException", () => Effect.void),
-              );
+              }),
+            ).pipe(
+              Effect.catchTag("NoSuchEntityException", () => Effect.void),
+            );
           }
         }
       });
@@ -317,6 +375,7 @@ export const RoleProvider = () =>
           // Ensure — create the role when missing. A peer reconciler may
           // have created it concurrently; tolerate that race by reading
           // the existing role.
+          let justCreated = false;
           if (!observedRole?.Role) {
             observedRole = yield* iam
               .createRole({
@@ -335,6 +394,7 @@ export const RoleProvider = () =>
                   iam.getRole({ RoleName: roleName }),
                 ),
               );
+            justCreated = true;
           }
 
           const observedAssumePolicy = parsePolicyDocument(
@@ -352,12 +412,14 @@ export const RoleProvider = () =>
             JSON.stringify(observedAssumePolicy ?? null) !==
             JSON.stringify(news.assumeRolePolicyDocument)
           ) {
-            yield* iam.updateAssumeRolePolicy({
-              RoleName: roleName,
-              PolicyDocument: stringifyPolicyDocument(
-                news.assumeRolePolicyDocument,
-              ),
-            });
+            yield* retryIamMutation(
+              iam.updateAssumeRolePolicy({
+                RoleName: roleName,
+                PolicyDocument: stringifyPolicyDocument(
+                  news.assumeRolePolicyDocument,
+                ),
+              }),
+            );
           }
 
           // Sync description / maxSessionDuration via updateRole.
@@ -365,29 +427,33 @@ export const RoleProvider = () =>
             observedDescription !== news.description ||
             observedMaxSessionDuration !== news.maxSessionDuration
           ) {
-            yield* iam.updateRole({
-              RoleName: roleName,
-              Description: news.description,
-              MaxSessionDuration: news.maxSessionDuration,
-            });
+            yield* retryIamMutation(
+              iam.updateRole({
+                RoleName: roleName,
+                Description: news.description,
+                MaxSessionDuration: news.maxSessionDuration,
+              }),
+            );
           }
 
           // Sync permissions boundary — put when desired, delete when
           // cleared, no-op when unchanged.
           if (news.permissionsBoundary !== observedPermissionsBoundary) {
             if (news.permissionsBoundary) {
-              yield* iam.putRolePermissionsBoundary({
-                RoleName: roleName,
-                PermissionsBoundary: news.permissionsBoundary,
-              });
-            } else if (observedPermissionsBoundary) {
-              yield* iam
-                .deleteRolePermissionsBoundary({
+              yield* retryIamMutation(
+                iam.putRolePermissionsBoundary({
                   RoleName: roleName,
-                })
-                .pipe(
-                  Effect.catchTag("NoSuchEntityException", () => Effect.void),
-                );
+                  PermissionsBoundary: news.permissionsBoundary,
+                }),
+              );
+            } else if (observedPermissionsBoundary) {
+              yield* retryIamMutation(
+                iam.deleteRolePermissionsBoundary({
+                  RoleName: roleName,
+                }),
+              ).pipe(
+                Effect.catchTag("NoSuchEntityException", () => Effect.void),
+              );
             }
           }
 
@@ -403,11 +469,13 @@ export const RoleProvider = () =>
             roleName,
             olds: observedManagedPolicies,
             news: news.managedPolicyArns ?? [],
+            justCreated,
           });
           yield* syncInlinePolicies({
             roleName,
             olds: observedInlinePolicies,
             news: news.inlinePolicies ?? {},
+            justCreated,
           });
 
           // Sync tags against the cloud's actual tags so adoption /
@@ -415,16 +483,20 @@ export const RoleProvider = () =>
           const observedTags = yield* readTags(roleName);
           const { removed, upsert } = diffTags(observedTags, desiredTags);
           if (upsert.length > 0) {
-            yield* iam.tagRole({
-              RoleName: roleName,
-              Tags: upsert,
-            });
+            yield* retryIamMutation(
+              iam.tagRole({
+                RoleName: roleName,
+                Tags: upsert,
+              }),
+            );
           }
           if (removed.length > 0) {
-            yield* iam.untagRole({
-              RoleName: roleName,
-              TagKeys: removed,
-            });
+            yield* retryIamMutation(
+              iam.untagRole({
+                RoleName: roleName,
+                TagKeys: removed,
+              }),
+            );
           }
 
           // Re-read for fresh attributes after all mutations.
@@ -456,59 +528,85 @@ export const RoleProvider = () =>
           };
         }),
         delete: Effect.fn(function* ({ output }) {
-          yield* iam
-            .deleteRolePermissionsBoundary({
+          yield* retryIamMutation(
+            iam.deleteRolePermissionsBoundary({
               RoleName: output.roleName,
-            })
-            .pipe(Effect.catchTag("NoSuchEntityException", () => Effect.void));
+            }),
+          ).pipe(Effect.catchTag("NoSuchEntityException", () => Effect.void));
 
-          yield* iam.listRolePolicies({ RoleName: output.roleName }).pipe(
-            Effect.flatMap((policies) =>
-              Effect.all(
-                (policies.PolicyNames ?? []).map((policyName) =>
-                  iam
-                    .deleteRolePolicy({
-                      RoleName: output.roleName,
-                      PolicyName: policyName,
-                    })
-                    .pipe(
+          yield* iam
+            .listRolePolicies({ RoleName: output.roleName })
+            .pipe(
+              Effect.catchTag("NoSuchEntityException", () =>
+                Effect.succeed({ PolicyNames: [] as string[] }),
+              ),
+            )
+            .pipe(
+              Effect.flatMap((policies) =>
+                Effect.all(
+                  (policies.PolicyNames ?? []).map((policyName) =>
+                    retryIamMutation(
+                      iam.deleteRolePolicy({
+                        RoleName: output.roleName,
+                        PolicyName: policyName,
+                      }),
+                    ).pipe(
                       Effect.catchTag(
                         "NoSuchEntityException",
                         () => Effect.void,
                       ),
                     ),
-                ),
-              ),
-            ),
-          );
-
-          yield* iam
-            .listAttachedRolePolicies({ RoleName: output.roleName })
-            .pipe(
-              Effect.flatMap((policies) =>
-                Effect.all(
-                  (policies.AttachedPolicies ?? []).map((policy) =>
-                    iam
-                      .detachRolePolicy({
-                        RoleName: output.roleName,
-                        PolicyArn: policy.PolicyArn!,
-                      })
-                      .pipe(
-                        Effect.catchTag(
-                          "NoSuchEntityException",
-                          () => Effect.void,
-                        ),
-                      ),
                   ),
                 ),
               ),
             );
 
           yield* iam
+            .listAttachedRolePolicies({ RoleName: output.roleName })
+            .pipe(
+              Effect.catchTag("NoSuchEntityException", () =>
+                Effect.succeed({ AttachedPolicies: [] }),
+              ),
+            )
+            .pipe(
+              Effect.flatMap((policies) =>
+                Effect.all(
+                  (policies.AttachedPolicies ?? []).map((policy) =>
+                    retryIamMutation(
+                      iam.detachRolePolicy({
+                        RoleName: output.roleName,
+                        PolicyArn: policy.PolicyArn!,
+                      }),
+                    ).pipe(
+                      Effect.catchTag(
+                        "NoSuchEntityException",
+                        () => Effect.void,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            );
+
+          // `DeleteConflict` happens when something still references the
+          // role (e.g. an instance profile that hasn't finished detaching).
+          // It usually clears within a few seconds — bound the retry so a
+          // genuine, persistent reference surfaces.
+          yield* iam
             .deleteRole({
               RoleName: output.roleName,
             })
-            .pipe(Effect.catchTag("NoSuchEntityException", () => Effect.void));
+            .pipe(
+              Effect.retry({
+                while: (e) =>
+                  e._tag === "DeleteConflictException" ||
+                  isRetryableIamControlPlaneError(e),
+                schedule: Schedule.exponential(500).pipe(
+                  Schedule.both(Schedule.recurs(10)),
+                ),
+              }),
+              Effect.catchTag("NoSuchEntityException", () => Effect.void),
+            );
         }),
       };
     }),

--- a/packages/alchemy/test/AWS/IAM/Role.test.ts
+++ b/packages/alchemy/test/AWS/IAM/Role.test.ts
@@ -213,3 +213,384 @@ test.provider(
       expect(deleted._tag).toBe("None");
     }),
 );
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Role("IdempotentRole", {
+            assumeRolePolicyDocument: assumeRolePolicy,
+            inlinePolicies: {
+              AllowLogs: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: ["logs:CreateLogGroup"],
+                    Resource: "*",
+                  },
+                ],
+              },
+            },
+            tags: { env: "test" },
+          });
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Role("IdempotentRole", {
+            assumeRolePolicyDocument: assumeRolePolicy,
+            inlinePolicies: {
+              AllowLogs: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: ["logs:CreateLogGroup"],
+                    Resource: "*",
+                  },
+                ],
+              },
+            },
+            tags: { env: "test" },
+          });
+        }),
+      );
+
+      expect(second.roleArn).toEqual(initial.roleArn);
+      expect(second.roleName).toEqual(initial.roleName);
+
+      yield* stack.destroy();
+
+      const deleted = yield* IAM.getRole({ RoleName: initial.roleName }).pipe(
+        Effect.option,
+      );
+      expect(deleted._tag).toBe("None");
+    }),
+);
+
+test.provider(
+  "reconcile resets assume-role policy and inline policies mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const role = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Role("DriftRole", {
+            assumeRolePolicyDocument: assumeRolePolicy,
+            inlinePolicies: {
+              AllowLogs: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: ["logs:CreateLogGroup"],
+                    Resource: "*",
+                  },
+                ],
+              },
+            },
+          });
+        }),
+      );
+
+      // Mutate the assume-role policy out-of-band.
+      const driftedAssume = {
+        Version: "2012-10-17" as const,
+        Statement: [
+          {
+            Effect: "Allow" as const,
+            Principal: { Service: "ec2.amazonaws.com" },
+            Action: ["sts:AssumeRole"],
+          },
+        ],
+      };
+      yield* IAM.updateAssumeRolePolicy({
+        RoleName: role.roleName,
+        PolicyDocument: JSON.stringify(driftedAssume),
+      });
+
+      // Mutate the inline policy out-of-band.
+      yield* IAM.putRolePolicy({
+        RoleName: role.roleName,
+        PolicyName: "AllowLogs",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Deny",
+              Action: "*",
+              Resource: "*",
+            },
+          ],
+        }),
+      });
+
+      // Re-deploy with the original desired state — reconcile must reset.
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Role("DriftRole", {
+            assumeRolePolicyDocument: assumeRolePolicy,
+            inlinePolicies: {
+              AllowLogs: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: ["logs:CreateLogGroup"],
+                    Resource: "*",
+                  },
+                ],
+              },
+            },
+          });
+        }),
+      );
+
+      const observed = yield* IAM.getRole({ RoleName: role.roleName });
+      const observedAssume = JSON.parse(
+        decodeURIComponent(observed.Role.AssumeRolePolicyDocument ?? ""),
+      );
+      expect(observedAssume.Statement[0].Principal.Service).toEqual(
+        "lambda.amazonaws.com",
+      );
+
+      const observedInline = yield* IAM.getRolePolicy({
+        RoleName: role.roleName,
+        PolicyName: "AllowLogs",
+      });
+      const observedDoc = JSON.parse(
+        decodeURIComponent(observedInline.PolicyDocument ?? ""),
+      );
+      expect(observedDoc.Statement[0].Effect).toEqual("Allow");
+      expect(observedDoc.Statement[0].Action).toEqual([
+        "logs:CreateLogGroup",
+      ]);
+
+      yield* stack.destroy();
+
+      const deleted = yield* IAM.getRole({ RoleName: role.roleName }).pipe(
+        Effect.option,
+      );
+      expect(deleted._tag).toBe("None");
+    }),
+);
+
+test.provider(
+  "reconcile re-creates a role that was deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const roleName = `alchemy-test-role-recreate-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Role("RecreateRole", {
+            roleName,
+            assumeRolePolicyDocument: assumeRolePolicy,
+          });
+        }),
+      );
+      expect(initial.roleName).toEqual(roleName);
+
+      // Out-of-band: delete the role.
+      yield* IAM.deleteRole({ RoleName: roleName });
+      const gone = yield* IAM.getRole({ RoleName: roleName }).pipe(
+        Effect.option,
+      );
+      expect(gone._tag).toBe("None");
+
+      // Reconcile must recreate. IAM is eventually consistent globally
+      // so the recreate may need a moment to propagate to subsequent
+      // mutating calls — the reconciler handles this internally.
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Role("RecreateRole", {
+            roleName,
+            assumeRolePolicyDocument: assumeRolePolicy,
+            inlinePolicies: {
+              AllowLogs: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: ["logs:CreateLogGroup"],
+                    Resource: "*",
+                  },
+                ],
+              },
+            },
+          });
+        }),
+      );
+      expect(recreated.roleName).toEqual(roleName);
+
+      const observedInline = yield* IAM.getRolePolicy({
+        RoleName: roleName,
+        PolicyName: "AllowLogs",
+      });
+      expect(observedInline.PolicyName).toEqual("AllowLogs");
+
+      yield* stack.destroy();
+
+      const deleted = yield* IAM.getRole({ RoleName: roleName }).pipe(
+        Effect.option,
+      );
+      expect(deleted._tag).toBe("None");
+    }),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "changing roleName triggers replace, old role is deleted",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const nameA = `alchemy-test-role-replace-a-${suffix}`;
+      const nameB = `alchemy-test-role-replace-b-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Role("ReplaceRole", {
+            roleName: nameA,
+            assumeRolePolicyDocument: assumeRolePolicy,
+          });
+        }),
+      );
+      expect(a.roleName).toEqual(nameA);
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Role("ReplaceRole", {
+            roleName: nameB,
+            assumeRolePolicyDocument: assumeRolePolicy,
+          });
+        }),
+      );
+      expect(b.roleName).toEqual(nameB);
+      expect(b.roleArn).not.toEqual(a.roleArn);
+
+      // The old role must be gone after replace.
+      const oldGone = yield* IAM.getRole({ RoleName: nameA }).pipe(
+        Effect.option,
+      );
+      expect(oldGone._tag).toBe("None");
+
+      yield* stack.destroy();
+
+      const newGone = yield* IAM.getRole({ RoleName: nameB }).pipe(
+        Effect.option,
+      );
+      expect(newGone._tag).toBe("None");
+    }),
+);
+
+test.provider(
+  "adding/removing managed-policy attachments diffs against cloud state",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const basicExec =
+        "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole";
+      const readOnly = "arn:aws:iam::aws:policy/ReadOnlyAccess";
+
+      // Start with one managed policy.
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Role("ManagedRole", {
+            assumeRolePolicyDocument: assumeRolePolicy,
+            managedPolicyArns: [basicExec],
+          });
+        }),
+      );
+
+      const observedAfterCreate = yield* IAM.listAttachedRolePolicies({
+        RoleName: initial.roleName,
+      });
+      expect(
+        (observedAfterCreate.AttachedPolicies ?? []).map((p) => p.PolicyArn),
+      ).toContain(basicExec);
+
+      // Out-of-band: detach the managed policy and attach a different one.
+      yield* IAM.detachRolePolicy({
+        RoleName: initial.roleName,
+        PolicyArn: basicExec,
+      });
+      yield* IAM.attachRolePolicy({
+        RoleName: initial.roleName,
+        PolicyArn: readOnly,
+      });
+
+      // Reconcile back to the desired set [basicExec] — diff against
+      // observed cloud state must remove `readOnly` and re-attach `basicExec`.
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Role("ManagedRole", {
+            assumeRolePolicyDocument: assumeRolePolicy,
+            managedPolicyArns: [basicExec],
+          });
+        }),
+      );
+
+      const observedAfterRedeploy = yield* IAM.listAttachedRolePolicies({
+        RoleName: initial.roleName,
+      });
+      const arns = (observedAfterRedeploy.AttachedPolicies ?? []).map(
+        (p) => p.PolicyArn,
+      );
+      expect(arns).toContain(basicExec);
+      expect(arns).not.toContain(readOnly);
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider(
+  "destroying an already-deleted role is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const role = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Role("DoubleDestroyRole", {
+            assumeRolePolicyDocument: assumeRolePolicy,
+            inlinePolicies: {
+              AllowLogs: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: ["logs:CreateLogGroup"],
+                    Resource: "*",
+                  },
+                ],
+              },
+            },
+          });
+        }),
+      );
+
+      // Out-of-band: scrub the role completely. The provider's `delete`
+      // must catch `NoSuchEntity` from each cleanup step and complete.
+      yield* IAM.deleteRolePolicy({
+        RoleName: role.roleName,
+        PolicyName: "AllowLogs",
+      }).pipe(Effect.option);
+      yield* IAM.deleteRole({ RoleName: role.roleName }).pipe(Effect.option);
+
+      yield* stack.destroy();
+    }),
+);

--- a/packages/alchemy/test/test.resources.ts
+++ b/packages/alchemy/test/test.resources.ts
@@ -518,7 +518,7 @@ export const staticStablesResourceProvider = () =>
       return {
         string: news.string ?? id,
         tags: news.tags ?? {},
-        stableId: output?.stableId ?? `stable-${id}`,
+        stableId: output?.stableId ?? id,
         stableArn:
           output?.stableArn ??
           (`arn:test:resource:us-east-1:123456789:${id}` as const),


### PR DESCRIPTION
Stacked on #179. Per-resource hardening sweep for `AWS.IAM.Role`.

### Reconciler changes

Wrap mutating IAM calls in `retryIamMutation`. `ConcurrentModificationException` and `EntityTemporarilyUnmodifiableException` are documented as transient — IAM serializes mutations to a role and surfaces these when two writes overlap. Without the wrap they surface as hard `ConflictError`.

```ts
const isRetryableIamControlPlaneError = (error: { _tag?: string }) =>
  error._tag === "ConcurrentModificationException" ||
  error._tag === "EntityTemporarilyUnmodifiableException";

const retryIamMutation = <A, E extends { _tag?: string }, R>(
  effect: Effect.Effect<A, E, R>,
) =>
  effect.pipe(
    Effect.retry({
      while: isRetryableIamControlPlaneError,
      schedule: Schedule.exponential(250).pipe(
        Schedule.both(Schedule.recurs(20)),
      ),
    }),
  );
```

Wrap post-create attach/put calls in `retryNoSuchEntityAfterCreate`. IAM is eventually consistent globally — a brand-new role can briefly `NoSuchEntity` from a different IAM host on subsequent mutating calls.

```ts
const retryNoSuchEntityAfterCreate = <A, E extends { _tag?: string }, R>(
  effect: Effect.Effect<A, E, R>,
) =>
  effect.pipe(
    Effect.retry({
      while: (e) =>
        e._tag === "NoSuchEntityException" ||
        isRetryableIamControlPlaneError(e),
      schedule: Schedule.exponential(500).pipe(
        Schedule.both(Schedule.recurs(8)),
      ),
    }),
  );
```

Bound the delete-role retry on `DeleteConflictException`. A role mid-detach from an instance profile clears within seconds; we cap the retry so a genuine, persistent reference still surfaces.

```diff
  yield* iam
    .deleteRole({ RoleName: output.roleName })
-   .pipe(Effect.catchTag("NoSuchEntityException", () => Effect.void));
+   .pipe(
+     Effect.retry({
+       while: (e) =>
+         e._tag === "DeleteConflictException" ||
+         isRetryableIamControlPlaneError(e),
+       schedule: Schedule.exponential(500).pipe(
+         Schedule.both(Schedule.recurs(10)),
+       ),
+     }),
+     Effect.catchTag("NoSuchEntityException", () => Effect.void),
+   );
```

Scope the implicit catches around `listRolePolicies` / `listAttachedRolePolicies` in delete to `NoSuchEntityException` so other failures (auth, throttling) surface.

### New lifecycle tests

Each test runs `destroy → deploy → … → destroy` on a `ScratchStack` and asserts convergence at every step.

- redeploy with same props is a no-op (idempotent)
- reconcile resets assume-role policy and inline policies mutated out-of-band via the raw IAM SDK
- reconcile re-creates a role that was deleted out-of-band (rides the eventual-consistency window)
- changing `roleName` triggers replace; old role is deleted
- adding/removing managed-policy attachments diffs against cloud state (out-of-band detach + foreign attach is reverted on next reconcile)
- destroying an already-deleted role is a no-op

The pre-existing `adopt(true)` test already covers re-tagging a foreign role with internal alchemy tags.

### Distilled patch

IAM error category fixes at https://github.com/alchemy-run/distilled/pull/244 — once published, `ConcurrentModificationException`, `EntityTemporarilyUnmodifiableException`, `ServiceFailureException`, and `RequestLimitExceeded` participate in the AWS retry layer instead of surfacing as hard `ConflictError` / `ServerError`. The reconciler-level retry helpers stay because the AWS retry layer is bounded; per-call control-plane retries fit within that budget.

### Baseline fix

`packages/alchemy/test/test.resources.ts` lines 521-522 had a pre-existing tsc error on this branch (`output` is possibly undefined post-reconcile refactor). Carried forward the same fix the SQS/DynamoDB/S3 hardening PRs applied so the baseline `bun tsc -b` is clean.
