### PR TITLE
fix(aws/eventbridge): harden Rule reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/EventBridge/EventBus.ts
+++ b/packages/alchemy/src/AWS/EventBridge/EventBus.ts
@@ -1,6 +1,7 @@
 import { Region } from "@distilled.cloud/aws/Region";
 import * as eventbridge from "@distilled.cloud/aws/eventbridge";
 import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
 
 import { Unowned } from "../../AdoptPolicy.ts";
 import { isResolved } from "../../Diff.ts";
@@ -117,6 +118,24 @@ export interface EventBus extends Resource<
 > {}
 export const EventBus = Resource<EventBus>("AWS.EventBridge.EventBus");
 
+/**
+ * Retry transient EventBridge faults: `ConcurrentModificationException`
+ * fires when two writers race on the same event bus, and `InternalException`
+ * is the catch-all for service-side hiccups. Both are safe to replay because
+ * the bus operations we wrap are idempotent on matching params.
+ */
+const retryEventBridgeTransients = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  effect.pipe(
+    Effect.retry({
+      while: (error: any) =>
+        error?._tag === "ConcurrentModificationException" ||
+        error?._tag === "InternalException",
+      schedule: Schedule.exponential(200).pipe(
+        Schedule.both(Schedule.recurs(8)),
+      ),
+    }),
+  );
+
 export const EventBusProvider = () =>
   Provider.effect(
     EventBus,
@@ -151,23 +170,33 @@ export const EventBusProvider = () =>
         read: Effect.fn(function* ({ id, olds, output }) {
           const eventBusName =
             output?.eventBusName ?? (yield* createEventBusName(id, olds ?? {}));
-          const described = yield* eventbridge
-            .describeEventBus({
-              Name: eventBusName,
-            })
-            .pipe(
-              Effect.catchTag("ResourceNotFoundException", () =>
-                Effect.succeed(undefined),
+          const described = yield* retryEventBridgeTransients(
+            eventbridge
+              .describeEventBus({
+                Name: eventBusName,
+              })
+              .pipe(
+                Effect.catchTag("ResourceNotFoundException", () =>
+                  Effect.succeed(undefined),
+                ),
               ),
-            );
+          );
 
           if (!described?.Arn || !described.Name) {
             return undefined;
           }
 
-          const { Tags } = yield* eventbridge.listTagsForResource({
-            ResourceARN: described.Arn,
-          });
+          const { Tags } = yield* retryEventBridgeTransients(
+            eventbridge
+              .listTagsForResource({
+                ResourceARN: described.Arn,
+              })
+              .pipe(
+                Effect.catchTag("ResourceNotFoundException", () =>
+                  Effect.succeed({ Tags: [] as eventbridge.Tag[] }),
+                ),
+              ),
+          );
           const attrs = {
             eventBusName: described.Name,
             eventBusArn: described.Arn as EventBusArn,
@@ -192,40 +221,8 @@ export const EventBusProvider = () =>
           // blindly: a bus deleted out of band shows up as missing and we
           // recreate. Foreign-tagged buses have already been screened by
           // `read` upstream.
-          let described = yield* eventbridge
-            .describeEventBus({
-              Name: eventBusName,
-            })
-            .pipe(
-              Effect.catchTag("ResourceNotFoundException", () =>
-                Effect.succeed(undefined),
-              ),
-            );
-
-          // Ensure — create the bus if missing. Tolerate
-          // `ResourceAlreadyExistsException` as a race with a peer
-          // reconciler: re-read and continue with the sync path.
-          if (!described?.Arn) {
-            yield* eventbridge
-              .createEventBus({
-                Name: eventBusName,
-                EventSourceName: news.eventSourceName,
-                Description: news.description,
-                KmsKeyIdentifier: news.kmsKeyIdentifier as string | undefined,
-                DeadLetterConfig: news.deadLetterConfig
-                  ? { Arn: news.deadLetterConfig.Arn as string | undefined }
-                  : undefined,
-                LogConfig: news.logConfig,
-                Tags: createTagsList(desiredTags),
-              })
-              .pipe(
-                Effect.catchTag(
-                  "ResourceAlreadyExistsException",
-                  () => Effect.void,
-                ),
-              );
-
-            described = yield* eventbridge
+          let described = yield* retryEventBridgeTransients(
+            eventbridge
               .describeEventBus({
                 Name: eventBusName,
               })
@@ -233,30 +230,83 @@ export const EventBusProvider = () =>
                 Effect.catchTag("ResourceNotFoundException", () =>
                   Effect.succeed(undefined),
                 ),
-              );
+              ),
+          );
+
+          // Ensure — create the bus if missing. Tolerate
+          // `ResourceAlreadyExistsException` as a race with a peer
+          // reconciler: re-read and continue with the sync path.
+          if (!described?.Arn) {
+            yield* retryEventBridgeTransients(
+              eventbridge
+                .createEventBus({
+                  Name: eventBusName,
+                  EventSourceName: news.eventSourceName,
+                  Description: news.description,
+                  KmsKeyIdentifier: news.kmsKeyIdentifier as string | undefined,
+                  DeadLetterConfig: news.deadLetterConfig
+                    ? { Arn: news.deadLetterConfig.Arn as string | undefined }
+                    : undefined,
+                  LogConfig: news.logConfig,
+                  Tags: createTagsList(desiredTags),
+                })
+                .pipe(
+                  Effect.catchTag(
+                    "ResourceAlreadyExistsException",
+                    () => Effect.void,
+                  ),
+                ),
+            );
+
+            described = yield* retryEventBridgeTransients(
+              eventbridge
+                .describeEventBus({
+                  Name: eventBusName,
+                })
+                .pipe(
+                  Effect.catchTag("ResourceNotFoundException", () =>
+                    Effect.succeed(undefined),
+                  ),
+                ),
+            );
           }
 
           // Sync mutable bus configuration — `updateEventBus` overwrites
           // `description`, KMS key, DLQ, and log config in one shot, so we
           // call it unconditionally (idempotent for matching values).
-          yield* eventbridge.updateEventBus({
-            Name: eventBusName,
-            Description: news.description,
-            KmsKeyIdentifier: news.kmsKeyIdentifier as string | undefined,
-            DeadLetterConfig: news.deadLetterConfig
-              ? { Arn: news.deadLetterConfig.Arn as string | undefined }
-              : undefined,
-            LogConfig: news.logConfig,
-          });
+          // `ResourceNotFoundException` is a race with delete; rest in
+          // peace, the engine will re-converge on the next pass.
+          yield* retryEventBridgeTransients(
+            eventbridge
+              .updateEventBus({
+                Name: eventBusName,
+                Description: news.description,
+                KmsKeyIdentifier: news.kmsKeyIdentifier as string | undefined,
+                DeadLetterConfig: news.deadLetterConfig
+                  ? { Arn: news.deadLetterConfig.Arn as string | undefined }
+                  : undefined,
+                LogConfig: news.logConfig,
+              })
+              .pipe(
+                Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+              ),
+          );
 
           // Sync tags — diff observed cloud tags against desired. Adoption
           // may bring us a bus with its own tag set; diffing against the
           // freshly-fetched tags lets the reconciler converge regardless.
-          const observedTagsList = yield* eventbridge
-            .listTagsForResource({
-              ResourceARN: eventBusArn,
-            })
-            .pipe(Effect.map((r) => r.Tags ?? []));
+          const observedTagsList = yield* retryEventBridgeTransients(
+            eventbridge
+              .listTagsForResource({
+                ResourceARN: eventBusArn,
+              })
+              .pipe(
+                Effect.map((r) => r.Tags ?? []),
+                Effect.catchTag("ResourceNotFoundException", () =>
+                  Effect.succeed([] as eventbridge.Tag[]),
+                ),
+              ),
+          );
           const observedTags: Record<string, string> = {};
           for (const tag of observedTagsList) {
             if (tag.Key && tag.Value !== undefined) {
@@ -266,17 +316,33 @@ export const EventBusProvider = () =>
           const { removed, upsert } = diffTags(observedTags, desiredTags);
 
           if (removed.length > 0) {
-            yield* eventbridge.untagResource({
-              ResourceARN: eventBusArn,
-              TagKeys: removed,
-            });
+            yield* retryEventBridgeTransients(
+              eventbridge
+                .untagResource({
+                  ResourceARN: eventBusArn,
+                  TagKeys: removed,
+                })
+                .pipe(
+                  Effect.catchTag("ResourceNotFoundException", () =>
+                    Effect.void,
+                  ),
+                ),
+            );
           }
 
           if (upsert.length > 0) {
-            yield* eventbridge.tagResource({
-              ResourceARN: eventBusArn,
-              Tags: upsert,
-            });
+            yield* retryEventBridgeTransients(
+              eventbridge
+                .tagResource({
+                  ResourceARN: eventBusArn,
+                  Tags: upsert,
+                })
+                .pipe(
+                  Effect.catchTag("ResourceNotFoundException", () =>
+                    Effect.void,
+                  ),
+                ),
+            );
           }
 
           yield* session.note(eventBusArn);
@@ -287,9 +353,25 @@ export const EventBusProvider = () =>
           };
         }),
         delete: Effect.fn(function* (input) {
-          yield* eventbridge.deleteEventBus({
-            Name: input.output.eventBusName,
-          });
+          // Idempotent destroy: ignore `ResourceNotFoundException` so a
+          // double-destroy (or out-of-band delete) is a no-op. The error
+          // is missing from `deleteEventBus`'s typed union upstream so we
+          // pattern-match by `_tag` and re-raise anything else. Wrap in
+          // the transient-retry helper to ride out
+          // `ConcurrentModificationException` from peer writers.
+          yield* retryEventBridgeTransients(
+            eventbridge
+              .deleteEventBus({
+                Name: input.output.eventBusName,
+              })
+              .pipe(
+                Effect.catch((error: any) =>
+                  error?._tag === "ResourceNotFoundException"
+                    ? Effect.void
+                    : Effect.fail(error),
+                ),
+              ),
+          );
         }),
       };
     }),

