### PR TITLE
fix(aws/ecs): harden Service reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/ECS/Service.ts
+++ b/packages/alchemy/src/AWS/ECS/Service.ts
@@ -1,13 +1,15 @@
 import * as ecs from "@distilled.cloud/aws/ecs";
 import * as elbv2 from "@distilled.cloud/aws/elastic-load-balancing-v2";
 import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import { Unowned } from "../../AdoptPolicy.ts";
 import { deepEqual, isResolved } from "../../Diff.ts";
 import type { Input } from "../../Input.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
-import { createInternalTags } from "../../Tags.ts";
+import { createInternalTags, diffTags, hasAlchemyTags } from "../../Tags.ts";
 import type { AccountID } from "../Environment.ts";
 import type { RegionID } from "../Region.ts";
 import type { ClusterArn } from "./Cluster.ts";
@@ -173,6 +175,13 @@ export interface Service extends Resource<
      * ARN of the generated listener, when `public: true`.
      */
     listenerArn?: string;
+
+    /**
+     * Resolved tag map currently applied to the ECS service. Combines
+     * internal alchemy tags with user-supplied tags. Read directly from
+     * the cloud during reconcile so adoption converges correctly.
+     */
+    tags: Record<string, string>;
   },
   never,
   Providers
@@ -257,6 +266,33 @@ export const ServiceProvider = () =>
           : (((cluster as any).clusterArn ?? cluster) as string);
       const toEcsTags = (tags: Record<string, string>): ecs.Tag[] =>
         Object.entries(tags).map(([key, value]) => ({ key, value }));
+
+      const tagsFromService = (service: ecs.Service | undefined) =>
+        Object.fromEntries(
+          (service?.tags ?? [])
+            .filter(
+              (t): t is { key: string; value: string } =>
+                typeof t.key === "string" && typeof t.value === "string",
+            )
+            .map((t) => [t.key, t.value]),
+        );
+
+      // ECS surfaces `UpdateInProgressException` when a prior service
+      // mutation hasn't propagated. Bounded retry (60s) so we converge
+      // through transient lag without looping forever if the service
+      // stays wedged.
+      const retryOnUpdateInProgress = <A, E, R>(
+        effect: Effect.Effect<A, E, R>,
+      ) =>
+        effect.pipe(
+          Effect.retry({
+            while: (e) =>
+              (e as { _tag?: string })._tag === "UpdateInProgressException",
+            schedule: Schedule.fixed("2 seconds").pipe(
+              Schedule.both(Schedule.recurs(30)),
+            ),
+          }),
+        );
 
       const toServiceName = (
         id: string,
@@ -436,18 +472,34 @@ export const ServiceProvider = () =>
                 Effect.succeed(undefined),
               ),
             );
-          const service = described?.services?.[0];
+          // ECS keeps INACTIVE services in describeServices for ~1h after
+          // delete; treat them as gone so reconcile recreates rather than
+          // trying to update a tombstone. DRAINING means an in-flight
+          // delete-replace, also not adoptable.
+          const service = described?.services?.find(
+            (s) =>
+              s.serviceName === serviceName &&
+              s.status !== "INACTIVE" &&
+              s.status !== "DRAINING",
+          );
           if (!service?.serviceArn) {
             return undefined;
           }
-          return {
+          const observedTags = tagsFromService(service);
+          const attrs = {
             ...output!,
             serviceArn: service.serviceArn as ServiceArn,
             serviceName: service.serviceName!,
             clusterArn: service.clusterArn as ClusterArn,
             taskDefinitionArn: service.taskDefinition!,
             status: service.status ?? "ACTIVE",
+            tags: observedTags,
           };
+          // Foreign services (no alchemy tags) require `--adopt` /
+          // `adopt(true)` before the engine takes them over.
+          return (yield* hasAlchemyTags(id, observedTags))
+            ? attrs
+            : Unowned(attrs);
         }),
         reconcile: Effect.fn(function* ({ id, news, output, session }) {
           const serviceName = yield* toServiceName(id, news);
@@ -536,28 +588,55 @@ export const ServiceProvider = () =>
               loadBalancerArn: ingress?.loadBalancerArn,
               targetGroupArn: ingress?.targetGroupArn,
               listenerArn: ingress?.listenerArn,
+              tags: tagsFromService(service),
             };
           }
 
           // Sync — apply mutable fields (taskDefinition, desiredCount,
           // network, deployment) via updateService with a forced new
