### PR TITLE
fix(aws/rds): harden DBInstance reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/RDS/DBInstance.ts
+++ b/packages/alchemy/src/AWS/RDS/DBInstance.ts
@@ -1,4 +1,5 @@
 import * as rds from "@distilled.cloud/aws/rds";
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 import { isResolved } from "../../Diff.ts";
@@ -58,6 +59,20 @@ export interface DBInstanceProps {
    */
   copyTagsToSnapshot?: boolean;
   /**
+   * Allocated storage in GiB. Only used for non-Aurora instances —
+   * Aurora cluster members ignore this and consume the cluster volume.
+   */
+  allocatedStorage?: number;
+  /**
+   * Daily backup retention window in days. Aurora cluster members
+   * inherit this from the cluster, so set it on the cluster instead.
+   */
+  backupRetentionPeriod?: number;
+  /**
+   * Preferred backup window in `hh24:mi-hh24:mi` UTC format.
+   */
+  preferredBackupWindow?: string;
+  /**
    * User-defined tags.
    */
   tags?: Record<string, string>;
@@ -78,6 +93,9 @@ export interface DBInstance extends Resource<
     status: string | undefined;
     promotionTier: number | undefined;
     publiclyAccessible: boolean | undefined;
+    allocatedStorage: number | undefined;
+    backupRetentionPeriod: number | undefined;
+    preferredBackupWindow: string | undefined;
     dbSubnetGroupName: string | undefined;
     dbParameterGroupNames: string[];
     tags: Record<string, string>;
@@ -121,12 +139,44 @@ const toAttrs = ({
   status: instance.DBInstanceStatus,
   promotionTier: instance.PromotionTier,
   publiclyAccessible: instance.PubliclyAccessible,
+  allocatedStorage: instance.AllocatedStorage,
+  backupRetentionPeriod: instance.BackupRetentionPeriod,
+  preferredBackupWindow: instance.PreferredBackupWindow,
   dbSubnetGroupName: instance.DBSubnetGroup?.DBSubnetGroupName,
   dbParameterGroupNames: (instance.DBParameterGroups ?? []).flatMap((group) =>
     group.DBParameterGroupName ? [group.DBParameterGroupName] : [],
   ),
   tags,
 });
+
+// Status snapshot used to drive `waitForStableState`. The reconciler
+// should only mutate or read attributes off an instance that has reached
+// one of these terminal-for-our-purposes states; otherwise control-plane
+// calls fail with `InvalidDBInstanceStateFault`.
+const isStableInstanceStatus = (status: string | undefined): boolean =>
+  status === "available" ||
+  status === "stopped" ||
+  status === "incompatible-network" ||
+  status === "incompatible-parameters" ||
+  status === "incompatible-restore" ||
+  status === "incompatible-credentials" ||
+  status === "failed";
+
+class DBInstanceUnreadable extends Data.TaggedError("DBInstanceUnreadable")<{
+  identifier: string;
+  phase: "post-create" | "post-modify" | "wait-stable";
+}> {}
+
+class DBInstanceNotStable extends Data.TaggedError("DBInstanceNotStable")<{
+  identifier: string;
+  status: string | undefined;
+}> {}
+
+class DBInstanceStillDeleting extends Data.TaggedError(
+  "DBInstanceStillDeleting",
+)<{
+  identifier: string;
+}> {}
 
 export const DBInstanceProvider = () =>
   Provider.effect(
@@ -150,19 +200,190 @@ export const DBInstanceProvider = () =>
         return response?.DBInstances?.[0];
       });
 
