### PR TITLE
fix(aws/cloudwatch): harden Alarm reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/CloudWatch/Alarm.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/Alarm.ts
@@ -131,16 +131,19 @@ export const AlarmProvider = () =>
             ? state
             : Unowned(state);
         }),
-        reconcile: Effect.fn(function* ({ id, news, olds, output, session }) {
+        reconcile: Effect.fn(function* ({ id, news, output, session }) {
           // Observe — derive the alarm name and read whatever is currently
           // in CloudWatch under that name. `output.alarmName` wins when
-          // present so an existing physical resource is never renamed.
+          // present so an existing physical resource is never renamed. We
+          // never trust `output` blindly: if the alarm was deleted
+          // out-of-band, `existing` is undefined and the upsert recreates.
           const name = output?.alarmName ?? (yield* createAlarmName(id, news));
           const existing = yield* readAlarm(name);
 
           // Ensure — `putMetricAlarm` is an upsert; we always send the full
           // desired config so the cloud converges to `news` regardless of
-          // whether the alarm pre-existed.
+          // whether the alarm pre-existed (greenfield, drifted, or
+          // out-of-band-deleted).
           yield* retryConcurrent(
             cloudwatch.putMetricAlarm({
               ...news,
@@ -148,13 +151,14 @@ export const AlarmProvider = () =>
             }),
           );
 
-          // Sync tags — diff observed (or prior) tags against desired and
-          // apply only the delta. On adoption `olds` is undefined, so we
-          // fall back to whatever we just observed.
+          // Sync tags — diff OBSERVED cloud tags against desired so
+          // adoption (which may bring foreign user tags) and out-of-band
+          // tag mutations both converge correctly. `olds` is never the
+          // source of truth here.
           const tags = yield* updateResourceTags({
             id,
             resourceArn: alarmArn(name),
-            olds: olds?.tags ?? existing?.tags,
+            olds: existing?.tags,
             news: news.tags,
           });
 
@@ -173,10 +177,15 @@ export const AlarmProvider = () =>
           };
         }),
         delete: Effect.fn(function* ({ output }) {
+          // `DeleteAlarms` returns `ResourceNotFound` if the alarm is
+          // already gone — out-of-band deletion or a prior partial
+          // destroy. Treat it as success so destroy is idempotent.
           yield* retryConcurrent(
             cloudwatch.deleteAlarms({
               AlarmNames: [output.alarmName],
             }),
+          ).pipe(
+            Effect.catchTag("ResourceNotFound", () => Effect.void),
           );
         }),
       };

--- a/packages/alchemy/src/AWS/CloudWatch/CompositeAlarm.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/CompositeAlarm.ts
@@ -124,16 +124,19 @@ export const CompositeAlarmProvider = () =>
             ? state
             : Unowned(state);
         }),
-        reconcile: Effect.fn(function* ({ id, news, olds, output, session }) {
+        reconcile: Effect.fn(function* ({ id, news, output, session }) {
           // Observe — pin the physical name from `output` if present so we
           // never rename an existing alarm; otherwise derive from desired
-          // props.
+          // props. We never trust `output` blindly: if the alarm was
+          // deleted out-of-band, `existing` is undefined and the upsert
+          // recreates.
           const name = output?.alarmName ?? (yield* createAlarmName(id, news));
           const existing = yield* readCompositeAlarm(name);
 
           // Ensure — `putCompositeAlarm` is an upsert. We always send the
           // full desired config so the cloud converges to `news` whether
-          // the alarm pre-existed or not.
+          // the alarm pre-existed (greenfield, drifted, or
+          // out-of-band-deleted).
           yield* retryConcurrent(
             cloudwatch.putCompositeAlarm({
               ...news,
@@ -141,13 +144,13 @@ export const CompositeAlarmProvider = () =>
             }),
           );
 
-          // Sync tags — diff observed (or prior) tags against desired.
-          // `olds` is undefined on adoption, so fall back to what we just
-          // observed.
+          // Sync tags — diff OBSERVED cloud tags against desired so
+          // adoption (foreign user tags) and out-of-band tag mutations
+          // both converge correctly. `olds` is never the source of truth.
           const tags = yield* updateResourceTags({
             id,
             resourceArn: alarmArn(name),
-            olds: olds?.tags ?? existing?.tags,
+            olds: existing?.tags,
             news: news.tags,
           });
 
@@ -166,10 +169,14 @@ export const CompositeAlarmProvider = () =>
           };
         }),
         delete: Effect.fn(function* ({ output }) {
+          // `DeleteAlarms` returns `ResourceNotFound` if the alarm is
+          // already gone. Treat it as success so destroy is idempotent.
           yield* retryConcurrent(
             cloudwatch.deleteAlarms({
               AlarmNames: [output.alarmName],
             }),
+          ).pipe(
+            Effect.catchTag("ResourceNotFound", () => Effect.void),
           );
         }),
       };

