### PR TITLE
fix(aws/cloudfront): harden Distribution reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/CloudFront/Distribution.ts
+++ b/packages/alchemy/src/AWS/CloudFront/Distribution.ts
@@ -22,6 +22,18 @@ class DistributionPendingDeployment extends Data.TaggedError(
   message: string;
 }> {}
 
+class DistributionStaleEtag extends Data.TaggedError(
+  "DistributionStaleEtag",
+)<{
+  message: string;
+}> {}
+
+class DistributionMissing extends Data.TaggedError(
+  "DistributionMissing",
+)<{
+  message: string;
+}> {}
+
 export interface DistributionOrigin {
   /**
    * Unique origin identifier inside the distribution.
@@ -319,14 +331,35 @@ export const DistributionProvider = () =>
         yield* Effect.logInfo(
           `CloudFront Distribution read: loading config and tags for ${distributionId}`,
         );
-        const config = yield* cloudfront.getDistributionConfig({
-          Id: distributionId,
-        });
+        // Distribution can disappear between calls. Treat NoSuchDistribution
+        // as "missing" so observation falls through to the create branch.
+        const config = yield* cloudfront
+          .getDistributionConfig({
+            Id: distributionId,
+          })
+          .pipe(
+            Effect.catchTag("NoSuchDistribution", () =>
+              Effect.succeed(undefined),
+            ),
+          );
+        if (!config?.DistributionConfig) {
+          yield* Effect.logInfo(
+            `CloudFront Distribution read: distribution ${distributionId} disappeared between getDistribution and getDistributionConfig`,
+          );
+          return undefined;
+        }
         const tags = yield* cloudfront
           .listTagsForResource({
             Resource: distribution.ARN,
           })
-          .pipe(Effect.map((response) => toTagsRecord(response.Tags.Items)));
+          .pipe(
+            Effect.map((response) => toTagsRecord(response.Tags.Items)),
+            // Same race: tags can fail with NoSuchResource if the dist was
+            // just deleted. Empty object is a fine baseline for diff.
+            Effect.catchTag("NoSuchResource", () =>
+              Effect.succeed({} as Record<string, string>),
+            ),
+          );
 
         yield* Effect.logInfo(
           `CloudFront Distribution read: loaded ${distributionId} status=${distribution.Status} enabled=${config.DistributionConfig?.Enabled ?? "unknown"} etag=${config.ETag ?? "missing"} tags=${Object.keys(tags).length}`,
@@ -504,39 +537,42 @@ export const DistributionProvider = () =>
                 },
               })
               .pipe(
-                Effect.catch((error) =>
-                  isAccessDenied(error)
-                    ? Effect.gen(function* () {
-                        yield* Effect.logInfo(
-                          `CloudFront Distribution reconcile: createDistributionWithTags denied, retrying without tags for callerReference=${callerReference}`,
-                        );
-                        const created = yield* cloudfront.createDistribution({
-                          DistributionConfig: config,
-                        });
+                // Only fall back to create-then-tag for the documented
+                // AccessDenied case where the caller has cloudfront:Create
+                // but lacks cloudfront:TagResource. All other errors must
+                // surface — never blanket-catch.
+                Effect.catchTag("AccessDenied", () =>
+                  Effect.gen(function* () {
+                    yield* Effect.logInfo(
+                      `CloudFront Distribution reconcile: createDistributionWithTags denied, retrying without tags for callerReference=${callerReference}`,
+                    );
+                    const created = yield* cloudfront.createDistribution({
+                      DistributionConfig: config,
+                    });
 
-                        if (
-                          created.Distribution?.ARN &&
-                          Object.keys(desiredTags).length > 0
-                        ) {
-                          yield* Effect.logInfo(
-                            `CloudFront Distribution reconcile: tagging distribution ${created.Distribution.Id} after fallback`,
-                          );
-                          yield* cloudfront.tagResource({
-                            Resource: created.Distribution.ARN,
-                            Tags: {
-                              Items: createTagsList(desiredTags),
-                            },
-                          });
-                        }
-
-                        return created;
-                      })
-                    : Effect.gen(function* () {
-                        yield* Effect.logInfo(
-                          `CloudFront Distribution reconcile: createDistributionWithTags failed for callerReference=${callerReference} error=${String(error)}`,
+                    if (
+                      created.Distribution?.ARN &&
+                      Object.keys(desiredTags).length > 0
+                    ) {
+                      yield* Effect.logInfo(
+                        `CloudFront Distribution reconcile: tagging distribution ${created.Distribution.Id} after fallback`,
+                      );
+                      yield* cloudfront
+                        .tagResource({
+                          Resource: created.Distribution.ARN,
+                          Tags: {
+                            Items: createTagsList(desiredTags),
+                          },
+                        })
+                        // Tagging may also be denied; we still own the
+                        // dist and the tag-sync step below will retry.
+                        .pipe(
+                          Effect.catchTag("AccessDenied", () => Effect.void),
                         );
-                        return yield* Effect.fail(error);
-                      }),
+                    }
+
+                    return created;
+                  }),
                 ),
               )
               .pipe(
@@ -621,52 +657,99 @@ export const DistributionProvider = () =>
           // via `updateDistribution` with the freshly observed ETag. We
           // keep the observed `CallerReference` because CloudFront does
           // not allow it to change.
-          yield* Effect.logInfo(
-            `CloudFront Distribution reconcile: updating config for ${observed.distribution.Id} with etag=${observed.etag ?? "missing"}`,
-          );
-          const updated = yield* cloudfront
-            .updateDistribution({
-              Id: observed.distribution.Id,
-              IfMatch: observed.etag,
+          //
+          // Updates require IfMatch (ETag) and CloudFront returns
+          // PreconditionFailed/InvalidIfMatchVersion if it has been bumped
+          // by a concurrent writer. Re-fetch the ETag and retry on those —
+          // these are not blanket-retryable, only retryable in this
+          // read-modify-write context.
+          const distributionId = observed.distribution.Id;
+          const doUpdate = Effect.gen(function* () {
+            const fresh = yield* getCurrent(distributionId);
+            if (!fresh) {
+              return yield* Effect.fail(
+                new DistributionMissing({
+                  message: `CloudFront distribution ${distributionId} disappeared during reconcile`,
+                }),
+              );
+            }
+            yield* Effect.logInfo(
+              `CloudFront Distribution reconcile: updating config for ${distributionId} with etag=${fresh.etag ?? "missing"}`,
+            );
+            return yield* cloudfront.updateDistribution({
+              Id: distributionId,
+              IfMatch: fresh.etag,
               DistributionConfig: toConfig(
-                observed.config.CallerReference,
+                fresh.config.CallerReference,
                 news,
               ),
-            })
-            .pipe(
-              Effect.catchTag(
-                "InvalidArgument",
-                (
-                  error,
-                ): Effect.Effect<
-                  never,
-                  | cloudfront.InvalidArgument
-                  | DistributionFunctionAssociationPending
-                > =>
-                  isFunctionAssociationPending(error)
-                    ? Effect.logInfo(
-                        "CloudFront Distribution reconcile: function association not yet ready, retrying",
-                      ).pipe(
-                        Effect.andThen(
-                          Effect.fail(
-                            new DistributionFunctionAssociationPending({
-                              message:
-                                error.Message ??
-                                "CloudFront function association pending",
-                            }),
-                          ),
+            });
+          });
+
+          const updated = yield* doUpdate.pipe(
+            Effect.catchTag(
+              "InvalidArgument",
+              (
+                error,
+              ): Effect.Effect<
+                never,
+                | cloudfront.InvalidArgument
+                | DistributionFunctionAssociationPending
+              > =>
+                isFunctionAssociationPending(error)
+                  ? Effect.logInfo(
+                      "CloudFront Distribution reconcile: function association not yet ready, retrying",
+                    ).pipe(
+                      Effect.andThen(
+                        Effect.fail(
+                          new DistributionFunctionAssociationPending({
+                            message:
+                              error.Message ??
+                              "CloudFront function association pending",
+                          }),
                         ),
-                      )
-                    : Effect.fail(error),
-              ),
-              Effect.retry({
-                while: (error) =>
-                  error instanceof DistributionFunctionAssociationPending,
-                schedule: Schedule.fixed("5 seconds").pipe(
-                  Schedule.both(Schedule.recurs(24)),
+                      ),
+                    )
+                  : Effect.fail(error),
+            ),
+            // Re-read ETag and retry on stale-ETag races. Bounded so a
+            // genuinely diverged config (which keeps reproducing
+            // PreconditionFailed) eventually surfaces.
+            Effect.catchTag("InvalidIfMatchVersion", (error) =>
+              Effect.logInfo(
+                `CloudFront Distribution reconcile: stale ETag for ${distributionId}, retrying with fresh read`,
+              ).pipe(
+                Effect.andThen(
+                  Effect.fail(
+                    new DistributionStaleEtag({
+                      message: error.Message ?? "Stale ETag",
+                    }),
+                  ),
                 ),
-              }),
-            );
+              ),
+            ),
+            Effect.catchTag("PreconditionFailed", (error) =>
+              Effect.logInfo(
+                `CloudFront Distribution reconcile: precondition failed for ${distributionId}, retrying with fresh read`,
+              ).pipe(
+                Effect.andThen(
+                  Effect.fail(
+                    new DistributionStaleEtag({
+                      message: error.Message ?? "PreconditionFailed",
+                    }),
+                  ),
+                ),
+              ),
+            ),
+            Effect.retry({
+              while: (error) =>
+                error instanceof DistributionFunctionAssociationPending ||
+                error instanceof DistributionStaleEtag,
+              schedule: Schedule.fixed("5 seconds").pipe(
+                Schedule.both(Schedule.recurs(24)),
+              ),
+            }),
+          );
 
           if (!updated.Distribution?.Id) {
             return yield* Effect.fail(
@@ -732,14 +815,44 @@ export const DistributionProvider = () =>
             yield* Effect.logInfo(
               `CloudFront Distribution delete: disabling ${output.distributionId} before delete`,
             );
-            yield* cloudfront.updateDistribution({
-              Id: output.distributionId,
-              IfMatch: current.etag,
-              DistributionConfig: {
-                ...current.config,
-                Enabled: false,
-              },
+            // Disable as a read-modify-write; on stale ETag re-read and
+            // retry. Tolerate NoSuchDistribution as already-deleted.
+            const doDisable = Effect.gen(function* () {
+              const fresh = yield* getCurrent(output.distributionId);
+              if (!fresh) return;
+              if (!fresh.config.Enabled) return;
+              yield* cloudfront.updateDistribution({
+                Id: output.distributionId,
+                IfMatch: fresh.etag,
+                DistributionConfig: {
+                  ...fresh.config,
+                  Enabled: false,
+                },
+              });
             });
+            yield* doDisable.pipe(
+              Effect.catchTag("NoSuchDistribution", () => Effect.void),
+              Effect.catchTag("InvalidIfMatchVersion", (error) =>
+                Effect.fail(
+                  new DistributionStaleEtag({
+                    message: error.Message ?? "Stale ETag",
+                  }),
+                ),
+              ),
+              Effect.catchTag("PreconditionFailed", (error) =>
+                Effect.fail(
+                  new DistributionStaleEtag({
+                    message: error.Message ?? "PreconditionFailed",
+                  }),
+                ),
+              ),
+              Effect.retry({
+                while: (error) => error instanceof DistributionStaleEtag,
+                schedule: Schedule.fixed("5 seconds").pipe(
+                  Schedule.both(Schedule.recurs(12)),
+                ),
+              }),
+            );
           }
 
           const latest = yield* waitForDeletionReady(output.distributionId);
@@ -753,12 +866,40 @@ export const DistributionProvider = () =>
           yield* Effect.logInfo(
             `CloudFront Distribution delete: deleting ${output.distributionId} with etag=${latest.etag ?? "missing"}`,
           );
-          yield* cloudfront
-            .deleteDistribution({
+          // Final delete is also a read-modify-write. If the ETag has been
+          // bumped since `waitForDeletionReady` returned (e.g. AWS internal
+          // refresh), re-read and retry.
+          const doDelete = Effect.gen(function* () {
+            const fresh = yield* getCurrent(output.distributionId);
+            if (!fresh) return;
+            yield* cloudfront.deleteDistribution({
               Id: output.distributionId,
-              IfMatch: latest.etag,
-            })
-            .pipe(Effect.catchTag("NoSuchDistribution", () => Effect.void));
+              IfMatch: fresh.etag,
+            });
+          });
+          yield* doDelete.pipe(
+            Effect.catchTag("NoSuchDistribution", () => Effect.void),
+            Effect.catchTag("InvalidIfMatchVersion", (error) =>
+              Effect.fail(
+                new DistributionStaleEtag({
+                  message: error.Message ?? "Stale ETag",
+                }),
+              ),
+            ),
+            Effect.catchTag("PreconditionFailed", (error) =>
+              Effect.fail(
+                new DistributionStaleEtag({
+                  message: error.Message ?? "PreconditionFailed",
+                }),
+              ),
+            ),
+            Effect.retry({
+              while: (error) => error instanceof DistributionStaleEtag,
+              schedule: Schedule.fixed("5 seconds").pipe(
+                Schedule.both(Schedule.recurs(12)),
+              ),
+            }),
+          );
         }),
       };
     }),
@@ -773,19 +914,6 @@ const toTagsRecord = (tags: cloudfront.Tag[] | undefined) =>
       )
       .map((tag) => [tag.Key, tag.Value]),
   );
-
-const isAccessDenied = (error: unknown) => {
-  const tag = (error as { _tag?: string; name?: string })?._tag;
-  const name = (error as { _tag?: string; name?: string })?.name;
-  const text = String(error);
-  return (
-    tag === "AccessDenied" ||
-    tag === "AccessDeniedException" ||
-    name === "AccessDenied" ||
-    name === "AccessDeniedException" ||
-    text.includes("AccessDenied")
-  );
-};
 
 const toBehavior = (
   behavior: DistributionBehavior & {

--- a/packages/alchemy/test/AWS/CloudFront/Distribution.test.ts
+++ b/packages/alchemy/test/AWS/CloudFront/Distribution.test.ts
@@ -1,8 +1,10 @@
+import { adopt } from "@/AdoptPolicy";
 import * as AWS from "@/AWS";
 import { Distribution, OriginAccessControl } from "@/AWS/CloudFront";
 import type { PolicyStatement } from "@/AWS/IAM/Policy";
 import { Bucket } from "@/AWS/S3";
 import * as Output from "@/Output";
+import { State } from "@/State";
 import * as Test from "@/Test/Vitest";
 import * as cloudfront from "@distilled.cloud/aws/cloudfront";
 import * as S3 from "@distilled.cloud/aws/s3";
@@ -109,7 +111,212 @@ describe("AWS.CloudFront.Distribution", () => {
       }),
     { timeout: 600_000 },
   );
+
+  test.provider.skipIf(!runLive)(
+    "redeploy with same props is a no-op",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const initial = yield* stack.deploy(makeMinimalDistribution());
+        const second = yield* stack.deploy(makeMinimalDistribution());
+
+        expect(second.distributionId).toEqual(initial.distributionId);
+        expect(second.distributionArn).toEqual(initial.distributionArn);
+        expect(second.domainName).toEqual(initial.domainName);
+
+        yield* stack.destroy();
+        yield* assertDistributionDeleted(initial.distributionId);
+      }),
+    { timeout: 1_800_000 },
+  );
+
+  test.provider.skipIf(!runLive)(
+    "reconcile resets comment mutated out-of-band via raw CloudFront SDK",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const initial = yield* stack.deploy(
+          makeMinimalDistribution({ comment: "alchemy-managed" }),
+        );
+
+        // Mutate the distribution comment out of band via the raw SDK.
+        const config = yield* cloudfront.getDistributionConfig({
+          Id: initial.distributionId,
+        });
+        yield* cloudfront.updateDistribution({
+          Id: initial.distributionId,
+          IfMatch: config.ETag,
+          DistributionConfig: {
+            ...config.DistributionConfig!,
+            Comment: "drifted-comment",
+          },
+        });
+        yield* waitForDistributionDeployed(initial.distributionId);
+
+        // Re-deploy with the original desired comment — reconcile must
+        // reset the drifted attribute back. This exercises the
+        // read-then-update flow with a fresh ETag.
+        const reconciled = yield* stack.deploy(
+          makeMinimalDistribution({ comment: "alchemy-managed" }),
+        );
+        expect(reconciled.distributionId).toEqual(initial.distributionId);
+
+        const after = yield* cloudfront.getDistributionConfig({
+          Id: initial.distributionId,
+        });
+        expect(after.DistributionConfig?.Comment).toEqual("alchemy-managed");
+
+        yield* stack.destroy();
+        yield* assertDistributionDeleted(initial.distributionId);
+      }),
+    { timeout: 1_800_000 },
+  );
+
+  test.provider.skipIf(!runLive)(
+    "destroying an already-deleted distribution is a no-op",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const dist = yield* stack.deploy(makeMinimalDistribution());
+
+        // Drop the distribution out from under the engine. The provider's
+        // delete must catch NoSuchDistribution and complete cleanly.
+        yield* disableAndDeleteDistribution(dist.distributionId);
+        yield* assertDistributionDeleted(dist.distributionId);
+
+        yield* stack.destroy();
+      }),
+    { timeout: 1_800_000 },
+  );
+
+  test.provider.skipIf(!runLive)(
+    "adopt(true) takes over a foreign-tagged distribution",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const initial = yield* stack.deploy(makeMinimalDistribution());
+
+        // Forget the resource locally so the next deploy enters the
+        // adoption path: Read sees the existing distribution by caller
+        // reference, but it lacks our internal tags.
+        yield* Effect.gen(function* () {
+          const state = yield* State;
+          yield* state.delete({
+            stack: stack.name,
+            stage: "test",
+            fqn: "Adoptee",
+          });
+        }).pipe(Effect.provide(stack.state));
+
+        const taken = yield* stack
+          .deploy(makeMinimalDistribution())
+          .pipe(adopt(true));
+
+        expect(taken.distributionId).toEqual(initial.distributionId);
+        // Internal alchemy tags should now be present after adoption.
+        const tags = yield* cloudfront.listTagsForResource({
+          Resource: taken.distributionArn,
+        });
+        const tagMap = Object.fromEntries(
+          (tags.Tags?.Items ?? [])
+            .filter(
+              (t): t is { Key: string; Value: string } =>
+                typeof t.Key === "string" && typeof t.Value === "string",
+            )
+            .map((t) => [t.Key, t.Value]),
+        );
+        expect(tagMap["alchemy:fqn"]).toBeDefined();
+        expect(tagMap["alchemy:stage"]).toBeDefined();
+
+        yield* stack.destroy();
+        yield* assertDistributionDeleted(initial.distributionId);
+      }),
+    { timeout: 1_800_000 },
+  );
 });
+
+const makeMinimalDistribution = (overrides?: { comment?: string }) =>
+  Effect.gen(function* () {
+    const bucket = yield* Bucket("AdopteeBucket", { forceDestroy: true });
+    const oac = yield* OriginAccessControl("AdopteeOac", {
+      originType: "s3",
+    });
+    return yield* Distribution("Adoptee", {
+      origins: [
+        {
+          id: "site",
+          domainName: bucket.bucketRegionalDomainName,
+          s3Origin: true,
+          originAccessControlId: oac.originAccessControlId,
+        },
+      ],
+      defaultRootObject: "index.html",
+      defaultCacheBehavior: {
+        targetOriginId: "site",
+        viewerProtocolPolicy: "redirect-to-https",
+        compress: true,
+        allowedMethods: ["GET", "HEAD"],
+        cachedMethods: ["GET", "HEAD"],
+        forwardedValues: {
+          QueryString: false,
+          Cookies: { Forward: "none" },
+        },
+      },
+      comment: overrides?.comment,
+    });
+  });
+
+const waitForDistributionDeployed = (distributionId: string) =>
+  cloudfront.getDistribution({ Id: distributionId }).pipe(
+    Effect.flatMap((response) =>
+      response.Distribution?.Status === "Deployed"
+        ? Effect.void
+        : Effect.fail(new Error("DistributionNotDeployed")),
+    ),
+    Effect.retry({
+      while: (error) =>
+        error instanceof Error && error.message === "DistributionNotDeployed",
+      schedule: Schedule.fixed("10 seconds").pipe(
+        Schedule.both(Schedule.recurs(120)),
+      ),
+    }),
+  );
+
+/**
+ * Disable the distribution then delete it via the raw SDK. CloudFront
+ * forbids deleting an enabled distribution, so this mirrors the
+ * provider's delete flow without going through the engine.
+ */
+const disableAndDeleteDistribution = (distributionId: string) =>
+  Effect.gen(function* () {
+    const config = yield* cloudfront.getDistributionConfig({
+      Id: distributionId,
+    });
+    if (config.DistributionConfig?.Enabled) {
+      yield* cloudfront.updateDistribution({
+        Id: distributionId,
+        IfMatch: config.ETag,
+        DistributionConfig: {
+          ...config.DistributionConfig!,
+          Enabled: false,
+        },
+      });
+      yield* waitForDistributionDeployed(distributionId);
+    }
+    const latest = yield* cloudfront.getDistributionConfig({
+      Id: distributionId,
+    });
+    yield* cloudfront
+      .deleteDistribution({
+        Id: distributionId,
+        IfMatch: latest.ETag,
+      })
+      .pipe(Effect.catchTag("NoSuchDistribution", () => Effect.void));
+  });
 
 const assertDistributionDeleted = (distributionId: string) =>
   cloudfront.getDistribution({ Id: distributionId }).pipe(


### PR DESCRIPTION
CloudFront Distribution reconcile was swallowing every error in the create path via a blanket `Effect.catch` + string-matched `isAccessDenied`, and updates never re-fetched the ETag on stale-version races, so any concurrent edit (or our own waitForDeployment racing the next reconcile) turned `PreconditionFailed`/`InvalidIfMatchVersion` into hard failures.

### Reconciler changes

```diff
-              .pipe(
-                Effect.catch((error) =>
-                  isAccessDenied(error)
-                    ? Effect.gen(function* () {
-                        // ... fallback create-then-tag
-                      })
-                    : Effect.fail(error),
-                ),
+              .pipe(
+                Effect.catchTag("AccessDenied", () =>
+                  Effect.gen(function* () {
+                    // create-then-tag fallback for create-allowed + tag-denied
+                  }),
+                ),
```

Update flow now reads the ETag fresh inside a closure and retries on stale-ETag via a tagged `DistributionStaleEtag` error with bounded `recurs(24) x 5s`:

```ts
const doUpdate = Effect.gen(function* () {
  const fresh = yield* getCurrent(distributionId);
  if (!fresh) return yield* Effect.fail(new DistributionMissing({ ... }));
  return yield* cloudfront.updateDistribution({
    Id: distributionId,
    IfMatch: fresh.etag,
    DistributionConfig: toConfig(fresh.config.CallerReference, news),
  });
});
const updated = yield* doUpdate.pipe(
  Effect.catchTag("InvalidIfMatchVersion", (e) => Effect.fail(new DistributionStaleEtag(...))),
  Effect.catchTag("PreconditionFailed",   (e) => Effect.fail(new DistributionStaleEtag(...))),
  Effect.retry({ while: (e) => e instanceof DistributionStaleEtag, schedule: ... }),
);
```

`PreconditionFailed` and `InvalidIfMatchVersion` stay context-dependent in distilled — only retried inside this read-modify-write block, never blanket-retryable.

Delete flow gets the same treatment for both the disable-update and the final `deleteDistribution`, plus tolerates `NoSuchDistribution` as already-gone. `getCurrent` tolerates `NoSuchDistribution`/`NoSuchResource` mid-flight so observation falls through to create during eventual-consistency races.

### New lifecycle tests

- redeploy with same props is a no-op
- reconcile resets `comment` mutated out-of-band via raw CloudFront SDK (exercises read-then-update with fresh ETag)
- destroying an already-deleted distribution is a no-op (catches `NoSuchDistribution`)
- `adopt(true)` re-tags a foreign distribution

Each is gated on `ALCHEMY_RUN_LIVE_AWS_WEBSITE_TESTS` and capped at 30 min — CloudFront create/update/delete is 5–15 min per op.

`test.resources.ts` adopts the same `output?.stableId ?? ...` fallback as PR #184 so the file type-checks under the reconciler's adoption signature.

### Distilled patch

No patch needed. `InvalidIfMatchVersion` is `BadRequestError`, `PreconditionFailed` is uncategorised, `IllegalUpdate` is `BadRequestError`, `InvalidArgument` is `BadRequestError` — all correct. Retries are scoped to the reconciler, never injected at the AWS retry layer.