-      const waitForInstance = Effect.fn(function* (instanceId: string) {
-        const readinessPolicy = Schedule.fixed("2 seconds").pipe(
-          Schedule.both(Schedule.recurs(30)),
+      // RDS create / modify cycles are 5-15 minutes. Poll every 10s for
+      // up to ~25 minutes — long enough for `db.t3.micro` cluster members
+      // and standalone instances, while still bounded so a stuck instance
+      // surfaces instead of hanging forever.
+      const stableStatePolicy = Schedule.fixed("10 seconds").pipe(
+        Schedule.both(Schedule.recurs(150)),
+      );
+
+      // Modify-time control-plane retries: AWS returns
+      // `InvalidDBInstanceStateFault` when an instance is mid-transition
+      // (e.g. another modify is still applying). Ride that out with a
+      // short bounded retry so we don't surface a transient race.
+      const controlPlaneRetryPolicy = Schedule.exponential("1 second").pipe(
+        Schedule.both(Schedule.recurs(20)),
+      );
+
+      const isControlPlaneRetryable = (error: { _tag?: string }) =>
+        error._tag === "InvalidDBInstanceStateFault" ||
+        error._tag === "DBInstanceNotFoundFault";
+
+      const retryControlPlane = <A, E extends { _tag?: string }, R>(
+        effect: Effect.Effect<A, E, R>,
+      ) =>
+        effect.pipe(
+          Effect.retry({
+            while: isControlPlaneRetryable,
+            schedule: controlPlaneRetryPolicy,
+          }),
         );
-        return yield* readInstance(instanceId).pipe(
-          Effect.flatMap((instance) =>
-            instance?.DBInstanceArn
-              ? Effect.succeed(instance)
-              : Effect.fail(new Error(`DB instance '${instanceId}' not ready`)),
-          ),
-          Effect.retry({ schedule: readinessPolicy }),
+
+      const waitForStableInstance = Effect.fn(function* (
+        instanceId: string,
+        session: { note: (msg: string) => Effect.Effect<void> },
+      ) {
+        return yield* Effect.gen(function* () {
+          const instance = yield* readInstance(instanceId);
+          if (!instance?.DBInstanceArn) {
+            yield* session.note(
+              `DB instance ${instanceId}: waiting for stable state, observed missing`,
+            );
+            return yield* Effect.fail(
+              new DBInstanceNotStable({
+                identifier: instanceId,
+                status: instance?.DBInstanceStatus,
+              }),
+            );
+          }
+          if (!isStableInstanceStatus(instance.DBInstanceStatus)) {
+            yield* session.note(
+              `DB instance ${instanceId}: waiting for stable state, observed ${instance.DBInstanceStatus ?? "UNKNOWN"}`,
+            );
+            return yield* Effect.fail(
+              new DBInstanceNotStable({
+                identifier: instanceId,
+                status: instance.DBInstanceStatus,
+              }),
+            );
+          }
+          return instance;
+        }).pipe(
+          Effect.retry({
+            while: (e) =>
+              (e as { _tag?: string })._tag === "DBInstanceNotStable",
+            schedule: stableStatePolicy,
+          }),
         );
       });
+
+      const waitForInstanceDeleted = Effect.fn(function* (instanceId: string) {
+        return yield* readInstance(instanceId).pipe(
+          Effect.flatMap((instance) =>
+            instance ? Effect.fail(new DBInstanceStillDeleting({
+              identifier: instanceId,
+            })) : Effect.void,
+          ),
+          Effect.retry({
+            while: (e) => e._tag === "DBInstanceStillDeleting",
+            schedule: stableStatePolicy,
+          }),
+        );
+      });
+
+      // Compute the modify payload by diffing observed → desired. RDS
+      // accepts a partial modify, so omitting fields whose desired value
+      // matches observed avoids needlessly bumping `PendingModifiedValues`
+      // and accidentally re-applying a stale value the user fixed
+      // out-of-band. Returns `undefined` when nothing has drifted, which
+      // signals the caller to skip `modifyDBInstance` entirely.
+      const computeModifyPayload = (
+        observed: rds.DBInstance,
+        news: DBInstanceProps,
+      ): rds.ModifyDBInstanceMessage | undefined => {
+        const payload: rds.ModifyDBInstanceMessage = {
+          DBInstanceIdentifier: observed.DBInstanceIdentifier!,
+          ApplyImmediately: true,
+        };
+        let dirty = false;
+        const set = <K extends keyof rds.ModifyDBInstanceMessage>(
+          key: K,
+          value: rds.ModifyDBInstanceMessage[K],
+        ) => {
+          payload[key] = value;
+          dirty = true;
+        };
+        if (
+          news.dbInstanceClass !== undefined &&
+          news.dbInstanceClass !== observed.DBInstanceClass
+        ) {
+          set("DBInstanceClass", news.dbInstanceClass);
+        }
+        if (
+          news.engineVersion !== undefined &&
+          news.engineVersion !== observed.EngineVersion
+        ) {
+          // EngineVersion changes are major — let AWS choose whether to
+          // apply at maintenance window if not eligible for immediate.
+          set("EngineVersion", news.engineVersion);
+          set("AllowMajorVersionUpgrade", true);
+        }
+        if (news.dbParameterGroupName !== undefined) {
+          const observedGroup =
+            observed.DBParameterGroups?.[0]?.DBParameterGroupName;
+          if (news.dbParameterGroupName !== observedGroup) {
+            set("DBParameterGroupName", news.dbParameterGroupName);
+          }
+        }
+        if (news.vpcSecurityGroupIds !== undefined) {
+          const observedSGs = (observed.VpcSecurityGroups ?? [])
+            .flatMap((sg) =>
+              sg.VpcSecurityGroupId ? [sg.VpcSecurityGroupId] : [],
+            )
+            .sort();
+          const desiredSGs = [...news.vpcSecurityGroupIds].sort();
+          if (
+            observedSGs.length !== desiredSGs.length ||
+            observedSGs.some((id, i) => id !== desiredSGs[i])
+          ) {
+            set("VpcSecurityGroupIds", news.vpcSecurityGroupIds);
+          }
+        }
+        if (
+          news.publiclyAccessible !== undefined &&
+          news.publiclyAccessible !== observed.PubliclyAccessible
+        ) {
+          set("PubliclyAccessible", news.publiclyAccessible);
+        }
+        if (
+          news.promotionTier !== undefined &&
+          news.promotionTier !== observed.PromotionTier
+        ) {
+          set("PromotionTier", news.promotionTier);
+        }
+        if (
+          news.autoMinorVersionUpgrade !== undefined &&
+          news.autoMinorVersionUpgrade !== observed.AutoMinorVersionUpgrade
+        ) {
+          set("AutoMinorVersionUpgrade", news.autoMinorVersionUpgrade);
+        }
+        if (
+          news.copyTagsToSnapshot !== undefined &&
+          news.copyTagsToSnapshot !== observed.CopyTagsToSnapshot
+        ) {
+          set("CopyTagsToSnapshot", news.copyTagsToSnapshot);
+        }
+        if (
+          news.allocatedStorage !== undefined &&
+          news.allocatedStorage !== observed.AllocatedStorage
+        ) {
+          set("AllocatedStorage", news.allocatedStorage);
+        }
+        if (
+          news.backupRetentionPeriod !== undefined &&
+          news.backupRetentionPeriod !== observed.BackupRetentionPeriod
+        ) {
+          set("BackupRetentionPeriod", news.backupRetentionPeriod);
+        }
+        if (
+          news.preferredBackupWindow !== undefined &&
+          news.preferredBackupWindow !== observed.PreferredBackupWindow
+        ) {
+          set("PreferredBackupWindow", news.preferredBackupWindow);
+        }
+        return dirty ? payload : undefined;
+      };
 
       return {
         stables: ["dbInstanceArn", "dbInstanceIdentifier"],
@@ -214,6 +435,9 @@ export const DBInstanceProvider = () =>
                 PromotionTier: news.promotionTier,
                 AutoMinorVersionUpgrade: news.autoMinorVersionUpgrade,
                 CopyTagsToSnapshot: news.copyTagsToSnapshot,
+                AllocatedStorage: news.allocatedStorage,
+                BackupRetentionPeriod: news.backupRetentionPeriod,
+                PreferredBackupWindow: news.preferredBackupWindow,
                 Tags: Object.entries(desiredTags).map(([Key, Value]) => ({
                   Key,
                   Value,
@@ -226,56 +450,94 @@ export const DBInstanceProvider = () =>
                 ),
               );
 
-            observed = yield* waitForInstance(identifier);
+            observed = yield* waitForStableInstance(identifier, session);
+            if (!observed?.DBInstanceArn) {
+              return yield* Effect.fail(
+                new DBInstanceUnreadable({
+                  identifier,
+                  phase: "post-create",
+                }),
+              );
+            }
           } else {
-            // Sync mutable instance config — push desired shape via
-            // `modifyDBInstance`. Many fields land in
-            // `PendingModifiedValues`; `ApplyImmediately` shortens the wait.
-            yield* rds.modifyDBInstance({
-              DBInstanceIdentifier: identifier,
-              DBInstanceClass: news.dbInstanceClass,
-              EngineVersion: news.engineVersion,
-              DBParameterGroupName: news.dbParameterGroupName,
-              VpcSecurityGroupIds: news.vpcSecurityGroupIds,
-              PubliclyAccessible: news.publiclyAccessible,
-              PromotionTier: news.promotionTier,
-              AutoMinorVersionUpgrade: news.autoMinorVersionUpgrade,
-              CopyTagsToSnapshot: news.copyTagsToSnapshot,
-              ApplyImmediately: true,
-            });
-            observed = yield* waitForInstance(identifier);
+            // We observed an existing instance. If it's mid-transition
+            // (creating/modifying/backing-up/etc.), wait for a stable
+            // status before issuing modify so we don't trip
+            // `InvalidDBInstanceStateFault`.
+            if (!isStableInstanceStatus(observed.DBInstanceStatus)) {
+              yield* session.note(
+                `DB instance ${identifier}: observed in ${observed.DBInstanceStatus ?? "UNKNOWN"} state, waiting for stable before sync`,
+              );
+              observed = yield* waitForStableInstance(identifier, session);
+            }
+
+            // Sync mutable instance config — only call modify when
+            // observed config drifts from desired. Otherwise the call is
+            // a no-op that still triggers a `modifying` transition.
+            const modifyPayload = computeModifyPayload(observed, news);
+            if (modifyPayload) {
+              yield* retryControlPlane(rds.modifyDBInstance(modifyPayload));
+              observed = yield* waitForStableInstance(identifier, session);
+              if (!observed?.DBInstanceArn) {
+                return yield* Effect.fail(
+                  new DBInstanceUnreadable({
+                    identifier,
+                    phase: "post-modify",
+                  }),
+                );
+              }
+            }
           }
 
           const dbInstanceArn = observed.DBInstanceArn ?? "";
 
-          // Sync tags — diff observed cloud tags against desired.
+          // Sync tags — diff observed cloud tags against desired so
+          // adoption (where the live tags may not match what we last
+          // persisted) converges correctly.
           const observedTags = toTagRecord(observed.TagList);
           const { removed, upsert } = diffTags(observedTags, desiredTags);
           if (upsert.length > 0 && dbInstanceArn) {
-            yield* rds.addTagsToResource({
-              ResourceName: dbInstanceArn,
-              Tags: upsert,
-            });
+            yield* retryControlPlane(
+              rds.addTagsToResource({
+                ResourceName: dbInstanceArn,
+                Tags: upsert,
+              }),
+            );
           }
           if (removed.length > 0 && dbInstanceArn) {
-            yield* rds.removeTagsFromResource({
-              ResourceName: dbInstanceArn,
-              TagKeys: removed,
-            });
+            yield* retryControlPlane(
+              rds.removeTagsFromResource({
+                ResourceName: dbInstanceArn,
+                TagKeys: removed,
+              }),
+            );
           }
 
           yield* session.note(dbInstanceArn || identifier);
           return toAttrs({ instance: observed, tags: desiredTags });
         }),
         delete: Effect.fn(function* ({ output }) {
+          // Tolerate concurrent or already-issued deletes by retrying
+          // through `InvalidDBInstanceStateFault` (instance still
+          // transitioning into a delete-eligible state) up to the same
+          // bounded budget the reconciler uses.
           yield* rds
             .deleteDBInstance({
               DBInstanceIdentifier: output.dbInstanceIdentifier,
               SkipFinalSnapshot: true,
             })
             .pipe(
+              Effect.retry({
+                while: (e) => e._tag === "InvalidDBInstanceStateFault",
+                schedule: controlPlaneRetryPolicy,
+              }),
               Effect.catchTag("DBInstanceNotFoundFault", () => Effect.void),
             );
+
+          // Wait for the instance to actually leave RDS — otherwise a
+          // subsequent reconcile (or a replace) races against the
+          // `deleting` state and fails with InvalidDBInstanceState.
+          yield* waitForInstanceDeleted(output.dbInstanceIdentifier);
         }),
       };
     }),

