### PR TITLE
fix(aws/elbv2): harden LoadBalancer reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/ELBv2/LoadBalancer.ts
+++ b/packages/alchemy/src/AWS/ELBv2/LoadBalancer.ts
@@ -1,16 +1,24 @@
 import * as elbv2 from "@distilled.cloud/aws/elastic-load-balancing-v2";
 import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import { Unowned } from "../../AdoptPolicy.ts";
 import { deepEqual, isResolved } from "../../Diff.ts";
 import type { Input } from "../../Input.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
-import { createInternalTags, diffTags } from "../../Tags.ts";
+import {
+  createInternalTags,
+  diffTags,
+  hasAlchemyTags,
+} from "../../Tags.ts";
 import type { AccountID } from "../Environment.ts";
 import type { SecurityGroupId } from "../EC2/SecurityGroup.ts";
 import type { SubnetId } from "../EC2/Subnet.ts";
 import type { RegionID } from "../Region.ts";
+import * as Data from "effect/Data";
+import type { ScopedPlanStatusSession } from "../../Cli/Cli.ts";
 
 export type LoadBalancerName = string;
 export type LoadBalancerArn =
@@ -93,10 +101,12 @@ export const LoadBalancerProvider = () =>
             return { action: "replace" } as const;
           }
         }),
