### PR TITLE
fix(axiom): harden Dataset reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/Axiom/Dataset.ts
+++ b/packages/alchemy/src/Axiom/Dataset.ts
@@ -210,67 +210,119 @@ export const DatasetProvider = () =>
           // also stable input. Probe for live state by name (preferring the
           // cached `output.id` when present). `read` upstream has already
           // surfaced foreign datasets as `Unowned`, so by the time we land
-          // here mutation is safe.
+          // here mutation is safe — but we still re-confirm ownership on
+          // the conflict path below to avoid hijacking on a state-loss
+          // race where `read` returned `undefined` (transient NotFound or
+          // an out-of-band recreate by a foreign owner).
           const datasetId = output?.id ?? news.name;
           const observed = yield* get({ dataset_id: datasetId }).pipe(
             Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
           );
 
-          // Ensure — POST creates the dataset. Tolerate Conflict/
-          // UnprocessableEntity as a race with a peer reconciler (or with
-          // upstream read↔create), falling through to the sync path.
-          let current = observed;
-          if (current === undefined) {
-            current = yield* (
-              create({
-                name: news.name,
-                description: augmentDescription(news.description, marker),
-                kind: news.kind,
-                retentionDays: news.retentionDays,
-                useRetentionPeriod: news.useRetentionPeriod,
-              }) as Effect.Effect<
-                Axiom.CreateDatasetOutput,
-                { readonly _tag: string },
-                never
-              >
-            ).pipe(
-              Effect.catchIf(
-                (
-                  e,
-                ): e is { readonly _tag: "Conflict" | "UnprocessableEntity" } =>
-                  e._tag === "Conflict" || e._tag === "UnprocessableEntity",
-                () =>
-                  update({
-                    dataset_id: news.name,
-                    description: augmentDescription(news.description, marker),
-                    retentionDays: news.retentionDays,
-                    useRetentionPeriod: news.useRetentionPeriod,
-                  }),
-              ),
-            );
-            return toAttrs(current);
-          }
-
-          // Sync — the dataset exists. Apply mutable aspects (description,
-          // retentionDays, useRetentionPeriod) via PATCH. `kind` and `name`
-          // are stable and replacement-only via diff above.
           const desiredDescription = augmentDescription(
             news.description,
             marker,
           );
+
+          // Ensure — POST creates the dataset. Axiom's `createDataset`
+          // declares `BadRequest | Forbidden | UnprocessableEntity`, but
+          // the underlying client routes HTTP 409 to a typed `Conflict`
+          // (via HTTP_STATUS_MAP) and falls back to `UnknownAxiomError`
+          // for unmapped statuses. All three are name-collision shapes we
+          // can recover from by re-observing and either updating (if we
+          // own it) or surfacing the foreign-owner error so the engine's
+          // adoption gate fires.
+          if (observed === undefined) {
+            const created = yield* create({
+              name: news.name,
+              description: desiredDescription,
+              kind: news.kind,
+              retentionDays: news.retentionDays,
+              useRetentionPeriod: news.useRetentionPeriod,
+            }).pipe(
+              // `Effect.catch` widens the error channel to any cause; the
+              // inner branch narrows on `_tag` against the known collision
+              // shapes and rethrows everything else. This replaces the
+              // previous unsafe cast that hid real types.
+              Effect.catch((e: { readonly _tag?: string }) => {
+                const tag = e._tag;
+                if (
+                  tag === "UnprocessableEntity" ||
+                  tag === "Conflict" ||
+                  tag === "UnknownAxiomError"
+                ) {
+                  return Effect.gen(function* () {
+                    // Re-observe to confirm a) the dataset really is
+                    // present (i.e. the conflict came from name reuse,
+                    // not some other 422) and b) we still own it. If
+                    // ownership has flipped to a foreign owner since
+                    // engine-level read, refuse to clobber.
+                    const existing = yield* get({
+                      dataset_id: news.name,
+                    }).pipe(
+                      Effect.catchTag("NotFound", () =>
+                        Effect.succeed(undefined),
+                      ),
+                    );
+                    if (existing === undefined) {
+                      // The collision is gone — bubble the original
+                      // create error so the engine retries / fails loudly
+                      // instead of silently masking a transient.
+                      return yield* Effect.fail(e);
+                    }
+                    const ownership = parseMarker(existing.description);
+                    const isOurs =
+                      ownership === undefined ||
+                      (ownership.stack === stack.name &&
+                        ownership.stage === stage &&
+                        ownership.id === id);
+                    if (!isOurs) {
+                      return yield* Effect.fail(e);
+                    }
+                    return yield* update({
+                      dataset_id: existing.id,
+                      description: desiredDescription,
+                      retentionDays: news.retentionDays,
+                      useRetentionPeriod: news.useRetentionPeriod,
+                    });
+                  });
+                }
+                return Effect.fail(e);
+              }),
+            );
+            return toAttrs(created);
+          }
+
+          // Sync — the dataset exists. Apply mutable aspects
+          // (`description`, `retentionDays`, `useRetentionPeriod`) via
+          // PUT. `kind` and `name` are stable and replacement-only via
+          // diff above. Diff against OBSERVED state, not `output` /
+          // `olds`, so out-of-band drift converges on re-deploy.
           const needsSync =
