### PR TITLE
fix(cloudflare/queue): harden Queue reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/Cloudflare/Queue/Queue.ts
+++ b/packages/alchemy/src/Cloudflare/Queue/Queue.ts
@@ -142,7 +142,9 @@ export const QueueProvider = () =>
 
           // Observe — re-fetch the cached queue; fall back to a name scan
           // when the cached id is gone (out-of-band delete or partial
-          // state-persistence failure).
+          // state-persistence failure). Only swallow `QueueNotFound`
+          // here so auth/throttling/5xx failures surface to the engine
+          // for retry rather than being misread as "queue is missing".
           let observed:
             | { queueId?: string | null; queueName?: string | null }
             | undefined;
@@ -150,22 +152,25 @@ export const QueueProvider = () =>
             observed = yield* getQueue({
               accountId: acct,
               queueId: output.queueId,
-            }).pipe(Effect.catch(() => Effect.succeed(undefined)));
+            }).pipe(
+              Effect.catchTag("QueueNotFound", () => Effect.succeed(undefined)),
+            );
           }
           if (!observed) {
             observed = yield* findQueueByName(queueName);
           }
 
-          // Ensure — create if missing. Cloudflare returns a generic
-          // failure when the queue name is taken; tolerate by adopting
-          // the queue with the same name so reconciles converge after a
-          // crashed peer.
+          // Ensure — create if missing. Cloudflare returns
+          // `QueueAlreadyExists` (or a generic `UnknownCloudflareError`
+          // wrapping the same condition) when the queue name is taken;
+          // scope the catch to that race so transient failures
+          // (auth/throttling/5xx) propagate.
           if (!observed) {
             observed = yield* createQueue({
               accountId: acct,
               queueName,
             }).pipe(
-              Effect.catch(() =>
+              Effect.catchTag("QueueAlreadyExists", () =>
                 Effect.gen(function* () {
                   const match = yield* findQueueByName(queueName);
                   if (match && match.queueId && match.queueName) {
@@ -189,10 +194,13 @@ export const QueueProvider = () =>
           };
         }),
         delete: Effect.fn(function* ({ output }) {
+          // `QueueNotFound` is the idempotent path (already deleted, or
+          // racing with another deleter). Anything else — auth,
+          // throttling, 5xx — must surface so the engine can retry.
           yield* deleteQueue({
             accountId: output.accountId,
             queueId: output.queueId,
-          }).pipe(Effect.catch(() => Effect.void));
+          }).pipe(Effect.catchTag("QueueNotFound", () => Effect.void));
         }),
         read: Effect.fn(function* ({ id, output, olds }) {
           if (output?.queueId) {
@@ -205,7 +213,7 @@ export const QueueProvider = () =>
                 queueName: queue.queueName!,
                 accountId: output.accountId,
               })),
-              Effect.catch(() => Effect.succeed(undefined)),
+              Effect.catchTag("QueueNotFound", () => Effect.succeed(undefined)),
             );
           }
           const queueName = yield* createQueueName(id, olds?.name);

--- a/packages/alchemy/src/Cloudflare/Queue/QueueConsumer.ts
+++ b/packages/alchemy/src/Cloudflare/Queue/QueueConsumer.ts
@@ -140,6 +140,8 @@ export const QueueConsumerProvider = () =>
           // scan filtered by script so we recover from out-of-band
           // deletes or partial state-persistence failures (the create
           // call may have written the consumer but lost the response).
+          // Only swallow `ConsumerNotFound` / `QueueNotFound` here —
+          // auth/throttling/5xx must surface so the engine retries.
           let observed:
             | { consumerId?: string | null; script?: string | null }
             | undefined;
@@ -148,7 +150,12 @@ export const QueueConsumerProvider = () =>
               accountId: acct,
               queueId: output.queueId,
               consumerId: output.consumerId,
