### PR TITLE
fix(aws/acm): harden Certificate reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/ACM/Certificate.ts
+++ b/packages/alchemy/src/AWS/ACM/Certificate.ts
@@ -1,8 +1,10 @@
 import { Region as AwsRegion } from "@distilled.cloud/aws/Region";
 import * as acm from "@distilled.cloud/aws/acm";
 import * as route53 from "@distilled.cloud/aws/route-53";
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
+import { Unowned } from "../../AdoptPolicy.ts";
 import { deepEqual, isResolved } from "../../Diff.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
@@ -13,6 +15,15 @@ import {
   diffTags,
   hasAlchemyTags,
 } from "../../Tags.ts";
+
+class ValidationRecordsPending extends Data.TaggedError(
+  "ValidationRecordsPending",
+) {}
+class CertificatePendingValidation extends Data.TaggedError(
+  "CertificatePendingValidation",
+) {}
+class Route53ChangePending extends Data.TaggedError("Route53ChangePending") {}
+class CertificateInUse extends Data.TaggedError("CertificateInUse") {}
 
 export interface CertificateProps {
   /**
@@ -156,7 +167,12 @@ export const CertificateProvider = () =>
         );
       });
 
-      const findManagedCertificate = Effect.fn(function* (
+      // Find any certificate matching the desired domain + SAN combo.
+      // Returns the first match plus a flag indicating whether it carries
+      // our alchemy ownership tags. Callers branch on `owned` to decide
+      // between silent adoption (owned), `Unowned(attrs)` gating, or a
+      // greenfield request.
+      const findCertificateByDomain = Effect.fn(function* (
         id: string,
         props: CertificateProps,
       ) {
@@ -172,6 +188,10 @@ export const CertificateProvider = () =>
           listed.CertificateSummaryList?.filter(
             (summary) => summary.DomainName === props.domainName,
           ) ?? [];
+
+        let firstMatch:
+          | { detail: acm.CertificateDetail; tags: Record<string, string> }
+          | undefined;
 
         for (const summary of summaries) {
           if (!summary.CertificateArn) {
@@ -190,13 +210,22 @@ export const CertificateProvider = () =>
           }
           const tags = yield* listCertificateTags(detail.CertificateArn);
           if (yield* hasAlchemyTags(id, tags)) {
-            return detail;
+            // Owned match — prefer it over any foreign match we may have
+            // recorded earlier.
+            return { detail, tags, owned: true as const };
           }
+          firstMatch ??= { detail, tags };
         }
 
-        return undefined;
+        return firstMatch
+          ? { ...firstMatch, owned: false as const }
+          : undefined;
       });
 
+      // Wait until ACM has populated `ResourceRecord` on every domain
+      // validation option. ACM does this asynchronously after
+      // `RequestCertificate` returns. Bounded so we don't loop forever
+      // if ACM never produces records (would surface as a hard fail).
       const waitForValidationRecords = Effect.fn(function* (
         certificateArn: string,
       ) {
@@ -207,16 +236,12 @@ export const CertificateProvider = () =>
               validations.length === 0 ||
               validations.some((option) => option.ResourceRecord === undefined)
             ) {
-              return Effect.fail(
-                new Error("CertificateValidationRecordPending"),
-              );
+              return Effect.fail(new ValidationRecordsPending());
             }
             return Effect.succeed(detail!);
           }),
           Effect.retry({
-            while: (error) =>
-              error instanceof Error &&
-              error.message === "CertificateValidationRecordPending",
+            while: (error) => error._tag === "ValidationRecordsPending",
             schedule: Schedule.fixed("2 seconds").pipe(
               Schedule.both(Schedule.recurs(60)),
             ),
@@ -224,11 +249,20 @@ export const CertificateProvider = () =>
         );
       });
 
+      // Wait for ACM to mark the certificate ISSUED. Only retry while the
+      // status is `PENDING_VALIDATION`; terminal failures (`FAILED`,
+      // `VALIDATION_TIMED_OUT`) surface immediately. Capped at 10 minutes
+      // (60 * 10s) — DNS validation typically completes in under a minute,
+      // but we leave headroom for slow Route 53 propagation.
       const waitForIssued = Effect.fn(function* (certificateArn: string) {
         return yield* describeCertificate(certificateArn).pipe(
           Effect.flatMap((detail) => {
             if (!detail?.CertificateArn) {
-              return Effect.fail(new Error("CertificateNotFound"));
+              return Effect.fail(
+                new Error(
+                  `Certificate ${certificateArn} disappeared while waiting for issuance`,
+                ),
+              );
             }
             if (detail.Status === "ISSUED") {
               return Effect.succeed(detail);
@@ -240,12 +274,12 @@ export const CertificateProvider = () =>
                 ),
               );
             }
-            return Effect.fail(new Error("CertificatePendingValidation"));
+            return Effect.fail(new CertificatePendingValidation());
           }),
           Effect.retry({
             while: (error) =>
-              error instanceof Error &&
-              error.message === "CertificatePendingValidation",
+              (error as { _tag?: string })._tag ===
+              "CertificatePendingValidation",
             schedule: Schedule.fixed("10 seconds").pipe(
               Schedule.both(Schedule.recurs(60)),
             ),
@@ -253,18 +287,18 @@ export const CertificateProvider = () =>
         );
       });
 
+      // Wait for the Route 53 change to reach INSYNC across all edge
+      // locations. Capped at 2 minutes (60 * 2s) — typically takes <30s.
       const waitForChange = Effect.fn(function* (changeId: string) {
         return yield* route53.getChange({ Id: changeId }).pipe(
           Effect.map((response) => response.ChangeInfo),
           Effect.flatMap((changeInfo) =>
             changeInfo.Status === "INSYNC"
               ? Effect.succeed(changeInfo)
-              : Effect.fail(new Error("Route53ChangePending")),
+              : Effect.fail(new Route53ChangePending()),
           ),
           Effect.retry({
-            while: (error) =>
-              error instanceof Error &&
-              error.message === "Route53ChangePending",
+            while: (error) => error._tag === "Route53ChangePending",
             schedule: Schedule.fixed("2 seconds").pipe(
               Schedule.both(Schedule.recurs(60)),
             ),
@@ -327,16 +361,26 @@ export const CertificateProvider = () =>
           }
         }),
         read: Effect.fn(function* ({ id, olds, output }) {
-          const certificate = output?.certificateArn
-            ? yield* describeCertificate(output.certificateArn)
-            : yield* findManagedCertificate(id, olds!);
-
-          if (!certificate?.CertificateArn) {
-            return undefined;
+          // Fast path: cached ARN. We trust output.certificateArn (a stable
+          // ID) and just refresh attributes from cloud — no ownership check
+          // because the engine recorded this ARN itself.
+          if (output?.certificateArn) {
+            const detail = yield* describeCertificate(output.certificateArn);
+            if (!detail?.CertificateArn) {
+              return undefined;
+            }
+            const tags = yield* listCertificateTags(detail.CertificateArn);
+            return toAttrs(olds ?? ({} as CertificateProps), detail, tags);
           }
 
-          const tags = yield* listCertificateTags(certificate.CertificateArn);
-          return toAttrs(olds!, certificate, tags);
+          // Slow path: state was lost. Search by domain + SAN. If we find
+          // a match without our ownership tags, return Unowned(attrs) so
+          // the engine gates on `--adopt`/`adopt(true)`.
+          if (!olds) return undefined;
+          const found = yield* findCertificateByDomain(id, olds);
+          if (!found) return undefined;
+          const attrs = toAttrs(olds, found.detail, found.tags);
+          return found.owned ? attrs : Unowned(attrs);
         }),
         reconcile: Effect.fn(function* ({
           id,
@@ -354,11 +398,17 @@ export const CertificateProvider = () =>
           // can't be renamed, and most fields trigger replace via diff,
           // so the only real ensure path is "request if no managed
           // certificate exists".
+          //
+          // We accept any matching cert here (including foreign-tagged):
+          // the engine has already passed the adopt gate by this point if
+          // `read` returned `Unowned`, so reconciling is safe and the
+          // tag-sync block below will reassert ownership.
           let certificate = output?.certificateArn
             ? yield* describeCertificate(output.certificateArn)
             : undefined;
           if (!certificate?.CertificateArn) {
-            certificate = yield* findManagedCertificate(id, news);
+            const found = yield* findCertificateByDomain(id, news);
+            certificate = found?.detail;
           }
 
           // Ensure — request a new certificate if none exists. The
@@ -450,6 +500,15 @@ export const CertificateProvider = () =>
           return toAttrs(news, certificate, finalTags);
         }),
         delete: Effect.fn(function* ({ output }) {
+          // ACM forbids deleting a certificate that's still attached to
+          // an integrated service (CloudFront, ELB, API Gateway, etc.).
+          // Detachment is eventually consistent — even after the user
+          // removes the association, ACM may continue to surface
+          // `ResourceInUseException` for tens of seconds. Bounded retry
+          // (5 minutes total) rides this out so a destroy that immediately
+          // follows an unwiring of dependencies still converges, while
+          // capping us so a cert that's genuinely still in use surfaces
+          // a clear error instead of looping forever.
           yield* withAcmRegion(
             acm
               .deleteCertificate({
@@ -457,6 +516,15 @@ export const CertificateProvider = () =>
               })
               .pipe(
                 Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+                Effect.catchTag("ResourceInUseException", () =>
+                  Effect.fail(new CertificateInUse()),
+                ),
+                Effect.retry({
+                  while: (e) => e._tag === "CertificateInUse",
+                  schedule: Schedule.fixed("5 seconds").pipe(
+                    Schedule.both(Schedule.recurs(60)),
+                  ),
+                }),
               ),
           );
         }),

--- a/packages/alchemy/test/AWS/ACM/Certificate.test.ts
+++ b/packages/alchemy/test/AWS/ACM/Certificate.test.ts
@@ -1,0 +1,377 @@
+import { adopt } from "@/AdoptPolicy";
+import * as AWS from "@/AWS";
+import { Certificate } from "@/AWS/ACM";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import { Region as AwsRegion } from "@distilled.cloud/aws/Region";
+import * as acm from "@distilled.cloud/aws/acm";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+// All ACM operations for CloudFront-grade certs run in us-east-1.
+const ACM_REGION = "us-east-1" as const;
+const inAcm = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  effect.pipe(Effect.provideService(AwsRegion, ACM_REGION as any));
+
+// We use `*.example.com` domains throughout. ACM accepts the request and
+// drives the cert into `PENDING_VALIDATION` immediately — we never assert
+// it reaches `ISSUED`, so no real DNS is required. Each test deploys with
+// `validationMethod: "DNS"` (the default) and inspects the cert before
+// validation completes.
+
+const suffix = () => Math.random().toString(36).slice(2, 8);
+
+class CertificateStillExists extends Data.TaggedError(
+  "CertificateStillExists",
+) {}
+
+const assertCertificateDeleted = (certificateArn: string) =>
+  inAcm(
+    acm.describeCertificate({ CertificateArn: certificateArn }).pipe(
+      Effect.flatMap(() => Effect.fail(new CertificateStillExists())),
+      Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+      Effect.retry({
+        while: (e) => (e as { _tag?: string })._tag === "CertificateStillExists",
+        schedule: Schedule.fixed("2 seconds").pipe(
+          Schedule.both(Schedule.recurs(15)),
+        ),
+      }),
+    ),
+  );
+
+const listTags = (certificateArn: string) =>
+  inAcm(
+    acm
+      .listTagsForCertificate({ CertificateArn: certificateArn })
+      .pipe(Effect.map((r) => r.Tags ?? [])),
+  );
+
+test.provider("create and delete a DNS-validated certificate", (stack) =>
+  Effect.gen(function* () {
+    yield* stack.destroy();
+
+    const cert = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Certificate("BasicCert", {
+          domainName: `basic-${suffix()}.example.com`,
+        });
+      }),
+    );
+
+    expect(cert.certificateArn).toBeDefined();
+    expect(cert.domainName).toContain(".example.com");
+    expect(cert.validationMethod).toEqual("DNS");
+    // ACM populates DomainValidationOptions for the request, but the
+    // ResourceRecord may take a few seconds to appear. We don't gate on
+    // it here — the issuance test below covers PENDING_VALIDATION shape.
+    expect(cert.status).toBeDefined();
+
+    yield* stack.destroy();
+    yield* assertCertificateDeleted(cert.certificateArn);
+  }),
+);
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const domainName = `idempotent-${suffix()}.example.com`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Certificate("IdempotentCert", {
+            domainName,
+            tags: { Project: "alpha" },
+          });
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Certificate("IdempotentCert", {
+            domainName,
+            tags: { Project: "alpha" },
+          });
+        }),
+      );
+
+      // ARN is stable across redeploys with identical props — a new
+      // RequestCertificate would have minted a fresh ARN.
+      expect(second.certificateArn).toEqual(initial.certificateArn);
+      expect(second.domainName).toEqual(initial.domainName);
+
+      const detail = yield* inAcm(
+        acm.describeCertificate({ CertificateArn: second.certificateArn }),
+      );
+      expect(detail.Certificate?.DomainName).toEqual(domainName);
+
+      yield* stack.destroy();
+      yield* assertCertificateDeleted(initial.certificateArn);
+    }),
+);
+
+test.provider(
+  "reconcile resets tags mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const domainName = `drift-tags-${suffix()}.example.com`;
+
+      const cert = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Certificate("DriftTagsCert", {
+            domainName,
+            tags: { Project: "alpha", Owner: "team-platform" },
+          });
+        }),
+      );
+
+      // Drift the tags out-of-band: drop one user tag and add a stray.
+      yield* inAcm(
+        acm.removeTagsFromCertificate({
+          CertificateArn: cert.certificateArn,
+          Tags: [{ Key: "Project" }],
+        }),
+      );
+      yield* inAcm(
+        acm.addTagsToCertificate({
+          CertificateArn: cert.certificateArn,
+          Tags: [{ Key: "Stray", Value: "yes" }],
+        }),
+      );
+
+      // Re-deploy with the original desired props — reconcile must
+      // restore Project and remove Stray.
+      const redeployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Certificate("DriftTagsCert", {
+            domainName,
+            tags: { Project: "alpha", Owner: "team-platform" },
+          });
+        }),
+      );
+      expect(redeployed.certificateArn).toEqual(cert.certificateArn);
+
+      const tags = yield* listTags(cert.certificateArn);
+      const tagMap = Object.fromEntries(
+        tags.map((t) => [t.Key, t.Value] as const),
+      );
+      expect(tagMap.Project).toEqual("alpha");
+      expect(tagMap.Owner).toEqual("team-platform");
+      expect(tagMap.Stray).toBeUndefined();
+      // Internal ownership tags must still be present.
+      expect(tagMap["alchemy:fqn"]).toBeDefined();
+      expect(tagMap["alchemy:stage"]).toBeDefined();
+
+      yield* stack.destroy();
+      yield* assertCertificateDeleted(cert.certificateArn);
+    }),
+);
+
+test.provider(
+  "reconcile resets transparency-logging mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      // ACM's `Options.CertificateTransparencyLoggingPreference` is set
+      // at request time and triggers replace via diff if changed in
+      // props. This test asserts that an out-of-band toggle of the
+      // logging preference via UpdateCertificateOptions does NOT cause
+      // reconcile to drift away from the user's recorded desired state
+      // (a re-deploy with the same props returns the same ARN). For a
+      // true convergence here we'd need an update path on Options;
+      // ACM provides `UpdateCertificateOptions`, but our diff already
+      // declared this property as replace-only, so a redeploy is a
+      // no-op even with cloud drift.
+      yield* stack.destroy();
+
+      const domainName = `drift-options-${suffix()}.example.com`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Certificate("DriftOptionsCert", {
+            domainName,
+            certificateTransparencyLoggingPreference: "ENABLED",
+          });
+        }),
+      );
+
+      // Out-of-band toggle to DISABLED.
+      yield* inAcm(
+        acm.updateCertificateOptions({
+          CertificateArn: initial.certificateArn,
+          Options: { CertificateTransparencyLoggingPreference: "DISABLED" },
+        }),
+      );
+
+      // Redeploying with the same desired props should keep the same
+      // ARN. (Our diff says `certificateTransparencyLoggingPreference`
+      // is replace-only; a real "fix this on update" would need a
+      // dedicated reconciliation API — out of scope here.)
+      const redeployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Certificate("DriftOptionsCert", {
+            domainName,
+            certificateTransparencyLoggingPreference: "ENABLED",
+          });
+        }),
+      );
+      expect(redeployed.certificateArn).toEqual(initial.certificateArn);
+
+      yield* stack.destroy();
+      yield* assertCertificateDeleted(initial.certificateArn);
+    }),
+);
+
+test.provider("changing domainName triggers replace", (stack) =>
+  Effect.gen(function* () {
+    yield* stack.destroy();
+
+    const s = suffix();
+    const domainA = `replace-a-${s}.example.com`;
+    const domainB = `replace-b-${s}.example.com`;
+
+    const a = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Certificate("RenameCert", { domainName: domainA });
+      }),
+    );
+    expect(a.domainName).toEqual(domainA);
+
+    const b = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Certificate("RenameCert", { domainName: domainB });
+      }),
+    );
+    expect(b.domainName).toEqual(domainB);
+    expect(b.certificateArn).not.toEqual(a.certificateArn);
+
+    // The old certificate must be gone after replace.
+    yield* assertCertificateDeleted(a.certificateArn);
+
+    yield* stack.destroy();
+    yield* assertCertificateDeleted(b.certificateArn);
+  }),
+);
+
+test.provider("destroying an already-deleted certificate is a no-op", (stack) =>
+  Effect.gen(function* () {
+    yield* stack.destroy();
+
+    const cert = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Certificate("DoubleDestroyCert", {
+          domainName: `double-destroy-${suffix()}.example.com`,
+        });
+      }),
+    );
+
+    // Delete out-of-band, then ask the engine to destroy.
+    // Provider's `delete` must catch ResourceNotFoundException and
+    // complete cleanly.
+    yield* inAcm(
+      acm.deleteCertificate({ CertificateArn: cert.certificateArn }),
+    );
+    yield* assertCertificateDeleted(cert.certificateArn);
+
+    yield* stack.destroy();
+  }),
+);
+
+test.provider(
+  "adopt(true) re-tags a foreign certificate",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const domainName = `adopt-${suffix()}.example.com`;
+
+      const original = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Certificate("Original", { domainName });
+        }),
+      );
+
+      // Wipe state — the certificate stays in ACM. The new resource has
+      // a different fqn so its tags will be foreign.
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "Original",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      const takenOver = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* Certificate("Different", { domainName });
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(takenOver.domainName).toEqual(domainName);
+      expect(takenOver.certificateArn).toEqual(original.certificateArn);
+
+      // adopt(true) must re-tag the certificate with internal alchemy
+      // tags so subsequent runs route through silent adoption.
+      const tags = yield* listTags(takenOver.certificateArn);
+      const tagMap = Object.fromEntries(
+        tags.map((t) => [t.Key, t.Value] as const),
+      );
+      expect(tagMap["alchemy:fqn"]).toBeDefined();
+      expect(tagMap["alchemy:stage"]).toBeDefined();
+
+      yield* stack.destroy();
+      yield* assertCertificateDeleted(takenOver.certificateArn);
+    }),
+);
+
+test.provider(
+  "DNS-validated certificate enters PENDING_VALIDATION with populated DomainValidationOptions",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const domainName = `pending-${suffix()}.example.com`;
+
+      const cert = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Certificate("PendingCert", {
+            domainName,
+            subjectAlternativeNames: [`alt-${suffix()}.example.com`],
+          });
+        }),
+      );
+
+      // Wait a few seconds for ACM to populate the validation records,
+      // then assert shape. ACM is eventually consistent on
+      // ResourceRecord population; we don't validate (no real DNS).
+      yield* Effect.sleep("3 seconds");
+      const detail = yield* inAcm(
+        acm.describeCertificate({ CertificateArn: cert.certificateArn }),
+      );
+      expect(detail.Certificate?.Status).toEqual("PENDING_VALIDATION");
+
+      const validations = detail.Certificate?.DomainValidationOptions ?? [];
+      // Every requested name (primary + SAN) gets a validation entry.
+      expect(validations.length).toBeGreaterThanOrEqual(2);
+      // The primary domain's validation entry must surface a CNAME record
+      // (DNS validation method).
+      const primary = validations.find(
+        (v) => v.DomainName === domainName,
+      );
+      expect(primary?.ValidationMethod).toEqual("DNS");
+
+      yield* stack.destroy();
+      yield* assertCertificateDeleted(cert.certificateArn);
+    }),
+  { timeout: 120_000 },
+);


### PR DESCRIPTION
Audits the ACM Certificate reconciler for the same classes of issues SQS / S3 / IAM had, and adds lifecycle convergence tests on top of #179.

### Reconciler changes

`waitForValidationRecords`, `waitForIssued`, and `waitForChange` were retrying on bare `new Error("…")` sentinels and matching by `error.message`. Any other unrelated `Error` with the same message would have been retried; any genuine failure with a different message would short-circuit. Replaced with tagged data errors so retry conditions match precisely:

```diff
- return Effect.fail(new Error("CertificateValidationRecordPending"));
+ return Effect.fail(new ValidationRecordsPending());
  …
- while: (error) =>
-   error instanceof Error &&
-   error.message === "CertificateValidationRecordPending",
+ while: (error) => error._tag === "ValidationRecordsPending",
```

`delete` was unconditionally calling `deleteCertificate` and only catching `ResourceNotFoundException`. ACM forbids deleting a cert that's still attached to CloudFront / ELB / API Gateway, and detachment is eventually consistent — even after the user removes the association, ACM may continue surfacing `ResourceInUseException` for tens of seconds. Now bounded-retry (5 minutes total) on `ResourceInUseException`:

```diff
  acm.deleteCertificate({ CertificateArn: output.certificateArn }).pipe(
    Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+   Effect.catchTag("ResourceInUseException", () =>
+     Effect.fail(new CertificateInUse()),
+   ),
+   Effect.retry({
+     while: (e) => e._tag === "CertificateInUse",
+     schedule: Schedule.fixed("5 seconds").pipe(
+       Schedule.both(Schedule.recurs(60)),
+     ),
+   }),
  )
```

`read` now supports adoption. Previously `findManagedCertificate` filtered out every cert that didn't carry our alchemy ownership tags, so when state was lost the engine could never see a foreign cert and `adopt(true)` had no effect. The new helper returns the first cert matching domain + SAN regardless of tags and reports whether it's owned; `read` returns `Unowned(attrs)` for foreign matches so the engine gates on `--adopt`:

```diff
- const certificate = output?.certificateArn
-   ? yield* describeCertificate(output.certificateArn)
-   : yield* findManagedCertificate(id, olds!);
- return certificate ? toAttrs(olds!, certificate, tags) : undefined;
+ // Slow path: search by domain + SAN. If the cert lacks our ownership
+ // tags, return Unowned(attrs) so the engine gates on --adopt.
+ const found = yield* findCertificateByDomain(id, olds);
+ if (!found) return undefined;
+ const attrs = toAttrs(olds, found.detail, found.tags);
+ return found.owned ? attrs : Unowned(attrs);
```

`reconcile` now also accepts any matching cert (owned or foreign) — by the time `reconcile` runs, the engine has already passed the adopt gate, so reconciling is safe and the existing tag-sync block reasserts ownership.

### New lifecycle tests

Each test runs `destroy -> deploy -> ... -> destroy` on a `ScratchStack` and asserts at every step:

- create and delete a DNS-validated certificate
- redeploy with same props is a no-op (idempotent)
- reconcile resets tags mutated out-of-band via raw ACM SDK (and re-asserts internal `alchemy:fqn` / `alchemy:stage` tags)
- transparency-logging drift behavior (replace-only via diff; redeploy keeps the same ARN)
- changing `domainName` triggers replace; old cert is deleted
- destroying an already-deleted certificate is a no-op
- `adopt(true)` re-tags a foreign certificate (asserts internal alchemy tags appear after takeover)
- DNS-validated certificate enters `PENDING_VALIDATION` with populated `DomainValidationOptions` (uses `*.example.com` domains; never validates, just asserts shape)

`test.resources.ts` picks up the same `output?.stableId` fix from prior hardening PRs so this branch type-checks in isolation.

### Distilled patch

ACM error category fixes at https://github.com/alchemy-run/distilled/pull/252 — `ThrottlingException` is currently tagged `BadRequestError` (because AWS surfaces it as HTTP 400) so the AWS retry layer doesn't back off on it. `LimitExceededException` is uncategorized; semantically it's a quota error. `RequestInProgressException` becomes `ConflictError + RetryableError`. `ResourceInUseException` (semantically `DependencyViolationError`) and `ResourceNotFoundException` (`NotFoundError`) are not patched — those category tags are gated on alchemy-run/distilled#246. The reconciler-level `Effect.catchTag("ResourceInUseException", …)` retry handles the in-use case directly without depending on category-based behavior.
