### PR TITLE
fix(aws/ecs): harden Cluster reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/ECS/Cluster.ts
+++ b/packages/alchemy/src/AWS/ECS/Cluster.ts
@@ -1,12 +1,14 @@
 import * as ecs from "@distilled.cloud/aws/ecs";
 import { Region } from "@distilled.cloud/aws/Region";
 import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import { Unowned } from "../../AdoptPolicy.ts";
 import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
-import { createInternalTags, diffTags } from "../../Tags.ts";
+import { createInternalTags, diffTags, hasAlchemyTags } from "../../Tags.ts";
 import { AWSEnvironment, type AccountID } from "../Environment.ts";
 import type { RegionID } from "../Region.ts";
 
@@ -95,6 +97,22 @@ export const ClusterProvider = () =>
           ? Effect.succeed(props.clusterName)
           : createPhysicalName({ id, maxLength: 255, lowercase: true });
 
+      // `UpdateInProgressException` is raised when ECS is still applying a
+      // prior cluster mutation. It is transient — back off and retry on a
+      // bounded schedule so we don't loop forever if the cluster is wedged.
+      const retryOnUpdateInProgress = <A, E, R>(
+        effect: Effect.Effect<A, E, R>,
+      ) =>
+        effect.pipe(
+          Effect.retry({
+            while: (e) =>
+              (e as { _tag?: string })._tag === "UpdateInProgressException",
+            schedule: Schedule.fixed("2 seconds").pipe(
+              Schedule.both(Schedule.recurs(30)),
+            ),
+          }),
+        );
+
       const applyCapacityProviders = Effect.fn(function* ({
         cluster,
         capacityProviders,
@@ -108,12 +126,14 @@ export const ClusterProvider = () =>
           capacityProviders !== undefined ||
           defaultCapacityProviderStrategy !== undefined
         ) {
-          yield* ecs.putClusterCapacityProviders({
-            cluster,
-            capacityProviders: capacityProviders ?? [],
-            defaultCapacityProviderStrategy:
-              defaultCapacityProviderStrategy ?? [],
-          });
+          yield* retryOnUpdateInProgress(
+            ecs.putClusterCapacityProviders({
+              cluster,
+              capacityProviders: capacityProviders ?? [],
+              defaultCapacityProviderStrategy:
+                defaultCapacityProviderStrategy ?? [],
+            }),
+          );
         }
       });
 
@@ -135,11 +155,27 @@ export const ClusterProvider = () =>
             clusters: [output?.clusterArn ?? clusterName],
             include: ["SETTINGS", "TAGS", "CONFIGURATIONS"],
           });
-          const cluster = described.clusters?.[0];
+          // ECS keeps INACTIVE clusters in describeClusters for ~1h after
+          // delete; treat them as gone so the reconciler recreates rather
+          // than trying to update a tombstone.
+          const cluster = described.clusters?.find(
+            (c) =>
+              c.clusterName === clusterName &&
+              c.status !== "INACTIVE" &&
+              c.status !== "DEPROVISIONING",
+          );
           if (!cluster?.clusterArn) {
             return undefined;
           }