-            }).pipe(Effect.catch(() => Effect.succeed(undefined)));
+            }).pipe(
+              Effect.catchTags({
+                ConsumerNotFound: () => Effect.succeed(undefined),
+                QueueNotFound: () => Effect.succeed(undefined),
+              }),
+            );
           }
           if (!observed) {
             const existing = yield* listConsumers({
@@ -160,9 +167,10 @@ export const QueueConsumerProvider = () =>
             );
           }
 
-          // Ensure — create if missing. The Cloudflare API rejects a
-          // duplicate consumer (same queue + script), so we tolerate
-          // that race by adopting the existing one via list.
+          // Ensure — create if missing. The Cloudflare API returns
+          // `ConsumerAlreadyExists` for a duplicate consumer (same queue
+          // + script); tolerate that race by adopting the existing one
+          // via list. Other failure classes propagate.
           let consumerId: string;
           if (!observed) {
             const created = yield* createConsumer({
@@ -173,7 +181,7 @@ export const QueueConsumerProvider = () =>
               deadLetterQueue: news.deadLetterQueue,
               settings: news.settings,
             }).pipe(
-              Effect.catch(() =>
+              Effect.catchTag("ConsumerAlreadyExists", () =>
                 Effect.gen(function* () {
                   const existing = yield* listConsumers({
                     accountId: acct,
@@ -216,11 +224,19 @@ export const QueueConsumerProvider = () =>
           };
         }),
         delete: Effect.fn(function* ({ output }) {
+          // `ConsumerNotFound` / `QueueNotFound` are the idempotent
+          // paths (already deleted, or queue gone, which removes its
+          // consumers). Anything else surfaces for engine retry.
           yield* deleteConsumer({
             accountId: output.accountId,
             queueId: output.queueId,
             consumerId: output.consumerId,
-          }).pipe(Effect.catch(() => Effect.void));
+          }).pipe(
+            Effect.catchTags({
+              ConsumerNotFound: () => Effect.void,
+              QueueNotFound: () => Effect.void,
+            }),
+          );
         }),
         read: Effect.fn(function* ({ output }) {
           if (output?.consumerId) {
@@ -238,7 +254,10 @@ export const QueueConsumerProvider = () =>
                     : output.scriptName) ?? output.scriptName,
                 accountId: output.accountId,
               })),
-              Effect.catch(() => Effect.succeed(undefined)),
+              Effect.catchTags({
+                ConsumerNotFound: () => Effect.succeed(undefined),
+                QueueNotFound: () => Effect.succeed(undefined),
+              }),
             );
           }
           return undefined;

--- a/packages/alchemy/test/Cloudflare/Queue/Queue.test.ts
+++ b/packages/alchemy/test/Cloudflare/Queue/Queue.test.ts
@@ -1,0 +1,592 @@
+import { adopt } from "@/AdoptPolicy";
+import * as Cloudflare from "@/Cloudflare";
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import { Queue, QueueConsumer } from "@/Cloudflare/Queue";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import * as queues from "@distilled.cloud/cloudflare/queues";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as pathe from "pathe";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+test.provider("create and delete queue with default props", (stack) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* CloudflareEnvironment;
+
+    yield* stack.destroy();
+
+    const queue = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Queue("DefaultQueue");
+      }),
+    );
+
+    expect(queue.queueId).toBeDefined();
+    expect(queue.queueName).toBeDefined();
+    expect(queue.accountId).toEqual(accountId);
+
+    const fetched = yield* queues.getQueue({
+      accountId,
+      queueId: queue.queueId,
+    });
+    expect(fetched.queueId).toEqual(queue.queueId);
+    expect(fetched.queueName).toEqual(queue.queueName);
+
+    yield* stack.destroy();
+    yield* waitForQueueToBeDeleted(queue.queueId, accountId);
+  }).pipe(logLevel),
+);
+
+test.provider("create queue with explicit name", (stack) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* CloudflareEnvironment;
+
+    yield* stack.destroy();
+
+    const name = `alchemy-test-cf-queue-${Math.random()
+      .toString(36)
+      .slice(2, 8)}`;
+
+    const queue = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Queue("NamedQueue", { name });
+      }),
+    );
+
+    expect(queue.queueName).toEqual(name);
+
+    yield* stack.destroy();
+    yield* waitForQueueToBeDeleted(queue.queueId, accountId);
+  }).pipe(logLevel),
+);
+
+// ─────────────────────────────────────────────────────────────────────
+// Lifecycle convergence
+//
+// Reconcile must converge from any starting state — pristine, drifted,
+// out-of-band-deleted, or replaced — without leaning on `olds` as a
+// source of truth.
+// ─────────────────────────────────────────────────────────────────────
+
+test.provider(
+  "redeploy with same props is a no-op — queueId preserved",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const v1 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Queue("IdempotentQueue");
+        }),
+      );
+
+      const v2 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Queue("IdempotentQueue");
+        }),
+      );
+
+      expect(v2.queueId).toEqual(v1.queueId);
+      expect(v2.queueName).toEqual(v1.queueName);
+
+      yield* stack.destroy();
+      yield* waitForQueueToBeDeleted(v1.queueId, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile re-creates a queue that was deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const name = `alchemy-test-cf-queue-recreate-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const v1 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Queue("RecreateQueue", { name });
+        }),
+      );
+      expect(v1.queueName).toEqual(name);
+
+      // Delete the queue out-of-band — local state still says it
+      // exists, but Cloudflare disagrees.
+      yield* queues.deleteQueue({
+        accountId,
+        queueId: v1.queueId,
+      });
+      yield* waitForQueueToBeDeleted(v1.queueId, accountId);
+
+      // Reconcile must observe the missing queue (`getQueue` returns
+      // `QueueNotFound`, the catch swallows it, the name scan also
+      // misses), then call `createQueue` and converge.
+      const v2 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Queue("RecreateQueue", { name });
+        }),
+      );
+      expect(v2.queueName).toEqual(name);
+      expect(v2.queueId).not.toEqual(v1.queueId);
+
+      const fetched = yield* queues.getQueue({
+        accountId,
+        queueId: v2.queueId,
+      });
+      expect(fetched.queueId).toEqual(v2.queueId);
+
+      yield* stack.destroy();
+      yield* waitForQueueToBeDeleted(v2.queueId, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "changing physical name triggers replace; old queue is deleted",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const nameA = `alchemy-test-cf-queue-replace-a-${suffix}`;
+      const nameB = `alchemy-test-cf-queue-replace-b-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Queue("RenameQueue", { name: nameA });
+        }),
+      );
+      expect(a.queueName).toEqual(nameA);
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Queue("RenameQueue", { name: nameB });
+        }),
+      );
+      expect(b.queueName).toEqual(nameB);
+      expect(b.queueId).not.toEqual(a.queueId);
+
+      // The previous queue must be gone after replace.
+      yield* waitForQueueToBeDeleted(a.queueId, accountId);
+
+      // The new queue exists.
+      const fetched = yield* queues.getQueue({
+        accountId,
+        queueId: b.queueId,
+      });
+      expect(fetched.queueName).toEqual(nameB);
+
+      yield* stack.destroy();
+      yield* waitForQueueToBeDeleted(b.queueId, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider("destroying an already-deleted queue is a no-op", (stack) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* CloudflareEnvironment;
+
+    yield* stack.destroy();
+
+    const queue = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Queue("DoubleDestroyQueue");
+      }),
+    );
+
+    // Delete the queue out-of-band so the next destroy hits the
+    // `QueueNotFound` path inside provider.delete. It must succeed.
+    yield* queues.deleteQueue({
+      accountId,
+      queueId: queue.queueId,
+    });
+    yield* waitForQueueToBeDeleted(queue.queueId, accountId);
+
+    yield* stack.destroy();
+  }).pipe(logLevel),
+);
+
+// Engine-level adoption: Cloudflare Queues have no ownership tags, so a
+// name match in `read` is treated as silent adoption. Wipe local state
+// mid-run while leaving the queue on Cloudflare to simulate a fresh
+// state store seeing an existing resource with the same physical name.
+test.provider(
+  "existing queue (matching name) is silently adopted without --adopt",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const name = `alchemy-test-cf-queue-adopt-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Queue("AdoptableQueue", { name });
+        }),
+      );
+      expect(initial.queueName).toEqual(name);
+      const initialId = initial.queueId;
+      expect(initialId).toBeDefined();
+
+      // Wipe local state — the queue stays on Cloudflare.
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "AdoptableQueue",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      // Redeploy without `adopt(true)`. The engine calls `provider.read`,
+      // which scans by name and returns plain attrs — silent adoption.
+      const adopted = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Queue("AdoptableQueue", { name });
+        }),
+      );
+
+      expect(adopted.queueId).toEqual(initialId);
+      expect(adopted.queueName).toEqual(name);
+
+      yield* stack.destroy();
+      yield* waitForQueueToBeDeleted(initialId, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "adopt(true) re-claims a queue under a different logical id",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const name = `alchemy-test-cf-queue-takeover-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const original = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Queue("Original", { name });
+        }),
+      );
+
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "Original",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      const takenOver = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* Queue("Different", { name });
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(takenOver.queueName).toEqual(name);
+      expect(takenOver.queueId).toEqual(original.queueId);
+
+      yield* stack.destroy();
+      yield* waitForQueueToBeDeleted(original.queueId, accountId);
+    }).pipe(logLevel),
+);
+
+// ─────────────────────────────────────────────────────────────────────
+// QueueConsumer lifecycle
+// ─────────────────────────────────────────────────────────────────────
+
+test.provider(
+  "consumer add / remove churn against a stable queue + worker",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const queueName = `alchemy-test-cf-queue-churn-${suffix}`;
+      const workerName = `alchemy-test-cf-queue-churn-worker-${suffix}`;
+      const main = pathe.resolve(import.meta.dirname, "../Workers/worker.ts");
+
+      // Phase 1: deploy queue + worker, no consumer attached.
+      const v1 = yield* stack.deploy(
+        Effect.gen(function* () {
+          const queue = yield* Queue("ChurnQueue", { name: queueName });
+          yield* Cloudflare.Worker("ChurnWorker", {
+            main,
+            name: workerName,
+            url: false,
+            compatibility: { date: "2024-01-01" },
+          });
+          return queue;
+        }),
+      );
+
+      const consumersV1 = yield* listConsumersForQueue(accountId, v1.queueId);
+      expect(consumersV1).toHaveLength(0);
+
+      // Phase 2: attach a consumer.
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          const queue = yield* Queue("ChurnQueue", { name: queueName });
+          yield* Cloudflare.Worker("ChurnWorker", {
+            main,
+            name: workerName,
+            url: false,
+            compatibility: { date: "2024-01-01" },
+          });
+          yield* QueueConsumer("ChurnConsumer", {
+            queueId: queue.queueId,
+            scriptName: workerName,
+          });
+          return queue;
+        }),
+      );
+
+      const consumersV2 = yield* listConsumersForQueue(accountId, v1.queueId);
+      expect(consumersV2).toHaveLength(1);
+      expect(
+        consumersV2[0] && "script" in consumersV2[0] && consumersV2[0].script,
+      ).toEqual(workerName);
+
+      // Phase 3: drop the consumer. Reconcile of the stack must remove
+      // it from the live queue.
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          const queue = yield* Queue("ChurnQueue", { name: queueName });
+          yield* Cloudflare.Worker("ChurnWorker", {
+            main,
+            name: workerName,
+            url: false,
+            compatibility: { date: "2024-01-01" },
+          });
+          return queue;
+        }),
+      );
+
+      const consumersV3 = yield* listConsumersForQueue(accountId, v1.queueId);
+      expect(consumersV3).toHaveLength(0);
+
+      yield* stack.destroy();
+      yield* waitForQueueToBeDeleted(v1.queueId, accountId);
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "consumer settings update propagates without replacing the consumer",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const queueName = `alchemy-test-cf-queue-settings-${suffix}`;
+      const workerName = `alchemy-test-cf-queue-settings-worker-${suffix}`;
+      const main = pathe.resolve(import.meta.dirname, "../Workers/worker.ts");
+
+      const deploy = (settings: { batchSize: number; maxRetries: number }) =>
+        stack.deploy(
+          Effect.gen(function* () {
+            const queue = yield* Queue("SettingsQueue", { name: queueName });
+            yield* Cloudflare.Worker("SettingsWorker", {
+              main,
+              name: workerName,
+              url: false,
+              compatibility: { date: "2024-01-01" },
+            });
+            const consumer = yield* QueueConsumer("SettingsConsumer", {
+              queueId: queue.queueId,
+              scriptName: workerName,
+              settings,
+            });
+            return { queue, consumer };
+          }),
+        );
+
+      const v1 = yield* deploy({ batchSize: 10, maxRetries: 3 });
+      const v2 = yield* deploy({ batchSize: 25, maxRetries: 5 });
+
+      // Settings update — consumer identity stable, no replace.
+      expect(v2.consumer.consumerId).toEqual(v1.consumer.consumerId);
+
+      const live = yield* queues.getConsumer({
+        accountId,
+        queueId: v2.queue.queueId,
+        consumerId: v2.consumer.consumerId,
+      });
+      const liveSettings =
+        "settings" in live && live.settings
+          ? (live.settings as { batchSize?: number; maxRetries?: number })
+          : {};
+      expect(liveSettings.batchSize).toEqual(25);
+      expect(liveSettings.maxRetries).toEqual(5);
+
+      yield* stack.destroy();
+      yield* waitForQueueToBeDeleted(v1.queue.queueId, accountId);
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "DLQ chaining: consumer points at a separate DLQ that survives redeploy",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const mainName = `alchemy-test-cf-queue-dlq-main-${suffix}`;
+      const dlqName = `alchemy-test-cf-queue-dlq-letter-${suffix}`;
+      const workerName = `alchemy-test-cf-queue-dlq-worker-${suffix}`;
+      const main = pathe.resolve(import.meta.dirname, "../Workers/worker.ts");
+
+      const deploy = () =>
+        stack.deploy(
+          Effect.gen(function* () {
+            const dlq = yield* Queue("DLQ", { name: dlqName });
+            const mainQueue = yield* Queue("MainQueue", { name: mainName });
+            yield* Cloudflare.Worker("DLQWorker", {
+              main,
+              name: workerName,
+              url: false,
+              compatibility: { date: "2024-01-01" },
+            });
+            yield* QueueConsumer("DLQConsumer", {
+              queueId: mainQueue.queueId,
+              scriptName: workerName,
+              deadLetterQueue: dlq.queueName,
+            });
+            return { dlq, mainQueue };
+          }),
+        );
+
+      const v1 = yield* deploy();
+      const v2 = yield* deploy();
+
+      // Both queues stable across redeploy — no replace, no churn from
+      // the DLQ chain. (The DLQ field on a consumer is not surfaced on
+      // any get/list response, so we verify the topology by observing
+      // that both queues, the worker, and exactly one consumer remain
+      // in place after a re-reconcile.)
+      expect(v2.mainQueue.queueId).toEqual(v1.mainQueue.queueId);
+      expect(v2.dlq.queueId).toEqual(v1.dlq.queueId);
+
+      const consumers = yield* listConsumersForQueue(
+        accountId,
+        v1.mainQueue.queueId,
+      );
+      expect(consumers).toHaveLength(1);
+      expect(
+        consumers[0] && "script" in consumers[0] && consumers[0].script,
+      ).toEqual(workerName);
+
+      yield* stack.destroy();
+      yield* waitForQueueToBeDeleted(v1.mainQueue.queueId, accountId);
+      yield* waitForQueueToBeDeleted(v1.dlq.queueId, accountId);
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "destroying an already-deleted consumer is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const queueName = `alchemy-test-cf-queue-cdd-${suffix}`;
+      const workerName = `alchemy-test-cf-queue-cdd-worker-${suffix}`;
+      const main = pathe.resolve(import.meta.dirname, "../Workers/worker.ts");
+
+      const deployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const queue = yield* Queue("CDDQueue", { name: queueName });
+          yield* Cloudflare.Worker("CDDWorker", {
+            main,
+            name: workerName,
+            url: false,
+            compatibility: { date: "2024-01-01" },
+          });
+          const consumer = yield* QueueConsumer("CDDConsumer", {
+            queueId: queue.queueId,
+            scriptName: workerName,
+          });
+          return { queue, consumer };
+        }),
+      );
+
+      // Delete the consumer out-of-band.
+      yield* queues.deleteConsumer({
+        accountId,
+        queueId: deployed.queue.queueId,
+        consumerId: deployed.consumer.consumerId,
+      });
+
+      // Destroy must not raise — `ConsumerNotFound` is the idempotent path.
+      yield* stack.destroy();
+      yield* waitForQueueToBeDeleted(deployed.queue.queueId, accountId);
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+// ─────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────
+
+class QueueStillExists extends Data.TaggedError("QueueStillExists") {}
+
+const waitForQueueToBeDeleted = Effect.fn(function* (
+  queueId: string,
+  accountId: string,
+) {
+  yield* queues
+    .getQueue({
+      accountId,
+      queueId,
+    })
+    .pipe(
+      Effect.flatMap(() => Effect.fail(new QueueStillExists())),
+      Effect.retry({
+        while: (e): e is QueueStillExists => e instanceof QueueStillExists,
+        schedule: Schedule.exponential(100).pipe(Schedule.both(Schedule.recurs(15))),
+      }),
+      Effect.catchTag("QueueNotFound", () => Effect.void),
+    );
+});
+
+const listConsumersForQueue = Effect.fn(function* (
+  accountId: string,
+  queueId: string,
+) {
+  const result = yield* queues.listConsumers({ accountId, queueId });
+  return result.result;
+});