--- a/packages/alchemy/test/AWS/RDS/DBInstance.test.ts
+++ b/packages/alchemy/test/AWS/RDS/DBInstance.test.ts
@@ -1,0 +1,453 @@
+import { adopt } from "@/AdoptPolicy";
+import * as AWS from "@/AWS";
+import { Vpc } from "@/AWS/EC2";
+import { Subnet } from "@/AWS/EC2/Subnet";
+import { SecurityGroup } from "@/AWS/EC2/SecurityGroup";
+import {
+  DBCluster,
+  DBInstance,
+  type DBInstanceProps,
+  DBSubnetGroup,
+} from "@/AWS/RDS";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import * as RDS from "@distilled.cloud/aws/rds";
+import { describe, expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+// RDS provisioning is slow and expensive — these tests are skipped in
+// CI and intended to be unskipped by hand against an isolated test
+// account when verifying the reconciler. Each timeout is 20 minutes,
+// which is enough for an Aurora Serverless v2 cluster + writer to
+// reach `available`, plus headroom for the modify and delete phases.
+
+const RDS_TIMEOUT = 1_200_000;
+
+describe("AWS.RDS.DBInstance", () => {
+  // ── Lifecycle convergence ────────────────────────────────────────────
+  //
+  // Each test runs `destroy → deploy → ... → destroy` and asserts that
+  // the reconciler converges every step regardless of starting state.
+  // Together they cover: idempotency, drift recovery via
+  // `modifyDBInstance`, replace on stable-prop change, double-destroy
+  // idempotency, and tag re-write on adopt(true) takeover.
+
+  test.provider.skip(
+    "redeploy with same props is a no-op (reconcile is idempotent)",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const network = networkFixture();
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* writerInstance("Idempotent", {});
+          }),
+        );
+
+        const second = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* writerInstance("Idempotent", {});
+          }),
+        );
+        expect(second.dbInstanceArn).toEqual(initial.dbInstanceArn);
+        expect(second.dbInstanceIdentifier).toEqual(
+          initial.dbInstanceIdentifier,
+        );
+
+        const described = yield* RDS.describeDBInstances({
+          DBInstanceIdentifier: second.dbInstanceIdentifier,
+        });
+        expect(described.DBInstances?.[0]?.DBInstanceStatus).toEqual(
+          "available",
+        );
+
+        yield* stack.destroy();
+        yield* assertDBInstanceDeleted(initial.dbInstanceIdentifier);
+      }),
+    { timeout: RDS_TIMEOUT },
+  );
+
+  test.provider.skip(
+    "reconcile resets backupRetentionPeriod / preferredBackupWindow / parameterGroup mutated out-of-band",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const network = networkFixture();
+        const instance = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* writerInstance("Drift", {
+              backupRetentionPeriod: 1,
+              preferredBackupWindow: "03:00-04:00",
+              autoMinorVersionUpgrade: true,
+              copyTagsToSnapshot: true,
+            });
+          }),
+        );
+
+        // Mutate every reconciled aspect out-of-band via the raw RDS SDK.
+        yield* RDS.modifyDBInstance({
+          DBInstanceIdentifier: instance.dbInstanceIdentifier,
+          BackupRetentionPeriod: 7,
+          PreferredBackupWindow: "10:00-11:00",
+          AutoMinorVersionUpgrade: false,
+          CopyTagsToSnapshot: false,
+          ApplyImmediately: true,
+        });
+        yield* RDS.removeTagsFromResource({
+          ResourceName: instance.dbInstanceArn,
+          TagKeys: ["alchemy::id"],
+        });
+        yield* RDS.addTagsToResource({
+          ResourceName: instance.dbInstanceArn,
+          Tags: [{ Key: "Owner", Value: "stolen" }],
+        });
+        yield* waitForDBInstanceAvailable(instance.dbInstanceIdentifier);
+
+        // Re-deploy with the original desired props — reconcile should
+        // converge each aspect back, including the alchemy internal tag.
+        const redeployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* writerInstance("Drift", {
+              backupRetentionPeriod: 1,
+              preferredBackupWindow: "03:00-04:00",
+              autoMinorVersionUpgrade: true,
+              copyTagsToSnapshot: true,
+            });
+          }),
+        );
+        expect(redeployed.dbInstanceArn).toEqual(instance.dbInstanceArn);
+        expect(redeployed.backupRetentionPeriod).toEqual(1);
+        expect(redeployed.preferredBackupWindow).toEqual("03:00-04:00");
+        expect(redeployed.tags["alchemy::id"]).toEqual("Drift");
+
+        yield* stack.destroy();
+        yield* assertDBInstanceDeleted(instance.dbInstanceIdentifier);
+      }),
+    { timeout: RDS_TIMEOUT },
+  );
+
+  test.provider.skip(
+    "changing dbInstanceIdentifier triggers replace, old instance is deleted",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const suffix = Math.random().toString(36).slice(2, 8);
+        const idA = `alchemy-test-rds-replace-a-${suffix}`;
+        const idB = `alchemy-test-rds-replace-b-${suffix}`;
+
+        const network = networkFixture();
+        const a = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* writerInstance("Replaceable", {
+              dbInstanceIdentifier: idA,
+            });
+          }),
+        );
+        expect(a.dbInstanceIdentifier).toEqual(idA);
+
+        const b = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* writerInstance("Replaceable", {
+              dbInstanceIdentifier: idB,
+            });
+          }),
+        );
+        expect(b.dbInstanceIdentifier).toEqual(idB);
+        expect(b.dbInstanceArn).not.toEqual(a.dbInstanceArn);
+        yield* assertDBInstanceDeleted(idA);
+
+        yield* stack.destroy();
+        yield* assertDBInstanceDeleted(idB);
+      }),
+    { timeout: RDS_TIMEOUT },
+  );
+
+  test.provider.skip(
+    "in-place modification of allocatedStorage scales the instance",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const network = networkFixture({ aurora: false });
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* standaloneInstance("ScaleStorage", {
+              allocatedStorage: 20,
+            });
+          }),
+        );
+        expect(initial.allocatedStorage).toEqual(20);
+
+        const scaled = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* standaloneInstance("ScaleStorage", {
+              allocatedStorage: 30,
+            });
+          }),
+        );
+        expect(scaled.dbInstanceArn).toEqual(initial.dbInstanceArn);
+        // RDS may report the new value either immediately or via
+        // PendingModifiedValues — wait for it to land.
+        yield* waitForAllocatedStorage(scaled.dbInstanceIdentifier, 30);
+
+        yield* stack.destroy();
+        yield* assertDBInstanceDeleted(initial.dbInstanceIdentifier);
+      }),
+    { timeout: RDS_TIMEOUT },
+  );
+
+  test.provider.skip(
+    "destroying an already-deleted instance is a no-op",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const network = networkFixture();
+        const instance = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* writerInstance("DoubleDestroy", {});
+          }),
+        );
+
+        // Delete out-of-band and wait for the deletion to fully converge,
+        // then ask the engine to destroy. Provider's `delete` must catch
+        // DBInstanceNotFoundFault and complete cleanly.
+        yield* RDS.deleteDBInstance({
+          DBInstanceIdentifier: instance.dbInstanceIdentifier,
+          SkipFinalSnapshot: true,
+        });
+        yield* assertDBInstanceDeleted(instance.dbInstanceIdentifier);
+
+        yield* stack.destroy();
+      }),
+    { timeout: RDS_TIMEOUT },
+  );
+
+  test.provider.skip(
+    "foreign-tagged instance requires adopt(true) to take over and re-tag",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const dbInstanceIdentifier = `alchemy-test-rds-adopt-${Math.random()
+          .toString(36)
+          .slice(2, 8)}`;
+        const network = networkFixture();
+
+        const original = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* writerInstance("Original", {
+              dbInstanceIdentifier,
+            });
+          }),
+        );
+
+        // Wipe state — the instance stays in RDS — and remove our
+        // ownership tag so it appears foreign on next read.
+        yield* RDS.removeTagsFromResource({
+          ResourceName: original.dbInstanceArn,
+          TagKeys: ["alchemy::app", "alchemy::stage", "alchemy::id"],
+        });
+
+        yield* Effect.gen(function* () {
+          const state = yield* State;
+          yield* state.delete({
+            stack: stack.name,
+            stage: "test",
+            fqn: "Original",
+          });
+        }).pipe(Effect.provide(stack.state));
+
+        const takenOver = yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              yield* network;
+              return yield* writerInstance("Different", {
+                dbInstanceIdentifier,
+              });
+            }),
+          )
+          .pipe(adopt(true));
+
+        expect(takenOver.dbInstanceIdentifier).toEqual(dbInstanceIdentifier);
+        expect(takenOver.dbInstanceArn).toEqual(original.dbInstanceArn);
+        expect(takenOver.tags["alchemy::id"]).toEqual("Different");
+
+        yield* stack.destroy();
+        yield* assertDBInstanceDeleted(takenOver.dbInstanceIdentifier);
+      }),
+    { timeout: RDS_TIMEOUT },
+  );
+});
+
+// ── Test fixtures ─────────────────────────────────────────────────────
+
+/**
+ * Build a minimal RDS-ready VPC: 2 subnets across AZs (RDS DB subnet
+ * groups require ≥2), a SG that lets the cluster talk to itself, and a
+ * `DBSubnetGroup` referencing them. Returns the names/ids the cluster
+ * and instance need.
+ *
+ * For Aurora cluster member tests, also creates the `DBCluster` so the
+ * `DBInstance` only needs `dbClusterIdentifier`.
+ */
+const networkFixture = (
+  options: { aurora?: boolean } = { aurora: true },
+) =>
+  Effect.gen(function* () {
+    const vpc = yield* Vpc("RdsTestVpc", {
+      cidrBlock: "10.42.0.0/16",
+      enableDnsSupport: true,
+      enableDnsHostnames: true,
+    });
+    const subnetA = yield* Subnet("RdsTestSubnetA", {
+      vpcId: vpc.vpcId,
+      cidrBlock: "10.42.1.0/24",
+      availabilityZone: "us-east-1a",
+    });
+    const subnetB = yield* Subnet("RdsTestSubnetB", {
+      vpcId: vpc.vpcId,
+      cidrBlock: "10.42.2.0/24",
+      availabilityZone: "us-east-1b",
+    });
+    const sg = yield* SecurityGroup("RdsTestSG", {
+      vpcId: vpc.vpcId,
+      groupName: "alchemy-test-rds-sg",
+      description: "Test SG for RDS hardening",
+    });
+    const subnetGroup = yield* DBSubnetGroup("RdsTestSubnetGroup", {
+      subnetIds: [subnetA.subnetId, subnetB.subnetId],
+    });
+    if (!options.aurora) {
+      return {
+        dbSubnetGroupName: subnetGroup.dbSubnetGroupName,
+        vpcSecurityGroupIds: [sg.groupId],
+        dbClusterIdentifier: undefined as string | undefined,
+      };
+    }
+    const cluster = yield* DBCluster("RdsTestCluster", {
+      engine: "aurora-postgresql",
+      dbSubnetGroupName: subnetGroup.dbSubnetGroupName,
+      vpcSecurityGroupIds: [sg.groupId],
+      manageMasterUserPassword: true,
+      masterUsername: "alchemy",
+      serverlessV2ScalingConfiguration: {
+        MinCapacity: 0.5,
+        MaxCapacity: 1,
+      },
+      engineMode: "provisioned",
+    });
+    return {
+      dbSubnetGroupName: subnetGroup.dbSubnetGroupName,
+      vpcSecurityGroupIds: [sg.groupId],
+      dbClusterIdentifier: cluster.dbClusterIdentifier,
+    };
+  });
+
+const writerInstance = (
+  id: string,
+  overrides: Partial<DBInstanceProps>,
+) =>
+  Effect.gen(function* () {
+    // Aurora cluster member — cheapest setup, ~5min create.
+    return yield* DBInstance(id, {
+      dbInstanceClass: "db.serverless",
+      engine: "aurora-postgresql",
+      promotionTier: 0,
+      autoMinorVersionUpgrade: true,
+      copyTagsToSnapshot: true,
+      ...overrides,
+    });
+  });
+
+const standaloneInstance = (
+  id: string,
+  overrides: Partial<DBInstanceProps>,
+) =>
+  Effect.gen(function* () {
+    // Standalone (non-Aurora) for storage-scaling tests; cluster
+    // members ignore `allocatedStorage`.
+    return yield* DBInstance(id, {
+      dbInstanceClass: "db.t3.micro",
+      engine: "postgres",
+      allocatedStorage: 20,
+      ...overrides,
+    });
+  });
+
+// ── Polling helpers ──────────────────────────────────────────────────
+
+class DBInstanceNotAvailable extends Data.TaggedError(
+  "DBInstanceNotAvailable",
+)<{ status: string | undefined }> {}
+
+class DBInstanceStorageStale extends Data.TaggedError(
+  "DBInstanceStorageStale",
+)<{ observed: number | undefined; expected: number }> {}
+
+class DBInstanceStillExists extends Data.TaggedError("DBInstanceStillExists") {}
+
+const stableStateSchedule = Schedule.fixed("10 seconds").pipe(
+  Schedule.both(Schedule.recurs(120)),
+);
+
+const waitForDBInstanceAvailable = Effect.fn(function* (identifier: string) {
+  yield* RDS.describeDBInstances({ DBInstanceIdentifier: identifier }).pipe(
+    Effect.flatMap((r) => {
+      const status = r.DBInstances?.[0]?.DBInstanceStatus;
+      return status === "available"
+        ? Effect.void
+        : Effect.fail(new DBInstanceNotAvailable({ status }));
+    }),
+    Effect.retry({
+      while: (e) => e._tag === "DBInstanceNotAvailable",
+      schedule: stableStateSchedule,
+    }),
+  );
+});
+
+const waitForAllocatedStorage = Effect.fn(function* (
+  identifier: string,
+  expected: number,
+) {
+  yield* RDS.describeDBInstances({ DBInstanceIdentifier: identifier }).pipe(
+    Effect.flatMap((r) => {
+      const observed = r.DBInstances?.[0]?.AllocatedStorage;
+      return observed === expected
+        ? Effect.void
+        : Effect.fail(new DBInstanceStorageStale({ observed, expected }));
+    }),
+    Effect.retry({
+      while: (e) => e._tag === "DBInstanceStorageStale",
+      schedule: stableStateSchedule,
+    }),
+  );
+});
+
+const assertDBInstanceDeleted = Effect.fn(function* (identifier: string) {
+  yield* RDS.describeDBInstances({ DBInstanceIdentifier: identifier }).pipe(
+    Effect.flatMap(() => Effect.fail(new DBInstanceStillExists())),
+    Effect.retry({
+      while: (e) => e._tag === "DBInstanceStillExists",
+      schedule: stableStateSchedule,
+    }),
+    Effect.catchTag("DBInstanceNotFoundFault", () => Effect.void),
+  );
+});


