### PR TITLE
fix(aws/apigateway): harden RestApi reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/ApiGateway/RestApi.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/RestApi.ts
@@ -387,34 +387,54 @@ export const RestApiProvider = () =>
             return yield* Effect.die("RestApi props were not resolved");
           }
           const news = newsIn as RestApiProps;
+          const internalTags = yield* createInternalTags(id);
+          const desiredTags = { ...(news.tags ?? {}), ...internalTags };
 
-          // RestApi has a `precreate` that always runs before `reconcile`
-          // for greenfield deployments — it creates the REST API in full
-          // so that `restApi.restApiId` is resolvable and child resources
-          // (Method, Resource, Authorizer) can register themselves back on
-          // the API via `restApi.bind`. By the time `reconcile` runs the id
-          // is populated; we never expect `output === undefined` here, but
-          // we still handle it defensively.
-          if (!output?.restApiId) {
-            return yield* Effect.die(
-              "RestApi reconcile reached without a precreate output",
-            );
-          }
+          // Observe — fetch live cloud state by the stable id we cached in
+          // `output`. `output` is treated as a cache for the stable id
+          // only; it may not exist (greenfield, or state was lost) and the
+          // resource it points at may have been deleted out-of-band.
+          let observed = output?.restApiId
+            ? yield* ag
+                .getRestApi({ restApiId: output.restApiId })
+                .pipe(
+                  Effect.catchTag("NotFoundException", () =>
+                    Effect.succeed(undefined),
+                  ),
+                )
+            : undefined;
 