-          return {
+          const observedTags = Object.fromEntries(
+            (cluster.tags ?? [])
+              .filter(
+                (t): t is { key: string; value: string } =>
+                  typeof t.key === "string" && typeof t.value === "string",
+              )
+              .map((t) => [t.key, t.value]),
+          );
+          const attrs = {
             clusterArn: cluster.clusterArn as ClusterArn,
             clusterName: cluster.clusterName!,
             status: cluster.status ?? "ACTIVE",
@@ -151,8 +187,13 @@ export const ClusterProvider = () =>
             serviceConnectDefaults: cluster.serviceConnectDefaults?.namespace
               ? { namespace: cluster.serviceConnectDefaults.namespace }
               : undefined,
-            tags: output?.tags ?? {},
+            tags: observedTags,
           };
+          // Foreign clusters (no alchemy tags) require `--adopt` / `adopt(true)`
+          // before the engine will take them over.
+          return (yield* hasAlchemyTags(id, observedTags))
+            ? attrs
+            : Unowned(attrs);
         }),
         reconcile: Effect.fn(function* ({ id, news, session }) {
           const clusterName = yield* toClusterName(id, news);
@@ -161,39 +202,55 @@ export const ClusterProvider = () =>
           const internalTags = yield* createInternalTags(id);
           const desiredTags = { ...internalTags, ...news.tags };
 
-          // Observe — fetch live cloud state.
-          let described = yield* ecs.describeClusters({
-            clusters: [clusterArn],
-            include: ["SETTINGS", "TAGS", "CONFIGURATIONS"],
-          });
-          let cluster = described.clusters?.find(
-            (c) =>
-              c.clusterName === clusterName &&
-              (c.status === "ACTIVE" || c.status === "PROVISIONING"),
-          );
+          // Observe — fetch live cloud state. INACTIVE / DEPROVISIONING
+          // clusters linger for ~1h after delete; treat them as gone so we
+          // recreate rather than trying to update a tombstone.
+          const observe = ecs
+            .describeClusters({
+              clusters: [clusterArn],
+              include: ["SETTINGS", "TAGS", "CONFIGURATIONS"],
+            })
+            .pipe(
+              Effect.map(
+                (r) =>
+                  r.clusters?.find(
+                    (c) =>
+                      c.clusterName === clusterName &&
+                      c.status !== "INACTIVE" &&
+                      c.status !== "DEPROVISIONING",
+                  ),
+              ),
+            );
+          let cluster = yield* observe;
 
-          // Ensure — create if missing. ECS createCluster is idempotent for
-          // identical params and returns the existing cluster on conflict;
-          // we always sync below regardless.
+          // Ensure — create if missing. `createCluster` does not raise on a
+          // pre-existing cluster of the same name; it returns the existing
+          // resource. We always sync below regardless.
           if (!cluster?.clusterArn) {
-            const created = yield* ecs.createCluster({
+            yield* ecs.createCluster({
               clusterName,
               settings: news.settings,
               configuration: news.configuration,
               serviceConnectDefaults: news.serviceConnectDefaults,
               tags: toEcsTags(desiredTags),
             });
-            cluster = created.cluster;
+            // Re-read so the tag-diff baseline reflects what's actually on
+            // the cluster (createCluster's response doesn't echo tags).
+            cluster = yield* observe;
           }
 
           // Sync cluster config — call updateCluster to converge settings,
           // configuration, and serviceConnectDefaults to desired state.
-          yield* ecs.updateCluster({
-            cluster: clusterArn,
-            settings: news.settings,
-            configuration: news.configuration,
-            serviceConnectDefaults: news.serviceConnectDefaults,
-          });
+          // ECS may surface `UpdateInProgressException` if a previous update
+          // hasn't fully propagated; back off and retry.
+          yield* retryOnUpdateInProgress(
+            ecs.updateCluster({
+              cluster: clusterArn,
+              settings: news.settings,
+              configuration: news.configuration,
+              serviceConnectDefaults: news.serviceConnectDefaults,
+            }),
+          );
 
           // Sync capacity providers — observed ↔ desired.
           yield* applyCapacityProviders({
@@ -241,21 +298,21 @@ export const ClusterProvider = () =>
           };
         }),
         delete: Effect.fn(function* ({ output }) {
-          yield* ecs
-            .deleteCluster({
+          // ECS rejects delete while a prior mutation is in flight; retry
+          // briefly. `ClusterContainsServicesException` /
+          // `ClusterContainsTasksException` /
+          // `ClusterContainsContainerInstancesException` /
+          // `ClusterContainsCapacityProviderException` mean the cluster
+          // still has dependents — surface those so the engine reports a
+          // dependency violation rather than pretending we deleted.
+          // `ClusterNotFoundException` is success (already gone).
+          yield* retryOnUpdateInProgress(
+            ecs.deleteCluster({
               cluster: output.clusterArn,
-            })
-            .pipe(
-              Effect.catchTag("ClusterNotFoundException", () => Effect.void),
-              Effect.catchTag(
-                "ClusterContainsServicesException",
-                () => Effect.void,
-              ),
-              Effect.catchTag(
-                "ClusterContainsTasksException",
-                () => Effect.void,
-              ),
-            );
+            }),
+          ).pipe(
+            Effect.catchTag("ClusterNotFoundException", () => Effect.void),
+          );
         }),
       };
     }),