-            current.description !== desiredDescription ||
-            current.retentionDays !== news.retentionDays ||
-            current.useRetentionPeriod !== news.useRetentionPeriod;
+            observed.description !== desiredDescription ||
+            observed.retentionDays !== news.retentionDays ||
+            observed.useRetentionPeriod !== news.useRetentionPeriod;
           if (!needsSync) {
-            return toAttrs(current);
+            return toAttrs(observed);
           }
           const updated = yield* update({
-            dataset_id: current.id,
+            dataset_id: observed.id,
             description: desiredDescription,
             retentionDays: news.retentionDays,
             useRetentionPeriod: news.useRetentionPeriod,
-          });
+          }).pipe(
+            // If the dataset disappeared between observe and update
+            // (deleted out-of-band mid-reconcile), recover by recreating.
+            Effect.catchTag("NotFound", () =>
+              create({
+                name: news.name,
+                description: desiredDescription,
+                kind: news.kind,
+                retentionDays: news.retentionDays,
+                useRetentionPeriod: news.useRetentionPeriod,
+              }),
+            ),
+          );
           return toAttrs(updated);
         }),
         delete: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/test/Axiom/Dataset.test.ts
+++ b/packages/alchemy/test/Axiom/Dataset.test.ts
@@ -1,0 +1,365 @@
+import { adopt } from "@/AdoptPolicy";
+import * as Axiom from "@/Axiom";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import * as AxiomSdk from "@distilled.cloud/axiom";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+
+const { test } = Test.make({ providers: Axiom.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const randomSuffix = () => Math.random().toString(36).slice(2, 8);
+
+/** Probe Axiom for a dataset; resolve to undefined on NotFound. */
+const getDataset = (datasetId: string) =>
+  AxiomSdk.getDataset({ dataset_id: datasetId }).pipe(
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
+  );
+
+const assertDatasetDeleted = Effect.fn(function* (datasetId: string) {
+  const found = yield* getDataset(datasetId);
+  expect(found).toBeUndefined();
+});
+
+test.provider(
+  "create and delete dataset with default props",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const datasetName = `alchemy-test-default-${randomSuffix()}`;
+
+      const dataset = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dataset("DefaultDataset", {
+            name: datasetName,
+            description: "default-test",
+          });
+        }),
+      );
+
+      expect(dataset.name).toEqual(datasetName);
+      expect(dataset.id).toBeDefined();
+      expect(dataset.description).toEqual("default-test");
+      expect(dataset.kind).toBeDefined();
+      expect(dataset.otelTracesEndpoint).toContain("/v1/traces");
+
+      const observed = yield* getDataset(dataset.id);
+      expect(observed?.name).toEqual(datasetName);
+
+      yield* stack.destroy();
+      yield* assertDatasetDeleted(datasetName);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "create, update, delete dataset (mutable description + retention)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const datasetName = `alchemy-test-update-${randomSuffix()}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dataset("UpdateDataset", {
+            name: datasetName,
+            description: "initial",
+            retentionDays: 30,
+            useRetentionPeriod: true,
+          });
+        }),
+      );
+      expect(initial.description).toEqual("initial");
+
+      const updated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dataset("UpdateDataset", {
+            name: datasetName,
+            description: "updated copy",
+            retentionDays: 7,
+            useRetentionPeriod: true,
+          });
+        }),
+      );
+      expect(updated.id).toEqual(initial.id);
+      expect(updated.description).toEqual("updated copy");
+
+      const live = yield* getDataset(datasetName);
+      expect(live?.retentionDays).toEqual(7);
+      // Cloud description still carries the alchemy ownership marker.
+      expect(live?.description).toContain("[alchemy:");
+      expect(live?.description).toContain("updated copy");
+
+      yield* stack.destroy();
+      yield* assertDatasetDeleted(datasetName);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const datasetName = `alchemy-test-idempotent-${randomSuffix()}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dataset("IdempotentDataset", {
+            name: datasetName,
+            description: "stable",
+            retentionDays: 14,
+          });
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dataset("IdempotentDataset", {
+            name: datasetName,
+            description: "stable",
+            retentionDays: 14,
+          });
+        }),
+      );
+
+      expect(second.id).toEqual(initial.id);
+      expect(second.created).toEqual(initial.created);
+      expect(second.description).toEqual("stable");
+
+      const live = yield* getDataset(datasetName);
+      expect(live?.retentionDays).toEqual(14);
+
+      yield* stack.destroy();
+      yield* assertDatasetDeleted(datasetName);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile resets description / retention mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const datasetName = `alchemy-test-drift-${randomSuffix()}`;
+
+      const dataset = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dataset("DriftDataset", {
+            name: datasetName,
+            description: "managed",
+            retentionDays: 30,
+            useRetentionPeriod: true,
+          });
+        }),
+      );
+
+      // Mutate out-of-band: bypass alchemy and stomp on description +
+      // retentionDays directly via the raw Axiom API. The marker that
+      // `reconcile` appended is intentionally dropped here so we exercise
+      // the marker-restoration path too.
+      yield* AxiomSdk.updateDataset({
+        dataset_id: dataset.id,
+        description: "drifted-out-of-band",
+        retentionDays: 90,
+        useRetentionPeriod: true,
+      });
+
+      const drifted = yield* getDataset(datasetName);
+      expect(drifted?.description).toEqual("drifted-out-of-band");
+      expect(drifted?.retentionDays).toEqual(90);
+
+      // Re-deploy with the same desired props — reconcile must observe
+      // the cloud (not olds) and converge it back.
+      const redeployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dataset("DriftDataset", {
+            name: datasetName,
+            description: "managed",
+            retentionDays: 30,
+            useRetentionPeriod: true,
+          });
+        }),
+      );
+      expect(redeployed.id).toEqual(dataset.id);
+
+      const reconverged = yield* getDataset(datasetName);
+      expect(reconverged?.retentionDays).toEqual(30);
+      expect(reconverged?.description).toContain("managed");
+      expect(reconverged?.description).toContain("[alchemy:");
+
+      yield* stack.destroy();
+      yield* assertDatasetDeleted(datasetName);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile re-creates a dataset that was deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const datasetName = `alchemy-test-recreate-${randomSuffix()}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dataset("RecreateDataset", {
+            name: datasetName,
+            description: "first",
+          });
+        }),
+      );
+
+      // Delete the dataset out-of-band — alchemy state still believes
+      // the dataset exists at this id. Reconcile must observe NotFound
+      // and re-create.
+      yield* AxiomSdk.deleteDataset({ dataset_id: initial.id });
+      yield* assertDatasetDeleted(datasetName);
+
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dataset("RecreateDataset", {
+            name: datasetName,
+            description: "first",
+          });
+        }),
+      );
+      expect(recreated.name).toEqual(datasetName);
+      expect(recreated.description).toEqual("first");
+
+      const live = yield* getDataset(datasetName);
+      expect(live?.name).toEqual(datasetName);
+
+      yield* stack.destroy();
+      yield* assertDatasetDeleted(datasetName);
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "changing name triggers replace; old dataset is deleted",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const nameA = `alchemy-test-rename-a-${suffix}`;
+      const nameB = `alchemy-test-rename-b-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dataset("RenameDataset", {
+            name: nameA,
+            description: "rename-source",
+          });
+        }),
+      );
+      expect(a.name).toEqual(nameA);
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dataset("RenameDataset", {
+            name: nameB,
+            description: "rename-source",
+          });
+        }),
+      );
+      expect(b.name).toEqual(nameB);
+      expect(b.id).not.toEqual(a.id);
+
+      yield* assertDatasetDeleted(nameA);
+
+      yield* stack.destroy();
+      yield* assertDatasetDeleted(nameB);
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "destroying an already-deleted dataset is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const datasetName = `alchemy-test-doubledel-${randomSuffix()}`;
+
+      const dataset = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dataset("DoubleDestroyDataset", {
+            name: datasetName,
+            description: "to-be-deleted",
+          });
+        }),
+      );
+
+      // Delete out-of-band, then ask the engine to destroy it.
+      // Provider's `delete` must catch NotFound and complete cleanly.
+      yield* AxiomSdk.deleteDataset({ dataset_id: dataset.id });
+      yield* assertDatasetDeleted(datasetName);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "adopt(true) re-claims a foreign dataset by name",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const datasetName = `alchemy-test-adopt-${randomSuffix()}`;
+
+      // First create via alchemy under one logical id.
+      const original = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dataset("Original", {
+            name: datasetName,
+            description: "original",
+          });
+        }),
+      );
+
+      // Wipe state but leave the dataset alive — same as cold-start
+      // from a foreign-tagged cloud resource.
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "Original",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      // A different logical id pointing at the same cloud name. Without
+      // `adopt(true)` the engine refuses (foreign marker). With it, we
+      // take over and re-tag with our own marker.
+      const takenOver = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* Axiom.Dataset("Taken", {
+              name: datasetName,
+              description: "taken-over",
+            });
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(takenOver.name).toEqual(datasetName);
+      expect(takenOver.id).toEqual(original.id);
+
+      // Marker re-pointed at the new logical id so subsequent runs route
+      // through silent adoption.
+      const live = yield* getDataset(datasetName);
+      expect(live?.description).toContain("id=Taken");
+
+      yield* stack.destroy();
+      yield* assertDatasetDeleted(datasetName);
+    }).pipe(logLevel),
+);


### PR DESCRIPTION
Stacked on top of [#179](https://github.com/alchemy-run/alchemy-effect/pull/179). Hardens the Axiom Dataset reconcile path the same way [#184](https://github.com/alchemy-run/alchemy-effect/pull/184) (SQS) and [#190](https://github.com/alchemy-run/alchemy-effect/pull/190) (Cloudflare Worker) did for their resources.

### Reconciler changes

The collision-recovery path on `createDataset` was casting the error channel to `{ _tag: string }`, hiding the real types, and only catching `Conflict | UnprocessableEntity` — but Axiom's `createDataset` doesn't actually declare `Conflict`, and 409s come back as `UnknownAxiomError` via the SDK's `HTTP_STATUS_MAP` fallback.

```diff
- ).pipe(
-   Effect.catchIf(
-     (e): e is { readonly _tag: "Conflict" | "UnprocessableEntity" } =>
-       e._tag === "Conflict" || e._tag === "UnprocessableEntity",
-     () => update({ ... }),
-   ),
- );
+ ).pipe(
+   Effect.catch((e: { readonly _tag?: string }) => {
+     const tag = e._tag;
+     if (
+       tag === "UnprocessableEntity" ||
+       tag === "Conflict" ||
+       tag === "UnknownAxiomError"
+     ) {
+       return Effect.gen(function* () {
+         const existing = yield* get({ dataset_id: news.name }).pipe(
+           Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
+         );
+         if (existing === undefined) return yield* Effect.fail(e);
+         const ownership = parseMarker(existing.description);
+         const isOurs =
+           ownership === undefined ||
+           (ownership.stack === stack.name &&
+             ownership.stage === stage &&
+             ownership.id === id);
+         if (!isOurs) return yield* Effect.fail(e);
+         return yield* update({ dataset_id: existing.id, ... });
+       });
+     }
+     return Effect.fail(e);
+   }),
+ );
```

`Conflict` was unreachable as written, and the cast widened the channel to "anything tagged" so genuine `BadRequest` / `Forbidden` failures could fall through silently. Re-observing before update also closes a hijack window: if state was lost and a foreign owner held the same dataset name, the previous code would silently overwrite their description with our marker.

The sync step now diffs against OBSERVED state instead of `olds`, and recovers from a mid-reconcile out-of-band delete by recreating:

```diff
- const needsSync =
-   current.description !== desiredDescription ||
-   current.retentionDays !== news.retentionDays ||
-   current.useRetentionPeriod !== news.useRetentionPeriod;
+ const needsSync =
+   observed.description !== desiredDescription ||
+   observed.retentionDays !== news.retentionDays ||
+   observed.useRetentionPeriod !== news.useRetentionPeriod;
```

```diff
  const updated = yield* update({
    dataset_id: observed.id,
    description: desiredDescription,
    retentionDays: news.retentionDays,
    useRetentionPeriod: news.useRetentionPeriod,
- });
+ }).pipe(
+   Effect.catchTag("NotFound", () =>
+     create({ name: news.name, description: desiredDescription, ... }),
+   ),
+ );
```

### New lifecycle tests

Each test runs `destroy -> deploy -> ... -> destroy` on a `ScratchStack` and asserts convergence at every step.

- redeploy with same props is a no-op (id + created stable)
- reconcile resets description / `retentionDays` mutated out-of-band via `AxiomSdk.updateDataset` (also exercises marker restoration)
- reconcile re-creates a dataset that was deleted out-of-band via `AxiomSdk.deleteDataset`
- changing `name` triggers replace; old dataset is gone
- destroying an already-deleted dataset is a no-op (delete catches `NotFound`)
- `adopt(true)` re-claims a foreign-marked dataset and re-points the marker at the new logical id

### Distilled patch

No patch needed. Axiom's `client/api.ts` already routes HTTP status to typed errors via `HTTP_STATUS_MAP` (with `UnknownAxiomError` as the fallback) and the `Retry` Context.Service already drives backoff for transient categories. The reconciler change is purely about catching the right shapes alchemy-side.

The pre-existing `output?.stableId` TS error from #167/#179 in `test.resources.ts` is fixed the same way the prior hardening PRs did.