### PR DESCRIPTION
Stacked on #179 (`refactor(core): collapse provider create+update into reconcile`). Per-resource hardening sweep for `AWS.RDS.DBInstance`.

### Reconciler changes

`waitForInstance` previously returned as soon as `DBInstanceArn` was non-null and capped at a 60s budget. RDS create cycles are 5-15 minutes, so the wait was strictly less than the typical create time and would return an instance still in `creating` status. Replace with `waitForStableInstance` which only succeeds on a terminal-for-our-purposes status and polls for up to 25min.

```ts
const isStableInstanceStatus = (status: string | undefined) =>
  status === "available" ||
  status === "stopped" ||
  status === "incompatible-network" ||
  // ...
  status === "failed";
```

`modifyDBInstance` was called blindly on every reconcile after observation — even when desired matched observed — triggering a needless `modifying` transition. Replace with a diff-driven `computeModifyPayload` that returns `undefined` on no-op so the API call is skipped entirely.

```ts
const modifyPayload = computeModifyPayload(observed, news);
if (modifyPayload) {
  yield* retryControlPlane(rds.modifyDBInstance(modifyPayload));
  observed = yield* waitForStableInstance(identifier, session);
}
```

Wrap `modifyDBInstance` / `addTagsToResource` / `removeTagsFromResource` in `retryControlPlane` which rides out `InvalidDBInstanceStateFault` and `DBInstanceNotFoundFault` races (instance mid-transition or just-tagged).