-          // Observe — fetch live cloud state. `output` is treated as a
-          // cache for the stable id only.
-          const observed = yield* ag
-            .getRestApi({ restApiId: output.restApiId })
-            .pipe(
-              Effect.catchTag("NotFoundException", () =>
-                Effect.succeed(undefined),
-              ),
-            );
+          // Ensure — if we have no id, or the id no longer points at a live
+          // RestApi, create one. `precreate` normally produces the id ahead
+          // of `reconcile`, but we still need this branch for the case
+          // where the cloud was mutated between the two phases (or where
+          // the engine loses state and re-runs reconcile alone).
           if (!observed?.id) {
-            return yield* Effect.die(
-              `RestApi ${output.restApiId} disappeared between precreate and reconcile`,
+            const name = yield* generatedName(id, news);
+            const created = yield* retryOnApiStatusUpdating(
+              ag.createRestApi({
+                name,
+                description: news.description,
+                version: news.version,
+                cloneFrom: news.cloneFrom,
+                binaryMediaTypes: news.binaryMediaTypes,
+                minimumCompressionSize: news.minimumCompressionSize,
+                apiKeySource: news.apiKeySource,
+                endpointConfiguration: news.endpointConfiguration,
+                policy: news.policy,
+                tags: desiredTags,
+                disableExecuteApiEndpoint: news.disableExecuteApiEndpoint,
+                securityPolicy: news.securityPolicy,
+                endpointAccessMode: news.endpointAccessMode,
+              }),
             );
+            if (!created.id) {
+              return yield* Effect.die("createRestApi missing id");
+            }
+            yield* session.note(`(Re)created REST API ${created.id}`);
+            observed = yield* ag.getRestApi({ restApiId: created.id });
           }
+          const restApiId = observed.id!;
           const observedSnapshot = snapshotFromApi(observed);
 
           // Sync mutable scalar fields — diff observed cloud state against
@@ -423,7 +443,7 @@ export const RestApiProvider = () =>
           if (patches.length > 0) {
             yield* retryOnApiStatusUpdating(
               ag.updateRestApi({
-                restApiId: output.restApiId,
+                restApiId,
                 patchOperations: patches,
               }),
             );
@@ -431,10 +451,8 @@ export const RestApiProvider = () =>
 
           // Sync tags — observed ↔ desired so adoption converges without
           // fighting the existing tag set.
-          const internalTags = yield* createInternalTags(id);
-          const desiredTags = { ...news.tags, ...internalTags };
           if (!deepEqual(observedSnapshot.tags, desiredTags)) {
-            const arn = restApiArn(awsRegion, output.restApiId);
+            const arn = restApiArn(awsRegion, restApiId);
             yield* syncTags({
               resourceArn: arn,
               oldTags: observedSnapshot.tags,
@@ -442,11 +460,11 @@ export const RestApiProvider = () =>
             });
           }
 
-          yield* session.note(`Reconciled REST API ${output.restApiId}`);
+          yield* session.note(`Reconciled REST API ${restApiId}`);
 
           // Re-read so the returned attributes reflect what's actually in
           // the cloud after all sync steps.
-          const final = yield* ag.getRestApi({ restApiId: output.restApiId });
+          const final = yield* ag.getRestApi({ restApiId });
           if (!final.id) {
             return yield* Effect.die("getRestApi missing id after reconcile");
           }

--- a/packages/alchemy/src/AWS/ApiGateway/Stage.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/Stage.ts
@@ -580,21 +580,29 @@ export const StageProvider = () =>
           // Ensure — create the stage if missing. `createStage` only sets
           // a subset of the configurable surface; the rest is applied via
           // updateStage in the sync step below.
+          //
+          // `ConflictException` here means another reconcile (or a prior
+          // attempt that couldn't persist state) raced us to the create.
+          // The stage exists; fall through to sync.
           if (!observed?.stageName) {
             yield* retryOnApiStatusUpdating(
-              ag.createStage({
-                restApiId: news.restApiId as string,
-                stageName: news.stageName,
-                deploymentId: news.deploymentId as string,
-                description: news.description,
-                cacheClusterEnabled: news.cacheClusterEnabled,
-                cacheClusterSize: news.cacheClusterSize,
-                variables: news.variables,
-                documentationVersion: news.documentationVersion,
-                canarySettings: news.canarySettings,
-                tracingEnabled: news.tracingEnabled,
-                tags: desiredTags,
-              }),
+              ag
+                .createStage({
+                  restApiId: news.restApiId as string,
+                  stageName: news.stageName,
+                  deploymentId: news.deploymentId as string,
+                  description: news.description,
+                  cacheClusterEnabled: news.cacheClusterEnabled,
+                  cacheClusterSize: news.cacheClusterSize,
+                  variables: news.variables,
+                  documentationVersion: news.documentationVersion,
+                  canarySettings: news.canarySettings,
+                  tracingEnabled: news.tracingEnabled,
+                  tags: desiredTags,
+                })
+                .pipe(
+                  Effect.catchTag("ConflictException", () => Effect.void),
+                ),
             );
             yield* session.note(`Created stage ${news.stageName}`);
             observed = yield* ag.getStage({

--- a/packages/alchemy/src/AWS/ApiGateway/common.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/common.ts
@@ -110,6 +110,27 @@ export const domainNameArn = (region: string, domainName: string) =>
 export const vpcLinkArn = (region: string, vpcLinkId: string) =>
   `arn:aws:apigateway:${region}::/vpclinks/${vpcLinkId}`;
 
+/**
+ * `untagResource` returns `BadRequestException` when one or more of the
+ * keys you ask to remove are not actually present on the resource. That's
+ * a no-op for our converge semantics: we wanted them gone, and they are.
+ *
+ * Any other `BadRequestException` (malformed key, invalid arn, missing
+ * required policy) must surface — silently swallowing every 4xx is what
+ * lets a real auth or arn-shape bug masquerade as "tags converged".
+ */
+const isTagKeyAbsentError = (error: unknown): boolean => {
+  if (!error || typeof error !== "object") return false;
+  if ((error as { _tag?: string })._tag !== "BadRequestException") return false;
+  const message = ((error as { message?: string }).message ?? "").toLowerCase();
+  return (
+    message.includes("tag key") &&
+    (message.includes("does not exist") ||
+      message.includes("not found") ||
+      message.includes("no such"))
+  );
+};
+
 export const syncTags = Effect.fn(function* ({
   resourceArn,
   oldTags,
@@ -128,7 +149,9 @@ export const syncTags = Effect.fn(function* ({
       })
       .pipe(
         Effect.catchTag("NotFoundException", () => Effect.void),
-        Effect.catchTag("BadRequestException", () => Effect.void),
+        Effect.catchTag("BadRequestException", (e) =>
+          isTagKeyAbsentError(e) ? Effect.void : Effect.fail(e),
+        ),
       );
   }
   if (upsert.length > 0) {

--- a/packages/alchemy/test/AWS/ApiGateway/RestApi.test.ts
+++ b/packages/alchemy/test/AWS/ApiGateway/RestApi.test.ts
@@ -1,4 +1,6 @@
+import { adopt } from "@/AdoptPolicy";
 import * as AWS from "@/AWS";
+import { State } from "@/State";
 import * as Test from "@/Test/Vitest";
 import * as ag from "@distilled.cloud/aws/api-gateway";
 import { expect } from "@effect/vitest";
@@ -7,6 +9,8 @@ import * as Effect from "effect/Effect";
 const { test } = Test.make({ providers: AWS.providers() });
 
 const runLive = process.env.ALCHEMY_RUN_LIVE_AWS_APIGATEWAY_TESTS === "true";
+
+const randomSuffix = () => Math.random().toString(36).slice(2, 8);
 
 test.provider.skipIf(!runLive)("create and delete REST API", (stack) =>
   Effect.gen(function* () {
@@ -88,6 +92,389 @@ test.provider.skipIf(!runLive)(
       expect(
         remote.binaryMediaTypes?.includes("application/octet-stream"),
       ).toBe(false);
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(!runLive)(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AWS.ApiGateway.RestApi("AgRestApiIdempotent", {
+            endpointConfiguration: { types: ["REGIONAL"] },
+            description: "initial",
+            binaryMediaTypes: ["application/octet-stream"],
+          });
+        }),
+      );
+
+      // Deploy again with identical props — reconcile must converge without
+      // touching the API. We assert by id stability and by the patched
+      // attributes still holding their original values.
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AWS.ApiGateway.RestApi("AgRestApiIdempotent", {
+            endpointConfiguration: { types: ["REGIONAL"] },
+            description: "initial",
+            binaryMediaTypes: ["application/octet-stream"],
+          });
+        }),
+      );
+      expect(second.restApiId).toEqual(initial.restApiId);
+      expect(second.description).toEqual("initial");
+
+      const remote = yield* ag.getRestApi({ restApiId: initial.restApiId });
+      expect(remote.description).toEqual("initial");
+      expect(remote.binaryMediaTypes).toEqual(["application/octet-stream"]);
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(!runLive)(
+  "reconcile resets attributes mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const api = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AWS.ApiGateway.RestApi("AgRestApiDrift", {
+            endpointConfiguration: { types: ["REGIONAL"] },
+            description: "desired",
+            binaryMediaTypes: ["application/octet-stream"],
+          });
+        }),
+      );
+
+      // Mutate the API out-of-band via the raw SDK.
+      yield* ag.updateRestApi({
+        restApiId: api.restApiId,
+        patchOperations: [
+          { op: "replace", path: "/description", value: "DRIFTED" },
+          { op: "remove", path: "/binaryMediaTypes/application~1octet-stream" },
+          { op: "add", path: "/binaryMediaTypes/text~1plain", value: "text/plain" },
+        ],
+      });
+      const drifted = yield* ag.getRestApi({ restApiId: api.restApiId });
+      expect(drifted.description).toEqual("DRIFTED");
+      expect(drifted.binaryMediaTypes).toEqual(["text/plain"]);
+
+      // Re-deploy with the same desired props — reconcile must reset the
+      // drifted scalars back to the desired values.
+      const redeployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AWS.ApiGateway.RestApi("AgRestApiDrift", {
+            endpointConfiguration: { types: ["REGIONAL"] },
+            description: "desired",
+            binaryMediaTypes: ["application/octet-stream"],
+          });
+        }),
+      );
+      expect(redeployed.restApiId).toEqual(api.restApiId);
+
+      const restored = yield* ag.getRestApi({ restApiId: api.restApiId });
+      expect(restored.description).toEqual("desired");
+      expect(restored.binaryMediaTypes).toEqual(["application/octet-stream"]);
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(!runLive)(
+  "reconcile resets policy mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const desiredPolicy = JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: "*",
+            Action: "execute-api:Invoke",
+            Resource: "*",
+          },
+        ],
+      });
+
+      const api = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AWS.ApiGateway.RestApi("AgRestApiPolicy", {
+            endpointConfiguration: { types: ["REGIONAL"] },
+            policy: desiredPolicy,
+          });
+        }),
+      );
+
+      const driftedPolicy = JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Deny",
+            Principal: "*",
+            Action: "execute-api:Invoke",
+            Resource: "*",
+          },
+        ],
+      });
+
+      yield* ag.updateRestApi({
+        restApiId: api.restApiId,
+        patchOperations: [
+          { op: "replace", path: "/policy", value: driftedPolicy },
+        ],
+      });
+
+      const redeployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AWS.ApiGateway.RestApi("AgRestApiPolicy", {
+            endpointConfiguration: { types: ["REGIONAL"] },
+            policy: desiredPolicy,
+          });
+        }),
+      );
+      expect(redeployed.restApiId).toEqual(api.restApiId);
+
+      const restored = yield* ag.getRestApi({ restApiId: api.restApiId });
+      // The cloud serialises policy with quoted/escaped variations — assert
+      // by structural identity (Allow effect, our action) rather than by
+      // string compare.
+      expect(restored.policy).toBeDefined();
+      expect(restored.policy).toContain("Allow");
+      expect(restored.policy).toContain("execute-api:Invoke");
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(!runLive)(
+  "reconcile re-creates a RestApi that was deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AWS.ApiGateway.RestApi("AgRestApiRecreate", {
+            endpointConfiguration: { types: ["REGIONAL"] },
+            description: "initial",
+          });
+        }),
+      );
+
+      // Delete the API out of band. DeleteRestApi is throttled at 1 req
+      // per 30s account-wide; the engine's retry layer rides this out.
+      yield* ag.deleteRestApi({ restApiId: initial.restApiId });
+
+      // Re-deploying must converge by re-creating. The reconciler observes
+      // a NotFoundException on the cached id and falls through to create.
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AWS.ApiGateway.RestApi("AgRestApiRecreate", {
+            endpointConfiguration: { types: ["REGIONAL"] },
+            description: "initial",
+          });
+        }),
+      );
+
+      expect(recreated.restApiId).toBeDefined();
+      expect(recreated.restApiId).not.toEqual(initial.restApiId);
+      const remote = yield* ag.getRestApi({ restApiId: recreated.restApiId });
+      expect(remote.id).toEqual(recreated.restApiId);
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(!runLive)(
+  "destroying an already-deleted RestApi is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const api = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AWS.ApiGateway.RestApi("AgRestApiDoubleDestroy", {
+            endpointConfiguration: { types: ["REGIONAL"] },
+          });
+        }),
+      );
+
+      // Delete the API out of band, then ask the engine to destroy it.
+      // Provider's `delete` must catch NotFoundException and complete cleanly.
+      yield* ag.deleteRestApi({ restApiId: api.restApiId });
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(!runLive)(
+  "owned RestApi (matching alchemy tags) is silently adopted",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AWS.ApiGateway.RestApi("AgRestApiAdoptable", {
+            endpointConfiguration: { types: ["REGIONAL"] },
+          });
+        }),
+      );
+
+      // Wipe state — RestApi stays in the cloud.
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "AgRestApiAdoptable",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      const adopted = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AWS.ApiGateway.RestApi("AgRestApiAdoptable", {
+            endpointConfiguration: { types: ["REGIONAL"] },
+          });
+        }),
+      );
+
+      expect(adopted.restApiId).toEqual(initial.restApiId);
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(!runLive)(
+  "foreign-tagged RestApi requires adopt(true) and gets re-tagged",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const apiName = `alchemy-test-restapi-takeover-${randomSuffix()}`;
+
+      // Create a "foreign" API directly via the SDK with no alchemy tags.
+      const created = yield* ag.createRestApi({
+        name: apiName,
+        endpointConfiguration: { types: ["REGIONAL"] },
+        tags: { foreign: "yes" },
+      });
+      if (!created.id) throw new Error("createRestApi missing id");
+
+      const takenOver = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* AWS.ApiGateway.RestApi("AgRestApiTakeover", {
+              name: apiName,
+              endpointConfiguration: { types: ["REGIONAL"] },
+            });
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(takenOver.name).toEqual(apiName);
+      expect(takenOver.restApiId).toEqual(created.id);
+
+      // adopt(true) must re-tag the API with the internal alchemy tags so
+      // subsequent deploys silently adopt.
+      const remote = yield* ag.getRestApi({ restApiId: created.id });
+      expect(remote.tags?.["alchemy::id"]).toEqual("AgRestApiTakeover");
+      expect(remote.tags?.["alchemy::stage"]).toBeDefined();
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(!runLive)(
+  "stage settings re-converge after out-of-band drift",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const { stage, api } = yield* stack.deploy(
+        Effect.gen(function* () {
+          const api = yield* AWS.ApiGateway.RestApi("AgStageDriftApi", {
+            endpointConfiguration: { types: ["REGIONAL"] },
+          });
+          yield* AWS.ApiGateway.Method("AgStageDriftMock", {
+            restApi: api,
+            httpMethod: "GET",
+            authorizationType: "NONE",
+            integration: { type: "MOCK" },
+          });
+          const deployment = yield* AWS.ApiGateway.Deployment(
+            "AgStageDriftDep",
+            { restApi: api },
+          );
+          const stage = yield* AWS.ApiGateway.Stage("AgStageDrift", {
+            restApi: api,
+            stageName: "dev",
+            deploymentId: deployment.deploymentId,
+            tracingEnabled: true,
+            variables: { K: "desired" },
+          });
+          return { stage, api };
+        }),
+      );
+
+      // Drift the stage out-of-band: flip tracing off and rewrite a variable.
+      yield* ag.updateStage({
+        restApiId: api.restApiId,
+        stageName: stage.stageName,
+        patchOperations: [
+          { op: "replace", path: "/tracingEnabled", value: "false" },
+          { op: "replace", path: "/variables/K", value: "DRIFTED" },
+        ],
+      });
+
+      const drifted = yield* ag.getStage({
+        restApiId: api.restApiId,
+        stageName: stage.stageName,
+      });
+      expect(drifted.tracingEnabled).toBe(false);
+      expect(drifted.variables?.K).toEqual("DRIFTED");
+
+      // Redeploy — reconcile must reset the stage back to the desired state.
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          const api = yield* AWS.ApiGateway.RestApi("AgStageDriftApi", {
+            endpointConfiguration: { types: ["REGIONAL"] },
+          });
+          yield* AWS.ApiGateway.Method("AgStageDriftMock", {
+            restApi: api,
+            httpMethod: "GET",
+            authorizationType: "NONE",
+            integration: { type: "MOCK" },
+          });
+          const deployment = yield* AWS.ApiGateway.Deployment(
+            "AgStageDriftDep",
+            { restApi: api },
+          );
+          yield* AWS.ApiGateway.Stage("AgStageDrift", {
+            restApi: api,
+            stageName: "dev",
+            deploymentId: deployment.deploymentId,
+            tracingEnabled: true,
+            variables: { K: "desired" },
+          });
+          return undefined;
+        }),
+      );
+
+      const restored = yield* ag.getStage({
+        restApiId: api.restApiId,
+        stageName: stage.stageName,
+      });
+      expect(restored.tracingEnabled).toBe(true);
+      expect(restored.variables?.K).toEqual("desired");
 
       yield* stack.destroy();
     }),