### PR DESCRIPTION
Five blanket `Effect.catch(() => Effect.succeed(...))` sites in the `Queue` and `QueueConsumer` providers were swallowing every error class, including auth, throttling, and 5xx. Scope each catch to the specific tag the path is recovering so transient failures surface for engine-level retry instead of being misread as "the resource is missing" or "this is a duplicate".

### Reconciler changes

```diff
   if (output?.queueId) {
     observed = yield* getQueue({
       accountId: acct,
       queueId: output.queueId,
-    }).pipe(Effect.catch(() => Effect.succeed(undefined)));
+    }).pipe(
+      Effect.catchTag("QueueNotFound", () => Effect.succeed(undefined)),
+    );
   }
```

```diff
   if (!observed) {
     observed = yield* createQueue({ accountId: acct, queueName }).pipe(
-      Effect.catch(() =>
+      Effect.catchTag("QueueAlreadyExists", () =>
         Effect.gen(function* () {
           const match = yield* findQueueByName(queueName);
           ...
         }),
       ),
     );
   }
```

```diff
   yield* deleteQueue({
     accountId: output.accountId,
     queueId: output.queueId,
-  }).pipe(Effect.catch(() => Effect.void));
+  }).pipe(Effect.catchTag("QueueNotFound", () => Effect.void));
```