--- a/packages/alchemy/src/AWS/EventBridge/Rule.ts
+++ b/packages/alchemy/src/AWS/EventBridge/Rule.ts
@@ -1,6 +1,7 @@
 import { Region } from "@distilled.cloud/aws/Region";
 import * as eventbridge from "@distilled.cloud/aws/eventbridge";
 import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
 import { Unowned } from "../../AdoptPolicy.ts";
 import { isResolved } from "../../Diff.ts";
 import type { Input } from "../../Input.ts";
@@ -269,6 +270,26 @@ export interface Rule extends Resource<
 > {}
 export const Rule = Resource<Rule>("AWS.EventBridge.Rule");
 
+/**
+ * Retry transient EventBridge faults: `ConcurrentModificationException` is
+ * raised when two writers race on the same rule (e.g. put-rule + put-targets
+ * landing simultaneously) and `InternalException` is the catch-all for
+ * service-side hiccups. Both are safe to replay because the operations
+ * we wrap (putRule/putTargets/removeTargets/tag*) are idempotent on
+ * matching params.
+ */
+const retryEventBridgeTransients = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  effect.pipe(
+    Effect.retry({
+      while: (error: any) =>
+        error?._tag === "ConcurrentModificationException" ||
+        error?._tag === "InternalException",
+      schedule: Schedule.exponential(200).pipe(
+        Schedule.both(Schedule.recurs(8)),
+      ),
+    }),
+  );
+
 export const RuleProvider = () =>
   Provider.effect(
     Rule,
@@ -306,17 +327,19 @@ export const RuleProvider = () =>
             output?.ruleName ?? (yield* createRuleName(id, olds));
           const eventBusName =
             output?.eventBusName ?? olds.eventBusName ?? "default";
-          const described = yield* eventbridge
-            .describeRule({
-              Name: ruleName,
-              EventBusName:
-                eventBusName !== "default" ? eventBusName : undefined,
-            })
-            .pipe(
-              Effect.catchTag("ResourceNotFoundException", () =>
-                Effect.succeed(undefined),
+          const described = yield* retryEventBridgeTransients(
+            eventbridge
+              .describeRule({
+                Name: ruleName,
+                EventBusName:
+                  eventBusName !== "default" ? eventBusName : undefined,
+              })
+              .pipe(
+                Effect.catchTag("ResourceNotFoundException", () =>
+                  Effect.succeed(undefined),
+                ),
               ),
-            );
+          );
 
           if (!described?.Name) {
             return undefined;
@@ -329,9 +352,21 @@ export const RuleProvider = () =>
             resolvedEventBusName,
             described.Name,
           );
-          const { Tags } = yield* eventbridge.listTagsForResource({
-            ResourceARN: described.Arn ?? ruleArn,
-          });
+          // listTagsForResource can race with delete — fall back to an empty
+          // tag set so the upstream ownership check treats the rule as
+          // foreign (and the engine can recreate cleanly). Transient
+          // server-side faults are retried.
+          const { Tags } = yield* retryEventBridgeTransients(
+            eventbridge
+              .listTagsForResource({
+                ResourceARN: described.Arn ?? ruleArn,
+              })
+              .pipe(
+                Effect.catchTag("ResourceNotFoundException", () =>
+                  Effect.succeed({ Tags: [] as eventbridge.Tag[] }),
+                ),
+              ),
+          );
           const attrs = {
             ruleName: described.Name,
             ruleArn,
@@ -362,19 +397,23 @@ export const RuleProvider = () =>
           // matching params and overwrites schedule/eventPattern/state/etc.
           // on differences, so we call it unconditionally. `Tags` only
           // applies when creating; tags are reconciled separately below
-          // against observed cloud tags.
-          const { RuleArn } = yield* eventbridge.putRule({
-            Name: ruleName,
-            Description: news.description,
-            EventBusName: eventBusParam,
-            EventPattern: news.eventPattern
-              ? JSON.stringify(news.eventPattern)
-              : undefined,
-            ScheduleExpression: news.scheduleExpression,
-            State: news.state ?? "ENABLED",
-            RoleArn: news.roleArn as string | undefined,
-            Tags: createTagsList(desiredTags),
-          });
+          // against observed cloud tags. Retry transient
+          // `ConcurrentModificationException` / `InternalException` —
+          // both can fire when a peer reconciler races on the same rule.
+          const { RuleArn } = yield* retryEventBridgeTransients(
+            eventbridge.putRule({
+              Name: ruleName,
+              Description: news.description,
+              EventBusName: eventBusParam,
+              EventPattern: news.eventPattern
+                ? JSON.stringify(news.eventPattern)
+                : undefined,
+              ScheduleExpression: news.scheduleExpression,
+              State: news.state ?? "ENABLED",
+              RoleArn: news.roleArn as string | undefined,
+              Tags: createTagsList(desiredTags),
+            }),
+          );
           const ruleArn =
             (RuleArn as RuleArn | undefined) ??
             toRuleArn(region, accountId, eventBusName, ruleName);
@@ -385,17 +424,19 @@ export const RuleProvider = () =>
           const resolvedTargets =
             (news.targets as Input.Resolve<RuleTarget>[] | undefined) ?? [];
           const desiredTargetIds = new Set(resolvedTargets.map((t) => t.Id));
-          const observedTargets = yield* eventbridge
-            .listTargetsByRule({
-              Rule: ruleName,
-              EventBusName: eventBusParam,
-            })
-            .pipe(
-              Effect.map((r) => r.Targets ?? []),
-              Effect.catchTag("ResourceNotFoundException", () =>
-                Effect.succeed([] as eventbridge.Target[]),
+          const observedTargets = yield* retryEventBridgeTransients(
+            eventbridge
+              .listTargetsByRule({
+                Rule: ruleName,
+                EventBusName: eventBusParam,
+              })
+              .pipe(
+                Effect.map((r) => r.Targets ?? []),
+                Effect.catchTag("ResourceNotFoundException", () =>
+                  Effect.succeed([] as eventbridge.Target[]),
+                ),
               ),
-            );
+          );
           const removedTargetIds = observedTargets
             .map((t) => t.Id)
             .filter(
@@ -403,17 +444,19 @@ export const RuleProvider = () =>
             );
 
           if (removedTargetIds.length > 0) {
-            const response = yield* eventbridge
-              .removeTargets({
-                Rule: ruleName,
-                EventBusName: eventBusParam,
-                Ids: removedTargetIds,
-              })
-              .pipe(
-                Effect.catchTag("ResourceNotFoundException", () =>
-                  Effect.succeed(undefined),
+            const response = yield* retryEventBridgeTransients(
+              eventbridge
+                .removeTargets({
+                  Rule: ruleName,
+                  EventBusName: eventBusParam,
+                  Ids: removedTargetIds,
+                })
+                .pipe(
+                  Effect.catchTag("ResourceNotFoundException", () =>
+                    Effect.succeed(undefined),
+                  ),
                 ),
-              );
+            );
 
             if (response) {
               yield* assertRemoveTargetsSucceeded(response);
@@ -421,21 +464,35 @@ export const RuleProvider = () =>
           }
 
           if (resolvedTargets.length > 0) {
-            const response = yield* eventbridge.putTargets({
-              Rule: ruleName,
-              EventBusName: eventBusParam,
-              Targets: resolvedTargets.map(toTarget),
-            });
+            const response = yield* retryEventBridgeTransients(
+              eventbridge.putTargets({
+                Rule: ruleName,
+                EventBusName: eventBusParam,
+                Targets: resolvedTargets.map(toTarget),
+              }),
+            );
             yield* assertPutTargetsSucceeded(response);
           }
 
           // Sync tags — diff observed cloud tags against desired. Adoption
-          // and partial prior runs both converge here.
-          const observedTagsList = yield* eventbridge
-            .listTagsForResource({
-              ResourceARN: ruleArn,
-            })
-            .pipe(Effect.map((r) => r.Tags ?? []));
+          // and partial prior runs both converge here. We diff against
+          // freshly-fetched tags rather than `olds.tags`/`output.tags` so
+          // adopted rules with foreign tag sets converge on a single pass.
+          // `ResourceNotFoundException` catches a race where the rule was
+          // deleted between `putRule` and the tag sync — extremely
+          // unlikely in practice, but lets us fail soft instead of hard.
+          const observedTagsList = yield* retryEventBridgeTransients(
+            eventbridge
+              .listTagsForResource({
+                ResourceARN: ruleArn,
+              })
+              .pipe(
+                Effect.map((r) => r.Tags ?? []),
+                Effect.catchTag("ResourceNotFoundException", () =>
+                  Effect.succeed([] as eventbridge.Tag[]),
+                ),
+              ),
+          );
           const observedTags: Record<string, string> = {};
           for (const tag of observedTagsList) {
             if (tag.Key && tag.Value !== undefined) {
@@ -445,17 +502,33 @@ export const RuleProvider = () =>
           const { removed, upsert } = diffTags(observedTags, desiredTags);
 
           if (removed.length > 0) {
-            yield* eventbridge.untagResource({
-              ResourceARN: ruleArn,
-              TagKeys: removed,
-            });
+            yield* retryEventBridgeTransients(
+              eventbridge
+                .untagResource({
+                  ResourceARN: ruleArn,
+                  TagKeys: removed,
+                })
+                .pipe(
+                  Effect.catchTag("ResourceNotFoundException", () =>
+                    Effect.void,
+                  ),
+                ),
+            );
           }
 
           if (upsert.length > 0) {
-            yield* eventbridge.tagResource({
-              ResourceARN: ruleArn,
-              Tags: upsert,
-            });
+            yield* retryEventBridgeTransients(
+              eventbridge
+                .tagResource({
+                  ResourceARN: ruleArn,
+                  Tags: upsert,
+                })
+                .pipe(
+                  Effect.catchTag("ResourceNotFoundException", () =>
+                    Effect.void,
+                  ),
+                ),
+            );
           }
 
           yield* session.note(ruleArn);
@@ -471,40 +544,54 @@ export const RuleProvider = () =>
           const eventBusParam =
             eventBusName !== "default" ? eventBusName : undefined;
 
-          const { Targets } = yield* eventbridge
-            .listTargetsByRule({
-              Rule: ruleName,
-              EventBusName: eventBusParam,
-            })
-            .pipe(
-              Effect.catchTag("ResourceNotFoundException", () =>
-                Effect.succeed({ Targets: undefined }),
-              ),
-            );
-
-          if (Targets && Targets.length > 0) {
-            const response = yield* eventbridge
-              .removeTargets({
+          // EventBridge requires removing all targets before deleting the
+          // rule itself. List + remove is wrapped in a transient retry to
+          // ride out `ConcurrentModificationException` from peers.
+          const { Targets } = yield* retryEventBridgeTransients(
+            eventbridge
+              .listTargetsByRule({
                 Rule: ruleName,
                 EventBusName: eventBusParam,
-                Ids: Targets.map((t) => t.Id),
               })
               .pipe(
-                Effect.catchTag("ResourceNotFoundException", () => Effect.void),
-              );
+                Effect.catchTag("ResourceNotFoundException", () =>
+                  Effect.succeed({ Targets: undefined }),
+                ),
+              ),
+          );
+
+          if (Targets && Targets.length > 0) {
+            const response = yield* retryEventBridgeTransients(
+              eventbridge
+                .removeTargets({
+                  Rule: ruleName,
+                  EventBusName: eventBusParam,
+                  Ids: Targets.map((t) => t.Id),
+                })
+                .pipe(
+                  Effect.catchTag("ResourceNotFoundException", () =>
+                    Effect.void,
+                  ),
+                ),
+            );
             if (response) {
               yield* assertRemoveTargetsSucceeded(response);
             }
           }
 
-          yield* eventbridge
-            .deleteRule({
-              Name: ruleName,
-              EventBusName: eventBusParam,
-            })
-            .pipe(
-              Effect.catchTag("ResourceNotFoundException", () => Effect.void),
-            );
+          // Delete the rule. `ResourceNotFoundException` makes the destroy
+          // idempotent (already gone); `ConcurrentModificationException`
+          // is retried via the wrapper.
+          yield* retryEventBridgeTransients(
+            eventbridge
+              .deleteRule({
+                Name: ruleName,
+                EventBusName: eventBusParam,
+              })
+              .pipe(
+                Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+              ),
+          );
         }),
       };
     }),

--- a/packages/alchemy/test/AWS/EventBridge/Rule.test.ts
+++ b/packages/alchemy/test/AWS/EventBridge/Rule.test.ts
@@ -1,0 +1,522 @@
+import { adopt } from "@/AdoptPolicy";
+import * as AWS from "@/AWS";
+import { Rule } from "@/AWS/EventBridge";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import * as eventbridge from "@distilled.cloud/aws/eventbridge";
+import { describe, expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+const randomSuffix = () => Math.random().toString(36).slice(2, 8);
+
+describe("AWS.EventBridge.Rule", () => {
+  test.provider(
+    "create and delete a scheduled rule with default props",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const rule = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Rule("DefaultRule", {
+              scheduleExpression: "rate(1 hour)",
+            });
+          }),
+        );
+
+        expect(rule.ruleName).toBeDefined();
+        expect(rule.ruleArn).toMatch(/^arn:aws:events:/);
+        expect(rule.eventBusName).toEqual("default");
+
+        const described = yield* eventbridge.describeRule({
+          Name: rule.ruleName,
+        });
+        expect(described.ScheduleExpression).toEqual("rate(1 hour)");
+        expect(described.State).toEqual("ENABLED");
+
+        yield* stack.destroy();
+        yield* assertRuleDeleted(rule.ruleName);
+      }),
+  );
+
+  test.provider(
+    "redeploy with same props is a no-op (reconcile is idempotent)",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Rule("IdempotentRule", {
+              scheduleExpression: "rate(10 minutes)",
+              description: "first deploy",
+            });
+          }),
+        );
+
+        // Deploy again with identical props — must converge without
+        // changing the underlying rule.
+        const second = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Rule("IdempotentRule", {
+              scheduleExpression: "rate(10 minutes)",
+              description: "first deploy",
+            });
+          }),
+        );
+
+        expect(second.ruleName).toEqual(initial.ruleName);
+        expect(second.ruleArn).toEqual(initial.ruleArn);
+
+        const described = yield* eventbridge.describeRule({
+          Name: second.ruleName,
+        });
+        expect(described.ScheduleExpression).toEqual("rate(10 minutes)");
+        expect(described.Description).toEqual("first deploy");
+
+        yield* stack.destroy();
+        yield* assertRuleDeleted(initial.ruleName);
+      }),
+  );
+
+  test.provider(
+    "reconcile resets ScheduleExpression / State / Description mutated out-of-band",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const rule = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Rule("DriftRule", {
+              scheduleExpression: "rate(15 minutes)",
+              description: "managed by alchemy",
+              state: "ENABLED",
+            });
+          }),
+        );
+
+        // Mutate every mutable field via the raw SDK.
+        yield* eventbridge.putRule({
+          Name: rule.ruleName,
+          ScheduleExpression: "rate(2 hours)",
+          Description: "drifted manually",
+          State: "DISABLED",
+        });
+        yield* waitForRuleMatch(rule.ruleName, {
+          ScheduleExpression: "rate(2 hours)",
+          Description: "drifted manually",
+          State: "DISABLED",
+        });
+
+        // Re-deploy with the original desired props — reconcile should
+        // converge each drifted field back to the desired value.
+        const redeployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Rule("DriftRule", {
+              scheduleExpression: "rate(15 minutes)",
+              description: "managed by alchemy",
+              state: "ENABLED",
+            });
+          }),
+        );
+        expect(redeployed.ruleName).toEqual(rule.ruleName);
+
+        yield* waitForRuleMatch(rule.ruleName, {
+          ScheduleExpression: "rate(15 minutes)",
+          Description: "managed by alchemy",
+          State: "ENABLED",
+        });
+
+        yield* stack.destroy();
+        yield* assertRuleDeleted(rule.ruleName);
+      }),
+  );
+
+  test.provider(
+    "reconcile resets EventPattern mutated out-of-band",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const desiredPattern = {
+          source: ["alchemy.test"],
+          "detail-type": ["alchemy.original"],
+        };
+        const rule = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Rule("PatternDriftRule", {
+              eventPattern: desiredPattern,
+            });
+          }),
+        );
+
+        // Drift the pattern via the SDK.
+        yield* eventbridge.putRule({
+          Name: rule.ruleName,
+          EventPattern: JSON.stringify({
+            source: ["alchemy.test"],
+            "detail-type": ["alchemy.drifted"],
+          }),
+        });
+
+        // Re-deploy must reset the pattern to the alchemy-managed value.
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Rule("PatternDriftRule", {
+              eventPattern: desiredPattern,
+            });
+          }),
+        );
+
+        yield* waitForEventPatternMatch(rule.ruleName, desiredPattern);
+
+        yield* stack.destroy();
+        yield* assertRuleDeleted(rule.ruleName);
+      }),
+  );
+
+  test.provider(
+    "reconcile re-creates a rule that was deleted out-of-band",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const ruleName = `alchemy-test-rule-recreate-${randomSuffix()}`;
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Rule("RecreateRule", {
+              name: ruleName,
+              scheduleExpression: "rate(30 minutes)",
+            });
+          }),
+        );
+        expect(initial.ruleName).toEqual(ruleName);
+
+        // Delete the rule out-of-band. EventBridge requires removing
+        // targets first; this rule has none.
+        yield* eventbridge.deleteRule({ Name: ruleName });
+        yield* assertRuleDeleted(ruleName);
+
+        // Re-deploy must converge by re-creating the rule.
+        const recreated = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Rule("RecreateRule", {
+              name: ruleName,
+              scheduleExpression: "rate(30 minutes)",
+            });
+          }),
+        );
+        expect(recreated.ruleName).toEqual(ruleName);
+        const described = yield* eventbridge.describeRule({ Name: ruleName });
+        expect(described.ScheduleExpression).toEqual("rate(30 minutes)");
+
+        yield* stack.destroy();
+        yield* assertRuleDeleted(ruleName);
+      }),
+  );
+
+  test.provider(
+    "changing rule name triggers replace, old rule is deleted",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const suffix = randomSuffix();
+        const nameA = `alchemy-test-rule-replace-a-${suffix}`;
+        const nameB = `alchemy-test-rule-replace-b-${suffix}`;
+
+        const a = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Rule("RenameRule", {
+              name: nameA,
+              scheduleExpression: "rate(1 hour)",
+            });
+          }),
+        );
+        expect(a.ruleName).toEqual(nameA);
+
+        const b = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Rule("RenameRule", {
+              name: nameB,
+              scheduleExpression: "rate(1 hour)",
+            });
+          }),
+        );
+        expect(b.ruleName).toEqual(nameB);
+        expect(b.ruleArn).not.toEqual(a.ruleArn);
+
+        // Old rule must be gone after the replace.
+        yield* assertRuleDeleted(nameA);
+
+        yield* stack.destroy();
+        yield* assertRuleDeleted(nameB);
+      }),
+  );
+
+  test.provider(
+    "targets diff: add, remove, and update converge",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const suffix = randomSuffix();
+        const queueA = `https://sqs.us-east-1.amazonaws.com/000000000000/dummy-a-${suffix}`;
+        // We only need ARN-shaped strings; EventBridge accepts the ARN
+        // even if the target doesn't exist yet (validation happens on
+        // event delivery, not on PutTargets).
+        const arnA = `arn:aws:sqs:us-east-1:000000000000:dummy-a-${suffix}`;
+        const arnB = `arn:aws:sqs:us-east-1:000000000000:dummy-b-${suffix}`;
+        const arnC = `arn:aws:sqs:us-east-1:000000000000:dummy-c-${suffix}`;
+        // queueA is unused below; the underscore-prefix keeps tsc happy.
+        void queueA;
+
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Rule("TargetsRule", {
+              eventPattern: { source: ["alchemy.test.targets"] },
+              targets: [
+                { Id: "TargetA", Arn: arnA },
+                { Id: "TargetB", Arn: arnB },
+              ],
+            });
+          }),
+        );
+        const observedInitial = yield* eventbridge.listTargetsByRule({
+          Rule: initial.ruleName,
+        });
+        expect(
+          (observedInitial.Targets ?? []).map((t) => t.Id).sort(),
+        ).toEqual(["TargetA", "TargetB"]);
+
+        // Update: drop TargetB, change TargetA's input, add TargetC.
+        const updated = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Rule("TargetsRule", {
+              eventPattern: { source: ["alchemy.test.targets"] },
+              targets: [
+                { Id: "TargetA", Arn: arnA, Input: '{"updated":true}' },
+                { Id: "TargetC", Arn: arnC },
+              ],
+            });
+          }),
+        );
+        expect(updated.ruleName).toEqual(initial.ruleName);
+
+        const observedUpdated = yield* eventbridge.listTargetsByRule({
+          Rule: updated.ruleName,
+        });
+        const updatedById = new Map(
+          (observedUpdated.Targets ?? []).map((t) => [t.Id, t]),
+        );
+        expect([...updatedById.keys()].sort()).toEqual([
+          "TargetA",
+          "TargetC",
+        ]);
+        expect(updatedById.get("TargetA")?.Input).toEqual('{"updated":true}');
+
+        yield* stack.destroy();
+        yield* assertRuleDeleted(initial.ruleName);
+      }),
+  );
+
+  test.provider(
+    "destroying an already-deleted rule is a no-op",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const rule = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Rule("DoubleDestroyRule", {
+              scheduleExpression: "rate(1 hour)",
+            });
+          }),
+        );
+
+        // Delete the rule out of band, then ask the engine to destroy it.
+        // Provider's `delete` must catch ResourceNotFoundException and
+        // complete cleanly.
+        yield* eventbridge.deleteRule({ Name: rule.ruleName });
+        yield* assertRuleDeleted(rule.ruleName);
+
+        yield* stack.destroy();
+      }),
+  );
+
+  test.provider(
+    "owned rule (matching alchemy tags) is silently adopted without --adopt",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const ruleName = `alchemy-test-rule-adopt-${randomSuffix()}`;
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Rule("AdoptableRule", {
+              name: ruleName,
+              scheduleExpression: "rate(1 hour)",
+            });
+          }),
+        );
+        expect(initial.ruleName).toEqual(ruleName);
+
+        // Wipe state — rule remains in EventBridge.
+        yield* Effect.gen(function* () {
+          const state = yield* State;
+          yield* state.delete({
+            stack: stack.name,
+            stage: "test",
+            fqn: "AdoptableRule",
+          });
+        }).pipe(Effect.provide(stack.state));
+
+        const adopted = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Rule("AdoptableRule", {
+              name: ruleName,
+              scheduleExpression: "rate(1 hour)",
+            });
+          }),
+        );
+        expect(adopted.ruleArn).toEqual(initial.ruleArn);
+
+        yield* stack.destroy();
+        yield* assertRuleDeleted(initial.ruleName);
+      }),
+  );
+
+  test.provider(
+    "foreign-tagged rule requires adopt(true) to take over and gets re-tagged",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const ruleName = `alchemy-test-rule-takeover-${randomSuffix()}`;
+        const original = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Rule("Original", {
+              name: ruleName,
+              scheduleExpression: "rate(1 hour)",
+            });
+          }),
+        );
+
+        yield* Effect.gen(function* () {
+          const state = yield* State;
+          yield* state.delete({
+            stack: stack.name,
+            stage: "test",
+            fqn: "Original",
+          });
+        }).pipe(Effect.provide(stack.state));
+
+        const takenOver = yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              return yield* Rule("Different", {
+                name: ruleName,
+                scheduleExpression: "rate(1 hour)",
+              });
+            }),
+          )
+          .pipe(adopt(true));
+
+        expect(takenOver.ruleArn).toEqual(original.ruleArn);
+
+        // Adopting with `adopt(true)` must re-tag the rule with the
+        // internal alchemy tags so subsequent runs route through silent
+        // adoption.
+        const tagsResp = yield* eventbridge.listTagsForResource({
+          ResourceARN: takenOver.ruleArn,
+        });
+        const tagMap = Object.fromEntries(
+          (tagsResp.Tags ?? [])
+            .filter(
+              (t): t is { Key: string; Value: string } =>
+                typeof t.Value === "string",
+            )
+            .map((t) => [t.Key, t.Value]),
+        );
+        expect(tagMap["alchemy::id"]).toEqual("Different");
+        expect(tagMap["alchemy::stage"]).toBeDefined();
+
+        yield* stack.destroy();
+        yield* assertRuleDeleted(takenOver.ruleName);
+      }),
+  );
+
+  class RuleStillExists extends Data.TaggedError("RuleStillExists") {}
+  class RuleNotConverged extends Data.TaggedError("RuleNotConverged") {}
+  class EventPatternNotConverged extends Data.TaggedError(
+    "EventPatternNotConverged",
+  ) {}
+
+  /** Poll until describeRule reflects the desired props (EventBridge is eventually consistent). */
+  const waitForRuleMatch = Effect.fn(function* (
+    ruleName: string,
+    expected: {
+      ScheduleExpression?: string;
+      Description?: string;
+      State?: "ENABLED" | "DISABLED";
+    },
+  ) {
+    yield* Effect.gen(function* () {
+      const described = yield* eventbridge.describeRule({ Name: ruleName });
+      for (const [key, value] of Object.entries(expected)) {
+        if ((described as any)[key] !== value) {
+          return yield* Effect.fail(new RuleNotConverged());
+        }
+      }
+    }).pipe(
+      Effect.retry({
+        while: (e) => e._tag === "RuleNotConverged",
+        schedule: Schedule.fixed("500 millis").pipe(
+          Schedule.both(Schedule.recurs(40)),
+        ),
+      }),
+    );
+  });
+
+  const waitForEventPatternMatch = Effect.fn(function* (
+    ruleName: string,
+    expected: Record<string, unknown>,
+  ) {
+    const expectedJson = JSON.stringify(expected);
+    yield* Effect.gen(function* () {
+      const described = yield* eventbridge.describeRule({ Name: ruleName });
+      const parsed = described.EventPattern
+        ? JSON.parse(described.EventPattern)
+        : undefined;
+      if (JSON.stringify(parsed) !== expectedJson) {
+        return yield* Effect.fail(new EventPatternNotConverged());
+      }
+    }).pipe(
+      Effect.retry({
+        while: (e) => e._tag === "EventPatternNotConverged",
+        schedule: Schedule.fixed("500 millis").pipe(
+          Schedule.both(Schedule.recurs(40)),
+        ),
+      }),
+    );
+  });
+
+  const assertRuleDeleted = Effect.fn(function* (ruleName: string) {
+    yield* eventbridge
+      .describeRule({ Name: ruleName })
+      .pipe(
+        Effect.flatMap(() => Effect.fail(new RuleStillExists())),
+        Effect.retry({
+          while: (e) => e._tag === "RuleStillExists",
+          schedule: Schedule.exponential(100).pipe(
+            Schedule.both(Schedule.recurs(8)),
+          ),
+        }),
+        Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+      );
+  });
+});


