### PR TITLE
fix(aws/ecr): harden Repository reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/ECR/Repository.ts
+++ b/packages/alchemy/src/AWS/ECR/Repository.ts
@@ -5,9 +5,9 @@ import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
-import type { Providers } from "../Providers.ts";
 import { createInternalTags, diffTags, hasAlchemyTags } from "../../Tags.ts";
 import type { AccountID } from "../Environment.ts";
+import type { Providers } from "../Providers.ts";
 import type { RegionID } from "../Region.ts";
 
 export type RepositoryName = string;
@@ -38,6 +38,13 @@ export interface RepositoryProps {
    * User-defined tags to apply to the repository.
    */
   tags?: Record<string, string>;
+  /**
+   * If `true`, deleting the repository will also delete all of its images.
+   * Without this flag, ECR will return `RepositoryNotEmptyException` when
+   * the repository still contains images.
+   * @default false
+   */
+  forceDelete?: boolean;
 }
 
 export interface Repository extends Resource<
@@ -49,6 +56,7 @@ export interface Repository extends Resource<
     repositoryUri: RepositoryUri;
     registryId: string;
     imageTagMutability: ecr.ImageTagMutability;
+    scanOnPush: boolean;
     lifecyclePolicyText?: string;
     tags: Record<string, string>;
   },
@@ -85,6 +93,48 @@ export const RepositoryProvider = () =>
               lowercase: true,
             });
 