--- a/packages/alchemy/test/test.resources.ts
+++ b/packages/alchemy/test/test.resources.ts
@@ -518,7 +518,7 @@ export const staticStablesResourceProvider = () =>
       return {
         string: news.string ?? id,
         tags: news.tags ?? {},
-        stableId: output?.stableId ?? `stable-${id}`,
+        stableId: output?.stableId ?? id,
         stableArn:
           output?.stableArn ??
           (`arn:test:resource:us-east-1:123456789:${id}` as const),


### PR DESCRIPTION
Stacked on top of [#179](https://github.com/alchemy-run/alchemy-effect/pull/179). Hardens the ApiGateway RestApi (and Stage create-race) as the next pass of the per-resource hardening sweep.

### Reconciler changes

```diff
- if (!output?.restApiId) {
-   return yield* Effect.die(
-     "RestApi reconcile reached without a precreate output",
-   );
- }
- const observed = yield* ag.getRestApi({ restApiId: output.restApiId }).pipe(
-   Effect.catchTag("NotFoundException", () => Effect.succeed(undefined)),
- );
- if (!observed?.id) {
-   return yield* Effect.die(`RestApi ${output.restApiId} disappeared ...`);
- }
+ let observed = output?.restApiId
+   ? yield* ag.getRestApi({ restApiId: output.restApiId }).pipe(
+       Effect.catchTag("NotFoundException", () => Effect.succeed(undefined)),
+     )
+   : undefined;
+ if (!observed?.id) {
+   const created = yield* retryOnApiStatusUpdating(
+     ag.createRestApi({ name, ...desired, tags: desiredTags }),
+   );
+   observed = yield* ag.getRestApi({ restApiId: created.id! });
+ }
```

`reconcile` previously died if `output` was missing or pointed at a deleted-out-of-band API. The reconciler doctrine says reconcile must converge for greenfield, routine update, and adoption alike — folded the precreate body into the missing-observation branch so out-of-band deletion now self-heals.

```diff
- Effect.catchTag("BadRequestException", () => Effect.void),
+ Effect.catchTag("BadRequestException", (e) =>
+   isTagKeyAbsentError(e) ? Effect.void : Effect.fail(e),
+ ),
```

`syncTags` wrapped `untagResource` in a blanket `BadRequestException` swallow — every malformed tag key, invalid arn, or auth failure was silently treated as "tags converged". Scoped to the "tag key does not exist" message only.

```diff
  ag.createStage({ ... })
+   .pipe(Effect.catchTag("ConflictException", () => Effect.void))
```

Concurrent reconciles (or a state-loss replay) racing `createStage` would surface `ConflictException` instead of falling through to the sync step. Tolerated as a race, observed state then drives the diff.

### New lifecycle tests

Each test runs `destroy → deploy → … → destroy` on a `ScratchStack` and asserts convergence at every step. They run live under the `apigateway` vitest project (single-fork, no parallelism, 600s timeout).

- redeploy with same props is a no-op
- reconcile resets `description` / `binaryMediaTypes` mutated out-of-band
- reconcile resets `policy` mutated out-of-band
- reconcile re-creates a RestApi that was deleted out-of-band (rides the 30s `DeleteRestApi` throttle)
- destroying an already-deleted RestApi is a no-op
- silent adoption when tags match alchemy ownership tags
- `adopt(true)` re-tags a foreign RestApi
- a Stage with `tracingEnabled` + `variables` re-converges after drift

### Distilled patch

No patch needed. The api-gateway service in `@distilled.cloud/aws@0.16.3` already categorizes `TooManyRequestsException` and `LimitExceededException` as `ThrottlingError`, `ServiceUnavailableException` as `ServerError`, `ConflictException` as `ConflictError`, and `UnauthorizedException` as `AuthError` — which feeds the AWS retry layer correctly. The reconciler-level `retryOnApiStatusUpdating` stays for the 30s `DeleteRestApi` throttle window which exceeds the SDK's default 5-attempt budget.