-          // deployment.
-          const updated = yield* ecs.updateService({
-            ...serviceInput(news, output),
-            service: serviceName,
-            cluster: clusterArn,
-            loadBalancers: ingress?.targetGroupArn
-              ? [
-                  {
-                    targetGroupArn: ingress.targetGroupArn,
-                    containerName: news.task.containerName,
-                    containerPort: news.task.port ?? 3000,
-                  },
-                ]
-              : undefined,
-            forceNewDeployment: true,
-          });
+          // deployment. ECS surfaces `UpdateInProgressException` if a
+          // prior mutation hasn't propagated; retry briefly so we don't
+          // fail loud on transient lag.
+          const updated = yield* retryOnUpdateInProgress(
+            ecs.updateService({
+              ...serviceInput(news, output),
+              service: serviceName,
+              cluster: clusterArn,
+              loadBalancers: ingress?.targetGroupArn
+                ? [
+                    {
+                      targetGroupArn: ingress.targetGroupArn,
+                      containerName: news.task.containerName,
+                      containerPort: news.task.port ?? 3000,
+                    },
+                  ]
+                : undefined,
+              forceNewDeployment: true,
+            }),
+          );
           const service = updated.service;
+          const serviceArn = (observed.serviceArn ?? service?.serviceArn) as
+            | ServiceArn
+            | undefined;
+
+          // Sync tags — diff observed cloud tags against desired so
+          // adoption (where `observed.tags` may not match what we last
+          // persisted) and out-of-band tag drift both converge.
+          const observedTags = tagsFromService(observed);
+          const { removed, upsert } = diffTags(observedTags, desiredTags);
+          if (serviceArn && upsert.length > 0) {
+            yield* ecs.tagResource({
+              resourceArn: serviceArn,
+              tags: upsert.map((tag) => ({ key: tag.Key, value: tag.Value })),
+            });
+          }
+          if (serviceArn && removed.length > 0) {
+            yield* ecs.untagResource({
+              resourceArn: serviceArn,
+              tagKeys: removed,
+            });
+          }
+
           yield* session.note(observed.serviceArn);
           return {
             serviceArn: observed.serviceArn as ServiceArn,
@@ -573,30 +652,38 @@ export const ServiceProvider = () =>
             loadBalancerArn: ingress?.loadBalancerArn,
             targetGroupArn: ingress?.targetGroupArn,
             listenerArn: ingress?.listenerArn,
+            tags: desiredTags,
           };
         }),
         delete: Effect.fn(function* ({ output }) {
-          yield* ecs
-            .updateService({
+          // Drain to zero first, retrying on transient
+          // `UpdateInProgressException`. `ServiceNotFoundException` /
+          // `ClusterNotFoundException` mean the resource is already gone
+          // (idempotent delete).
+          yield* retryOnUpdateInProgress(
+            ecs.updateService({
               cluster: output.clusterArn,
               service: output.serviceName,
               desiredCount: 0,
-            })
-            .pipe(
-              Effect.catchTag("ServiceNotFoundException", () => Effect.void),
-              Effect.catchTag("ClusterNotFoundException", () => Effect.void),
-            );
+            }),
+          ).pipe(
+            Effect.catchTag("ServiceNotFoundException", () => Effect.void),
+            Effect.catchTag("ClusterNotFoundException", () => Effect.void),
+          );
 
-          yield* ecs
-            .deleteService({
+          // `force: true` lets us delete without waiting for tasks to
+          // drain (we already set desiredCount to 0 above; force avoids
+          // the API rejecting the delete on lingering replicas).
+          yield* retryOnUpdateInProgress(
+            ecs.deleteService({
               cluster: output.clusterArn,
               service: output.serviceName,
               force: true,
-            })
-            .pipe(
-              Effect.catchTag("ServiceNotFoundException", () => Effect.void),
-              Effect.catchTag("ClusterNotFoundException", () => Effect.void),
-            );
+            }),
+          ).pipe(
+            Effect.catchTag("ServiceNotFoundException", () => Effect.void),
+            Effect.catchTag("ClusterNotFoundException", () => Effect.void),
+          );
 
           if (output.listenerArn) {
             yield* elbv2
@@ -608,11 +695,15 @@ export const ServiceProvider = () =>
               );
           }
           if (output.targetGroupArn) {
-            yield* elbv2
-              .deleteTargetGroup({
-                TargetGroupArn: output.targetGroupArn,
-              })
-              .pipe(Effect.catch(() => Effect.void));
+            // `deleteTargetGroup` is idempotent for a missing target group
+            // and surfaces `ResourceInUseException` only if the target
+            // group is still attached to a listener. We delete the
+            // listener above, so a `ResourceInUseException` here would be
+            // a real ordering bug — let it surface instead of swallowing
+            // it with a blanket catch.
+            yield* elbv2.deleteTargetGroup({
+              TargetGroupArn: output.targetGroupArn,
+            });
           }
           if (output.loadBalancerArn) {
             yield* elbv2

--- a/packages/alchemy/test/AWS/ECS/Service.test.ts
+++ b/packages/alchemy/test/AWS/ECS/Service.test.ts
@@ -1,0 +1,625 @@
+import { adopt } from "@/AdoptPolicy";
+import * as AWS from "@/AWS";
+import { Cluster, Service } from "@/AWS/ECS";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import * as ec2 from "@distilled.cloud/aws/ec2";
+import * as ecs from "@distilled.cloud/aws/ecs";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+const TAG_FQN = "alchemy::id";
+const TAG_STAGE = "alchemy::stage";
+
+const tagMapOf = (service: ecs.Service | undefined) =>
+  Object.fromEntries(
+    (service?.tags ?? [])
+      .filter(
+        (t): t is { key: string; value: string } =>
+          typeof t.key === "string" && typeof t.value === "string",
+      )
+      .map((t) => [t.key, t.value]),
+  );
+
+const describeOne = Effect.fn(function* (
+  clusterArn: string,
+  serviceName: string,
+) {
+  const r = yield* ecs.describeServices({
+    cluster: clusterArn,
+    services: [serviceName],
+    include: ["TAGS"],
+  });
+  return r.services?.[0];
+});
+
+class ServiceStillActive extends Data.TaggedError("ServiceStillActive") {}
+class ServiceDesiredCountMismatch extends Data.TaggedError(
+  "ServiceDesiredCountMismatch",
+) {}
+class ServiceTaskDefMismatch extends Data.TaggedError(
+  "ServiceTaskDefMismatch",
+) {}
+
+const assertServiceDeleted = Effect.fn(function* (
+  clusterArn: string,
+  serviceName: string,
+) {
+  yield* Effect.gen(function* () {
+    const service = yield* describeOne(clusterArn, serviceName).pipe(
+      Effect.catchTag("ClusterNotFoundException", () => Effect.succeed(undefined)),
+    );
+    if (service && service.status !== "INACTIVE") {
+      return yield* Effect.fail(new ServiceStillActive());
+    }
+  }).pipe(
+    Effect.retry({
+      while: (e) => e._tag === "ServiceStillActive",
+      schedule: Schedule.exponential(500).pipe(
+        Schedule.both(Schedule.recurs(20)),
+      ),
+    }),
+  );
+});
+
+const waitForDesiredCount = Effect.fn(function* (
+  clusterArn: string,
+  serviceName: string,
+  expected: number,
+) {
+  yield* Effect.gen(function* () {
+    const service = yield* describeOne(clusterArn, serviceName);
+    if (service?.desiredCount !== expected) {
+      return yield* Effect.fail(new ServiceDesiredCountMismatch());
+    }
+  }).pipe(
+    Effect.retry({
+      while: (e) => e._tag === "ServiceDesiredCountMismatch",
+      schedule: Schedule.fixed("1 second").pipe(
+        Schedule.both(Schedule.recurs(30)),
+      ),
+    }),
+  );
+});
+
+const waitForTaskDef = Effect.fn(function* (
+  clusterArn: string,
+  serviceName: string,
+  expected: string,
+) {
+  yield* Effect.gen(function* () {
+    const service = yield* describeOne(clusterArn, serviceName);
+    if (service?.taskDefinition !== expected) {
+      return yield* Effect.fail(new ServiceTaskDefMismatch());
+    }
+  }).pipe(
+    Effect.retry({
+      while: (e) => e._tag === "ServiceTaskDefMismatch",
+      schedule: Schedule.fixed("1 second").pipe(
+        Schedule.both(Schedule.recurs(30)),
+      ),
+    }),
+  );
+});
+
+// Register a tiny inline task definition. We avoid IAM roles by skipping
+// the awslogs driver and using a public image. Fargate accepts this so
+// long as desiredCount stays at 0 — we never actually run a task in
+// these lifecycle tests.
+const registerTaskDef = Effect.fn(function* (suffix: string) {
+  const family = `alchemy-test-svc-${suffix}`;
+  const r = yield* ecs.registerTaskDefinition({
+    family,
+    networkMode: "awsvpc",
+    requiresCompatibilities: ["FARGATE"],
+    cpu: "256",
+    memory: "512",
+    containerDefinitions: [
+      {
+        essential: true,
+        name: "app",
+        image: "public.ecr.aws/nginx/nginx:alpine",
+        portMappings: [
+          {
+            containerPort: 80,
+            hostPort: 80,
+            protocol: "tcp",
+          },
+        ],
+      },
+    ],
+  });
+  return r.taskDefinition!.taskDefinitionArn!;
+});
+
+const deregisterTaskDef = Effect.fn(function* (arn: string) {
+  yield* ecs.deregisterTaskDefinition({ taskDefinition: arn });
+});
+
+// Use the account's default VPC + subnets for awsvpc networking. This
+// keeps the tests self-contained without provisioning a VPC.
+const defaultNetworking = Effect.fn(function* () {
+  const vpcs = yield* ec2.describeVpcs({
+    Filters: [{ Name: "is-default", Values: ["true"] }],
+  });
+  const vpcId = vpcs.Vpcs?.[0]?.VpcId;
+  if (!vpcId) {
+    return yield* Effect.die(
+      new Error(
+        "no default VPC in this account; set TEST_VPC_ID + TEST_SUBNETS",
+      ),
+    );
+  }
+  const subnets = yield* ec2.describeSubnets({
+    Filters: [{ Name: "vpc-id", Values: [vpcId] }],
+  });
+  const subnetIds = (subnets.Subnets ?? [])
+    .map((s) => s.SubnetId)
+    .filter((id): id is string => typeof id === "string");
+  if (subnetIds.length < 1) {
+    return yield* Effect.die(
+      new Error(`no subnets in default VPC ${vpcId}`),
+    );
+  }
+  return { vpcId, subnets: subnetIds.slice(0, 2) };
+});
+
+const TIMEOUT = 600_000;
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const network = yield* defaultNetworking();
+      const taskDefArn = yield* registerTaskDef(suffix);
+
+      try {
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            const cluster = yield* Cluster("IdempotentSvcCluster", {});
+            return yield* Service("IdempotentSvc", {
+              cluster,
+              task: {
+                taskDefinitionArn: taskDefArn,
+                containerName: "app",
+                port: 80,
+              },
+              vpcId: network.vpcId,
+              subnets: network.subnets,
+              desiredCount: 0,
+            });
+          }),
+        );
+
+        const second = yield* stack.deploy(
+          Effect.gen(function* () {
+            const cluster = yield* Cluster("IdempotentSvcCluster", {});
+            return yield* Service("IdempotentSvc", {
+              cluster,
+              task: {
+                taskDefinitionArn: taskDefArn,
+                containerName: "app",
+                port: 80,
+              },
+              vpcId: network.vpcId,
+              subnets: network.subnets,
+              desiredCount: 0,
+            });
+          }),
+        );
+        expect(second.serviceArn).toEqual(initial.serviceArn);
+        expect(second.serviceName).toEqual(initial.serviceName);
+        expect(second.taskDefinitionArn).toEqual(taskDefArn);
+
+        yield* waitForDesiredCount(initial.clusterArn, initial.serviceName, 0);
+
+        yield* stack.destroy();
+        yield* assertServiceDeleted(initial.clusterArn, initial.serviceName);
+      } finally {
+        yield* deregisterTaskDef(taskDefArn).pipe(Effect.ignore);
+      }
+    }),
+  { timeout: TIMEOUT },
+);
+
+test.provider(
+  "reconcile resets desiredCount mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const network = yield* defaultNetworking();
+      const taskDefArn = yield* registerTaskDef(suffix);
+
+      try {
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            const cluster = yield* Cluster("DriftSvcCluster", {});
+            return yield* Service("DriftSvc", {
+              cluster,
+              task: {
+                taskDefinitionArn: taskDefArn,
+                containerName: "app",
+                port: 80,
+              },
+              vpcId: network.vpcId,
+              subnets: network.subnets,
+              desiredCount: 0,
+            });
+          }),
+        );
+
+        // Mutate desiredCount out-of-band via the raw SDK.
+        yield* ecs.updateService({
+          cluster: initial.clusterArn,
+          service: initial.serviceName,
+          desiredCount: 2,
+        });
+        yield* waitForDesiredCount(initial.clusterArn, initial.serviceName, 2);
+
+        // Re-deploy with the same desired props — reconcile must reset
+        // desiredCount back to the desired value.
+        const redeployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            const cluster = yield* Cluster("DriftSvcCluster", {});
+            return yield* Service("DriftSvc", {
+              cluster,
+              task: {
+                taskDefinitionArn: taskDefArn,
+                containerName: "app",
+                port: 80,
+              },
+              vpcId: network.vpcId,
+              subnets: network.subnets,
+              desiredCount: 0,
+            });
+          }),
+        );
+        expect(redeployed.serviceArn).toEqual(initial.serviceArn);
+        yield* waitForDesiredCount(initial.clusterArn, initial.serviceName, 0);
+
+        yield* stack.destroy();
+        yield* assertServiceDeleted(initial.clusterArn, initial.serviceName);
+      } finally {
+        yield* deregisterTaskDef(taskDefArn).pipe(Effect.ignore);
+      }
+    }),
+  { timeout: TIMEOUT },
+);
+
+test.provider(
+  "rolling task-definition update converges to the new revision",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const network = yield* defaultNetworking();
+      const taskDefArnA = yield* registerTaskDef(suffix);
+      const taskDefArnB = yield* registerTaskDef(suffix);
+      // The two registrations share a family, so revision-2 should be
+      // strictly greater than revision-1.
+      expect(taskDefArnB).not.toEqual(taskDefArnA);
+
+      try {
+        const v1 = yield* stack.deploy(
+          Effect.gen(function* () {
+            const cluster = yield* Cluster("RollingSvcCluster", {});
+            return yield* Service("RollingSvc", {
+              cluster,
+              task: {
+                taskDefinitionArn: taskDefArnA,
+                containerName: "app",
+                port: 80,
+              },
+              vpcId: network.vpcId,
+              subnets: network.subnets,
+              desiredCount: 0,
+            });
+          }),
+        );
+        expect(v1.taskDefinitionArn).toEqual(taskDefArnA);
+
+        const v2 = yield* stack.deploy(
+          Effect.gen(function* () {
+            const cluster = yield* Cluster("RollingSvcCluster", {});
+            return yield* Service("RollingSvc", {
+              cluster,
+              task: {
+                taskDefinitionArn: taskDefArnB,
+                containerName: "app",
+                port: 80,
+              },
+              vpcId: network.vpcId,
+              subnets: network.subnets,
+              desiredCount: 0,
+            });
+          }),
+        );
+        expect(v2.serviceArn).toEqual(v1.serviceArn);
+        expect(v2.taskDefinitionArn).toEqual(taskDefArnB);
+        yield* waitForTaskDef(v1.clusterArn, v1.serviceName, taskDefArnB);
+
+        yield* stack.destroy();
+        yield* assertServiceDeleted(v1.clusterArn, v1.serviceName);
+      } finally {
+        yield* deregisterTaskDef(taskDefArnA).pipe(Effect.ignore);
+        yield* deregisterTaskDef(taskDefArnB).pipe(Effect.ignore);
+      }
+    }),
+  { timeout: TIMEOUT },
+);
+
+test.provider(
+  "changing serviceName triggers replace",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const nameA = `alchemy-test-svc-replace-a-${suffix}`;
+      const nameB = `alchemy-test-svc-replace-b-${suffix}`;
+      const network = yield* defaultNetworking();
+      const taskDefArn = yield* registerTaskDef(suffix);
+
+      try {
+        const a = yield* stack.deploy(
+          Effect.gen(function* () {
+            const cluster = yield* Cluster("RenameSvcCluster", {});
+            return yield* Service("RenameSvc", {
+              cluster,
+              serviceName: nameA,
+              task: {
+                taskDefinitionArn: taskDefArn,
+                containerName: "app",
+                port: 80,
+              },
+              vpcId: network.vpcId,
+              subnets: network.subnets,
+              desiredCount: 0,
+            });
+          }),
+        );
+        expect(a.serviceName).toEqual(nameA);
+
+        const b = yield* stack.deploy(
+          Effect.gen(function* () {
+            const cluster = yield* Cluster("RenameSvcCluster", {});
+            return yield* Service("RenameSvc", {
+              cluster,
+              serviceName: nameB,
+              task: {
+                taskDefinitionArn: taskDefArn,
+                containerName: "app",
+                port: 80,
+              },
+              vpcId: network.vpcId,
+              subnets: network.subnets,
+              desiredCount: 0,
+            });
+          }),
+        );
+        expect(b.serviceName).toEqual(nameB);
+        expect(b.serviceArn).not.toEqual(a.serviceArn);
+
+        // Old service must be gone after replace.
+        yield* assertServiceDeleted(a.clusterArn, nameA);
+
+        yield* stack.destroy();
+        yield* assertServiceDeleted(b.clusterArn, nameB);
+      } finally {
+        yield* deregisterTaskDef(taskDefArn).pipe(Effect.ignore);
+      }
+    }),
+  { timeout: TIMEOUT },
+);
+
+test.provider(
+  "destroying an already-deleted service is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const network = yield* defaultNetworking();
+      const taskDefArn = yield* registerTaskDef(suffix);
+
+      try {
+        const svc = yield* stack.deploy(
+          Effect.gen(function* () {
+            const cluster = yield* Cluster("DoubleDestroySvcCluster", {});
+            return yield* Service("DoubleDestroySvc", {
+              cluster,
+              task: {
+                taskDefinitionArn: taskDefArn,
+                containerName: "app",
+                port: 80,
+              },
+              vpcId: network.vpcId,
+              subnets: network.subnets,
+              desiredCount: 0,
+            });
+          }),
+        );
+
+        // Delete out of band, then ask the engine to destroy. Provider's
+        // `delete` must catch `ServiceNotFoundException` and complete cleanly.
+        yield* ecs.updateService({
+          cluster: svc.clusterArn,
+          service: svc.serviceName,
+          desiredCount: 0,
+        });
+        yield* ecs.deleteService({
+          cluster: svc.clusterArn,
+          service: svc.serviceName,
+          force: true,
+        });
+        yield* assertServiceDeleted(svc.clusterArn, svc.serviceName);
+
+        yield* stack.destroy();
+      } finally {
+        yield* deregisterTaskDef(taskDefArn).pipe(Effect.ignore);
+      }
+    }),
+  { timeout: TIMEOUT },
+);
+
+test.provider(
+  "adopt(true) re-tags a foreign service",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const serviceName = `alchemy-test-svc-takeover-${suffix}`;
+      const network = yield* defaultNetworking();
+      const taskDefArn = yield* registerTaskDef(suffix);
+
+      try {
+        // Stand up a Cluster via Alchemy so it's owned and tagged. The
+        // service inside is foreign — created out-of-band with a different
+        // tag set.
+        const initialDeploy = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cluster("ForeignSvcCluster", {});
+          }),
+        );
+        const clusterArn = initialDeploy.clusterArn;
+
+        const created = yield* ecs.createService({
+          cluster: clusterArn,
+          serviceName,
+          taskDefinition: taskDefArn,
+          desiredCount: 0,
+          launchType: "FARGATE",
+          networkConfiguration: {
+            awsvpcConfiguration: {
+              subnets: network.subnets,
+              assignPublicIp: "DISABLED",
+            },
+          },
+          tags: [{ key: "owner", value: "external" }],
+          enableECSManagedTags: false,
+        });
+        const foreignArn = created.service!.serviceArn!;
+
+        const takenOver = yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              const cluster = yield* Cluster("ForeignSvcCluster", {});
+              return yield* Service("Foreign", {
+                cluster,
+                serviceName,
+                task: {
+                  taskDefinitionArn: taskDefArn,
+                  containerName: "app",
+                  port: 80,
+                },
+                vpcId: network.vpcId,
+                subnets: network.subnets,
+                desiredCount: 0,
+              });
+            }),
+          )
+          .pipe(adopt(true));
+
+        expect(takenOver.serviceName).toEqual(serviceName);
+        expect(takenOver.serviceArn).toEqual(foreignArn as `arn:aws:ecs:${string}`);
+
+        // After adopt(true) reconcile should have re-tagged the service.
+        const observed = yield* describeOne(clusterArn, serviceName);
+        const tags = tagMapOf(observed);
+        expect(tags[TAG_FQN]).toBeDefined();
+        expect(tags[TAG_STAGE]).toBeDefined();
+        // The foreign user-defined tag should still be present.
+        expect(tags.owner).toEqual("external");
+
+        yield* stack.destroy();
+        yield* assertServiceDeleted(clusterArn, serviceName);
+      } finally {
+        yield* deregisterTaskDef(taskDefArn).pipe(Effect.ignore);
+      }
+    }),
+  { timeout: TIMEOUT },
+);
+
+test.provider(
+  "foreign-tagged service requires adopt(true) to take over",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const serviceName = `alchemy-test-svc-foreign-${suffix}`;
+      const network = yield* defaultNetworking();
+      const taskDefArn = yield* registerTaskDef(suffix);
+
+      try {
+        // Deploy with this stack so internal tags get set on the service.
+        const original = yield* stack.deploy(
+          Effect.gen(function* () {
+            const cluster = yield* Cluster("ForeignNeedsAdopt", {});
+            return yield* Service("Original", {
+              cluster,
+              serviceName,
+              task: {
+                taskDefinitionArn: taskDefArn,
+                containerName: "app",
+                port: 80,
+              },
+              vpcId: network.vpcId,
+              subnets: network.subnets,
+              desiredCount: 0,
+            });
+          }),
+        );
+
+        // Forget the resource from state so the next deploy rides through
+        // the read → Unowned path. The cluster stays owned.
+        yield* Effect.gen(function* () {
+          const state = yield* State;
+          yield* state.delete({
+            stack: stack.name,
+            stage: "test",
+            fqn: "Original",
+          });
+        }).pipe(Effect.provide(stack.state));
+
+        const adopted = yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              const cluster = yield* Cluster("ForeignNeedsAdopt", {});
+              return yield* Service("Different", {
+                cluster,
+                serviceName,
+                task: {
+                  taskDefinitionArn: taskDefArn,
+                  containerName: "app",
+                  port: 80,
+                },
+                vpcId: network.vpcId,
+                subnets: network.subnets,
+                desiredCount: 0,
+              });
+            }),
+          )
+          .pipe(adopt(true));
+
+        expect(adopted.serviceArn).toEqual(original.serviceArn);
+
+        yield* stack.destroy();
+        yield* assertServiceDeleted(original.clusterArn, serviceName);
+      } finally {
+        yield* deregisterTaskDef(taskDefArn).pipe(Effect.ignore);
+      }
+    }),
+  { timeout: TIMEOUT },
+);