-        read: Effect.fn(function* ({ output }) {
+        read: Effect.fn(function* ({ id, output }) {
           if (!output) {
             return undefined;
           }
+          // Look up by ARN if we have it (faster, and survives deletion-and-
+          // recreate of a same-named LB).
           const described = yield* elbv2
             .describeLoadBalancers({
               LoadBalancerArns: [output.loadBalancerArn],
@@ -110,7 +120,12 @@ export const LoadBalancerProvider = () =>
           if (!loadBalancer?.LoadBalancerArn) {
             return undefined;
           }
-          return {
+          // Read tags from the cloud, not the cached output, so adoption
+          // sees the truth.
+          const observedTags = yield* fetchObservedTags(
+            loadBalancer.LoadBalancerArn,
+          );
+          const attrs = {
             ...output,
             dnsName: loadBalancer.DNSName!,
             canonicalHostedZoneId: loadBalancer.CanonicalHostedZoneId!,
@@ -122,7 +137,11 @@ export const LoadBalancerProvider = () =>
               loadBalancer.AvailabilityZones?.flatMap((zone) =>
                 zone.SubnetId ? [zone.SubnetId] : [],
               ) ?? [],
+            tags: observedTags,
           };
+          return (yield* hasAlchemyTags(id, observedTags))
+            ? attrs
+            : Unowned(attrs);
         }),
         reconcile: Effect.fn(function* ({ id, news, session }) {
           const name = yield* toName(id, news);
@@ -131,35 +150,37 @@ export const LoadBalancerProvider = () =>
             ...news.tags,
           };
 
-          // Observe — look up by deterministic name.
-          let described = yield* elbv2
-            .describeLoadBalancers({
-              Names: [name],
-            })
-            .pipe(
-              Effect.catchTag("LoadBalancerNotFoundException", () =>
-                Effect.succeed(undefined),
-              ),
-            );
-          let loadBalancer = described?.LoadBalancers?.[0];
+          // Observe — look up by deterministic name. `LoadBalancerNotFound`
+          // is the "doesn't exist yet" signal; nothing else is a race that
+          // we want to swallow.
+          let loadBalancer = yield* describeByName(name);
 
           // Ensure — create if missing. The replacement axes (scheme, type,
           // subnets, securityGroups, ipAddressType) are handled by diff so
-          // we don't need to deal with mismatches here.
+          // we don't need to deal with mismatches here. We tolerate
+          // `DuplicateLoadBalancerName` as a race with a peer reconciler:
+          // re-describe and continue.
           if (!loadBalancer?.LoadBalancerArn) {
-            const created = yield* elbv2.createLoadBalancer({
-              Name: name,
-              Scheme: news.scheme ?? "internet-facing",
-              Type: news.type ?? "application",
-              Subnets: news.subnets as string[],
-              SecurityGroups: news.securityGroups as string[] | undefined,
-              IpAddressType: news.ipAddressType,
-              Tags: Object.entries(desiredTags).map(([Key, Value]) => ({
-                Key,
-                Value,
-              })),
-            });
-            loadBalancer = created.LoadBalancers?.[0];
+            loadBalancer = yield* elbv2
+              .createLoadBalancer({
+                Name: name,
+                Scheme: news.scheme ?? "internet-facing",
+                Type: news.type ?? "application",
+                Subnets: news.subnets as string[],
+                SecurityGroups: news.securityGroups as string[] | undefined,
+                IpAddressType: news.ipAddressType,
+                Tags: Object.entries(desiredTags).map(([Key, Value]) => ({
+                  Key,
+                  Value,
+                })),
+              })
+              .pipe(
+                Effect.map((created) => created.LoadBalancers?.[0]),
+                Effect.catchTag(
+                  "DuplicateLoadBalancerNameException",
+                  () => describeByName(name),
+                ),
+              );
             if (!loadBalancer?.LoadBalancerArn) {
               return yield* Effect.die(
                 new Error("createLoadBalancer returned no load balancer"),
@@ -169,6 +190,15 @@ export const LoadBalancerProvider = () =>
 
           const loadBalancerArn =
             loadBalancer.LoadBalancerArn as LoadBalancerArn;
+
+          // Wait for `active` before mutating — `modifyLoadBalancerAttributes`
+          // and tag operations against an LB still in `provisioning` can
+          // race or fail with `OperationNotPermitted`. ALB provisioning
+          // typically completes in 30-60s; cap the wait at 5 minutes.
+          loadBalancer = yield* waitForLoadBalancerActive(
+            loadBalancerArn,
+            session,
+          );
 
           // Sync attributes — observed ↔ desired. We always apply when
           // desired attrs are non-empty; AWS rejects an empty list anyway,
@@ -187,17 +217,7 @@ export const LoadBalancerProvider = () =>
           }
 
           // Sync tags — diff observed cloud tags against desired.
-          const tagDescriptions = yield* elbv2.describeTags({
-            ResourceArns: [loadBalancerArn],
-          });
-          const observedTags = Object.fromEntries(
-            (tagDescriptions.TagDescriptions?.[0]?.Tags ?? [])
-              .filter(
-                (t): t is { Key: string; Value: string } =>
-                  typeof t.Key === "string" && typeof t.Value === "string",
-              )
-              .map((t) => [t.Key, t.Value]),
-          );
+          const observedTags = yield* fetchObservedTags(loadBalancerArn);
           const { removed, upsert } = diffTags(observedTags, desiredTags);
           if (upsert.length > 0) {
             yield* elbv2.addTags({
@@ -229,7 +249,12 @@ export const LoadBalancerProvider = () =>
             tags: desiredTags,
           };
         }),
-        delete: Effect.fn(function* ({ output }) {
+        delete: Effect.fn(function* ({ output, session }) {
+          // Tolerate the LB having already been deleted out-of-band, and
+          // ride out `ResourceInUse` (eventual-consistency: a listener or
+          // target-group attachment racing with us). Cap at 2 minutes so we
+          // surface persistent in-use failures (e.g. deletion protection
+          // enabled) instead of looping forever.
           yield* elbv2
             .deleteLoadBalancer({
               LoadBalancerArn: output.loadBalancerArn,
@@ -239,8 +264,103 @@ export const LoadBalancerProvider = () =>
                 "LoadBalancerNotFoundException",
                 () => Effect.void,
               ),
+              Effect.retry({
+                while: (e) => e._tag === "ResourceInUseException",
+                schedule: Schedule.fixed(5000).pipe(
+                  Schedule.both(Schedule.recurs(24)),
+                  Schedule.tapOutput(([, attempt]) =>
+                    session.note(
+                      `LoadBalancer in use, retrying delete... (${
+                        (attempt + 1) * 5
+                      }s)`,
+                    ),
+                  ),
+                ),
+              }),
             );
         }),
       };
     }),
   );
+
+class LoadBalancerNotActive extends Data.TaggedError("LoadBalancerNotActive")<{
+  arn: string;
+  state: string;
+}> {}
+
+const waitForLoadBalancerActive = (
+  loadBalancerArn: string,
+  session: ScopedPlanStatusSession,
+) =>
+  Effect.gen(function* () {
+    const result = yield* elbv2.describeLoadBalancers({
+      LoadBalancerArns: [loadBalancerArn],
+    });
+    const loadBalancer = result.LoadBalancers?.[0];
+    if (!loadBalancer) {
+      return yield* Effect.die(
+        new Error(
+          `LoadBalancer ${loadBalancerArn} disappeared while waiting for active state`,
+        ),
+      );
+    }
+    const state = loadBalancer.State?.Code ?? "unknown";
+    if (state === "active") {
+      return loadBalancer;
+    }
+    if (state === "failed") {
+      return yield* Effect.die(
+        new Error(
+          `LoadBalancer ${loadBalancerArn} entered failed state: ${
+            loadBalancer.State?.Reason ?? "no reason given"
+          }`,
+        ),
+      );
+    }
+    return yield* new LoadBalancerNotActive({ arn: loadBalancerArn, state });
+  }).pipe(
+    Effect.retry({
+      while: (e) => e instanceof LoadBalancerNotActive,
+      schedule: Schedule.fixed(5000).pipe(
+        Schedule.both(Schedule.recurs(60)), // up to 5 minutes
+        Schedule.tapOutput(([, attempt]) =>
+          session.note(
+            `Waiting for LoadBalancer to be active... (${(attempt + 1) * 5}s)`,
+          ),
+        ),
+      ),
+    }),
+  );
+
+const describeByName = (name: string) =>
+  elbv2
+    .describeLoadBalancers({ Names: [name] })
+    .pipe(
+      Effect.map((r) => r.LoadBalancers?.[0]),
+      Effect.catchTag("LoadBalancerNotFoundException", () =>
+        Effect.succeed(undefined),
+      ),
+    );
+
+const fetchObservedTags = (
+  loadBalancerArn: string,
+): Effect.Effect<Record<string, string>, any, any> =>
+  elbv2
+    .describeTags({ ResourceArns: [loadBalancerArn] })
+    .pipe(
+      Effect.map((r) =>
+        Object.fromEntries(
+          (r.TagDescriptions?.[0]?.Tags ?? [])
+            .filter(
+              (t): t is { Key: string; Value: string } =>
+                typeof t.Key === "string" && typeof t.Value === "string",
+            )
+            .map((t) => [t.Key, t.Value]),
+        ),
+      ),
+      // The LB can race away under us between the create and the tag fetch
+      // (rare, but possible in adoption flows). Treat that as "no tags".
+      Effect.catchTag("LoadBalancerNotFoundException", () =>
+        Effect.succeed({} as Record<string, string>),
+      ),
+    );

--- a/packages/alchemy/src/AWS/ELBv2/TargetGroup.ts
+++ b/packages/alchemy/src/AWS/ELBv2/TargetGroup.ts
@@ -1,5 +1,6 @@
 import * as elbv2 from "@distilled.cloud/aws/elastic-load-balancing-v2";
 import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
 import { deepEqual, isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
@@ -215,12 +216,31 @@ export const TargetGroupProvider = () =>
             tags: desiredTags,
           };
         }),
-        delete: Effect.fn(function* ({ output }) {
+        delete: Effect.fn(function* ({ output, session }) {
+          // `deleteTargetGroup` is idempotent — AWS does not raise NotFound
+          // when the group is already gone. The one error we should ride
+          // out is `ResourceInUse` (a listener forward action still points
+          // here while it is being torn down). Cap at 2 minutes so we
+          // surface persistent in-use failures instead of looping forever.
           yield* elbv2
             .deleteTargetGroup({
               TargetGroupArn: output.targetGroupArn,
             })
-            .pipe(Effect.catch(() => Effect.void));
+            .pipe(
+              Effect.retry({
+                while: (e) => e._tag === "ResourceInUseException",
+                schedule: Schedule.fixed(5000).pipe(
+                  Schedule.both(Schedule.recurs(24)),
+                  Schedule.tapOutput(([, attempt]) =>
+                    session.note(
+                      `TargetGroup in use, retrying delete... (${
+                        (attempt + 1) * 5
+                      }s)`,
+                    ),
+                  ),
+                ),
+              }),
+            );
         }),
       };
     }),

--- a/packages/alchemy/test/AWS/ELBv2/LoadBalancer.test.ts
+++ b/packages/alchemy/test/AWS/ELBv2/LoadBalancer.test.ts
@@ -1,0 +1,340 @@
+import { adopt } from "@/AdoptPolicy";
+import * as AWS from "@/AWS";
+import { Subnet, Vpc } from "@/AWS/EC2";
+import { LoadBalancer } from "@/AWS/ELBv2";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import * as EC2 from "@distilled.cloud/aws/ec2";
+import * as ELBv2 from "@distilled.cloud/aws/elastic-load-balancing-v2";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+class LoadBalancerStillExists extends Data.TaggedError(
+  "LoadBalancerStillExists",
+)<{ arn: string }> {}
+
+const assertLoadBalancerDeleted = (arn: string) =>
+  Effect.gen(function* () {
+    const result = yield* ELBv2.describeLoadBalancers({
+      LoadBalancerArns: [arn],
+    }).pipe(
+      Effect.catchTag("LoadBalancerNotFoundException", () =>
+        Effect.succeed({ LoadBalancers: [] as unknown[] }),
+      ),
+    );
+    if ((result.LoadBalancers ?? []).length > 0) {
+      return yield* new LoadBalancerStillExists({ arn });
+    }
+  }).pipe(
+    Effect.retry({
+      while: (e) => e instanceof LoadBalancerStillExists,
+      schedule: Schedule.fixed(2000).pipe(Schedule.both(Schedule.recurs(30))),
+    }),
+  );
+
+const minimalNetwork = Effect.fn(function* (suffix: string) {
+  const azResult = yield* EC2.describeAvailabilityZones({});
+  const availableAzs =
+    azResult.AvailabilityZones?.filter((az) => az.State === "available") ?? [];
+  const az1 = availableAzs[0]?.ZoneName!;
+  const az2 = availableAzs[1]?.ZoneName!;
+  const vpc = yield* Vpc(`Vpc-${suffix}`, { cidrBlock: "10.0.0.0/16" });
+  const subnetA = yield* Subnet(`SubnetA-${suffix}`, {
+    vpcId: vpc.vpcId,
+    cidrBlock: "10.0.1.0/24",
+    availabilityZone: az1,
+  });
+  const subnetB = yield* Subnet(`SubnetB-${suffix}`, {
+    vpcId: vpc.vpcId,
+    cidrBlock: "10.0.2.0/24",
+    availabilityZone: az2,
+  });
+  return { vpc, subnets: [subnetA.subnetId, subnetB.subnetId] };
+});
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { subnets } = yield* minimalNetwork(suffix);
+          return yield* LoadBalancer("IdempotentLb", {
+            scheme: "internet-facing",
+            subnets,
+            attributes: { "idle_timeout.timeout_seconds": "60" },
+          });
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { subnets } = yield* minimalNetwork(suffix);
+          return yield* LoadBalancer("IdempotentLb", {
+            scheme: "internet-facing",
+            subnets,
+            attributes: { "idle_timeout.timeout_seconds": "60" },
+          });
+        }),
+      );
+
+      expect(second.loadBalancerArn).toEqual(initial.loadBalancerArn);
+      expect(second.loadBalancerName).toEqual(initial.loadBalancerName);
+      expect(second.dnsName).toEqual(initial.dnsName);
+
+      yield* stack.destroy();
+      yield* assertLoadBalancerDeleted(initial.loadBalancerArn);
+    }).pipe(logLevel),
+  { timeout: 600_000 },
+);
+
+test.provider(
+  "reconcile resets attributes mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+
+      const lb = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { subnets } = yield* minimalNetwork(suffix);
+          return yield* LoadBalancer("DriftLb", {
+            subnets,
+            attributes: {
+              "idle_timeout.timeout_seconds": "60",
+              "deletion_protection.enabled": "false",
+            },
+          });
+        }),
+      );
+
+      // Drift: bump idle timeout and enable deletion protection out-of-band.
+      yield* ELBv2.modifyLoadBalancerAttributes({
+        LoadBalancerArn: lb.loadBalancerArn,
+        Attributes: [
+          { Key: "idle_timeout.timeout_seconds", Value: "240" },
+          { Key: "deletion_protection.enabled", Value: "true" },
+        ],
+      });
+
+      // Re-deploy with original desired props — reconcile must reset both.
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          const { subnets } = yield* minimalNetwork(suffix);
+          return yield* LoadBalancer("DriftLb", {
+            subnets,
+            attributes: {
+              "idle_timeout.timeout_seconds": "60",
+              "deletion_protection.enabled": "false",
+            },
+          });
+        }),
+      );
+
+      const attrs = yield* ELBv2.describeLoadBalancerAttributes({
+        LoadBalancerArn: lb.loadBalancerArn,
+      });
+      const attrMap = Object.fromEntries(
+        (attrs.Attributes ?? []).flatMap((a) =>
+          a.Key && a.Value ? [[a.Key, a.Value] as const] : [],
+        ),
+      );
+      expect(attrMap["idle_timeout.timeout_seconds"]).toEqual("60");
+      expect(attrMap["deletion_protection.enabled"]).toEqual("false");
+
+      yield* stack.destroy();
+      yield* assertLoadBalancerDeleted(lb.loadBalancerArn);
+    }).pipe(logLevel),
+  { timeout: 600_000 },
+);
+
+test.provider(
+  "reconcile re-creates a LoadBalancer that was deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const lbName = `alch-recreate-${suffix}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { subnets } = yield* minimalNetwork(suffix);
+          return yield* LoadBalancer("RecreateLb", {
+            name: lbName,
+            subnets,
+          });
+        }),
+      );
+
+      yield* ELBv2.deleteLoadBalancer({
+        LoadBalancerArn: initial.loadBalancerArn,
+      });
+      yield* assertLoadBalancerDeleted(initial.loadBalancerArn);
+
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { subnets } = yield* minimalNetwork(suffix);
+          return yield* LoadBalancer("RecreateLb", {
+            name: lbName,
+            subnets,
+          });
+        }),
+      );
+
+      expect(recreated.loadBalancerName).toEqual(lbName);
+      expect(recreated.loadBalancerArn).not.toEqual(initial.loadBalancerArn);
+
+      yield* stack.destroy();
+      yield* assertLoadBalancerDeleted(recreated.loadBalancerArn);
+    }).pipe(logLevel),
+  { timeout: 900_000 },
+);
+
+test.provider(
+  "changing name triggers replace, old LoadBalancer is deleted",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const nameA = `alch-rename-a-${suffix}`;
+      const nameB = `alch-rename-b-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { subnets } = yield* minimalNetwork(suffix);
+          return yield* LoadBalancer("RenameLb", {
+            name: nameA,
+            subnets,
+          });
+        }),
+      );
+      expect(a.loadBalancerName).toEqual(nameA);
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { subnets } = yield* minimalNetwork(suffix);
+          return yield* LoadBalancer("RenameLb", {
+            name: nameB,
+            subnets,
+          });
+        }),
+      );
+      expect(b.loadBalancerName).toEqual(nameB);
+      expect(b.loadBalancerArn).not.toEqual(a.loadBalancerArn);
+
+      yield* assertLoadBalancerDeleted(a.loadBalancerArn);
+
+      yield* stack.destroy();
+      yield* assertLoadBalancerDeleted(b.loadBalancerArn);
+    }).pipe(logLevel),
+  { timeout: 900_000 },
+);
+
+test.provider(
+  "destroying an already-deleted LoadBalancer is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+
+      const lb = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { subnets } = yield* minimalNetwork(suffix);
+          return yield* LoadBalancer("DoubleDestroyLb", {
+            subnets,
+          });
+        }),
+      );
+
+      // Out-of-band delete, then ask the engine to destroy. Provider must
+      // catch `LoadBalancerNotFoundException` and complete cleanly.
+      yield* ELBv2.deleteLoadBalancer({
+        LoadBalancerArn: lb.loadBalancerArn,
+      });
+      yield* assertLoadBalancerDeleted(lb.loadBalancerArn);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 600_000 },
+);
+
+test.provider(
+  "adopt(true) re-tags a foreign LoadBalancer",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const lbName = `alch-adopt-${suffix}`;
+
+      const original = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { subnets } = yield* minimalNetwork(suffix);
+          return yield* LoadBalancer("Original", {
+            name: lbName,
+            subnets,
+          });
+        }),
+      );
+
+      // Wipe state — LB stays in AWS.
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "Original",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      const takenOver = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            const { subnets } = yield* minimalNetwork(suffix);
+            return yield* LoadBalancer("Different", {
+              name: lbName,
+              subnets,
+            });
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(takenOver.loadBalancerName).toEqual(lbName);
+      expect(takenOver.loadBalancerArn).toEqual(original.loadBalancerArn);
+
+      // Adoption with `adopt(true)` should retag with the new logical id's
+      // alchemy tags so subsequent runs route through silent adoption.
+      const tagDescriptions = yield* ELBv2.describeTags({
+        ResourceArns: [takenOver.loadBalancerArn],
+      });
+      const tagMap = Object.fromEntries(
+        (tagDescriptions.TagDescriptions?.[0]?.Tags ?? []).flatMap((t) =>
+          t.Key && t.Value ? [[t.Key, t.Value] as const] : [],
+        ),
+      );
+      expect(tagMap["alchemy:fqn"]).toBeDefined();
+      expect(tagMap["alchemy:stage"]).toBeDefined();
+
+      yield* stack.destroy();
+      yield* assertLoadBalancerDeleted(takenOver.loadBalancerArn);
+    }).pipe(logLevel),
+  { timeout: 900_000 },
+);


### PR DESCRIPTION
Hardens the AWS ELBv2 `LoadBalancer` reconciler so it converges from any starting cloud state, and tightens the `TargetGroup` delete blanket-catch.

### Reconciler changes

```diff
+        // Wait for `active` before mutating — `modifyLoadBalancerAttributes`
+        // and tag operations against an LB still in `provisioning` can race
+        // or fail with `OperationNotPermitted`.
+        loadBalancer = yield* waitForLoadBalancerActive(loadBalancerArn, session);
```

```diff
+        // Tolerate the LB having already been deleted out-of-band, and ride
+        // out `ResourceInUse` (a listener/target-group attachment racing
+        // with us). Cap at 2 minutes.
+        Effect.catchTag("LoadBalancerNotFoundException", () => Effect.void),
+        Effect.retry({
+          while: (e) => e._tag === "ResourceInUseException",
+          schedule: Schedule.fixed(5000).pipe(Schedule.both(Schedule.recurs(24)), …),
+        }),
```

```diff
-        return { ...output, /* attrs */ };
+        // Read tags from the cloud, not the cached output — adoption needs
+        // the truth. Gate ownership with hasAlchemyTags/Unowned.
+        const observedTags = yield* fetchObservedTags(arn);
+        return (yield* hasAlchemyTags(id, observedTags)) ? attrs : Unowned(attrs);
```

```diff
-        // createLoadBalancer with no race tolerance.
+        // Tolerate `DuplicateLoadBalancerName` — a peer reconciler created it
+        // concurrently. Re-describe and continue.
+        Effect.catchTag("DuplicateLoadBalancerNameException", () =>
+          describeByName(name)),
```

`TargetGroup.delete`:

```diff
-      .pipe(Effect.catch(() => Effect.void));
+      .pipe(Effect.retry({ while: e => e._tag === "ResourceInUseException", … }));
```

The blanket catch silently swallowed auth/throttling. `deleteTargetGroup` is already idempotent for "not found" per the AWS error spec — only `ResourceInUseException` needs riding out.

### New lifecycle tests

`packages/alchemy/test/AWS/ELBv2/LoadBalancer.test.ts`:

- redeploy with same props is a no-op
- reconcile resets attributes (idle timeout, deletion protection) mutated out-of-band via raw ELBv2 SDK
- reconcile re-creates an LB that was deleted out-of-band
- changing `name` triggers replace, old LB is deleted
- destroying an already-deleted LB is a no-op
- `adopt(true)` re-tags a foreign LB with `alchemy:fqn` / `alchemy:stage`

### Distilled patch

No patch needed. ELBv2 throttling already routes through the common `ThrottlingException`. A follow-up could add `ConflictError`/`AlreadyExistsError` to `DuplicateLoadBalancerNameException`, `ResourceInUseException`, `PriorityInUseException`, but `AlreadyExistsError` is gated on distilled #246.