--- a/packages/alchemy/src/AWS/CloudWatch/common.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/common.ts
@@ -85,10 +85,14 @@ export const createTagList = (tags: Record<string, string>) =>
 export const retryConcurrent = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   effect.pipe(
     Effect.retry({
+      // ConcurrentModificationException / ConflictException signal a
+      // genuine race against another writer — bounded exponential retry.
+      // Capacity errors (`LimitException*`) are NOT retried here: AWS
+      // means "raise the alarm quota", not "try again", so retrying just
+      // burns 8 attempts before surfacing the same error.
       while: (error: any) =>
         error?._tag === "ConcurrentModificationException" ||
-        error?._tag === "ConflictException" ||
-        error?._tag === "LimitExceededException",
+        error?._tag === "ConflictException",
       schedule: Schedule.exponential(200).pipe(
         Schedule.both(Schedule.recurs(8)),
       ),

--- a/packages/alchemy/test/AWS/CloudWatch/Alarm.test.ts
+++ b/packages/alchemy/test/AWS/CloudWatch/Alarm.test.ts
@@ -1,0 +1,425 @@
+import { adopt } from "@/AdoptPolicy";
+import * as AWS from "@/AWS";
+import { Alarm } from "@/AWS/CloudWatch";
+import { Topic } from "@/AWS/SNS";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import * as cloudwatch from "@distilled.cloud/aws/cloudwatch";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+const baseAlarmProps = {
+  MetricName: "Errors",
+  Namespace: "AWS/Lambda",
+  Statistic: "Sum" as const,
+  Period: 60,
+  EvaluationPeriods: 1,
+  Threshold: 1,
+  ComparisonOperator: "GreaterThanOrEqualToThreshold" as const,
+  TreatMissingData: "notBreaching",
+};
+
+class AlarmStillExists extends Data.TaggedError("AlarmStillExists") {}
+class AlarmAttrNotReady extends Data.TaggedError("AlarmAttrNotReady") {}
+
+/** Read a metric alarm by name; returns undefined if it doesn't exist. */
+const describeMetricAlarm = (alarmName: string) =>
+  cloudwatch
+    .describeAlarms({
+      AlarmNames: [alarmName],
+      AlarmTypes: ["MetricAlarm"],
+    })
+    .pipe(
+      Effect.map((r) =>
+        r.MetricAlarms?.find((a) => a.AlarmName === alarmName),
+      ),
+    );
+
+/** Wait until describeAlarms reports the requested attribute values. */
+const waitForAlarmAttrs = Effect.fn(function* (
+  alarmName: string,
+  expected: Partial<{
+    Threshold: number;
+    EvaluationPeriods: number;
+    AlarmDescription: string;
+    AlarmActions: string[];
+  }>,
+) {
+  yield* Effect.gen(function* () {
+    const alarm = yield* describeMetricAlarm(alarmName);
+    if (!alarm) {
+      return yield* Effect.fail(new AlarmAttrNotReady());
+    }
+    if (
+      expected.Threshold !== undefined &&
+      alarm.Threshold !== expected.Threshold
+    ) {
+      return yield* Effect.fail(new AlarmAttrNotReady());
+    }
+    if (
+      expected.EvaluationPeriods !== undefined &&
+      alarm.EvaluationPeriods !== expected.EvaluationPeriods
+    ) {
+      return yield* Effect.fail(new AlarmAttrNotReady());
+    }
+    if (
+      expected.AlarmDescription !== undefined &&
+      alarm.AlarmDescription !== expected.AlarmDescription
+    ) {
+      return yield* Effect.fail(new AlarmAttrNotReady());
+    }
+    if (expected.AlarmActions !== undefined) {
+      const actual = [...(alarm.AlarmActions ?? [])].sort();
+      const want = [...expected.AlarmActions].sort();
+      if (
+        actual.length !== want.length ||
+        actual.some((v, i) => v !== want[i])
+      ) {
+        return yield* Effect.fail(new AlarmAttrNotReady());
+      }
+    }
+  }).pipe(
+    Effect.retry({
+      while: (e) => e._tag === "AlarmAttrNotReady",
+      schedule: Schedule.fixed("500 millis").pipe(
+        Schedule.both(Schedule.recurs(40)),
+      ),
+    }),
+  );
+});
+
+const assertAlarmDeleted = Effect.fn(function* (alarmName: string) {
+  yield* Effect.gen(function* () {
+    const alarm = yield* describeMetricAlarm(alarmName);
+    if (alarm) {
+      return yield* Effect.fail(new AlarmStillExists());
+    }
+  }).pipe(
+    Effect.retry({
+      while: (e) => e._tag === "AlarmStillExists",
+      schedule: Schedule.exponential(100).pipe(
+        Schedule.both(Schedule.recurs(8)),
+      ),
+    }),
+  );
+});
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Alarm("IdempotentAlarm", {
+            ...baseAlarmProps,
+            AlarmDescription: "alchemy idempotent test",
+          });
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Alarm("IdempotentAlarm", {
+            ...baseAlarmProps,
+            AlarmDescription: "alchemy idempotent test",
+          });
+        }),
+      );
+      expect(second.alarmName).toEqual(initial.alarmName);
+      expect(second.alarmArn).toEqual(initial.alarmArn);
+
+      const fresh = yield* describeMetricAlarm(second.alarmName);
+      expect(fresh?.Threshold).toEqual(1);
+      expect(fresh?.AlarmDescription).toEqual("alchemy idempotent test");
+
+      yield* stack.destroy();
+      yield* assertAlarmDeleted(initial.alarmName);
+    }),
+);
+
+test.provider(
+  "reconcile resets attributes mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const alarm = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Alarm("DriftAlarm", {
+            ...baseAlarmProps,
+            Threshold: 1,
+            EvaluationPeriods: 1,
+            AlarmDescription: "desired-description",
+          });
+        }),
+      );
+
+      // Mutate the alarm out-of-band via the raw CloudWatch SDK.
+      yield* cloudwatch.putMetricAlarm({
+        ...baseAlarmProps,
+        AlarmName: alarm.alarmName,
+        Threshold: 999,
+        EvaluationPeriods: 5,
+        AlarmDescription: "drifted-description",
+      });
+      yield* waitForAlarmAttrs(alarm.alarmName, {
+        Threshold: 999,
+        EvaluationPeriods: 5,
+        AlarmDescription: "drifted-description",
+      });
+
+      // Re-deploy with the same desired props — reconcile should reset
+      // the drifted attributes back to the desired values.
+      const redeployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Alarm("DriftAlarm", {
+            ...baseAlarmProps,
+            Threshold: 1,
+            EvaluationPeriods: 1,
+            AlarmDescription: "desired-description",
+          });
+        }),
+      );
+      expect(redeployed.alarmArn).toEqual(alarm.alarmArn);
+
+      yield* waitForAlarmAttrs(alarm.alarmName, {
+        Threshold: 1,
+        EvaluationPeriods: 1,
+        AlarmDescription: "desired-description",
+      });
+
+      yield* stack.destroy();
+      yield* assertAlarmDeleted(alarm.alarmName);
+    }),
+);
+
+test.provider(
+  "reconcile resets AlarmActions mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      // Stand up two SNS topics so we have real, valid alarm action ARNs.
+      const { desiredArn, driftedArn } = yield* stack.deploy(
+        Effect.gen(function* () {
+          const desired = yield* Topic("ActionsAlarmTargetA");
+          const drifted = yield* Topic("ActionsAlarmTargetB");
+          return {
+            desiredArn: desired.topicArn,
+            driftedArn: drifted.topicArn,
+          };
+        }),
+      );
+
+      const alarm = yield* stack.deploy(
+        Effect.gen(function* () {
+          // Re-create the topics so the engine carries them through.
+          yield* Topic("ActionsAlarmTargetA");
+          yield* Topic("ActionsAlarmTargetB");
+          return yield* Alarm("ActionsAlarm", {
+            ...baseAlarmProps,
+            AlarmActions: [desiredArn],
+          });
+        }),
+      );
+      yield* waitForAlarmAttrs(alarm.alarmName, {
+        AlarmActions: [desiredArn],
+      });
+
+      // Drift the actions out-of-band.
+      yield* cloudwatch.putMetricAlarm({
+        ...baseAlarmProps,
+        AlarmName: alarm.alarmName,
+        AlarmActions: [driftedArn],
+      });
+      yield* waitForAlarmAttrs(alarm.alarmName, {
+        AlarmActions: [driftedArn],
+      });
+
+      // Re-deploy: reconcile must reset to desired actions.
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Topic("ActionsAlarmTargetA");
+          yield* Topic("ActionsAlarmTargetB");
+          return yield* Alarm("ActionsAlarm", {
+            ...baseAlarmProps,
+            AlarmActions: [desiredArn],
+          });
+        }),
+      );
+      yield* waitForAlarmAttrs(alarm.alarmName, {
+        AlarmActions: [desiredArn],
+      });
+
+      yield* stack.destroy();
+      yield* assertAlarmDeleted(alarm.alarmName);
+    }),
+);
+
+test.provider(
+  "reconcile re-creates an alarm that was deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const alarmName = `alchemy-test-cw-recreate-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Alarm("RecreateAlarm", {
+            ...baseAlarmProps,
+            name: alarmName,
+          });
+        }),
+      );
+
+      // Delete the alarm out of band.
+      yield* cloudwatch.deleteAlarms({ AlarmNames: [initial.alarmName] });
+      yield* assertAlarmDeleted(initial.alarmName);
+
+      // Re-deploying must converge by re-creating.
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Alarm("RecreateAlarm", {
+            ...baseAlarmProps,
+            name: alarmName,
+          });
+        }),
+      );
+
+      expect(recreated.alarmName).toEqual(alarmName);
+      const fresh = yield* describeMetricAlarm(recreated.alarmName);
+      expect(fresh).toBeDefined();
+      expect(fresh?.Threshold).toEqual(1);
+
+      yield* stack.destroy();
+      yield* assertAlarmDeleted(recreated.alarmName);
+    }),
+);
+
+test.provider(
+  "changing alarmName triggers replace, old alarm is deleted",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const nameA = `alchemy-test-cw-replace-a-${suffix}`;
+      const nameB = `alchemy-test-cw-replace-b-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Alarm("RenameAlarm", {
+            ...baseAlarmProps,
+            name: nameA,
+          });
+        }),
+      );
+      expect(a.alarmName).toEqual(nameA);
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Alarm("RenameAlarm", {
+            ...baseAlarmProps,
+            name: nameB,
+          });
+        }),
+      );
+      expect(b.alarmName).toEqual(nameB);
+      expect(b.alarmArn).not.toEqual(a.alarmArn);
+
+      // The old alarm must be gone after replace.
+      yield* assertAlarmDeleted(a.alarmName);
+
+      yield* stack.destroy();
+      yield* assertAlarmDeleted(b.alarmName);
+    }),
+);
+
+test.provider(
+  "destroying an already-deleted alarm is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const alarm = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Alarm("DoubleDestroyAlarm", baseAlarmProps);
+        }),
+      );
+
+      // Delete out-of-band, then ask the engine to destroy. The provider's
+      // `delete` must catch ResourceNotFound and complete cleanly.
+      yield* cloudwatch.deleteAlarms({ AlarmNames: [alarm.alarmName] });
+      yield* assertAlarmDeleted(alarm.alarmName);
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider(
+  "foreign-tagged alarm requires adopt(true) to take over and is retagged",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const alarmName = `alchemy-test-cw-takeover-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const original = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Alarm("Original", {
+            ...baseAlarmProps,
+            name: alarmName,
+          });
+        }),
+      );
+
+      // Wipe state but leave the alarm in CloudWatch.
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "Original",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      const takenOver = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* Alarm("Different", {
+              ...baseAlarmProps,
+              name: alarmName,
+            });
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(takenOver.alarmName).toEqual(alarmName);
+      expect(takenOver.alarmArn).toEqual(original.alarmArn);
+
+      // adopt(true) must retag the alarm with internal alchemy tags so
+      // subsequent runs route through silent adoption.
+      const tags = yield* cloudwatch.listTagsForResource({
+        ResourceARN: takenOver.alarmArn,
+      });
+      const tagMap = Object.fromEntries(
+        (tags.Tags ?? []).map((t) => [t.Key ?? "", t.Value ?? ""]),
+      );
+      expect(tagMap["alchemy:fqn"]).toBeDefined();
+      expect(tagMap["alchemy:stage"]).toBeDefined();
+
+      yield* stack.destroy();
+      yield* assertAlarmDeleted(takenOver.alarmName);
+    }),
+);

