### PR TITLE
fix(aws/route53): harden Record reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/Route53/Record.ts
+++ b/packages/alchemy/src/AWS/Route53/Record.ts
@@ -1,4 +1,5 @@
 import * as route53 from "@distilled.cloud/aws/route-53";
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 import { isResolved } from "../../Diff.ts";
@@ -162,7 +163,7 @@ const toRecordSet = (props: RecordProps): route53.ResourceRecordSet => ({
         HostedZoneId: normalizeHostedZoneId(
           props.aliasTarget.hostedZoneId as string,
         ),
-        DNSName: props.aliasTarget.dnsName as string,
+        DNSName: normalizeName(props.aliasTarget.dnsName as string),
         EvaluateTargetHealth: props.aliasTarget.evaluateTargetHealth ?? false,
       }
     : undefined,
@@ -181,41 +182,111 @@ const toAttrs = (
   setIdentifier: recordSet.SetIdentifier,
 });
 
+const recordSetMatches = (
+  observed: route53.ResourceRecordSet,
+  desired: route53.ResourceRecordSet,
+) => {
+  if (observed.Name !== desired.Name) return false;
+  if (observed.Type !== desired.Type) return false;
+  if ((observed.SetIdentifier ?? undefined) !== desired.SetIdentifier)
+    return false;
+  if ((observed.TTL ?? undefined) !== desired.TTL) return false;
+  const observedValues = (observed.ResourceRecords ?? [])
+    .map((r) => r.Value)
+    .sort();
+  const desiredValues = (desired.ResourceRecords ?? [])
+    .map((r) => r.Value)
+    .sort();
+  if (observedValues.length !== desiredValues.length) return false;
+  if (observedValues.some((v, i) => v !== desiredValues[i])) return false;
+  if ((observed.AliasTarget ?? undefined) === undefined) {
+    if ((desired.AliasTarget ?? undefined) !== undefined) return false;
+  } else {
+    if ((desired.AliasTarget ?? undefined) === undefined) return false;
+    const a = observed.AliasTarget!;
+    const b = desired.AliasTarget!;
+    if (normalizeHostedZoneId(a.HostedZoneId) !== b.HostedZoneId) return false;
+    if (normalizeName(a.DNSName) !== b.DNSName) return false;
+    if ((a.EvaluateTargetHealth ?? false) !== (b.EvaluateTargetHealth ?? false))
+      return false;
+  }
+  return true;
+};
+
+class Route53ChangePending extends Data.TaggedError(
+  "Route53ChangePending",
+)<{
+  changeId: string;
+}> {}
+
+class Route53RecordNotVisible extends Data.TaggedError(
+  "Route53RecordNotVisible",
+)<{
+  hostedZoneId: string;
+  name: string;
+  type: string;
+}> {}
+
 export const RecordProvider = () =>
   Provider.effect(
     Record,
     Effect.gen(function* () {
-      const waitForChange = Effect.fn(function* (changeId: string) {
+      // PriorRequestNotComplete is thrown when concurrent change batches
+      // target the same hosted zone. AWS classifies it as a BadRequestError
+      // in the Smithy model, so it's not auto-retried by the AWS retry layer.
+      // Wrap each mutating call to retry explicitly with bounded backoff.
+      const retryOnConcurrentChange = <A, E, R>(
+        eff: Effect.Effect<A, E, R>,
+      ): Effect.Effect<A, E, R> =>
+        eff.pipe(
+          Effect.retry({
+            while: (e) =>
+              (e as { _tag?: string })._tag === "PriorRequestNotComplete",
+            schedule: Schedule.exponential("250 millis", 2).pipe(
+              Schedule.either(Schedule.spaced("4 seconds")),
+              Schedule.both(Schedule.recurs(20)),
+            ),
+          }),
+        );
+
+      const waitForChange = Effect.fn("Route53.waitForChange")(function* (
+        changeId: string,
+      ) {
         return yield* route53.getChange({ Id: changeId }).pipe(
+          retryOnConcurrentChange,
           Effect.map((response) => response.ChangeInfo),
           Effect.flatMap((changeInfo) =>
             changeInfo.Status === "INSYNC"
               ? Effect.succeed(changeInfo)
-              : Effect.die(new Error("Route53ChangePending")),
+              : Effect.fail(new Route53ChangePending({ changeId })),
           ),
           Effect.retry({
             while: (error) =>
-              error instanceof Error &&
-              error.message === "Route53ChangePending",
+              (error as { _tag?: string })._tag === "Route53ChangePending",
             schedule: Schedule.fixed("2 seconds").pipe(
-              Schedule.both(Schedule.recurs(60)),
+              Schedule.both(Schedule.recurs(150)),
             ),
           }),
         );
       });
 
-      const findRecord = Effect.fn(function* (
+      const findRecord = Effect.fn("Route53.findRecord")(function* (
         hostedZoneId: string,
         props: Pick<RecordProps, "name" | "type" | "setIdentifier">,
       ) {
+        const targetName = normalizeName(props.name);
         const response = yield* route53
           .listResourceRecordSets({
             HostedZoneId: normalizeHostedZoneId(hostedZoneId),
-            StartRecordName: normalizeName(props.name),
+            StartRecordName: targetName,
             StartRecordType: props.type,
+            StartRecordIdentifier: props.setIdentifier,
             MaxItems: 100,
           })
           .pipe(
+            retryOnConcurrentChange,
+            // The hosted zone may have raced away between read and find;
+            // treat that the same as a missing record.
             Effect.catchTag("NoSuchHostedZone", () =>
               Effect.succeed(undefined),
             ),
@@ -223,25 +294,29 @@ export const RecordProvider = () =>
 
         return response?.ResourceRecordSets.find(
           (recordSet) =>
-            recordSet.Name === normalizeName(props.name) &&
+            recordSet.Name === targetName &&
             recordSet.Type === props.type &&
             (recordSet.SetIdentifier ?? undefined) === props.setIdentifier,
         );
       });
 
-      const upsertRecord = Effect.fn(function* (props: RecordProps) {
-        const response = yield* route53.changeResourceRecordSets({
-          HostedZoneId: normalizeHostedZoneId(props.hostedZoneId),
-          ChangeBatch: {
-            Comment: "Alchemy Route53 record upsert",
-            Changes: [
-              {
-                Action: "UPSERT",
-                ResourceRecordSet: toRecordSet(props),
-              },
-            ],
-          },
-        });
+      const upsertRecord = Effect.fn("Route53.upsertRecord")(function* (
+        props: RecordProps,
+      ) {
+        const response = yield* route53
+          .changeResourceRecordSets({
+            HostedZoneId: normalizeHostedZoneId(props.hostedZoneId),
+            ChangeBatch: {
+              Comment: "Alchemy Route53 record upsert",
+              Changes: [
+                {
+                  Action: "UPSERT",
+                  ResourceRecordSet: toRecordSet(props),
+                },
+              ],
+            },
+          })
+          .pipe(retryOnConcurrentChange);
 
         yield* waitForChange(response.ChangeInfo.Id);
       });
@@ -277,26 +352,69 @@ export const RecordProvider = () =>
           return toAttrs(recordSet, output?.hostedZoneId ?? olds!.hostedZoneId);
         }),
         reconcile: Effect.fn(function* ({ news, session }) {
-          // Route 53 `changeResourceRecordSets` with `UPSERT` is naturally
-          // reconciler-friendly: it creates the record if missing and
-          // overwrites it if present. There's no separate ensure/sync split
-          // — one call converges to the desired record set.
-          yield* upsertRecord(news);
+          // Observe — read the record's current cloud state, then only
+          // upsert if it diverges from desired. Skipping the no-op API
+          // call avoids racking up `PriorRequestNotComplete` retries
+          // when many records share a hosted zone and are deployed in
+          // a single pass with no actual changes.
+          const desired = toRecordSet(news);
+          const observed = yield* findRecord(news.hostedZoneId, news);
 
-          // Re-read so the returned attributes reflect the actual current
-          // record (including server-applied defaults).
-          const recordSet = yield* findRecord(news.hostedZoneId, news);
-
-          if (!recordSet) {
-            return yield* Effect.die(
-              new Error("Route53 record was not found after upsert"),
-            );
+          if (observed === undefined || !recordSetMatches(observed, desired)) {
+            yield* upsertRecord(news);
           }
 
+          // Re-read so the returned attributes reflect the actual current
+          // record (including server-applied defaults) regardless of
+          // whether we just wrote. Route53 reads can briefly miss a
+          // freshly INSYNC change against a different name server, so
+          // retry on a short bounded schedule before declaring failure.
+          const finalRecord = yield* findRecord(news.hostedZoneId, news).pipe(
+            Effect.flatMap((r) =>
+              r
+                ? Effect.succeed(r)
+                : Effect.fail(
+                    new Route53RecordNotVisible({
+                      hostedZoneId: news.hostedZoneId,
+                      name: normalizeName(news.name),
+                      type: news.type,
+                    }),
+                  ),
+            ),
+            Effect.retry({
+              while: (e) =>
+                (e as { _tag?: string })._tag === "Route53RecordNotVisible",
+              schedule: Schedule.fixed("2 seconds").pipe(
+                Schedule.both(Schedule.recurs(5)),
+              ),
+            }),
+          );
+
           yield* session.note(`${news.type} ${normalizeName(news.name)}`);
-          return toAttrs(recordSet, news.hostedZoneId);
+          return toAttrs(finalRecord, news.hostedZoneId);
         }),
         delete: Effect.fn(function* ({ output }) {
+          // The record may have been removed out-of-band, or the hosted
+          // zone itself may be gone. Both are no-ops for delete.
+          //
+          // We deliberately do NOT swallow `InvalidChangeBatch` blanket-
+          // wide — it covers a spectrum of validation failures (bad TTL,
+          // malformed alias target, etc.) and silently dropping those
+          // would let a broken delete look successful. Instead, observe
+          // the record first; if it's gone, exit cleanly without
+          // submitting a change batch at all.
+          // `findRecord` already swallows `NoSuchHostedZone` and returns
+          // `undefined`, so we don't need to handle it here.
+          const observed = yield* findRecord(output.hostedZoneId, {
+            name: output.name,
+            type: output.type,
+            setIdentifier: output.setIdentifier,
+          });
+
+          if (!observed) {
+            return;
+          }
+
           yield* route53
             .changeResourceRecordSets({
               HostedZoneId: normalizeHostedZoneId(output.hostedZoneId),
@@ -305,35 +423,34 @@ export const RecordProvider = () =>
                 Changes: [
                   {
                     Action: "DELETE",
-                    ResourceRecordSet: {
-                      Name: output.name,
-                      Type: output.type,
-                      SetIdentifier: output.setIdentifier,
-                      TTL: output.aliasTarget ? undefined : output.ttl,
-                      ResourceRecords: output.records?.map((Value) => ({
-                        Value,
-                      })),
-                      AliasTarget: output.aliasTarget
-                        ? {
-                            HostedZoneId: normalizeHostedZoneId(
-                              output.aliasTarget.hostedZoneId as string,
-                            ),
-                            DNSName: output.aliasTarget.dnsName as string,
-                            EvaluateTargetHealth:
-                              output.aliasTarget.evaluateTargetHealth ?? false,
-                          }
-                        : undefined,
-                    },
+                    // Delete must echo the *observed* record exactly,
+                    // not the cached `output` shape. Out-of-band drift
+                    // (e.g. someone bumped the TTL) would otherwise make
+                    // the delete fail with InvalidChangeBatch.
+                    ResourceRecordSet: observed,
                   },
                 ],
               },
             })
             .pipe(
+              retryOnConcurrentChange,
               Effect.flatMap((response) =>
                 waitForChange(response.ChangeInfo.Id),
               ),
               Effect.catchTag("NoSuchHostedZone", () => Effect.void),
-              Effect.catchTag("InvalidChangeBatch", () => Effect.void),
+              // A concurrent delete may have removed the record between
+              // our find and our DELETE call — InvalidChangeBatch with
+              // "not found" is the only `InvalidChangeBatch` we tolerate.
+              Effect.catchTag("InvalidChangeBatch", (error) => {
+                const messages = [
+                  ...(error.messages ?? []),
+                  error.message ?? "",
+                ].join(" ");
+                if (/not found|but it was not found/i.test(messages)) {
+                  return Effect.void;
+                }
+                return Effect.fail(error);
+              }),
             );
         }),
       };

--- a/packages/alchemy/test/AWS/Route53/Record.test.ts
+++ b/packages/alchemy/test/AWS/Route53/Record.test.ts
@@ -1,0 +1,535 @@
+import * as AWS from "@/AWS";
+import { Record } from "@/AWS/Route53";
+import * as Test from "@/Test/Vitest";
+import * as route53 from "@distilled.cloud/aws/route-53";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+const randomSuffix = () => Math.random().toString(36).slice(2, 8);
+
+const stripHostedZoneId = (id: string) =>
+  id.replace(/^\/hostedzone\//, "");
+
+const normalizeName = (name: string) =>
+  name.endsWith(".") ? name : `${name}.`;
+
+class RecordStillExists extends Data.TaggedError("RecordStillExists") {}
+
+/**
+ * Create an isolated public hosted zone for the test. Public zones don't
+ * need to be delegated to be functional — Route53 still services them,
+ * which is all the resource needs to exercise its lifecycle. We use a
+ * randomized subdomain of `example.com` so collisions across parallel
+ * test runs are essentially impossible.
+ */
+const createTestHostedZone = (logicalSuffix: string) =>
+  Effect.gen(function* () {
+    const domain = `alchemy-test-${logicalSuffix}-${randomSuffix()}.example.com`;
+    const callerReference = `alchemy-test-${logicalSuffix}-${randomSuffix()}`;
+    const response = yield* route53.createHostedZone({
+      Name: domain,
+      CallerReference: callerReference,
+      HostedZoneConfig: {
+        Comment: "alchemy-test record hardening",
+        PrivateZone: false,
+      },
+    });
+    return {
+      domain,
+      hostedZoneId: stripHostedZoneId(response.HostedZone.Id),
+      changeId: response.ChangeInfo.Id,
+    };
+  });
+
+/**
+ * Tear down a test hosted zone, clearing any non-default records first.
+ * Route53 forbids deleting a non-empty zone.
+ */
+const deleteTestHostedZone = (hostedZoneId: string) =>
+  Effect.gen(function* () {
+    // Delete every non-NS/SOA record. Route53 creates NS+SOA on zone
+    // creation; those must remain untouched.
+    yield* clearNonDefaultRecords(hostedZoneId);
+
+    yield* route53
+      .deleteHostedZone({ Id: hostedZoneId })
+      .pipe(
+        Effect.catchTag("NoSuchHostedZone", () => Effect.void),
+        // The cleanup pass above issues async DELETEs — Route53 returns
+        // `HostedZoneNotEmpty` until propagation finishes.
+        Effect.retry({
+          while: (e) =>
+            (e as { _tag?: string })._tag === "HostedZoneNotEmpty",
+          schedule: Schedule.fixed("3 seconds").pipe(
+            Schedule.both(Schedule.recurs(20)),
+          ),
+        }),
+      );
+  });
+
+const clearNonDefaultRecords = (hostedZoneId: string) =>
+  Effect.gen(function* () {
+    const response = yield* route53.listResourceRecordSets({
+      HostedZoneId: hostedZoneId,
+      MaxItems: 100,
+    });
+    const deletable = response.ResourceRecordSets.filter(
+      (r) => r.Type !== "NS" && r.Type !== "SOA",
+    );
+    if (deletable.length === 0) return;
+
+    const changeResp = yield* route53.changeResourceRecordSets({
+      HostedZoneId: hostedZoneId,
+      ChangeBatch: {
+        Changes: deletable.map((ResourceRecordSet) => ({
+          Action: "DELETE",
+          ResourceRecordSet,
+        })),
+      },
+    });
+    yield* waitForInSync(changeResp.ChangeInfo.Id);
+  });
+
+const waitForInSync = (changeId: string) =>
+  route53.getChange({ Id: changeId }).pipe(
+    Effect.flatMap((response) =>
+      response.ChangeInfo.Status === "INSYNC"
+        ? Effect.void
+        : Effect.fail(new RecordStillExists()),
+    ),
+    Effect.retry({
+      while: (e) => (e as { _tag?: string })._tag === "RecordStillExists",
+      schedule: Schedule.fixed("2 seconds").pipe(
+        Schedule.both(Schedule.recurs(60)),
+      ),
+    }),
+  );
+
+const findRecord = (
+  hostedZoneId: string,
+  name: string,
+  type: route53.RRType,
+  setIdentifier?: string,
+) =>
+  route53
+    .listResourceRecordSets({
+      HostedZoneId: hostedZoneId,
+      StartRecordName: normalizeName(name),
+      StartRecordType: type,
+      StartRecordIdentifier: setIdentifier,
+      MaxItems: 100,
+    })
+    .pipe(
+      Effect.map((response) =>
+        response.ResourceRecordSets.find(
+          (r) =>
+            r.Name === normalizeName(name) &&
+            r.Type === type &&
+            (r.SetIdentifier ?? undefined) === setIdentifier,
+        ),
+      ),
+    );
+
+test.provider(
+  "redeploy with same props is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const zone = yield* createTestHostedZone("noop");
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Record("NoopRecord", {
+            hostedZoneId: zone.hostedZoneId,
+            name: `app.${zone.domain}`,
+            type: "A",
+            ttl: 300,
+            records: ["192.0.2.10"],
+          });
+        }),
+      );
+      expect(initial.records).toEqual(["192.0.2.10"]);
+      expect(initial.ttl).toEqual(300);
+
+      // Re-deploy with identical props. Reconciler should observe the
+      // record matches desired and skip the change-batch entirely.
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Record("NoopRecord", {
+            hostedZoneId: zone.hostedZoneId,
+            name: `app.${zone.domain}`,
+            type: "A",
+            ttl: 300,
+            records: ["192.0.2.10"],
+          });
+        }),
+      );
+      expect(second.records).toEqual(["192.0.2.10"]);
+      expect(second.ttl).toEqual(300);
+      expect(second.name).toEqual(initial.name);
+
+      yield* stack.destroy();
+      yield* deleteTestHostedZone(zone.hostedZoneId);
+    }),
+  { timeout: 240_000 },
+);
+
+test.provider(
+  "reconcile resets TTL/values mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const zone = yield* createTestHostedZone("drift");
+      const recordName = `drift.${zone.domain}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Record("DriftRecord", {
+            hostedZoneId: zone.hostedZoneId,
+            name: recordName,
+            type: "A",
+            ttl: 60,
+            records: ["192.0.2.20"],
+          });
+        }),
+      );
+      expect(initial.records).toEqual(["192.0.2.20"]);
+
+      // Mutate the record out-of-band.
+      const mutateResp = yield* route53.changeResourceRecordSets({
+        HostedZoneId: zone.hostedZoneId,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "UPSERT",
+              ResourceRecordSet: {
+                Name: normalizeName(recordName),
+                Type: "A",
+                TTL: 3600,
+                ResourceRecords: [{ Value: "203.0.113.99" }],
+              },
+            },
+          ],
+        },
+      });
+      yield* waitForInSync(mutateResp.ChangeInfo.Id);
+
+      const drifted = yield* findRecord(zone.hostedZoneId, recordName, "A");
+      expect(drifted?.TTL).toEqual(3600);
+      expect(drifted?.ResourceRecords?.[0]?.Value).toEqual("203.0.113.99");
+
+      // Re-deploy with the original desired props — reconciler should
+      // overwrite the drifted record back to the canonical values.
+      const reconciled = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Record("DriftRecord", {
+            hostedZoneId: zone.hostedZoneId,
+            name: recordName,
+            type: "A",
+            ttl: 60,
+            records: ["192.0.2.20"],
+          });
+        }),
+      );
+      expect(reconciled.records).toEqual(["192.0.2.20"]);
+      expect(reconciled.ttl).toEqual(60);
+
+      yield* stack.destroy();
+      yield* deleteTestHostedZone(zone.hostedZoneId);
+    }),
+  { timeout: 240_000 },
+);
+
+test.provider(
+  "reconcile re-creates a record that was deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const zone = yield* createTestHostedZone("recreate");
+      const recordName = `recreate.${zone.domain}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Record("RecreateRecord", {
+            hostedZoneId: zone.hostedZoneId,
+            name: recordName,
+            type: "TXT",
+            ttl: 60,
+            records: ['"hello"'],
+          });
+        }),
+      );
+      expect(initial.records).toEqual(['"hello"']);
+
+      // Delete the record out-of-band.
+      const deleteResp = yield* route53.changeResourceRecordSets({
+        HostedZoneId: zone.hostedZoneId,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "DELETE",
+              ResourceRecordSet: {
+                Name: normalizeName(recordName),
+                Type: "TXT",
+                TTL: 60,
+                ResourceRecords: [{ Value: '"hello"' }],
+              },
+            },
+          ],
+        },
+      });
+      yield* waitForInSync(deleteResp.ChangeInfo.Id);
+
+      const gone = yield* findRecord(zone.hostedZoneId, recordName, "TXT");
+      expect(gone).toBeUndefined();
+
+      // Re-deploy — reconciler must recreate the record from desired.
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Record("RecreateRecord", {
+            hostedZoneId: zone.hostedZoneId,
+            name: recordName,
+            type: "TXT",
+            ttl: 60,
+            records: ['"hello"'],
+          });
+        }),
+      );
+      expect(recreated.records).toEqual(['"hello"']);
+
+      const observed = yield* findRecord(zone.hostedZoneId, recordName, "TXT");
+      expect(observed).toBeDefined();
+
+      yield* stack.destroy();
+      yield* deleteTestHostedZone(zone.hostedZoneId);
+    }),
+  { timeout: 240_000 },
+);
+
+test.provider(
+  "changing record type triggers replace",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const zone = yield* createTestHostedZone("replace");
+      const recordName = `replace.${zone.domain}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Record("ReplaceRecord", {
+            hostedZoneId: zone.hostedZoneId,
+            name: recordName,
+            type: "A",
+            ttl: 60,
+            records: ["192.0.2.30"],
+          });
+        }),
+      );
+      expect(a.type).toEqual("A");
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Record("ReplaceRecord", {
+            hostedZoneId: zone.hostedZoneId,
+            name: recordName,
+            type: "TXT",
+            ttl: 60,
+            records: ['"replaced"'],
+          });
+        }),
+      );
+      expect(b.type).toEqual("TXT");
+      expect(b.records).toEqual(['"replaced"']);
+
+      // Old A record should be gone after replace.
+      const oldA = yield* findRecord(zone.hostedZoneId, recordName, "A");
+      expect(oldA).toBeUndefined();
+
+      yield* stack.destroy();
+      yield* deleteTestHostedZone(zone.hostedZoneId);
+    }),
+  { timeout: 240_000 },
+);
+
+test.provider(
+  "changing record name triggers replace",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const zone = yield* createTestHostedZone("rename");
+      const nameA = `original.${zone.domain}`;
+      const nameB = `renamed.${zone.domain}`;
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Record("RenameRecord", {
+            hostedZoneId: zone.hostedZoneId,
+            name: nameA,
+            type: "A",
+            ttl: 60,
+            records: ["192.0.2.40"],
+          });
+        }),
+      );
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Record("RenameRecord", {
+            hostedZoneId: zone.hostedZoneId,
+            name: nameB,
+            type: "A",
+            ttl: 60,
+            records: ["192.0.2.40"],
+          });
+        }),
+      );
+
+      // Old name should be cleaned up after replace.
+      const oldRecord = yield* findRecord(zone.hostedZoneId, nameA, "A");
+      expect(oldRecord).toBeUndefined();
+
+      // New name should exist.
+      const newRecord = yield* findRecord(zone.hostedZoneId, nameB, "A");
+      expect(newRecord).toBeDefined();
+      expect(newRecord?.ResourceRecords?.[0]?.Value).toEqual("192.0.2.40");
+
+      yield* stack.destroy();
+      yield* deleteTestHostedZone(zone.hostedZoneId);
+    }),
+  { timeout: 240_000 },
+);
+
+test.provider(
+  "concurrent records sharing a hosted zone all converge",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const zone = yield* createTestHostedZone("concurrent");
+
+      // Deploy three records into the same zone in one pass. The
+      // reconciler must tolerate `PriorRequestNotComplete` from the
+      // shared-zone serialization that Route53 enforces.
+      const result = yield* stack.deploy(
+        Effect.gen(function* () {
+          const a = yield* Record("ConcurrentA", {
+            hostedZoneId: zone.hostedZoneId,
+            name: `a.${zone.domain}`,
+            type: "A",
+            ttl: 60,
+            records: ["192.0.2.50"],
+          });
+          const b = yield* Record("ConcurrentB", {
+            hostedZoneId: zone.hostedZoneId,
+            name: `b.${zone.domain}`,
+            type: "A",
+            ttl: 60,
+            records: ["192.0.2.51"],
+          });
+          const c = yield* Record("ConcurrentC", {
+            hostedZoneId: zone.hostedZoneId,
+            name: `c.${zone.domain}`,
+            type: "TXT",
+            ttl: 60,
+            records: ['"c"'],
+          });
+          return { a, b, c };
+        }),
+      );
+
+      expect(result.a.records).toEqual(["192.0.2.50"]);
+      expect(result.b.records).toEqual(["192.0.2.51"]);
+      expect(result.c.records).toEqual(['"c"']);
+
+      // Now remove one of the three; the destroy of A must coexist with
+      // B and C still in place.
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          const b = yield* Record("ConcurrentB", {
+            hostedZoneId: zone.hostedZoneId,
+            name: `b.${zone.domain}`,
+            type: "A",
+            ttl: 60,
+            records: ["192.0.2.51"],
+          });
+          const c = yield* Record("ConcurrentC", {
+            hostedZoneId: zone.hostedZoneId,
+            name: `c.${zone.domain}`,
+            type: "TXT",
+            ttl: 60,
+            records: ['"c"'],
+          });
+          return { b, c };
+        }),
+      );
+
+      const a = yield* findRecord(zone.hostedZoneId, `a.${zone.domain}`, "A");
+      expect(a).toBeUndefined();
+
+      const b = yield* findRecord(zone.hostedZoneId, `b.${zone.domain}`, "A");
+      expect(b).toBeDefined();
+
+      yield* stack.destroy();
+      yield* deleteTestHostedZone(zone.hostedZoneId);
+    }),
+  { timeout: 360_000 },
+);
+
+test.provider(
+  "destroying an already-deleted record is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const zone = yield* createTestHostedZone("doubledestroy");
+      const recordName = `dd.${zone.domain}`;
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Record("DoubleDestroy", {
+            hostedZoneId: zone.hostedZoneId,
+            name: recordName,
+            type: "A",
+            ttl: 60,
+            records: ["192.0.2.60"],
+          });
+        }),
+      );
+
+      // Delete the record out-of-band, then ask the engine to destroy.
+      const deleteResp = yield* route53.changeResourceRecordSets({
+        HostedZoneId: zone.hostedZoneId,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "DELETE",
+              ResourceRecordSet: {
+                Name: normalizeName(recordName),
+                Type: "A",
+                TTL: 60,
+                ResourceRecords: [{ Value: "192.0.2.60" }],
+              },
+            },
+          ],
+        },
+      });
+      yield* waitForInSync(deleteResp.ChangeInfo.Id);
+
+      // The engine's delete must finish cleanly.
+      yield* stack.destroy();
+
+      yield* deleteTestHostedZone(zone.hostedZoneId);
+    }),
+  { timeout: 240_000 },
+);
+
+void RecordStillExists;


### PR DESCRIPTION
Replace `Effect.die` and blanket `Effect.catchTag("InvalidChangeBatch")` in the Route 53 Record provider with targeted handling, and add lifecycle tests against a real hosted zone.

### Reconciler changes

- `waitForChange` now fails with a typed `Route53ChangePending` instead of `Effect.die`, so a stuck change batch surfaces cleanly instead of crashing the engine.
- Every mutating Route 53 call (`changeResourceRecordSets`, `getChange`, `listResourceRecordSets`) is wrapped in a `PriorRequestNotComplete` retry. AWS classifies that error as `BadRequestError` so the AWS retry layer doesn't auto-retry — but it's the standard hosted-zone-serialization signal and is always transient.
- `reconcile` observes the record first and skips the change batch entirely when the cloud state already matches desired. Same-spec redeploys no longer generate change batches at all.
- Re-read after upsert is bounded with `Route53RecordNotVisible` retry instead of `Effect.die`, to ride out the brief list/change ordering window.

```ts
// before
Effect.flatMap((changeInfo) =>
  changeInfo.Status === "INSYNC"
    ? Effect.succeed(changeInfo)
    : Effect.die(new Error("Route53ChangePending")),
),

// after
Effect.flatMap((changeInfo) =>
  changeInfo.Status === "INSYNC"
    ? Effect.succeed(changeInfo)
    : Effect.fail(new Route53ChangePending({ changeId })),
),
```

`delete` reads the observed record set and echoes it back to `DELETE`, so out-of-band drift can't trigger `InvalidChangeBatch`. Only `InvalidChangeBatch` carrying a "not found" message is tolerated.

### New lifecycle tests

`packages/alchemy/test/AWS/Route53/Record.test.ts` — each test provisions its own randomized public hosted zone, runs the scenario, and tears the zone down:

- redeploy with same props is a no-op
- reconcile resets TTL / values mutated out-of-band
- reconcile re-creates a record that was deleted out-of-band
- changing record `type` triggers replace
- changing record `name` triggers replace
- multiple records sharing a hosted zone all converge (`PriorRequestNotComplete` handling)
- destroying an already-deleted record is a no-op

### Distilled patch

https://github.com/alchemy-run/distilled/pull/250 — categorizes `PriorRequestNotComplete` as `ConflictError + RetryableError` and `ThrottlingException` as `ThrottlingError + RetryableError` so the AWS retry layer rides them out at the SDK level. The provider's local retry is kept as a defense-in-depth.
