### PR TITLE
fix(cloudflare/kv): harden Namespace reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/Cloudflare/KV/KVNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/KV/KVNamespace.ts
@@ -151,6 +151,17 @@ export const KVNamespaceProvider = () =>
           // Sync — KV's only mutable property is the title. Rename only
           // when the observed title drifts from desired so we avoid
           // unnecessary API calls on every reconcile.
+          //
+          // Two races are tolerated on the rename hop:
+          //   * `NamespaceNotFound` — the namespace was deleted between
+          //     observe and update. Recurse via reconcile rather than
+          //     leaving the engine with stale state pointing at a dead
+          //     namespace; the next call observes "missing" and creates
+          //     fresh.
+          //   * `NamespaceTitleAlreadyExists` — a parallel deploy or
+          //     dashboard rename took the desired title first. Re-find
+          //     the namespace by title and adopt; if it's not actually
+          //     there, surface the original error so it isn't masked.
           let namespaceId = observed.id;
           let resolvedTitle = observed.title;
           let supportsUrlEncoding = observed.supportsUrlEncoding ?? undefined;
@@ -159,7 +170,30 @@ export const KVNamespaceProvider = () =>
               accountId: acct,
               namespaceId: observed.id,
               title,
-            });
+            }).pipe(
+              Effect.catchTag("NamespaceNotFound", () =>
+                createNamespace({ accountId: acct, title }).pipe(
+                  Effect.catchTag("NamespaceTitleAlreadyExists", () =>
+                    Effect.gen(function* () {
+                      const match = yield* findNamespaceByTitle(title);
+                      if (match) return match;
+                      return yield* Effect.die(
+                        `Namespace with title "${title}" already exists but could not be found`,
+                      );
+                    }),
+                  ),
+                ),
+              ),
+              Effect.catchTag("NamespaceTitleAlreadyExists", () =>
+                Effect.gen(function* () {
+                  const match = yield* findNamespaceByTitle(title);
+                  if (match) return match;
+                  return yield* Effect.die(
+                    `Namespace with title "${title}" already exists but could not be found`,
+                  );
+                }),
+              ),
+            );
             namespaceId = renamed.id;
             resolvedTitle = renamed.title;
             supportsUrlEncoding = renamed.supportsUrlEncoding ?? undefined;

--- a/packages/alchemy/test/Cloudflare/KV/Namespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/KV/Namespace.test.ts
@@ -1,3 +1,4 @@
+import { adopt } from "@/AdoptPolicy";
 import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as KV from "@/Cloudflare/KV/index";
