### PR TITLE
fix(cloudflare/r2): harden Bucket reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
@@ -172,7 +172,11 @@ export const R2BucketProvider = () =>
 
           // Ensure — create if missing. R2 reports a concurrent create
           // (or partial state-persistence failure) as
-          // `BucketAlreadyExists`; tolerate by re-fetching the bucket.
+          // `BucketAlreadyExists`; tolerate by re-fetching the bucket
+          // through the same resolved `jurisdiction` we used for the
+          // initial observe. Using `news.jurisdiction` here (which can
+          // be undefined while the resolved value is "default") would
+          // query a different namespace than the create just hit.
           if (!observed) {
             observed = yield* createBucket({
               accountId: acct,
@@ -185,7 +189,7 @@ export const R2BucketProvider = () =>
                 getBucket({
                   accountId: acct,
                   bucketName: name,
-                  jurisdiction: news.jurisdiction,
+                  jurisdiction,
                 }),
               ),
             );

--- a/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
+++ b/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
@@ -1,3 +1,4 @@
+import { adopt } from "@/AdoptPolicy";
 import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import { State } from "@/State";
@@ -146,6 +147,283 @@ test.provider(
       }).pipe(Effect.provide(stack.state));
 
       expect(persisted?.attr).toMatchObject({ bucketName });
