### PR TITLE
fix(cloudflare/aigateway): harden AiGateway reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/Cloudflare/AiGateway/AiGateway.ts
+++ b/packages/alchemy/src/Cloudflare/AiGateway/AiGateway.ts
@@ -485,33 +485,46 @@ export const AiGatewayProvider = () =>
           const gatewayId =
             output?.gatewayId ?? (yield* createGatewayId(id, news.id));
 
-          // Observe — fetch the gateway's current state. The Cloudflare API
-          // returns 404 when the gateway is missing, which we tolerate so the
-          // reconciler can fall through to create.
-          const observed = yield* getAiGateway({
-            accountId: acct,
-            id: gatewayId,
-          }).pipe(
-            Effect.catchTag("GatewayNotFound", () => Effect.succeed(undefined)),
-          );
-
-          // Ensure — create if missing. Tolerate `GatewayAlreadyExists` for
+          // Ensure the gateway exists. Tolerate `GatewayAlreadyExists` for
           // idempotency: a peer reconciler may have created it concurrently,
           // or state persistence may have failed after a previous create.
-          if (observed === undefined) {
+          const ensure = Effect.gen(function* () {
+            const observed = yield* getAiGateway({
+              accountId: acct,
+              id: gatewayId,
+            }).pipe(
+              Effect.catchTag("GatewayNotFound", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+            if (observed !== undefined) return;
             const request = yield* createRequest(id, news);
             yield* createAiGateway(request).pipe(
               Effect.catchTag("GatewayAlreadyExists", () =>
                 getAiGateway({ accountId: acct, id: request.id }),
               ),
             );
-          }
+          });
 
           // Sync — the Cloudflare AI Gateway update API is a full PATCH that
-          // overwrites all mutable fields. We always apply the desired shape
-          // so adoption, drift, and routine updates all converge.
+          // overwrites all mutable fields. Always apply the desired shape so
+          // adoption, drift, and routine updates all converge. The create API
+          // doesn't accept dlp/otel/storeId/stripe, so we must update even
+          // immediately after create.
+          //
+          // If the gateway was deleted out-of-band between ensure and update
+          // we'd see `GatewayNotFound` here — recover by re-ensuring and
+          // retrying once. Bounded so a persistent NotFound surfaces.
+          yield* ensure;
           const update = yield* updateRequest(id, news, acct);
-          const gateway = yield* updateAiGateway(update);
+          const gateway = yield* updateAiGateway(update).pipe(
+            Effect.catchTag("GatewayNotFound", () =>
+              Effect.gen(function* () {
+                yield* ensure;
+                return yield* updateAiGateway(update);
+              }),
+            ),
+          );
           return mapGateway(gateway, acct);
         }),
         delete: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/test/Cloudflare/AiGateway/AiGateway.test.ts
+++ b/packages/alchemy/test/Cloudflare/AiGateway/AiGateway.test.ts
@@ -1,3 +1,4 @@
+import { adopt } from "@/AdoptPolicy";
 import * as Alchemy from "@/index.ts";
 import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
@@ -169,6 +170,289 @@ test.provider(
       }).pipe(Effect.provide(stack.state));
 
       expect(persisted?.attr).toMatchObject({ gatewayId });