--- a/packages/alchemy/src/AWS/ECS/Service.ts
+++ b/packages/alchemy/src/AWS/ECS/Service.ts
@@ -608,11 +608,14 @@ export const ServiceProvider = () =>
               );
           }
           if (output.targetGroupArn) {
-            yield* elbv2
-              .deleteTargetGroup({
-                TargetGroupArn: output.targetGroupArn,
-              })
-              .pipe(Effect.catch(() => Effect.void));
+            // `deleteTargetGroup` is idempotent for a missing TG and surfaces
+            // `ResourceInUseException` if it's still attached to a listener.
+            // We delete the listener above, so `ResourceInUseException` here
+            // would be a real ordering bug — let it surface instead of
+            // swallowing it with a blanket catch.
+            yield* elbv2.deleteTargetGroup({
+              TargetGroupArn: output.targetGroupArn,
+            });
           }
           if (output.loadBalancerArn) {
             yield* elbv2

--- a/packages/alchemy/test/AWS/ECS/Cluster.test.ts
+++ b/packages/alchemy/test/AWS/ECS/Cluster.test.ts
@@ -1,0 +1,341 @@
+import { adopt } from "@/AdoptPolicy";
+import * as AWS from "@/AWS";
+import { Cluster } from "@/AWS/ECS";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import * as ecs from "@distilled.cloud/aws/ecs";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+const TAG_FQN = "alchemy::id";
+const TAG_STAGE = "alchemy::stage";
+
+const clusterTagMap = (cluster: ecs.Cluster | undefined) =>
+  Object.fromEntries(
+    (cluster?.tags ?? [])
+      .filter(
+        (t): t is { key: string; value: string } =>
+          typeof t.key === "string" && typeof t.value === "string",
+      )
+      .map((t) => [t.key, t.value]),
+  );
+
+const describeOne = Effect.fn(function* (clusterArn: string) {
+  const r = yield* ecs.describeClusters({
+    clusters: [clusterArn],
+    include: ["SETTINGS", "TAGS", "CONFIGURATIONS"],
+  });
+  return r.clusters?.[0];
+});
+
+class ClusterStillExists extends Data.TaggedError("ClusterStillExists") {}
+class ClusterSettingsNotMatched extends Data.TaggedError(
+  "ClusterSettingsNotMatched",
+) {}
+
+const assertClusterDeleted = Effect.fn(function* (clusterArn: string) {
+  yield* Effect.gen(function* () {
+    const cluster = yield* describeOne(clusterArn);
+    if (
+      cluster &&
+      cluster.status !== "INACTIVE" &&
+      cluster.status !== "DEPROVISIONING"
+    ) {
+      return yield* Effect.fail(new ClusterStillExists());
+    }
+  }).pipe(
+    Effect.retry({
+      while: (e) => e._tag === "ClusterStillExists",
+      schedule: Schedule.exponential(200).pipe(
+        Schedule.both(Schedule.recurs(20)),
+      ),
+    }),
+  );
+});
+
+const waitForContainerInsights = Effect.fn(function* (
+  clusterArn: string,
+  expected: string,
+) {
+  yield* Effect.gen(function* () {
+    const cluster = yield* describeOne(clusterArn);
+    const setting = cluster?.settings?.find((s) => s.name === "containerInsights");
+    if (setting?.value !== expected) {
+      return yield* Effect.fail(new ClusterSettingsNotMatched());
+    }
+  }).pipe(
+    Effect.retry({
+      while: (e) => e._tag === "ClusterSettingsNotMatched",
+      schedule: Schedule.fixed("1 second").pipe(
+        Schedule.both(Schedule.recurs(20)),
+      ),
+    }),
+  );
+});
+
+test.provider("create and delete cluster with default props", (stack) =>
+  Effect.gen(function* () {
+    const cluster = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cluster("DefaultCluster", {});
+      }),
+    );
+
+    expect(cluster.clusterArn).toMatch(/^arn:aws:ecs:[^:]+:\d+:cluster\//);
+    expect(cluster.clusterName).toBeDefined();
+    const described = yield* describeOne(cluster.clusterArn);
+    expect(described?.status).toEqual("ACTIVE");
+
+    yield* stack.destroy();
+    yield* assertClusterDeleted(cluster.clusterArn);
+  }),
+);
+
+test.provider("redeploy with same props is a no-op (reconcile is idempotent)", (stack) =>
+  Effect.gen(function* () {
+    yield* stack.destroy();
+
+    const initial = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cluster("IdempotentCluster", {
+          settings: [{ name: "containerInsights", value: "enabled" }],
+        });
+      }),
+    );
+
+    const second = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cluster("IdempotentCluster", {
+          settings: [{ name: "containerInsights", value: "enabled" }],
+        });
+      }),
+    );
+    expect(second.clusterArn).toEqual(initial.clusterArn);
+    expect(second.clusterName).toEqual(initial.clusterName);
+
+    yield* waitForContainerInsights(second.clusterArn, "enabled");
+
+    yield* stack.destroy();
+    yield* assertClusterDeleted(initial.clusterArn);
+  }),
+);
+
+test.provider(
+  "reconcile resets settings mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const cluster = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cluster("DriftCluster", {
+            settings: [{ name: "containerInsights", value: "enabled" }],
+          });
+        }),
+      );
+      yield* waitForContainerInsights(cluster.clusterArn, "enabled");
+
+      // Mutate settings out-of-band via the raw SDK.
+      yield* ecs.updateClusterSettings({
+        cluster: cluster.clusterArn,
+        settings: [{ name: "containerInsights", value: "disabled" }],
+      });
+      yield* waitForContainerInsights(cluster.clusterArn, "disabled");
+
+      // Re-deploy with the same desired props — reconcile must reset the
+      // drifted setting back to the desired value.
+      const redeployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cluster("DriftCluster", {
+            settings: [{ name: "containerInsights", value: "enabled" }],
+          });
+        }),
+      );
+      expect(redeployed.clusterArn).toEqual(cluster.clusterArn);
+      yield* waitForContainerInsights(cluster.clusterArn, "enabled");
+
+      yield* stack.destroy();
+      yield* assertClusterDeleted(cluster.clusterArn);
+    }),
+);
+
+test.provider(
+  "reconcile re-creates a cluster that was deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const clusterName = `alchemy-test-ecs-recreate-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cluster("RecreateCluster", { clusterName });
+        }),
+      );
+
+      // Delete the cluster out of band.
+      yield* ecs.deleteCluster({ cluster: initial.clusterArn });
+      yield* assertClusterDeleted(initial.clusterArn);
+
+      // Re-deploy must converge by re-creating. ECS keeps INACTIVE clusters
+      // around for ~1h, so the reconciler has to skip them rather than try
+      // to update a tombstone.
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cluster("RecreateCluster", { clusterName });
+        }),
+      );
+      expect(recreated.clusterName).toEqual(clusterName);
+      const described = yield* describeOne(recreated.clusterArn);
+      expect(described?.status).toEqual("ACTIVE");
+
+      yield* stack.destroy();
+      yield* assertClusterDeleted(recreated.clusterArn);
+    }),
+  { timeout: 240_000 },
+);
+
+test.provider(
+  "changing clusterName triggers replace, old cluster is deleted",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const nameA = `alchemy-test-ecs-replace-a-${suffix}`;
+      const nameB = `alchemy-test-ecs-replace-b-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cluster("RenameCluster", { clusterName: nameA });
+        }),
+      );
+      expect(a.clusterName).toEqual(nameA);
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cluster("RenameCluster", { clusterName: nameB });
+        }),
+      );
+      expect(b.clusterName).toEqual(nameB);
+      expect(b.clusterArn).not.toEqual(a.clusterArn);
+
+      yield* assertClusterDeleted(a.clusterArn);
+
+      yield* stack.destroy();
+      yield* assertClusterDeleted(b.clusterArn);
+    }),
+);
+
+test.provider(
+  "destroying an already-deleted cluster is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const cluster = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cluster("DoubleDestroyCluster", {});
+        }),
+      );
+
+      // Delete out of band, then ask the engine to destroy. Provider's
+      // `delete` must catch `ClusterNotFoundException` and complete cleanly.
+      yield* ecs.deleteCluster({ cluster: cluster.clusterArn });
+      yield* assertClusterDeleted(cluster.clusterArn);
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider(
+  "adopt(true) re-tags a foreign cluster",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const clusterName = `alchemy-test-ecs-takeover-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      // Create a cluster out-of-band that has NO alchemy tags — this is a
+      // "foreign" cluster.
+      const created = yield* ecs.createCluster({
+        clusterName,
+        tags: [{ key: "owner", value: "external" }],
+      });
+      const foreignArn = created.cluster!.clusterArn!;
+
+      const takenOver = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* Cluster("Foreign", { clusterName });
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(takenOver.clusterName).toEqual(clusterName);
+      expect(takenOver.clusterArn).toEqual(foreignArn);
+
+      // After adopt(true), reconcile should have re-tagged the cluster
+      // with the internal alchemy tags.
+      const observed = yield* describeOne(takenOver.clusterArn);
+      const tagMap = clusterTagMap(observed);
+      expect(tagMap[TAG_FQN]).toBeDefined();
+      expect(tagMap[TAG_STAGE]).toBeDefined();
+      // The user-defined tag should still be present.
+      expect(tagMap.owner).toEqual("external");
+
+      yield* stack.destroy();
+      yield* assertClusterDeleted(takenOver.clusterArn);
+    }),
+);
+
+test.provider(
+  "foreign-tagged cluster requires adopt(true) to take over",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const clusterName = `alchemy-test-ecs-foreign-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      // First, deploy a cluster with this stack so internal tags get set.
+      const original = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cluster("Original", { clusterName });
+        }),
+      );
+
+      // Forget the resource from state so the next deploy goes through the
+      // read → Unowned path.
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "Original",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      const adopted = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* Cluster("Different", { clusterName });
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(adopted.clusterArn).toEqual(original.clusterArn);
+
+      yield* stack.destroy();
+      yield* assertClusterDeleted(original.clusterArn);
+    }),
+);


### PR DESCRIPTION
Stacked on top of [#179](https://github.com/alchemy-run/alchemy-effect/pull/179). Hardens the ECS Cluster resource as part of the per-resource hardening sweep.

### Reconciler changes

```diff
- const cluster = described.clusters?.[0];
+ const cluster = described.clusters?.find(
+   (c) =>
+     c.clusterName === clusterName &&
+     c.status !== "INACTIVE" &&
+     c.status !== "DEPROVISIONING",
+ );
```

ECS keeps INACTIVE clusters around in `describeClusters` for ~1h after delete. `read` was returning these tombstones as if alive, so out-of-band-deleted clusters never converged on redeploy.

```diff
- return { ... tags: output?.tags ?? {} };
+ const attrs = { ... tags: observedTags };
+ return (yield* hasAlchemyTags(id, observedTags))
+   ? attrs
+   : Unowned(attrs);
```

`read` had no adoption gate, so the engine would silently take over any cluster whose name happened to match. Wrap with `Unowned` based on observed alchemy tags so foreign clusters require `--adopt` / `adopt(true)`.

```diff
- yield* ecs.updateCluster({ ... });
+ yield* retryOnUpdateInProgress(ecs.updateCluster({ ... }));
```

`UpdateInProgressException` is transient — ECS surfaces it when a prior cluster mutation hasn't propagated. Bounded retry (60s) on `updateCluster` and `putClusterCapacityProviders`.

```diff
  yield* ecs.deleteCluster({ ... }).pipe(
    Effect.catchTag("ClusterNotFoundException", () => Effect.void),
-   Effect.catchTag("ClusterContainsServicesException", () => Effect.void),
-   Effect.catchTag("ClusterContainsTasksException", () => Effect.void),
  );
```

Silently swallowing `ClusterContains{Services,Tasks,ContainerInstances,CapacityProvider}Exception` made delete falsely report success while leaving the cluster live. Surface them so the engine reports a real dependency violation.

```diff
- yield* elbv2.deleteTargetGroup({ ... }).pipe(Effect.catch(() => Effect.void));
+ yield* elbv2.deleteTargetGroup({ ... });
```

`Service.delete`'s blanket catch on `deleteTargetGroup` would swallow `ResourceInUseException` — a real ordering bug, since the listener is removed first.

### New lifecycle tests

Each test runs `destroy → deploy → … → destroy` on a `ScratchStack` and asserts convergence at every step.

- redeploy with same props is a no-op
- reconcile resets `containerInsights` mutated out-of-band via the raw ECS SDK
- reconcile re-creates a cluster that was deleted out-of-band (rides the INACTIVE-tombstone window)
- changing `clusterName` triggers replace; old cluster is deleted
- destroying an already-deleted cluster is a no-op
- `adopt(true)` re-tags a foreign cluster and preserves user tags
- foreign-tagged cluster requires `adopt(true)` to take over

### Distilled patch

ECS errors had no category annotations in the SDK, so `UpdateInProgressException` failed loud and `ClusterContains*` errors weren't surfaced as dependency violations. Filed as [alchemy-run/distilled#253](https://github.com/alchemy-run/distilled/pull/253). Once published, the AWS retry layer will participate in the transient `UpdateInProgressException` window automatically — the reconciler-level retry stays for now since the default budget may be tighter than ECS's propagation window.

The `test.resources.ts` fallback (`output?.stableId ?? `stable-${id}``) is included since the `StaticStablesResource` update path otherwise refuses to type-check on adoption (where `output` may be undefined at the type level).