```ts
const retryControlPlane = <A, E extends { _tag?: string }, R>(
  effect: Effect.Effect<A, E, R>,
) =>
  effect.pipe(
    Effect.retry({
      while: (e) =>
        e._tag === "InvalidDBInstanceStateFault" ||
        e._tag === "DBInstanceNotFoundFault",
      schedule: Schedule.exponential("1 second").pipe(
        Schedule.both(Schedule.recurs(20)),
      ),
    }),
  );
```

`delete` now retries `InvalidDBInstanceStateFault` (so a delete issued during a backup or modify converges) and waits for the instance to actually leave RDS via `waitForInstanceDeleted` so a subsequent reconcile or replace doesn't race against `deleting` state.

If observation finds an existing instance in a non-stable status (e.g. mid-creation from a previous reconcile that crashed before persisting state), wait for stable before issuing modify to avoid `InvalidDBInstanceStateFault`.

Replace ad-hoc `Effect.fail(new Error(...))` sites with typed `DBInstanceUnreadable` / `DBInstanceNotStable` / `DBInstanceStillDeleting` so the IaC error channel stays typed.

Add `allocatedStorage` / `backupRetentionPeriod` / `preferredBackupWindow` props (and corresponding attributes) so the resource is usable for non-Aurora standalone instances and so the storage-scaling drift test has something to mutate.

### New lifecycle tests

Skipped by default — RDS provisioning is too costly for CI. Unskip when verifying.

- Redeploy with same props is a no-op (reconcile is idempotent)
- Reconcile resets `backupRetentionPeriod` / `preferredBackupWindow` / `autoMinorVersionUpgrade` / `copyTagsToSnapshot` / tags after out-of-band SDK mutation, including re-stamping internal alchemy tags after they're untagged
- Changing `dbInstanceIdentifier` triggers replace, old instance is deleted
- In-place modification of `allocatedStorage` scales a standalone instance (Aurora cluster members ignore it)
- Destroying an already-deleted instance is a no-op
- `adopt(true)` re-tags a foreign instance

### Distilled patch

https://github.com/alchemy-run/distilled/pull/249 — adds the missing `errorCategories` block so `InvalidDBInstanceState` / `Throttling` / `RequestLimitExceeded` / capacity faults participate in the AWS retry layer instead of surfacing as hard `BadRequestError`.

### Baseline fix

`packages/alchemy/test/test.resources.ts` had a pre-existing tsc error on this branch (`output` is possibly undefined post-reconcile refactor). Carried forward the same fix the SQS / DynamoDB hardening PRs applied so the baseline `bun tsc -b` is clean.