+
+      yield* stack.destroy();
+      yield* waitForGatewayToBeDeleted(gatewayId, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+      yield* stack.destroy();
+
+      const gatewayId = `alchemy-test-aigw-noop-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AiGateway("NoopGateway", {
+            id: gatewayId,
+            cacheTtl: 90,
+            collectLogs: true,
+            rateLimitingInterval: 60,
+            rateLimitingLimit: 50,
+            rateLimitingTechnique: "fixed",
+          });
+        }),
+      );
+
+      // Re-deploy with identical props — must converge to the same gateway
+      // without replacing it. internalId is server-assigned and stable
+      // across mutations on the same gateway, so we use it as the proof
+      // that no replacement happened.
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AiGateway("NoopGateway", {
+            id: gatewayId,
+            cacheTtl: 90,
+            collectLogs: true,
+            rateLimitingInterval: 60,
+            rateLimitingLimit: 50,
+            rateLimitingTechnique: "fixed",
+          });
+        }),
+      );
+      expect(second.gatewayId).toEqual(initial.gatewayId);
+      expect(second.internalId).toEqual(initial.internalId);
+      expect(second.cacheTtl).toEqual(90);
+      expect(second.rateLimitingLimit).toEqual(50);
+
+      yield* stack.destroy();
+      yield* waitForGatewayToBeDeleted(gatewayId, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile resets settings mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+      yield* stack.destroy();
+
+      const gatewayId = `alchemy-test-aigw-drift-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AiGateway("DriftGateway", {
+            id: gatewayId,
+            cacheTtl: 60,
+            rateLimitingInterval: 30,
+            rateLimitingLimit: 100,
+            rateLimitingTechnique: "fixed",
+            authentication: false,
+          });
+        }),
+      );
+      expect(initial.cacheTtl).toEqual(60);
+      expect(initial.rateLimitingLimit).toEqual(100);
+      expect(initial.authentication).toEqual(false);
+
+      // Mutate the gateway out-of-band via the raw distilled client.
+      yield* aiGateway.updateAiGateway({
+        accountId,
+        id: gatewayId,
+        cacheInvalidateOnUpdate: false,
+        cacheTtl: 999,
+        collectLogs: true,
+        rateLimitingInterval: 5,
+        rateLimitingLimit: 7,
+        rateLimitingTechnique: "sliding",
+        authentication: true,
+      });
+      const drifted = yield* aiGateway.getAiGateway({
+        accountId,
+        id: gatewayId,
+      });
+      expect(drifted.cacheTtl).toEqual(999);
+      expect(drifted.rateLimitingLimit).toEqual(7);
+      expect(drifted.authentication).toEqual(true);
+
+      // Re-deploy with original desired props — reconcile should reset
+      // the drifted settings back to what we asked for.
+      const reconciled = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AiGateway("DriftGateway", {
+            id: gatewayId,
+            cacheTtl: 60,
+            rateLimitingInterval: 30,
+            rateLimitingLimit: 100,
+            rateLimitingTechnique: "fixed",
+            authentication: false,
+          });
+        }),
+      );
+      expect(reconciled.cacheTtl).toEqual(60);
+      expect(reconciled.rateLimitingInterval).toEqual(30);
+      expect(reconciled.rateLimitingLimit).toEqual(100);
+      expect(reconciled.rateLimitingTechnique).toEqual("fixed");
+      expect(reconciled.authentication).toEqual(false);
+      expect(reconciled.internalId).toEqual(initial.internalId);
+
+      yield* stack.destroy();
+      yield* waitForGatewayToBeDeleted(gatewayId, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile re-creates a gateway that was deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+      yield* stack.destroy();
+
+      const gatewayId = `alchemy-test-aigw-recreate-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AiGateway("RecreateGateway", {
+            id: gatewayId,
+            cacheTtl: 60,
+          });
+        }),
+      );
+
+      // Delete the gateway out-of-band.
+      yield* aiGateway.deleteAiGateway({ accountId, id: gatewayId });
+      yield* waitForGatewayToBeDeleted(gatewayId, accountId);
+
+      // Re-deploy must converge by re-creating the gateway.
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AiGateway("RecreateGateway", {
+            id: gatewayId,
+            cacheTtl: 60,
+          });
+        }),
+      );
+      expect(recreated.gatewayId).toEqual(gatewayId);
+      expect(recreated.cacheTtl).toEqual(60);
+
+      const live = yield* aiGateway.getAiGateway({
+        accountId,
+        id: gatewayId,
+      });
+      expect(live.id).toEqual(gatewayId);
+
+      yield* stack.destroy();
+      yield* waitForGatewayToBeDeleted(gatewayId, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "changing id triggers replace",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const idA = `alchemy-test-aigw-replace-a-${suffix}`;
+      const idB = `alchemy-test-aigw-replace-b-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AiGateway("RenameGateway", { id: idA });
+        }),
+      );
+      expect(a.gatewayId).toEqual(idA);
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AiGateway("RenameGateway", { id: idB });
+        }),
+      );
+      expect(b.gatewayId).toEqual(idB);
+      expect(b.internalId).not.toEqual(a.internalId);
+
+      // Old gateway must be deleted after replacement.
+      yield* waitForGatewayToBeDeleted(idA, accountId);
+
+      yield* stack.destroy();
+      yield* waitForGatewayToBeDeleted(idB, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "destroying an already-deleted gateway is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+      yield* stack.destroy();
+
+      const gatewayId = `alchemy-test-aigw-doubledel-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AiGateway("DoubleDestroyGateway", {
+            id: gatewayId,
+          });
+        }),
+      );
+
+      // Delete out-of-band, then ask the engine to destroy.
+      // Provider's `delete` must catch GatewayNotFound and complete cleanly.
+      yield* aiGateway.deleteAiGateway({ accountId, id: gatewayId });
+      yield* waitForGatewayToBeDeleted(gatewayId, accountId);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "adopt(true) re-claims a foreign gateway",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+      yield* stack.destroy();
+
+      const gatewayId = `alchemy-test-aigw-takeover-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      // Phase 1: create a gateway out-of-band so it isn't tracked by the
+      // engine. AI Gateways have no ownership tags, so any existing gateway
+      // is treated as "foreign".
+      yield* aiGateway.createAiGateway({
+        accountId,
+        id: gatewayId,
+        cacheInvalidateOnUpdate: false,
+        cacheTtl: 0,
+        collectLogs: true,
+        rateLimitingInterval: 0,
+        rateLimitingLimit: 0,
+        rateLimitingTechnique: "fixed",
+      });
+
+      // Phase 2: deploy with `adopt(true)` — engine takes over via `read`
+      // and reconciles to our desired settings.
+      const takenOver = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.AiGateway("ForeignGateway", {
+              id: gatewayId,
+              cacheTtl: 120,
+              rateLimitingInterval: 60,
+              rateLimitingLimit: 25,
+              rateLimitingTechnique: "sliding",
+            });
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(takenOver.gatewayId).toEqual(gatewayId);
+      expect(takenOver.cacheTtl).toEqual(120);
+      expect(takenOver.rateLimitingLimit).toEqual(25);
+      expect(takenOver.rateLimitingTechnique).toEqual("sliding");
 
       yield* stack.destroy();
       yield* waitForGatewayToBeDeleted(gatewayId, accountId);


### PR DESCRIPTION
Stacked on top of [#179](https://github.com/alchemy-run/alchemy-effect/pull/179). Hardens the Cloudflare AiGateway resource as part of the per-resource hardening sweep on top of the reconcile migration.

### Reconciler changes

```diff
+ const ensure = Effect.gen(function* () {
+   const observed = yield* getAiGateway({ accountId: acct, id: gatewayId }).pipe(
+     Effect.catchTag("GatewayNotFound", () => Effect.succeed(undefined)),
+   );
+   if (observed !== undefined) return;
+   const request = yield* createRequest(id, news);
+   yield* createAiGateway(request).pipe(
+     Effect.catchTag("GatewayAlreadyExists", () =>
+       getAiGateway({ accountId: acct, id: request.id }),
+     ),
+   );
+ });

  yield* ensure;
  const update = yield* updateRequest(id, news, acct);
- const gateway = yield* updateAiGateway(update);
+ const gateway = yield* updateAiGateway(update).pipe(
+   Effect.catchTag("GatewayNotFound", () =>
+     Effect.gen(function* () {
+       yield* ensure;
+       return yield* updateAiGateway(update);
+     }),
+   ),
+ );
```

The Cloudflare AI Gateway create API doesn't accept `dlp` / `otel` / `storeId` / `stripe`, so the reconciler must always run `updateAiGateway` after ensure. If the gateway was deleted out-of-band between ensure and update — likely on adoption + concurrent operator paths — the update used to surface `GatewayNotFound` as a hard failure. Now we re-ensure (recreate) and retry the update once.

No blanket `Effect.catch` in this reconciler — every catch was already scoped to a single tag.

### New lifecycle tests

Each runs `destroy → deploy → … → destroy` on a `ScratchStack` and asserts convergence at every step.

- redeploy with same props is a no-op (`internalId` preserved)
- reconcile resets cache TTL / rate-limit / authentication mutated out-of-band via raw `updateAiGateway`
- reconcile re-creates a gateway that was deleted out-of-band via raw `deleteAiGateway`
- changing `id` triggers replace; old gateway is deleted
- destroying an already-deleted gateway is a no-op
- `adopt(true)` re-claims a foreign gateway (created out-of-band) and reconciles to desired settings

`test.resources.ts` picks up the same `output?.stableId ?? …` fallback prior hardening PRs used.

### Distilled patch

No patch needed. `GatewayNotFound` and `GatewayAlreadyExists` already cover every codepath the reconciler routes on — no `UnknownCloudflareError` surfaces.