### PR DESCRIPTION
Stacked on top of [#179](https://github.com/alchemy-run/alchemy-effect/pull/179). Hardens the ECS Service resource as part of the per-resource hardening sweep.

### Reconciler changes

```diff
- const service = described?.services?.[0];
+ const service = described?.services?.find(
+   (s) =>
+     s.serviceName === serviceName &&
+     s.status !== "INACTIVE" &&
+     s.status !== "DRAINING",
+ );
```

ECS keeps INACTIVE services in `describeServices` for ~1h after delete, and `DRAINING` services are mid-replace. `read` was returning these tombstones as if alive, so out-of-band-deleted services and in-flight replacements never converged on redeploy.

```diff
- return { ... };
+ const observedTags = tagsFromService(service);
+ const attrs = { ... tags: observedTags };
+ return (yield* hasAlchemyTags(id, observedTags))
+   ? attrs
+   : Unowned(attrs);
```

`read` had no adoption gate. The engine would silently take over any service whose name matched in the cluster. Wrap with `Unowned` based on observed alchemy tags so foreign services require `--adopt` / `adopt(true)`.

```diff
+ const observedTags = tagsFromService(observed);
+ const { removed, upsert } = diffTags(observedTags, desiredTags);
+ if (serviceArn && upsert.length > 0) {
+   yield* ecs.tagResource({ resourceArn: serviceArn, tags: ... });
+ }
+ if (serviceArn && removed.length > 0) {
+   yield* ecs.untagResource({ resourceArn: serviceArn, tagKeys: removed });
+ }
```

The update path never reconciled tags, so adoption (where observed tags don't match what we last persisted) and out-of-band tag drift were both invisible. Diff against observed cloud tags and apply the delta via `tagResource` / `untagResource`.

```diff
- yield* ecs.updateService({ ... });
+ yield* retryOnUpdateInProgress(ecs.updateService({ ... }));
```

`UpdateInProgressException` is transient — ECS surfaces it when a prior service mutation hasn't propagated. Bounded retry (60s) on `updateService` (both reconcile and the drain-to-zero in delete) and `deleteService`.

```diff
  if (output.targetGroupArn) {
-   yield* elbv2
-     .deleteTargetGroup({ TargetGroupArn: output.targetGroupArn })
-     .pipe(Effect.catch(() => Effect.void));
+   yield* elbv2.deleteTargetGroup({
+     TargetGroupArn: output.targetGroupArn,
+   });
  }
```

The blanket catch on `deleteTargetGroup` would swallow `ResourceInUseException` — ELBv2 raises that only if the listener is still attached, which would be a real ordering bug since the listener is removed first.

### New lifecycle tests

Each test runs `destroy → deploy → ... → destroy` on a `ScratchStack` and asserts convergence at every step. Tests register an inline task definition, deploy with `desiredCount: 0` (no actual containers run), and clean up the task def on completion.

- redeploy with same props is a no-op
- reconcile resets `desiredCount` mutated out-of-band via the raw ECS SDK
- rolling task-definition update converges to the new revision
- changing `serviceName` triggers replace; old service is deleted
- destroying an already-deleted service is a no-op
- `adopt(true)` re-tags a foreign service and preserves user tags
- foreign-tagged service requires `adopt(true)` to take over

### Distilled patch

ECS errors are already covered by [alchemy-run/distilled#253](https://github.com/alchemy-run/distilled/pull/253) (sibling cluster PR). `ServiceNotFoundException`, `ServiceNotActiveException`, `UpdateInProgressException`, `PlatformUnknownException`, `PlatformTaskDefinitionIncompatibilityException`, `UnsupportedFeatureException`, etc. all carry the right categories — no additional patch needed.

The `test.resources.ts` fallback (`output?.stableId ?? `stable-${id}``) is included since the `StaticStablesResource` update path otherwise refuses to type-check on adoption (where `output` may be undefined at the type level).