+
+      yield* stack.destroy();
+      yield* waitForBucketToBeDeleted(bucketName, accountId);
+    }).pipe(logLevel),
+);
+
+// ─────────────────────────────────────────────────────────────────────
+// Lifecycle convergence
+//
+// Reconcile must converge from any starting state — pristine, drifted,
+// out-of-band-deleted, or replaced — without leaning on `olds` as a
+// source of truth. The tests below pin down each of those starting
+// states.
+// ─────────────────────────────────────────────────────────────────────
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.R2Bucket("IdempotentBucket", {
+            storageClass: "Standard",
+          });
+        }),
+      );
+
+      // Deploy again with identical props — reconcile must converge
+      // without changing the bucket.
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.R2Bucket("IdempotentBucket", {
+            storageClass: "Standard",
+          });
+        }),
+      );
+
+      expect(second.bucketName).toEqual(initial.bucketName);
+      expect(second.storageClass).toEqual("Standard");
+
+      const observed = yield* r2.getBucket({
+        accountId,
+        bucketName: second.bucketName,
+      });
+      expect(observed.name).toEqual(second.bucketName);
+      expect(observed.storageClass ?? "Standard").toEqual("Standard");
+
+      yield* stack.destroy();
+      yield* waitForBucketToBeDeleted(initial.bucketName, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile resets storageClass mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const bucket = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.R2Bucket("DriftBucket", {
+            storageClass: "Standard",
+          });
+        }),
+      );
+
+      // Mutate storage class out-of-band via the raw R2 API.
+      yield* r2.patchBucket({
+        accountId,
+        bucketName: bucket.bucketName,
+        storageClass: "InfrequentAccess",
+      });
+      const drifted = yield* r2.getBucket({
+        accountId,
+        bucketName: bucket.bucketName,
+      });
+      expect(drifted.storageClass).toEqual("InfrequentAccess");
+
+      // Re-deploy with the original desired props — reconcile should
+      // observe the drifted cloud state and reset storageClass.
+      const redeployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.R2Bucket("DriftBucket", {
+            storageClass: "Standard",
+          });
+        }),
+      );
+      expect(redeployed.bucketName).toEqual(bucket.bucketName);
+      expect(redeployed.storageClass).toEqual("Standard");
+
+      const observed = yield* r2.getBucket({
+        accountId,
+        bucketName: bucket.bucketName,
+      });
+      expect(observed.storageClass ?? "Standard").toEqual("Standard");
+
+      yield* stack.destroy();
+      yield* waitForBucketToBeDeleted(bucket.bucketName, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile re-creates a bucket that was deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const bucketName = `alchemy-test-r2-recreate-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.R2Bucket("RecreateBucket", {
+            name: bucketName,
+          });
+        }),
+      );
+      expect(initial.bucketName).toEqual(bucketName);
+
+      // Delete the bucket out-of-band — local state still says it
+      // exists, but Cloudflare disagrees.
+      yield* r2.deleteBucket({
+        accountId,
+        bucketName,
+      });
+      yield* waitForBucketToBeDeleted(bucketName, accountId);
+
+      // Reconcile must observe the missing bucket via getBucket
+      // (which now returns NoSuchBucket), fall back to a fresh
+      // createBucket, and converge.
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.R2Bucket("RecreateBucket", {
+            name: bucketName,
+          });
+        }),
+      );
+      expect(recreated.bucketName).toEqual(bucketName);
+
+      const observed = yield* r2.getBucket({ accountId, bucketName });
+      expect(observed.name).toEqual(bucketName);
+
+      yield* stack.destroy();
+      yield* waitForBucketToBeDeleted(bucketName, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "changing name triggers replace; old bucket is deleted",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const nameA = `alchemy-test-r2-rename-a-${suffix}`;
+      const nameB = `alchemy-test-r2-rename-b-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.R2Bucket("RenameBucket", {
+            name: nameA,
+          });
+        }),
+      );
+      expect(a.bucketName).toEqual(nameA);
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.R2Bucket("RenameBucket", {
+            name: nameB,
+          });
+        }),
+      );
+      expect(b.bucketName).toEqual(nameB);
+      expect(b.bucketName).not.toEqual(a.bucketName);
+
+      // The previous physical name must be gone after replace.
+      yield* waitForBucketToBeDeleted(nameA, accountId);
+
+      const liveB = yield* r2.getBucket({ accountId, bucketName: nameB });
+      expect(liveB.name).toEqual(nameB);
+
+      yield* stack.destroy();
+      yield* waitForBucketToBeDeleted(nameB, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider("destroying an already-deleted bucket is a no-op", (stack) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* CloudflareEnvironment;
+
+    yield* stack.destroy();
+
+    const bucket = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.R2Bucket("DoubleDestroyBucket");
+      }),
+    );
+
+    // Delete the bucket out-of-band, then ask the engine to destroy it.
+    // `delete` must catch `NoSuchBucket` and complete cleanly.
+    yield* r2.deleteBucket({
+      accountId,
+      bucketName: bucket.bucketName,
+    });
+    yield* waitForBucketToBeDeleted(bucket.bucketName, accountId);
+
+    yield* stack.destroy();
+  }).pipe(logLevel),
+);
+
+test.provider(
+  "adopt(true) re-claims a foreign bucket under a new logical id",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const bucketName = `alchemy-test-r2-adopt-takeover-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      // Phase 1: deploy under logical id "Original".
+      const original = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.R2Bucket("Original", {
+            name: bucketName,
+            storageClass: "Standard",
+          });
+        }),
+      );
+      expect(original.bucketName).toEqual(bucketName);
+
+      // Wipe state for the "Original" entry; the bucket stays on Cloudflare.
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "Original",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      // Phase 2: redeploy under a *different* logical id with the same
+      // physical name and `adopt(true)`. R2 has no ownership signal
+      // (no tags), so `read` returns plain attrs and the engine adopts.
+      // adopt(true) is the explicit user-driven takeover form.
+      const takenOver = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.R2Bucket("Different", {
+              name: bucketName,
+              storageClass: "InfrequentAccess",
+            });
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(takenOver.bucketName).toEqual(bucketName);
+      // Reconcile must have applied the new desired storage class on top
+      // of the adopted bucket.
+      expect(takenOver.storageClass).toEqual("InfrequentAccess");
+
+      const observed = yield* r2.getBucket({ accountId, bucketName });
+      expect(observed.storageClass).toEqual("InfrequentAccess");
 
       yield* stack.destroy();
       yield* waitForBucketToBeDeleted(bucketName, accountId);


### PR DESCRIPTION
Audits the R2 Bucket reconciler for the same classes of issues SQS / S3 / Worker had, and adds lifecycle convergence tests on top of #179.

### Reconciler changes

The `BucketAlreadyExists` re-fetch path in `reconcile` was inconsistent with the outer observe path:

```diff
   if (!observed) {
     observed = yield* createBucket({
       accountId: acct,
       name,
       storageClass: news.storageClass,
       jurisdiction: news.jurisdiction,
       locationHint: news.locationHint,
     }).pipe(
       Effect.catchTag("BucketAlreadyExists", () =>
         getBucket({
           accountId: acct,
           bucketName: name,
-          jurisdiction: news.jurisdiction,
+          jurisdiction,
         }),
       ),
     );
   }
```

The outer `getBucket` resolves `jurisdiction` via `output?.jurisdiction ?? news.jurisdiction ?? "default"`. The inner re-fetch was passing `news.jurisdiction`, which can be `undefined` while the outer call uses `"default"`. Same namespace in practice for default-jurisdiction buckets, but the inconsistency bites the moment a non-default jurisdiction is configured: the create hits one namespace, the re-fetch hits another, and we error out instead of converging.

No blanket `Effect.catch` sites to scope — the existing reconciler already routes only on the documented signals (`NoSuchBucket`, `BucketAlreadyExists`).

### New lifecycle tests

Each test runs `destroy -> deploy -> ... -> destroy` on a `ScratchStack` and asserts convergence at every step.

- redeploy with same props is a no-op (idempotent)
- reconcile resets `storageClass` mutated out-of-band via `r2.patchBucket`
- reconcile re-creates a bucket that was deleted out-of-band
- changing `name` triggers replace; old bucket is deleted
- destroying an already-deleted bucket is a no-op
- `adopt(true)` re-claims a foreign bucket under a new logical id and applies the new desired `storageClass`

`test.resources.ts` picks up the SQS PR's `output?.stableId` / `output?.stableArn` fix so this branch type-checks in isolation.

### Distilled patch

No patch needed. Cloudflare's HTTP status mapping in `client/api.ts` already attributes categories to `TooManyRequests` / `InternalServerError`, and R2's typed errors (`NoSuchBucket`, `BucketAlreadyExists`, `InvalidBucketName`, `InvalidRoute`, `NoRoute`) already cover every code the reconciler routes on.