### PR DESCRIPTION
Harden the EventBridge Rule reconcile path against transient EventBridge faults and adoption / drift edge cases, and add the lifecycle test suite that proves it.

### Reconciler changes

```ts
// retry the EventBridge transients that previously surfaced as terminal failures
const retryEventBridgeTransients = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
  effect.pipe(
    Effect.retry({
      while: (error: any) =>
        error?._tag === "ConcurrentModificationException" ||
        error?._tag === "InternalException",
      schedule: Schedule.exponential(200).pipe(Schedule.both(Schedule.recurs(8))),
    }),
  );
```

- Wrap `putRule` / `putTargets` / `removeTargets` / `listTargetsByRule` / `describeRule` and every tag operation in `retryEventBridgeTransients` so peer reconcilers don't take the deploy down.
- Catch `ResourceNotFoundException` on `tagResource` / `untagResource` / `listTagsForResource` (Rule + EventBus) so a delete-race during the tag sync degrades gracefully.
- `Rule.delete` and `EventBus.delete` are now idempotent (catch `ResourceNotFoundException`) and wrapped in the same retry helper.

### New lifecycle tests

`packages/alchemy/test/AWS/EventBridge/Rule.test.ts`:

- redeploy with same props is a no-op
- reconcile resets `ScheduleExpression` / `State` / `Description` / `EventPattern` mutated out-of-band
- reconcile re-creates a rule deleted out-of-band
- changing `name` triggers replace, old rule is deleted
- targets diff: add / remove / update converges
- destroying an already-deleted rule is a no-op
- silent adoption when alchemy tags match
- `adopt(true)` re-tags a foreign rule with the internal alchemy tags

### Distilled patch

https://github.com/alchemy-run/distilled/pull/251 — adds error categories so `ConcurrentModificationException`, `InternalException`, `ThrottlingException` participate in the AWS retry layer, plus `ResourceNotFoundException` on `deleteEventBus` (documented but missing from Smithy) so `catchTag` works.