@@ -154,6 +155,276 @@ test.provider(
 
       yield* stack.destroy();
       yield* waitForNamespaceToBeDeleted(initialId, accountId);
+    }).pipe(logLevel),
+);
+
+// ─────────────────────────────────────────────────────────────────────
+// Lifecycle convergence
+//
+// Reconcile must converge from any starting state — pristine, drifted,
+// out-of-band-deleted, or replaced — without leaning on `olds` as a
+// source of truth. The tests below pin down each of those starting
+// states for KV namespaces, where the only mutable property is `title`.
+// ─────────────────────────────────────────────────────────────────────
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const title = `alchemy-test-kv-idempotent-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const v1 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* KV.KVNamespace("IdempotentNamespace", { title });
+        }),
+      );
+
+      const v2 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* KV.KVNamespace("IdempotentNamespace", { title });
+        }),
+      );
+
+      // Same physical namespace — reconciler did not replace or rename.
+      expect(v2.namespaceId).toEqual(v1.namespaceId);
+      expect(v2.title).toEqual(v1.title);
+      expect(v2.title).toEqual(title);
+
+      const live = yield* kv.getNamespace({
+        accountId,
+        namespaceId: v2.namespaceId,
+      });
+      expect(live.id).toEqual(v1.namespaceId);
+      expect(live.title).toEqual(title);
+
+      yield* stack.destroy();
+      yield* waitForNamespaceToBeDeleted(v1.namespaceId, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile resets title mutated out-of-band via the raw KV API",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const desiredTitle = `alchemy-test-kv-drift-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const v1 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* KV.KVNamespace("DriftNamespace", {
+            title: desiredTitle,
+          });
+        }),
+      );
+      expect(v1.title).toEqual(desiredTitle);
+
+      // Mutate the title out-of-band — this is the kind of drift you'd
+      // see if someone renames the namespace via the Cloudflare
+      // dashboard or `wrangler kv:namespace rename`.
+      yield* kv.updateNamespace({
+        accountId,
+        namespaceId: v1.namespaceId,
+        title: `${desiredTitle}-tampered`,
+      });
+      const drifted = yield* kv.getNamespace({
+        accountId,
+        namespaceId: v1.namespaceId,
+      });
+      expect(drifted.title).toEqual(`${desiredTitle}-tampered`);
+
+      // Re-deploy with the original desired title — reconcile observes
+      // the live title, sees it doesn't match, and renames back.
+      const v2 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* KV.KVNamespace("DriftNamespace", {
+            title: desiredTitle,
+          });
+        }),
+      );
+      expect(v2.namespaceId).toEqual(v1.namespaceId);
+      expect(v2.title).toEqual(desiredTitle);
+
+      const repaired = yield* kv.getNamespace({
+        accountId,
+        namespaceId: v2.namespaceId,
+      });
+      expect(repaired.title).toEqual(desiredTitle);
+
+      yield* stack.destroy();
+      yield* waitForNamespaceToBeDeleted(v1.namespaceId, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile re-creates a namespace deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const title = `alchemy-test-kv-recreate-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const v1 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* KV.KVNamespace("RecreateNamespace", { title });
+        }),
+      );
+      const initialId = v1.namespaceId;
+
+      // Delete the namespace out-of-band — local state still says it
+      // exists, but Cloudflare disagrees. The KV API removes the
+      // namespace immediately; there is no "recently deleted" cooldown.
+      yield* kv.deleteNamespace({
+        accountId,
+        namespaceId: initialId,
+      });
+      yield* waitForNamespaceToBeDeleted(initialId, accountId);
+
+      // Reconcile must observe the missing namespace via getNamespace
+      // (returns NamespaceNotFound), fall back to a fresh
+      // createNamespace, and converge.
+      const v2 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* KV.KVNamespace("RecreateNamespace", { title });
+        }),
+      );
+      expect(v2.title).toEqual(title);
+
+      const live = yield* kv.getNamespace({
+        accountId,
+        namespaceId: v2.namespaceId,
+      });
+      expect(live.id).toEqual(v2.namespaceId);
+      expect(live.title).toEqual(title);
+
+      yield* stack.destroy();
+      yield* waitForNamespaceToBeDeleted(v2.namespaceId, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "changing title triggers in-place rename, not replace",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const titleA = `alchemy-test-kv-rename-a-${suffix}`;
+      const titleB = `alchemy-test-kv-rename-b-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* KV.KVNamespace("RenameNamespace", { title: titleA });
+        }),
+      );
+      expect(a.title).toEqual(titleA);
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* KV.KVNamespace("RenameNamespace", { title: titleB });
+        }),
+      );
+
+      // Same physical namespace — the diff returns `update`, not
+      // `replace`, and reconcile renames in place via updateNamespace.
+      expect(b.namespaceId).toEqual(a.namespaceId);
+      expect(b.title).toEqual(titleB);
+
+      const live = yield* kv.getNamespace({
+        accountId,
+        namespaceId: b.namespaceId,
+      });
+      expect(live.title).toEqual(titleB);
+
+      yield* stack.destroy();
+      yield* waitForNamespaceToBeDeleted(a.namespaceId, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "destroying an already-deleted namespace is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const namespace = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* KV.KVNamespace("DoubleDestroyNamespace");
+        }),
+      );
+
+      // Delete the namespace out-of-band so the next destroy hits the
+      // `NamespaceNotFound` path inside provider.delete. It must succeed.
+      yield* kv.deleteNamespace({
+        accountId,
+        namespaceId: namespace.namespaceId,
+      });
+      yield* waitForNamespaceToBeDeleted(namespace.namespaceId, accountId);
+
+      // First destroy: state says the namespace exists, cloud disagrees.
+      // delete catches NamespaceNotFound and completes cleanly.
+      yield* stack.destroy();
+
+      // Second destroy: state is gone; this is a true no-op. Repeated
+      // destroys must never throw.
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "adopt(true) re-claims a foreign namespace by title",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      // Phase 1: pre-create the namespace via the raw KV API so it has
+      // no Alchemy ownership. Cloudflare KV doesn't expose tags, so a
+      // foreign namespace looks identical to a silently-adoptable one;
+      // we use `adopt(true)` to make the takeover explicit.
+      const title = `alchemy-test-kv-takeover-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+      const foreign = yield* kv.createNamespace({ accountId, title });
+      const foreignId = foreign.id;
+      expect(foreignId).toBeDefined();
+
+      // Phase 2: deploy under a logical id that has never seen this
+      // namespace. With `adopt(true)` the engine's `read` returns plain
+      // attrs and reconcile binds to the existing namespace rather than
+      // creating a new one.
+      const adopted = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* KV.KVNamespace("ForeignAdopt", { title });
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(adopted.namespaceId).toEqual(foreignId);
+      expect(adopted.title).toEqual(title);
+
+      yield* stack.destroy();
+      yield* waitForNamespaceToBeDeleted(foreignId, accountId);
     }).pipe(logLevel),
 );
 


### PR DESCRIPTION
Tighten the rename hop in `KVNamespace.reconcile` so it tolerates two real-world races that previously surfaced as hard failures, and add lifecycle convergence tests covering the standard reconcile shape.

The rest of the reconciler was already well-scoped: every catch is a `catchTag` (no blanket `Effect.catch`), there are no unbounded retries, and `getNamespace` already races against out-of-band deletes on the observation hop. The gap was on the rename-via-`updateNamespace` hop.

### Reconciler changes

```diff
   if (observed.title !== title) {
     const renamed = yield* updateNamespace({
       accountId: acct,
       namespaceId: observed.id,
       title,
-    });
+    }).pipe(
+      Effect.catchTag("NamespaceNotFound", () =>
+        // namespace deleted between observe and update — recreate
+        createNamespace({ accountId: acct, title }).pipe(
+          Effect.catchTag("NamespaceTitleAlreadyExists", () =>
+            Effect.gen(function* () {
+              const match = yield* findNamespaceByTitle(title);
+              if (match) return match;
+              return yield* Effect.die(...);
+            }),
+          ),
+        ),
+      ),
+      Effect.catchTag("NamespaceTitleAlreadyExists", () =>
+        // parallel deploy / dashboard rename took the title — adopt
+        Effect.gen(function* () {
+          const match = yield* findNamespaceByTitle(title);
+          if (match) return match;
+          return yield* Effect.die(...);
+        }),
+      ),
+    );
```

Without these catches a same-title redeploy that races an OOB delete would crash and leave engine state pointing at a dead namespace; a parallel rename would crash with a confusing 409 instead of converging onto the existing namespace.

### New lifecycle tests

- redeploy with same props is a no-op (reconciler is idempotent)
- reconcile resets a title mutated out-of-band via `kv.updateNamespace`
- reconcile re-creates a namespace deleted out-of-band via `kv.deleteNamespace`
- changing `title` triggers in-place rename (same `namespaceId`, not replace)
- destroying an already-deleted namespace is a no-op (delete is idempotent)
- `adopt(true)` re-claims a foreign namespace by title

### Distilled patch

No patch needed. The named KV errors (`NamespaceNotFound`, `NamespaceTitleAlreadyExists`, `TitleRequired`, `InvalidObjectIdentifier`, `MethodNotAllowed`) already cover every code the reconciler routes on, and Cloudflare's `client/api.ts` already attributes throttling/5xx categories so they participate in engine-level retry instead of surfacing as `UnknownCloudflareError`.

The pre-existing `output?.stableId` / `output?.stableArn` TS error from #167/#179 in `test.resources.ts` is fixed the same way the prior hardening PRs did.