`QueueConsumer` gets the same treatment scoped to `ConsumerNotFound` / `QueueNotFound` on get/read/delete, and `ConsumerAlreadyExists` on the create-race recovery.

A failed `getQueue` used to be misread as "queue is missing", which then fell through to `findQueueByName` — but with auth/throttling, the list scan also fails, and the next ensure step would try to create a duplicate. A failed `createQueue` of any kind used to be silently treated as "name taken", masking quota / network / 5xx issues until the subsequent list-scan also surfaced nothing useful.

### New lifecycle tests

`packages/alchemy/test/Cloudflare/Queue/Queue.test.ts` (new file):

- redeploy with same props is a no-op (queueId preserved)
- reconcile re-creates a queue that was deleted out-of-band via `queues.deleteQueue`
- changing physical `name` triggers replace; old queue is gone
- destroying an already-deleted queue is a no-op
- existing queue (matching name) is silently adopted without `--adopt`
- `adopt(true)` re-claims a queue under a different logical id
- consumer add / remove churn against a stable queue + worker
- consumer settings update propagates without replacing the consumer
- DLQ chaining survives redeploy (main + DLQ + consumer all stable)
- destroying an already-deleted consumer is a no-op

### Distilled patch

No patch needed. The existing `packages/cloudflare/patches/queues/*.json` patches in distilled already map the response codes the reconciler now routes on: `QueueAlreadyExists` (11009), `QueueNotFound` (11000), `ConsumerAlreadyExists` (11004), `ConsumerNotFound` (11006).

The pre-existing `output.stableId` TS error from #167/#179 in `test.resources.ts` is fixed the same way the prior hardening PRs did (`output?.stableId ?? ...`, `output?.stableArn ?? ...`).