+      const fetchRepository = (repositoryName: string) =>
+        ecr
+          .describeRepositories({ repositoryNames: [repositoryName] })
+          .pipe(
+            Effect.map((res) => res.repositories?.[0]),
+            Effect.catchTag("RepositoryNotFoundException", () =>
+              Effect.succeed(undefined),
+            ),
+          );
+
+      const fetchLifecyclePolicy = (repositoryName: string) =>
+        ecr
+          .getLifecyclePolicy({ repositoryName })
+          .pipe(
+            Effect.map((r) => r.lifecyclePolicyText),
+            Effect.catchTag("LifecyclePolicyNotFoundException", () =>
+              Effect.succeed<string | undefined>(undefined),
+            ),
+            Effect.catchTag("RepositoryNotFoundException", () =>
+              Effect.succeed<string | undefined>(undefined),
+            ),
+          );
+
+      const fetchObservedTags = (repositoryArn: string) =>
+        ecr
+          .listTagsForResource({ resourceArn: repositoryArn })
+          .pipe(
+            Effect.map((res) =>
+              Object.fromEntries(
+                (res.tags ?? [])
+                  .filter(
+                    (t): t is { Key: string; Value: string } =>
+                      typeof t.Key === "string" && typeof t.Value === "string",
+                  )
+                  .map((t) => [t.Key, t.Value]),
+              ),
+            ),
+            Effect.catchTag("RepositoryNotFoundException", () =>
+              Effect.succeed({} as Record<string, string>),
+            ),
+          );
+
       return {
         stables: [
           "repositoryArn",
@@ -104,35 +154,37 @@ export const RepositoryProvider = () =>
         read: Effect.fn(function* ({ id, olds, output }) {
           const repositoryName =
             output?.repositoryName ?? (yield* toRepositoryName(id, olds ?? {}));
-          const described = yield* ecr
-            .describeRepositories({
-              repositoryNames: [repositoryName],
-            })
-            .pipe(
-              Effect.catchTag("RepositoryNotFoundException", () =>
-                Effect.succeed(undefined),
-              ),
-            );
-          const repository = described?.repositories?.[0];
+          const repository = yield* fetchRepository(repositoryName);
           if (!repository?.repositoryArn || !repository.repositoryUri) {
             return undefined;
           }
-          const listedTags = yield* ecr.listTagsForResource({
-            resourceArn: repository.repositoryArn,
-          });
+          const repositoryArn = repository.repositoryArn as RepositoryArn;
+          const observedTags = yield* fetchObservedTags(repositoryArn);
+          const lifecyclePolicyText =
+            yield* fetchLifecyclePolicy(repositoryName);
           const attrs = {
             repositoryName,
-            repositoryArn: repository.repositoryArn as RepositoryArn,
+            repositoryArn,
             repositoryUri: repository.repositoryUri as RepositoryUri,
             registryId: repository.registryId!,
             imageTagMutability:
               repository.imageTagMutability ??
               output?.imageTagMutability ??
               "MUTABLE",
-            lifecyclePolicyText: output?.lifecyclePolicyText,
-            tags: output?.tags ?? {},
+            scanOnPush:
+              repository.imageScanningConfiguration?.scanOnPush ??
+              output?.scanOnPush ??
+              false,
+            lifecyclePolicyText,
+            tags: observedTags,
           };
-          return (yield* hasAlchemyTags(id, listedTags.tags ?? []))
+          return (yield* hasAlchemyTags(
+            id,
+            Object.entries(observedTags).map(([Key, Value]) => ({
+              Key,
+              Value,
+            })),
+          ))
             ? attrs
             : Unowned(attrs);
         }),
@@ -140,50 +192,40 @@ export const RepositoryProvider = () =>
           const repositoryName = yield* toRepositoryName(id, news);
           const internalTags = yield* createInternalTags(id);
           const desiredTags = { ...internalTags, ...news.tags };
+          const desiredScanOnPush = news.scanOnPush ?? false;
+          const desiredImageTagMutability =
+            news.imageTagMutability ?? "MUTABLE";
 
           // Observe — fetch live cloud state. We never trust prior `output`
           // blindly: the repository may have been deleted out-of-band.
-          let described = yield* ecr
-            .describeRepositories({
-              repositoryNames: [repositoryName],
-            })
-            .pipe(
-              Effect.catchTag("RepositoryNotFoundException", () =>
-                Effect.succeed(undefined),
-              ),
-            );
-          let repository = described?.repositories?.[0];
+          let repository = yield* fetchRepository(repositoryName);
 
           // Ensure — create the repository if missing. Tolerate
           // `RepositoryAlreadyExistsException` as a race with a peer
-          // reconciler: re-describe and continue with the sync path.
+          // reconciler: re-describe and continue with the sync path. The
+          // re-describe itself can race with peer deletion, so swallow
+          // `RepositoryNotFoundException` there too and let the next
+          // reconcile loop recreate.
           if (!repository?.repositoryArn || !repository.repositoryUri) {
             const created = yield* ecr
               .createRepository({
                 repositoryName,
-                imageTagMutability: news.imageTagMutability,
-                imageScanningConfiguration: news.scanOnPush
-                  ? { scanOnPush: true }
-                  : undefined,
+                imageTagMutability: desiredImageTagMutability,
+                imageScanningConfiguration: {
+                  scanOnPush: desiredScanOnPush,
+                },
                 tags: Object.entries(desiredTags).map(([Key, Value]) => ({
                   Key,
                   Value,
                 })),
               })
               .pipe(
+                Effect.map((res) => res.repository),
                 Effect.catchTag("RepositoryAlreadyExistsException", () =>
-                  ecr
-                    .describeRepositories({
-                      repositoryNames: [repositoryName],
-                    })
-                    .pipe(
-                      Effect.map((res) => ({
-                        repository: res.repositories?.[0],
-                      })),
-                    ),
+                  fetchRepository(repositoryName),
                 ),
               );
-            repository = created.repository;
+            repository = created;
             if (!repository?.repositoryArn || !repository.repositoryUri) {
               return yield* Effect.fail(
                 new Error(
@@ -195,26 +237,51 @@ export const RepositoryProvider = () =>
 
           const repositoryArn = repository.repositoryArn as RepositoryArn;
 
-          // Sync lifecycle policy — observed ↔ desired.
-          if (news.lifecyclePolicyText) {
-            yield* ecr.putLifecyclePolicy({
+          // Sync image tag mutability — observed ↔ desired.
+          if (
+            (repository.imageTagMutability ?? "MUTABLE") !==
+            desiredImageTagMutability
+          ) {
+            yield* ecr.putImageTagMutability({
               repositoryName,
-              lifecyclePolicyText: news.lifecyclePolicyText,
+              imageTagMutability: desiredImageTagMutability,
             });
           }
 
-          // Sync tags — diff observed cloud tags against desired.
-          const listedTags = yield* ecr.listTagsForResource({
-            resourceArn: repositoryArn,
-          });
-          const observedTags = Object.fromEntries(
-            (listedTags.tags ?? [])
-              .filter(
-                (t): t is { Key: string; Value: string } =>
-                  typeof t.Key === "string" && typeof t.Value === "string",
-              )
-              .map((t) => [t.Key, t.Value]),
-          );
+          // Sync image scanning configuration — observed ↔ desired.
+          const observedScanOnPush =
+            repository.imageScanningConfiguration?.scanOnPush ?? false;
+          if (observedScanOnPush !== desiredScanOnPush) {
+            yield* ecr.putImageScanningConfiguration({
+              repositoryName,
+              imageScanningConfiguration: { scanOnPush: desiredScanOnPush },
+            });
+          }
+
+          // Sync lifecycle policy — diff observed cloud policy against
+          // desired. Apply, leave, or delete as needed.
+          const observedLifecyclePolicy =
+            yield* fetchLifecyclePolicy(repositoryName);
+          if (news.lifecyclePolicyText) {
+            if (observedLifecyclePolicy !== news.lifecyclePolicyText) {
+              yield* ecr.putLifecyclePolicy({
+                repositoryName,
+                lifecyclePolicyText: news.lifecyclePolicyText,
+              });
+            }
+          } else if (observedLifecyclePolicy !== undefined) {
+            yield* ecr
+              .deleteLifecyclePolicy({ repositoryName })
+              .pipe(
+                Effect.catchTag("LifecyclePolicyNotFoundException", () =>
+                  Effect.void,
+                ),
+              );
+          }
+
+          // Sync tags — diff observed cloud tags against desired so
+          // adoption and out-of-band drift converge correctly.
+          const observedTags = yield* fetchObservedTags(repositoryArn);
           const { removed, upsert } = diffTags(observedTags, desiredTags);
           if (upsert.length > 0) {
             yield* ecr.tagResource({
@@ -235,19 +302,17 @@ export const RepositoryProvider = () =>
             repositoryArn,
             repositoryUri: repository.repositoryUri as RepositoryUri,
             registryId: repository.registryId!,
-            imageTagMutability:
-              news.imageTagMutability ??
-              repository.imageTagMutability ??
-              "MUTABLE",
+            imageTagMutability: desiredImageTagMutability,
+            scanOnPush: desiredScanOnPush,
             lifecyclePolicyText: news.lifecyclePolicyText,
             tags: desiredTags,
           };
         }),
-        delete: Effect.fn(function* ({ output }) {
+        delete: Effect.fn(function* ({ olds, output }) {
           yield* ecr
             .deleteRepository({
               repositoryName: output.repositoryName,
-              force: true,
+              force: olds?.forceDelete ?? false,
             })
             .pipe(
               Effect.catchTag("RepositoryNotFoundException", () => Effect.void),

--- a/packages/alchemy/test/AWS/ECR/Repository.test.ts
+++ b/packages/alchemy/test/AWS/ECR/Repository.test.ts
@@ -1,0 +1,647 @@
+import { adopt } from "@/AdoptPolicy";
+import * as AWS from "@/AWS";
+import { Repository } from "@/AWS/ECR";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import * as ECR from "@distilled.cloud/aws/ecr";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+test.provider("create and delete repository with default props", (stack) =>
+  Effect.gen(function* () {
+    const repo = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Repository("DefaultRepo");
+      }),
+    );
+
+    expect(repo.repositoryName).toBeDefined();
+    expect(repo.repositoryArn).toBeDefined();
+    expect(repo.repositoryUri).toBeDefined();
+
+    const described = yield* ECR.describeRepositories({
+      repositoryNames: [repo.repositoryName],
+    });
+    expect(described.repositories?.[0]?.repositoryArn).toEqual(
+      repo.repositoryArn,
+    );
+
+    yield* stack.destroy();
+    yield* assertRepositoryDeleted(repo.repositoryName);
+  }),
+);
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("IdempotentRepo", {
+            scanOnPush: true,
+            tags: { Environment: "test" },
+          });
+        }),
+      );
+
+      // Deploy again with identical props — reconcile must converge
+      // without changing the repository.
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("IdempotentRepo", {
+            scanOnPush: true,
+            tags: { Environment: "test" },
+          });
+        }),
+      );
+
+      expect(second.repositoryName).toEqual(initial.repositoryName);
+      expect(second.repositoryArn).toEqual(initial.repositoryArn);
+      expect(second.scanOnPush).toEqual(true);
+
+      const tags = yield* ECR.listTagsForResource({
+        resourceArn: second.repositoryArn,
+      });
+      const tagMap = Object.fromEntries(
+        (tags.tags ?? []).map((t) => [t.Key!, t.Value!]),
+      );
+      expect(tagMap["Environment"]).toEqual("test");
+
+      yield* stack.destroy();
+      yield* assertRepositoryDeleted(initial.repositoryName);
+    }),
+);
+
+test.provider(
+  "reconcile resets imageScanningConfiguration mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const repo = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("DriftScanRepo", {
+            scanOnPush: true,
+          });
+        }),
+      );
+
+      // Mutate scanOnPush out-of-band via the raw SDK.
+      yield* ECR.putImageScanningConfiguration({
+        repositoryName: repo.repositoryName,
+        imageScanningConfiguration: { scanOnPush: false },
+      });
+      const drifted = yield* ECR.describeRepositories({
+        repositoryNames: [repo.repositoryName],
+      });
+      expect(
+        drifted.repositories?.[0]?.imageScanningConfiguration?.scanOnPush,
+      ).toEqual(false);
+
+      // Re-deploy with the same desired props — reconcile should reset.
+      const redeployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("DriftScanRepo", {
+            scanOnPush: true,
+          });
+        }),
+      );
+      expect(redeployed.repositoryArn).toEqual(repo.repositoryArn);
+
+      const reset = yield* ECR.describeRepositories({
+        repositoryNames: [repo.repositoryName],
+      });
+      expect(
+        reset.repositories?.[0]?.imageScanningConfiguration?.scanOnPush,
+      ).toEqual(true);
+
+      yield* stack.destroy();
+      yield* assertRepositoryDeleted(repo.repositoryName);
+    }),
+);
+
+test.provider(
+  "reconcile resets imageTagMutability mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const repo = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("DriftMutabilityRepo", {
+            imageTagMutability: "IMMUTABLE",
+          });
+        }),
+      );
+
+      // Drift to MUTABLE out-of-band.
+      yield* ECR.putImageTagMutability({
+        repositoryName: repo.repositoryName,
+        imageTagMutability: "MUTABLE",
+      });
+      const drifted = yield* ECR.describeRepositories({
+        repositoryNames: [repo.repositoryName],
+      });
+      expect(drifted.repositories?.[0]?.imageTagMutability).toEqual("MUTABLE");
+
+      // Re-deploy — reconcile should reset to IMMUTABLE.
+      const redeployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("DriftMutabilityRepo", {
+            imageTagMutability: "IMMUTABLE",
+          });
+        }),
+      );
+      expect(redeployed.imageTagMutability).toEqual("IMMUTABLE");
+
+      const reset = yield* ECR.describeRepositories({
+        repositoryNames: [repo.repositoryName],
+      });
+      expect(reset.repositories?.[0]?.imageTagMutability).toEqual("IMMUTABLE");
+
+      yield* stack.destroy();
+      yield* assertRepositoryDeleted(repo.repositoryName);
+    }),
+);
+
+test.provider(
+  "reconcile resets a lifecycle policy mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const desiredPolicy = JSON.stringify({
+        rules: [
+          {
+            rulePriority: 1,
+            description: "expire untagged after 7 days",
+            selection: {
+              tagStatus: "untagged",
+              countType: "sinceImagePushed",
+              countUnit: "days",
+              countNumber: 7,
+            },
+            action: { type: "expire" },
+          },
+        ],
+      });
+
+      const repo = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("DriftPolicyRepo", {
+            lifecyclePolicyText: desiredPolicy,
+          });
+        }),
+      );
+
+      // Replace the policy out-of-band with something foreign.
+      const foreignPolicy = JSON.stringify({
+        rules: [
+          {
+            rulePriority: 1,
+            description: "FOREIGN: keep last 3",
+            selection: {
+              tagStatus: "any",
+              countType: "imageCountMoreThan",
+              countNumber: 3,
+            },
+            action: { type: "expire" },
+          },
+        ],
+      });
+      yield* ECR.putLifecyclePolicy({
+        repositoryName: repo.repositoryName,
+        lifecyclePolicyText: foreignPolicy,
+      });
+
+      // Re-deploy — reconcile must reset the policy back to desired.
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("DriftPolicyRepo", {
+            lifecyclePolicyText: desiredPolicy,
+          });
+        }),
+      );
+
+      const observed = yield* ECR.getLifecyclePolicy({
+        repositoryName: repo.repositoryName,
+      });
+      expect(JSON.parse(observed.lifecyclePolicyText!)).toEqual(
+        JSON.parse(desiredPolicy),
+      );
+
+      yield* stack.destroy();
+      yield* assertRepositoryDeleted(repo.repositoryName);
+    }),
+);
+
+test.provider(
+  "removing lifecyclePolicyText deletes the lifecycle policy",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const policy = JSON.stringify({
+        rules: [
+          {
+            rulePriority: 1,
+            description: "expire untagged",
+            selection: {
+              tagStatus: "untagged",
+              countType: "sinceImagePushed",
+              countUnit: "days",
+              countNumber: 1,
+            },
+            action: { type: "expire" },
+          },
+        ],
+      });
+
+      const repo = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("PolicyRemovalRepo", {
+            lifecyclePolicyText: policy,
+          });
+        }),
+      );
+
+      const before = yield* ECR.getLifecyclePolicy({
+        repositoryName: repo.repositoryName,
+      });
+      expect(before.lifecyclePolicyText).toBeDefined();
+
+      // Re-deploy without the policy — reconcile must delete it.
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("PolicyRemovalRepo");
+        }),
+      );
+
+      yield* ECR.getLifecyclePolicy({
+        repositoryName: repo.repositoryName,
+      })
+        .pipe(
+          Effect.flatMap(() =>
+            Effect.fail(new Error("lifecycle policy still present")),
+          ),
+          Effect.catchTag("LifecyclePolicyNotFoundException", () => Effect.void),
+        );
+
+      yield* stack.destroy();
+      yield* assertRepositoryDeleted(repo.repositoryName);
+    }),
+);
+
+test.provider(
+  "reconcile resets tags mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const repo = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("DriftTagsRepo", {
+            tags: { Environment: "test" },
+          });
+        }),
+      );
+
+      // Mutate tags out-of-band via the raw SDK.
+      yield* ECR.tagResource({
+        resourceArn: repo.repositoryArn,
+        tags: [
+          { Key: "Drifted", Value: "yes" },
+          { Key: "Environment", Value: "WRONG" },
+        ],
+      });
+
+      // Re-deploy — reconcile should observe drifted cloud tags and reset them.
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("DriftTagsRepo", {
+            tags: { Environment: "test" },
+          });
+        }),
+      );
+
+      const tags = yield* ECR.listTagsForResource({
+        resourceArn: repo.repositoryArn,
+      });
+      const tagMap = Object.fromEntries(
+        (tags.tags ?? []).map((t) => [t.Key!, t.Value!]),
+      );
+      expect(tagMap["Environment"]).toEqual("test");
+      expect(tagMap["Drifted"]).toBeUndefined();
+
+      yield* stack.destroy();
+      yield* assertRepositoryDeleted(repo.repositoryName);
+    }),
+);
+
+test.provider(
+  "reconcile re-creates a repository that was deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const repositoryName = `alchemy-test-ecr-recreate-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("RecreateRepo", { repositoryName });
+        }),
+      );
+
+      // Delete the repository out of band.
+      yield* ECR.deleteRepository({
+        repositoryName: initial.repositoryName,
+        force: true,
+      });
+      yield* assertRepositoryDeleted(repositoryName);
+
+      // Re-deploying must converge by re-creating.
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("RecreateRepo", { repositoryName });
+        }),
+      );
+
+      expect(recreated.repositoryName).toEqual(repositoryName);
+      const described = yield* ECR.describeRepositories({
+        repositoryNames: [repositoryName],
+      });
+      expect(described.repositories?.[0]?.repositoryArn).toBeDefined();
+
+      yield* stack.destroy();
+      yield* assertRepositoryDeleted(recreated.repositoryName);
+    }),
+);
+
+test.provider(
+  "changing repositoryName triggers replace, old repository is deleted",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const nameA = `alchemy-test-ecr-replace-a-${suffix}`;
+      const nameB = `alchemy-test-ecr-replace-b-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("RenameRepo", { repositoryName: nameA });
+        }),
+      );
+      expect(a.repositoryName).toEqual(nameA);
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("RenameRepo", { repositoryName: nameB });
+        }),
+      );
+      expect(b.repositoryName).toEqual(nameB);
+      expect(b.repositoryArn).not.toEqual(a.repositoryArn);
+
+      // The old repository must be gone after replace.
+      yield* assertRepositoryDeleted(nameA);
+
+      yield* stack.destroy();
+      yield* assertRepositoryDeleted(nameB);
+    }),
+);
+
+test.provider(
+  "destroying a non-empty repo without forceDelete returns RepositoryNotEmptyException",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const repositoryName = `alchemy-test-ecr-nonempty-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const repo = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("NonEmptyRepo", {
+            repositoryName,
+            forceDelete: false,
+          });
+        }),
+      );
+
+      // Push a placeholder image manifest so the repository is non-empty.
+      yield* pushPlaceholderImage(repo.repositoryName);
+
+      // Destroy should fail with RepositoryNotEmptyException because
+      // forceDelete is false. The engine surfaces it as the underlying
+      // tagged error.
+      const result = yield* stack.destroy().pipe(Effect.flip);
+      const message =
+        result instanceof Error ? result.message : JSON.stringify(result);
+      expect(message).toMatch(/RepositoryNotEmptyException|not empty/i);
+
+      // Cleanup: empty the repo, then destroy.
+      yield* ECR.batchDeleteImage({
+        repositoryName: repo.repositoryName,
+        imageIds: [{ imageTag: "placeholder" }],
+      });
+      yield* stack.destroy();
+      yield* assertRepositoryDeleted(repo.repositoryName);
+    }),
+);
+
+test.provider(
+  "destroying a non-empty repo with forceDelete: true succeeds",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const repositoryName = `alchemy-test-ecr-force-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const repo = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("ForceDeleteRepo", {
+            repositoryName,
+            forceDelete: true,
+          });
+        }),
+      );
+
+      yield* pushPlaceholderImage(repo.repositoryName);
+
+      // Destroy must succeed despite the repository containing an image.
+      yield* stack.destroy();
+      yield* assertRepositoryDeleted(repo.repositoryName);
+    }),
+);
+
+test.provider(
+  "destroying an already-deleted repository is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const repo = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("DoubleDestroyRepo");
+        }),
+      );
+
+      // Delete out of band, then ask the engine to destroy.
+      // Provider's `delete` must catch RepositoryNotFoundException and
+      // complete cleanly.
+      yield* ECR.deleteRepository({
+        repositoryName: repo.repositoryName,
+        force: true,
+      });
+      yield* assertRepositoryDeleted(repo.repositoryName);
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider(
+  "owned repo (matching alchemy tags) is silently adopted without --adopt",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const repositoryName = `alchemy-test-ecr-adopt-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("AdoptableRepo", { repositoryName });
+        }),
+      );
+      expect(initial.repositoryName).toEqual(repositoryName);
+
+      // Wipe state — the repository stays in ECR.
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "AdoptableRepo",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      const adopted = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("AdoptableRepo", { repositoryName });
+        }),
+      );
+
+      expect(adopted.repositoryArn).toEqual(initial.repositoryArn);
+      expect(adopted.repositoryUri).toEqual(initial.repositoryUri);
+
+      yield* stack.destroy();
+      yield* assertRepositoryDeleted(initial.repositoryName);
+    }),
+);
+
+test.provider(
+  "foreign-tagged repo requires adopt(true) to take over and is re-tagged",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const repositoryName = `alchemy-test-ecr-takeover-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const original = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Repository("Original", { repositoryName });
+        }),
+      );
+
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "Original",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      const takenOver = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* Repository("Different", { repositoryName });
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(takenOver.repositoryName).toEqual(repositoryName);
+      expect(takenOver.repositoryArn).toEqual(original.repositoryArn);
+
+      // Adoption with adopt(true) must re-tag the repo with the alchemy
+      // internal tags so the next reconcile silently adopts.
+      const tags = yield* ECR.listTagsForResource({
+        resourceArn: takenOver.repositoryArn,
+      });
+      const tagMap = Object.fromEntries(
+        (tags.tags ?? []).map((t) => [t.Key!, t.Value!]),
+      );
+      expect(tagMap["alchemy:fqn"]).toBeDefined();
+      expect(tagMap["alchemy:stage"]).toBeDefined();
+
+      yield* stack.destroy();
+      yield* assertRepositoryDeleted(takenOver.repositoryName);
+    }),
+);
+
+class RepositoryStillExists extends Data.TaggedError("RepositoryStillExists") {}
+
+const assertRepositoryDeleted = Effect.fn(function* (repositoryName: string) {
+  yield* ECR.describeRepositories({ repositoryNames: [repositoryName] })
+    .pipe(
+      Effect.flatMap(() => Effect.fail(new RepositoryStillExists())),
+      Effect.retry({
+        while: (e) => e._tag === "RepositoryStillExists",
+        schedule: Schedule.exponential(100).pipe(
+          Schedule.both(Schedule.recurs(8)),
+        ),
+      }),
+      Effect.catchTag("RepositoryNotFoundException", () => Effect.void),
+    );
+});
+
+/**
+ * Push a tiny placeholder image manifest so the repository is non-empty.
+ * Uses ECR's PutImage API with an inlined OCI image manifest. We don't push
+ * the actual layer blobs — ECR allows orphan manifests, which is enough to
+ * trigger RepositoryNotEmptyException on a non-force delete.
+ */
+const pushPlaceholderImage = Effect.fn(function* (repositoryName: string) {
+  const manifest = JSON.stringify({
+    schemaVersion: 2,
+    mediaType: "application/vnd.docker.distribution.manifest.v2+json",
+    config: {
+      mediaType: "application/vnd.docker.container.image.v1+json",
+      size: 0,
+      digest:
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    },
+    layers: [],
+  });
+  yield* ECR.putImage({
+    repositoryName,
+    imageManifest: manifest,
+    imageTag: "placeholder",
+  }).pipe(
+    Effect.catchTag("ImageAlreadyExistsException", () => Effect.void),
+  );
+});


### PR DESCRIPTION
Audits the ECR Repository reconciler for the same classes of issues SQS / S3 had, and adds lifecycle convergence tests on top of #179.

### Reconciler changes

`read` now observes cloud state for tags and lifecycle policy, instead of echoing back the cached `output`:

```diff
- const listedTags = yield* ecr.listTagsForResource({ resourceArn: ... });
- const attrs = {
-   …,
-   lifecyclePolicyText: output?.lifecyclePolicyText,
-   tags: output?.tags ?? {},
- };
+ const observedTags = yield* fetchObservedTags(repositoryArn);
+ const lifecyclePolicyText = yield* fetchLifecyclePolicy(repositoryName);
+ const attrs = { …, lifecyclePolicyText, tags: observedTags };
```

Reconcile now diffs `imageTagMutability` and `imageScanningConfiguration` against observed state and resets drift via `putImageTagMutability` / `putImageScanningConfiguration`. Previously these were locked in at create time and any out-of-band change silently survived a redeploy.

Lifecycle policy is now fully reconciled — applied, re-applied on drift, or deleted via `deleteLifecyclePolicy` (catching `LifecyclePolicyNotFoundException`) when removed from props:

```diff
- if (news.lifecyclePolicyText) {
-   yield* ecr.putLifecyclePolicy({ repositoryName, lifecyclePolicyText });
- }
+ const observed = yield* fetchLifecyclePolicy(repositoryName);
+ if (news.lifecyclePolicyText) {
+   if (observed !== news.lifecyclePolicyText) {
+     yield* ecr.putLifecyclePolicy({ repositoryName, lifecyclePolicyText: news.lifecyclePolicyText });
+   }
+ } else if (observed !== undefined) {
+   yield* ecr.deleteLifecyclePolicy({ repositoryName }).pipe(
+     Effect.catchTag("LifecyclePolicyNotFoundException", () => Effect.void),
+   );
+ }
```

The post-`RepositoryAlreadyExistsException` re-describe now tolerates `RepositoryNotFoundException` (peer-deletion race) instead of throwing.

`delete` honours a new `forceDelete` prop (default `false`). The previous implementation hard-coded `force: true`, which silently deleted images the user may have wanted to preserve.

### New lifecycle tests

Each test runs `destroy -> deploy -> ... -> destroy` on a `ScratchStack` and asserts at every step:

- redeploy with same props is a no-op (idempotent)
- reconcile resets `imageScanningConfiguration` mutated out-of-band
- reconcile resets `imageTagMutability` mutated out-of-band
- reconcile resets a lifecycle policy mutated out-of-band
- removing `lifecyclePolicyText` deletes the lifecycle policy
- reconcile resets tags mutated out-of-band
- reconcile re-creates a repo deleted out-of-band
- changing `repositoryName` triggers replace; old repo is deleted
- `forceDelete: false` on a non-empty repo surfaces `RepositoryNotEmptyException`
- `forceDelete: true` on a non-empty repo destroys cleanly
- destroying an already-deleted repo is a no-op
- silent adoption on a repo with matching alchemy tags
- `adopt(true)` takes over a foreign-tagged repo and re-tags it

`test.resources.ts` picks up the same `output?.stableId` fix from the SQS PR so this branch type-checks in isolation.

### Distilled patch

ECR error category fixes at https://github.com/alchemy-run/distilled/pull/247.