--- a/packages/alchemy/test/test.resources.ts
+++ b/packages/alchemy/test/test.resources.ts
@@ -518,7 +518,8 @@ export const staticStablesResourceProvider = () =>
       return {
         string: news.string ?? id,
         tags: news.tags ?? {},
-        stableId: output?.stableId ?? `stable-${id}`,
+        stableId:
+          output?.stableId ?? (`stable-${id}` as const),
         stableArn:
           output?.stableArn ??
           (`arn:test:resource:us-east-1:123456789:${id}` as const),


### PR DESCRIPTION
Harden the CloudWatch `Alarm` reconciler so it converges from any starting state, and add lifecycle tests covering drift, out-of-band deletion, replace, double-destroy, and adoption-by-takeover.

### Reconciler changes

- Tag diff baseline now reads observed cloud tags, not `olds.tags`. Adoption (foreign user tags) and out-of-band tag mutation both converge.

```diff
  const tags = yield* updateResourceTags({
    id,
    resourceArn: alarmArn(name),
-   olds: olds?.tags ?? existing?.tags,
+   olds: existing?.tags,
    news: news.tags,
  });
```

- `delete` catches `ResourceNotFound` so destroying an already-deleted alarm is a no-op (matches AWS `DeleteAlarms` idempotency contract).

```diff
- yield* retryConcurrent(cloudwatch.deleteAlarms({ AlarmNames: [output.alarmName] }));
+ yield* retryConcurrent(
+   cloudwatch.deleteAlarms({ AlarmNames: [output.alarmName] }),
+ ).pipe(Effect.catchTag("ResourceNotFound", () => Effect.void));
```

- `retryConcurrent` no longer retries `LimitExceededException` — that's a quota error, not a race, so retrying just burns 8 attempts before surfacing the same error. `ConcurrentModificationException` and `ConflictException` are kept.

Same fixes applied to `CompositeAlarm`.

### New lifecycle tests

`packages/alchemy/test/AWS/CloudWatch/Alarm.test.ts`:

- redeploy with same props is a no-op
- reconcile resets `Threshold` / `EvaluationPeriods` / `AlarmDescription` mutated via raw `cloudwatch.putMetricAlarm`
- reconcile resets `AlarmActions` mutated out-of-band (uses two SNS topics for valid action ARNs)
- reconcile re-creates an alarm deleted out-of-band
- changing `name` triggers replace; old alarm is gone
- destroying an already-deleted alarm is a no-op
- adopt(true) on a foreign-tagged alarm re-tags with `alchemy:fqn` / `alchemy:stage`

### Distilled patch

Not needed. CloudWatch errors are already correctly categorized in `@distilled.cloud/aws@0.16.3`: `ConcurrentModificationException` -> `withThrottlingError` (handled by AWS retry layer), `InternalServiceFault` -> `withServerError`, `ConflictException` -> `withConflictError`, `LimitExceededFault` -> `withBadRequestError`.
