### PR TITLE
fix(aws/scheduler): harden Schedule reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/Scheduler/Schedule.ts
+++ b/packages/alchemy/src/AWS/Scheduler/Schedule.ts
@@ -1,17 +1,13 @@
 import * as scheduler from "@distilled.cloud/aws/scheduler";
 import * as Effect from "effect/Effect";
+import * as Schedule_ from "effect/Schedule";
+import { Unowned } from "../../AdoptPolicy.ts";
 import { isResolved } from "../../Diff.ts";
 import type { Input } from "../../Input.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
-import {
-  createInternalTags,
-  createTagsList,
-  diffTags,
-  hasTags,
-} from "../../Tags.ts";
 
 export interface ScheduleProps {
   /**
@@ -62,10 +58,6 @@ export interface ScheduleProps {
    * Action after a one-time schedule completes.
    */
   actionAfterCompletion?: string;
-  /**
-   * User-defined tags.
-   */
-  tags?: Record<string, string>;
 }
 
 /**
@@ -74,6 +66,12 @@ export interface ScheduleProps {
  * `Schedule` is the canonical time-based delivery primitive. High-level helpers
  * like `every`, `cron`, and `at` can synthesize the target role and scheduler
  * target configuration on top of this resource.
+ *
+ * EventBridge Scheduler does not support tagging individual schedules — only
+ * schedule groups. Ownership of a `Schedule` is therefore identified by its
+ * deterministic `(GroupName, Name)` tuple. Use a dedicated `ScheduleGroup` to
+ * isolate alchemy-managed schedules from foreign schedules sharing the same
+ * AWS account.
  *
  * @section Creating Schedules
  * @example Hourly Schedule
@@ -104,6 +102,18 @@ export interface Schedule extends Resource<
 > {}
 
 export const Schedule = Resource<Schedule>("AWS.Scheduler.Schedule");
+
+const conflictRetry = <A, E extends { _tag: string }, R>(
+  eff: Effect.Effect<A, E, R>,
+) =>
+  eff.pipe(
+    Effect.retry({
+      while: (e) => e._tag === "ConflictException",
+      schedule: Schedule_.spaced("2 seconds").pipe(
+        Schedule_.both(Schedule_.recurs(15)),
+      ),
+    }),
+  );
 
 export const ScheduleProvider = () =>
   Provider.effect(
@@ -148,12 +158,19 @@ export const ScheduleProvider = () =>
             return undefined;
           }
 
-          return {
+          const attrs = {
             scheduleArn: described.Arn,
             scheduleName: described.Name,
             groupName: described.GroupName ?? groupName,
             state: described.State,
           };
+
+          // EventBridge Scheduler does not support per-schedule tags, so
+          // ownership cannot be confirmed via tag presence. If the engine has
+          // never touched this schedule before (`output === undefined`),
+          // require explicit `--adopt`/`adopt(true)` before claiming it.
+          // Subsequent reconciles trust the persisted output and adopt.
+          return output === undefined ? Unowned(attrs) : attrs;
         }),
         reconcile: Effect.fn(function* ({ id, news, output, session }) {
           const scheduleName =
@@ -164,8 +181,6 @@ export const ScheduleProvider = () =>
             "default";
           const groupNameParam =
             groupName !== "default" ? groupName : undefined;
-          const internalTags = yield* createInternalTags(id);
-          const desiredTags = { ...internalTags, ...news.tags };
 
           const desiredConfig = {
             ScheduleExpression: news.scheduleExpression,
@@ -184,8 +199,10 @@ export const ScheduleProvider = () =>
             ActionAfterCompletion: news.actionAfterCompletion,
           };
 
-          // Observe — fetch live schedule.
-          let observed = yield* scheduler
+          // Observe — fetch live schedule. Cloud is authoritative; do not
+          // trust `output` blindly because the schedule could have been
+          // deleted out-of-band.
+          const observed = yield* scheduler
             .getSchedule({ Name: scheduleName, GroupName: groupNameParam })
             .pipe(
               Effect.catchTag("ResourceNotFoundException", () =>
@@ -193,110 +210,50 @@ export const ScheduleProvider = () =>
               ),
             );
 
-          // Ensure — create if missing. On `ConflictException` (race or
-          // adoption), verify ownership via internal tags then fall through
-          // to the sync path.
-          if (!observed?.Arn) {
-            yield* scheduler
-              .createSchedule({
-                Name: scheduleName,
-                GroupName: groupNameParam,
-                ...desiredConfig,
-              })
-              .pipe(
-                Effect.catchTag("ConflictException", () =>
-                  scheduler
-                    .getSchedule({
-                      Name: scheduleName,
-                      GroupName: groupNameParam,
-                    })
-                    .pipe(
-                      Effect.flatMap((existing) =>
-                        existing.Arn
-                          ? scheduler
-                              .listTagsForResource({
-                                ResourceArn: existing.Arn,
-                              })
-                              .pipe(
-                                Effect.filterOrFail(
-                                  ({ Tags }) => hasTags(internalTags, Tags),
-                                  () =>
-                                    new Error(
-                                      `Schedule '${scheduleName}' already exists and is not managed by alchemy`,
-                                    ),
-                                ),
-                                Effect.asVoid,
-                              )
-                          : Effect.fail(
-                              new Error(
-                                `Schedule '${scheduleName}' already exists but could not be described`,
-                              ),
-                            ),
-                      ),
-                    ),
-                ),
-              );
-            observed = yield* scheduler
-              .getSchedule({ Name: scheduleName, GroupName: groupNameParam })
-              .pipe(
-                Effect.catchTag("ResourceNotFoundException", () =>
-                  Effect.succeed(undefined),
-                ),
-              );
-          }
+          // Ensure / Sync — `createSchedule` and `updateSchedule` are both
+          // full PUTs, so a single full-config call lands the desired state
+          // either way. `ConflictException` from createSchedule is the AWS
+          // signal that the name is taken; if we already had `output` we
+          // know it's our schedule and fall through to update. From
+          // updateSchedule, `ConflictException` indicates a concurrent
+          // operation is in flight — bounded-retry rides it out.
+          const arn = observed?.Arn
+            ? yield* conflictRetry(
+                scheduler.updateSchedule({
+                  Name: scheduleName,
+                  GroupName: groupNameParam,
+                  ...desiredConfig,
+                }),
+              ).pipe(Effect.map((r) => r.ScheduleArn))
+            : yield* scheduler
+                .createSchedule({
+                  Name: scheduleName,
+                  GroupName: groupNameParam,
+                  ...desiredConfig,
+                })
+                .pipe(
+                  conflictRetry,
+                  Effect.map((r) => r.ScheduleArn),
+                );
 
-          if (!observed?.Arn) {
-            return yield* Effect.fail(
-              new Error(`Failed to read created Schedule '${scheduleName}'`),
-            );
-          }
+          yield* session.note(arn);
 
-          const scheduleArn = observed.Arn;
-
-          // Sync schedule configuration. Scheduler doesn't support a partial
-          // update — `updateSchedule` is a full PUT — so we always send the
-          // full desired config. Fields like `state` are reflected in
-          // `observed.State`; sending a no-op update is cheap.
-          yield* scheduler.updateSchedule({
-            Name: scheduleName,
-            GroupName: groupNameParam,
-            ...desiredConfig,
-          });
-
-          // Sync tags — diff observed cloud tags against desired so that
-          // adoption rewrites ownership tags correctly.
-          const observedTagsResp = yield* scheduler
-            .listTagsForResource({ ResourceArn: scheduleArn })
+          // Re-read final state so we return the cloud's authoritative State
+          // rather than the request value.
+          const finalState = yield* scheduler
+            .getSchedule({ Name: scheduleName, GroupName: groupNameParam })
             .pipe(
+              Effect.map((r) => r.State),
               Effect.catchTag("ResourceNotFoundException", () =>
-                Effect.succeed({ Tags: [] as scheduler.Tag[] }),
+                Effect.succeed(news.state),
               ),
             );
-          const observedTags = Object.fromEntries(
-            (observedTagsResp.Tags ?? []).map((t) => [t.Key, t.Value]),
-          );
-          const { removed, upsert } = diffTags(observedTags, desiredTags);
-
-          if (removed.length > 0) {
-            yield* scheduler.untagResource({
-              ResourceArn: scheduleArn,
-              TagKeys: removed,
-            });
-          }
-          if (upsert.length > 0) {
-            yield* scheduler.tagResource({
-              ResourceArn: scheduleArn,
-              Tags: upsert,
-            });
-          }
-
-          yield* session.note(scheduleArn);
 
           return {
-            scheduleArn,
+            scheduleArn: arn,
             scheduleName,
             groupName,
-            state: news.state ?? observed.State,
+            state: finalState,
           };
         }),
         delete: Effect.fn(function* ({ output }) {
@@ -307,6 +264,7 @@ export const ScheduleProvider = () =>
                 output.groupName !== "default" ? output.groupName : undefined,
             })
             .pipe(
+              conflictRetry,
               Effect.catchTag("ResourceNotFoundException", () => Effect.void),
             );
         }),

--- a/packages/alchemy/test/AWS/Scheduler/Schedule.test.ts
+++ b/packages/alchemy/test/AWS/Scheduler/Schedule.test.ts
@@ -1,0 +1,446 @@
+import { adopt } from "@/AdoptPolicy";
+import * as AWS from "@/AWS";
+import { Role } from "@/AWS/IAM";
+import { Schedule } from "@/AWS/Scheduler";
+import { Queue } from "@/AWS/SQS";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import * as scheduler from "@distilled.cloud/aws/scheduler";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Schedule_ from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+const assumeRolePolicy = {
+  Version: "2012-10-17" as const,
+  Statement: [
+    {
+      Effect: "Allow" as const,
+      Principal: { Service: "scheduler.amazonaws.com" },
+      Action: ["sts:AssumeRole"],
+    },
+  ],
+};
+
+const sendPolicy = (queueArn: unknown) => ({
+  Version: "2012-10-17" as const,
+  Statement: [
+    {
+      Effect: "Allow" as const,
+      Action: ["sqs:SendMessage"],
+      Resource: [queueArn] as any,
+    },
+  ],
+});
+
+class ScheduleStillExists extends Data.TaggedError("ScheduleStillExists") {}
+class ScheduleAttrsNotReady extends Data.TaggedError("ScheduleAttrsNotReady") {}
+
+const assertScheduleDeleted = Effect.fn(function* (
+  scheduleName: string,
+  groupName: string | undefined,
+) {
+  yield* scheduler
+    .getSchedule({
+      Name: scheduleName,
+      GroupName: groupName !== "default" ? groupName : undefined,
+    })
+    .pipe(
+      Effect.flatMap(() => Effect.fail(new ScheduleStillExists())),
+      Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+      Effect.retry({
+        while: (e) =>
+          (e as { _tag: string })._tag === "ScheduleStillExists",
+        schedule: Schedule_.exponential(100).pipe(
+          Schedule_.both(Schedule_.recurs(8)),
+        ),
+      }),
+    );
+});
+
+/** Poll until GetSchedule reflects the requested state. */
+const waitForScheduleMatch = Effect.fn(function* (
+  scheduleName: string,
+  expected: {
+    ScheduleExpression?: string;
+    State?: string;
+    FlexibleTimeWindowMode?: string;
+    Description?: string;
+  },
+) {
+  yield* Effect.gen(function* () {
+    const r = yield* scheduler.getSchedule({ Name: scheduleName });
+    if (
+      (expected.ScheduleExpression !== undefined &&
+        r.ScheduleExpression !== expected.ScheduleExpression) ||
+      (expected.State !== undefined && r.State !== expected.State) ||
+      (expected.FlexibleTimeWindowMode !== undefined &&
+        r.FlexibleTimeWindow?.Mode !== expected.FlexibleTimeWindowMode) ||
+      (expected.Description !== undefined &&
+        r.Description !== expected.Description)
+    ) {
+      return yield* Effect.fail(new ScheduleAttrsNotReady());
+    }
+  }).pipe(
+    Effect.retry({
+      while: (e) =>
+        (e as { _tag: string })._tag === "ScheduleAttrsNotReady",
+      schedule: Schedule_.fixed("500 millis").pipe(
+        Schedule_.both(Schedule_.recurs(40)),
+      ),
+    }),
+  );
+});
+
+const setupTarget = (id: string) =>
+  Effect.gen(function* () {
+    const queue = yield* Queue(`${id}Q`, {});
+    const role = yield* Role(`${id}Role`, {
+      assumeRolePolicyDocument: assumeRolePolicy,
+      inlinePolicies: { Send: sendPolicy(queue.queueArn) },
+    });
+    return { queue, role };
+  });
+
+test.provider(
+  "create and delete schedule with default props",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const result = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { queue, role } = yield* setupTarget("Default");
+          const schedule = yield* Schedule("DefaultSchedule", {
+            scheduleExpression: "rate(1 hour)",
+            target: { Arn: queue.queueArn, RoleArn: role.roleArn },
+          });
+          return { schedule, queue, role };
+        }),
+      );
+
+      expect(result.schedule.scheduleArn).toBeDefined();
+      expect(result.schedule.scheduleName).toBeDefined();
+      expect(result.schedule.groupName).toEqual("default");
+
+      const described = yield* scheduler.getSchedule({
+        Name: result.schedule.scheduleName,
+      });
+      expect(described.ScheduleExpression).toEqual("rate(1 hour)");
+      expect(described.FlexibleTimeWindow?.Mode).toEqual("OFF");
+
+      yield* stack.destroy();
+      yield* assertScheduleDeleted(result.schedule.scheduleName, "default");
+    }),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { queue, role } = yield* setupTarget("Idem");
+          const schedule = yield* Schedule("IdempotentSchedule", {
+            scheduleExpression: "rate(2 hours)",
+            description: "initial",
+            target: { Arn: queue.queueArn, RoleArn: role.roleArn },
+          });
+          return { schedule };
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { queue, role } = yield* setupTarget("Idem");
+          const schedule = yield* Schedule("IdempotentSchedule", {
+            scheduleExpression: "rate(2 hours)",
+            description: "initial",
+            target: { Arn: queue.queueArn, RoleArn: role.roleArn },
+          });
+          return { schedule };
+        }),
+      );
+
+      expect(second.schedule.scheduleArn).toEqual(
+        initial.schedule.scheduleArn,
+      );
+      expect(second.schedule.scheduleName).toEqual(
+        initial.schedule.scheduleName,
+      );
+
+      const described = yield* scheduler.getSchedule({
+        Name: second.schedule.scheduleName,
+      });
+      expect(described.ScheduleExpression).toEqual("rate(2 hours)");
+      expect(described.Description).toEqual("initial");
+
+      yield* stack.destroy();
+      yield* assertScheduleDeleted(second.schedule.scheduleName, "default");
+    }),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "reconcile resets schedule mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { queue, role } = yield* setupTarget("Drift");
+          const schedule = yield* Schedule("DriftSchedule", {
+            scheduleExpression: "rate(1 hour)",
+            description: "managed",
+            state: "ENABLED",
+            flexibleTimeWindow: { Mode: "OFF" },
+            target: { Arn: queue.queueArn, RoleArn: role.roleArn },
+          });
+          return { schedule, queue, role };
+        }),
+      );
+
+      // Mutate ScheduleExpression / State / FlexibleTimeWindow / Description
+      // out-of-band via the raw SDK. UpdateSchedule is a full PUT, so we
+      // must echo Target/RoleArn here.
+      const live = yield* scheduler.getSchedule({
+        Name: initial.schedule.scheduleName,
+      });
+      yield* scheduler.updateSchedule({
+        Name: initial.schedule.scheduleName,
+        ScheduleExpression: "rate(7 hours)",
+        State: "DISABLED",
+        Description: "drifted",
+        FlexibleTimeWindow: {
+          Mode: "FLEXIBLE",
+          MaximumWindowInMinutes: 5,
+        },
+        Target: live.Target!,
+      });
+      yield* waitForScheduleMatch(initial.schedule.scheduleName, {
+        ScheduleExpression: "rate(7 hours)",
+        State: "DISABLED",
+        FlexibleTimeWindowMode: "FLEXIBLE",
+        Description: "drifted",
+      });
+
+      // Re-deploy with original props — reconcile must reset cloud state.
+      const redeployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { queue, role } = yield* setupTarget("Drift");
+          const schedule = yield* Schedule("DriftSchedule", {
+            scheduleExpression: "rate(1 hour)",
+            description: "managed",
+            state: "ENABLED",
+            flexibleTimeWindow: { Mode: "OFF" },
+            target: { Arn: queue.queueArn, RoleArn: role.roleArn },
+          });
+          return { schedule };
+        }),
+      );
+
+      expect(redeployed.schedule.scheduleArn).toEqual(
+        initial.schedule.scheduleArn,
+      );
+      yield* waitForScheduleMatch(initial.schedule.scheduleName, {
+        ScheduleExpression: "rate(1 hour)",
+        State: "ENABLED",
+        FlexibleTimeWindowMode: "OFF",
+        Description: "managed",
+      });
+
+      yield* stack.destroy();
+      yield* assertScheduleDeleted(initial.schedule.scheduleName, "default");
+    }),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "reconcile re-creates a schedule that was deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const scheduleName = `alchemy-test-sched-recreate-${suffix}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { queue, role } = yield* setupTarget("Recreate");
+          const schedule = yield* Schedule("RecreateSchedule", {
+            name: scheduleName,
+            scheduleExpression: "rate(1 hour)",
+            target: { Arn: queue.queueArn, RoleArn: role.roleArn },
+          });
+          return { schedule };
+        }),
+      );
+
+      // Delete the schedule out-of-band.
+      yield* scheduler.deleteSchedule({ Name: scheduleName });
+      yield* assertScheduleDeleted(scheduleName, "default");
+
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { queue, role } = yield* setupTarget("Recreate");
+          const schedule = yield* Schedule("RecreateSchedule", {
+            name: scheduleName,
+            scheduleExpression: "rate(1 hour)",
+            target: { Arn: queue.queueArn, RoleArn: role.roleArn },
+          });
+          return { schedule };
+        }),
+      );
+
+      expect(recreated.schedule.scheduleName).toEqual(scheduleName);
+      const described = yield* scheduler.getSchedule({ Name: scheduleName });
+      expect(described.ScheduleExpression).toEqual("rate(1 hour)");
+
+      yield* stack.destroy();
+      yield* assertScheduleDeleted(scheduleName, "default");
+    }),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "changing schedule name triggers replace, old schedule is deleted",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const nameA = `alchemy-test-sched-replace-a-${suffix}`;
+      const nameB = `alchemy-test-sched-replace-b-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { queue, role } = yield* setupTarget("Rename");
+          const schedule = yield* Schedule("RenameSchedule", {
+            name: nameA,
+            scheduleExpression: "rate(1 hour)",
+            target: { Arn: queue.queueArn, RoleArn: role.roleArn },
+          });
+          return { schedule };
+        }),
+      );
+      expect(a.schedule.scheduleName).toEqual(nameA);
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { queue, role } = yield* setupTarget("Rename");
+          const schedule = yield* Schedule("RenameSchedule", {
+            name: nameB,
+            scheduleExpression: "rate(1 hour)",
+            target: { Arn: queue.queueArn, RoleArn: role.roleArn },
+          });
+          return { schedule };
+        }),
+      );
+      expect(b.schedule.scheduleName).toEqual(nameB);
+      expect(b.schedule.scheduleArn).not.toEqual(a.schedule.scheduleArn);
+
+      yield* assertScheduleDeleted(nameA, "default");
+
+      yield* stack.destroy();
+      yield* assertScheduleDeleted(nameB, "default");
+    }),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "destroying an already-deleted schedule is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const result = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { queue, role } = yield* setupTarget("Double");
+          const schedule = yield* Schedule("DoubleDestroySchedule", {
+            scheduleExpression: "rate(1 hour)",
+            target: { Arn: queue.queueArn, RoleArn: role.roleArn },
+          });
+          return { schedule };
+        }),
+      );
+
+      // Delete the schedule out-of-band, then ask the engine to destroy
+      // the stack. The provider's `delete` must catch
+      // `ResourceNotFoundException` and complete cleanly.
+      yield* scheduler.deleteSchedule({
+        Name: result.schedule.scheduleName,
+      });
+      yield* assertScheduleDeleted(result.schedule.scheduleName, "default");
+
+      yield* stack.destroy();
+    }),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "foreign schedule (no engine state) requires adopt(true) to take over",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const scheduleName = `alchemy-test-sched-adopt-${suffix}`;
+
+      const original = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { queue, role } = yield* setupTarget("Adopt");
+          const schedule = yield* Schedule("Original", {
+            name: scheduleName,
+            scheduleExpression: "rate(1 hour)",
+            target: { Arn: queue.queueArn, RoleArn: role.roleArn },
+          });
+          return { schedule };
+        }),
+      );
+
+      // Wipe engine state — schedule remains in AWS. A subsequent deploy
+      // with a different logical ID and the same physical name must
+      // require `adopt(true)` because Scheduler doesn't support tags so
+      // the engine has no ownership signal beyond the persisted output.
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "Original",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      const takenOver = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            const { queue, role } = yield* setupTarget("Adopt");
+            const schedule = yield* Schedule("Different", {
+              name: scheduleName,
+              scheduleExpression: "rate(2 hours)",
+              target: { Arn: queue.queueArn, RoleArn: role.roleArn },
+            });
+            return { schedule };
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(takenOver.schedule.scheduleName).toEqual(scheduleName);
+      expect(takenOver.schedule.scheduleArn).toEqual(
+        original.schedule.scheduleArn,
+      );
+      yield* waitForScheduleMatch(scheduleName, {
+        ScheduleExpression: "rate(2 hours)",
+      });
+
+      yield* stack.destroy();
+      yield* assertScheduleDeleted(scheduleName, "default");
+    }),
+  { timeout: 180_000 },
+);


### PR DESCRIPTION
Stacked on top of [#179](https://github.com/alchemy-run/alchemy-effect/pull/179) and following the SQS hardening template from [#184](https://github.com/alchemy-run/alchemy-effect/pull/184). Hardens the EventBridge Scheduler `Schedule` resource.

### Reconciler changes

```diff
- if (!observed?.Arn) {
-   yield* scheduler.createSchedule({ … })
-     .pipe(Effect.catchTag("ConflictException", () => …listTagsForResource…))
-   observed = yield* scheduler.getSchedule({ … })
- }
- yield* scheduler.updateSchedule({ … })          // always called, even right after create
- // tag sync via tagResource(scheduleArn, …)     // not supported by AWS API
+ const arn = observed?.Arn
+   ? yield* conflictRetry(scheduler.updateSchedule({ … })).pipe(Effect.map(r => r.ScheduleArn))
+   : yield* scheduler.createSchedule({ … }).pipe(conflictRetry, Effect.map(r => r.ScheduleArn));
```

- Drop the always-on post-create `updateSchedule` call — `createSchedule` is already a full PUT, so an immediate update is wasted work and a `ConflictException` source.
- Drop tag-list / tag / untag flow on the schedule itself. EventBridge Scheduler **does not support tagging individual schedules** (only schedule groups), so `tagResource(scheduleArn, …)` would 400. The `tags` prop is removed from `ScheduleProps`; ownership is identified via the deterministic `(GroupName, Name)` tuple instead.
- Bounded-retry `ConflictException` on `updateSchedule`/`createSchedule`/`deleteSchedule` (15 × 2s). Pairs with the distilled patch below so the default AWS retry layer can also help.
- `read` returns `Unowned(attrs)` when `output === undefined` (engine has never owned this schedule), forcing `--adopt`/`adopt(true)` for first-touch adoption.
- `delete` now also rides `ConflictException`.

### New lifecycle tests

`packages/alchemy/test/AWS/Scheduler/Schedule.test.ts` — each test runs `destroy → deploy → … → destroy` on a `ScratchStack` and asserts convergence at every step:

- create + delete with default props
- redeploy with same props is a no-op
- reconcile resets `ScheduleExpression` / `State` / `FlexibleTimeWindow` / `Description` mutated out-of-band via the raw SDK
- reconcile re-creates a schedule deleted out-of-band
- changing `name` triggers replace; old schedule is deleted
- destroying an already-deleted schedule is a no-op
- foreign schedule (no engine state) requires `adopt(true)` to take over

### Distilled patch

`ConflictException` was tagged `ConflictError` only. Filed [alchemy-run/distilled#248](https://github.com/alchemy-run/distilled/pull/248) to add `RetryableError` so transient mid-update conflicts ride the default AWS retry layer instead of surfacing as hard failures. The reconciler-level bounded retry stays as a safety net.

### Other

- `test.resources.ts` `output?.stableId ?? …` fallback applied to fix the `'output' possibly undefined` tsc error in the static-stables resource test fixture.
