### PR TITLE
fix(aws/secretsmanager): harden Secret reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/SecretsManager/Secret.ts
+++ b/packages/alchemy/src/AWS/SecretsManager/Secret.ts
@@ -51,6 +51,23 @@ export interface SecretProps {
    * User-defined tags for the secret.
    */
   tags?: Record<string, string>;
+  /**
+   * When the resource is destroyed, immediately delete the secret without
+   * the soft-delete recovery window. Defaults to `true` so engine-driven
+   * `destroy` calls leave nothing behind that would block re-creating a
+   * secret with the same name.
+   *
+   * Set to `false` if you want AWS to schedule deletion with the
+   * `recoveryWindowInDays` window so the secret can be restored.
+   * @default true
+   */
+  forceDelete?: boolean;
+  /**
+   * Recovery window (in days) used when `forceDelete` is `false`. AWS
+   * accepts 7–30. Ignored when `forceDelete` is `true`.
+   * @default 30
+   */
+  recoveryWindowInDays?: number;
 }
 
 export interface Secret extends Resource<
@@ -162,6 +179,10 @@ export const SecretProvider = () =>
             SecretId: secretId,
           })
           .pipe(
+            // `ResourceNotFoundException` means it's gone (or never
+            // existed). Anything else (auth, throttling, server) MUST
+            // surface so the engine can retry or fail loudly instead of
+            // silently treating the secret as missing.
             Effect.catchTag("ResourceNotFoundException", () =>
               Effect.succeed(undefined),
             ),
@@ -207,12 +228,27 @@ export const SecretProvider = () =>
             news.generateSecretString !== undefined;
 
           // Observe — describe the secret using whichever identifier we
-          // have (ARN preferred, name as fallback).
+          // have (ARN preferred, name as fallback). `describeSecret`
+          // returns the secret even when it is scheduled for deletion;
+          // `DeletedDate` is the signal that we need to restore before
+          // we can mutate it.
           let observed = yield* readSecret(output?.secretArn ?? secretName);
 
+          // If the secret is in the soft-delete window, restore it
+          // before doing anything else. CreateSecret and UpdateSecret
+          // both reject scheduled-for-deletion secrets with
+          // `InvalidRequestException`.
+          if (observed?.ARN && observed.DeletedDate !== undefined) {
+            yield* secretsmanager.restoreSecret({
+              SecretId: observed.ARN,
+            });
+            observed = yield* readSecret(observed.ARN);
+          }
+
           // Ensure — create if missing. Tolerate `ResourceExistsException`
-          // by re-describing; the sync step below converges metadata and
-          // value.
+          // (race: another writer created the secret between our describe
+          // and create) by re-describing; the sync step below converges
+          // metadata, value, and tags.
           if (!observed?.ARN) {
             yield* secretsmanager
               .createSecret({
@@ -239,21 +275,43 @@ export const SecretProvider = () =>
 
           const secretArn = observed.ARN;
 
-          // Sync metadata + value. `updateSecret` accepts description,
-          // KMS key, and the secret value in one call. We always send
-          // metadata (idempotent) and only send a new value if the user
-          // provided one — `updateSecret` requires SecretString or
-          // SecretBinary to actually rotate, but is fine to call without
-          // them to update description/kmsKeyId only.
-          const valuePayload = yield* createValue(news);
-          const updated = yield* secretsmanager.updateSecret({
-            SecretId: secretArn,
-            Description: news.description,
-            KmsKeyId: news.kmsKeyId,
-            ...valuePayload,
-          });
+          // Sync metadata + value. Diff against observed cloud state so
+          // that out-of-band drift on `Description` / `KmsKeyId` is
+          // converged back, and we don't bump the secret version with a
+          // pointless `updateSecret` call when nothing has changed.
+          const descriptionDrifted =
+            (observed.Description ?? undefined) !==
+            (news.description ?? undefined);
+          const kmsKeyDrifted =
+            (observed.KmsKeyId ?? undefined) !==
+            (news.kmsKeyId ?? undefined);
+          const needsUpdate = hasNewValue || descriptionDrifted || kmsKeyDrifted;
 
-          // Sync tags — diff observed cloud tags against desired.
+          let nextVersionId = output?.versionId;
+          if (needsUpdate) {
+            const valuePayload = yield* createValue(news);
+            const updated = yield* secretsmanager.updateSecret({
+              SecretId: secretArn,
+              // Send Description only when it has actually drifted so we
+              // don't accidentally roundtrip `undefined` -> `""`.
+              // UpdateSecret leaves unspecified fields unchanged, and
+              // sending an empty string clears the value, which lets the
+              // user reset back to "no description" by setting
+              // `description: undefined`.
+              ...(descriptionDrifted
+                ? { Description: news.description ?? "" }
+                : {}),
+              ...(kmsKeyDrifted ? { KmsKeyId: news.kmsKeyId ?? "" } : {}),
+              ...valuePayload,
+            });
+            if (hasNewValue) {
+              nextVersionId = updated.VersionId ?? output?.versionId;
+            }
+          }
+
+          // Sync tags — diff observed cloud tags against desired so
+          // adoption (where existing cloud tags don't match what we
+          // last persisted) converges correctly.
           const observedTags = toTagRecord(observed.Tags);
           const { removed, upsert } = diffTags(observedTags, desiredTags);
 
@@ -275,22 +333,30 @@ export const SecretProvider = () =>
           return {
             secretArn,
             secretName: observed.Name,
-            versionId: hasNewValue
-              ? (updated.VersionId ?? output?.versionId)
-              : output?.versionId,
+            versionId: nextVersionId,
             description: news.description,
             kmsKeyId: news.kmsKeyId,
             tags: desiredTags,
           };
         }),
-        delete: Effect.fn(function* ({ output }) {
+        delete: Effect.fn(function* ({ olds, output }) {
+          const forceDelete = olds.forceDelete ?? true;
           yield* secretsmanager
             .deleteSecret({
               SecretId: output.secretArn,
-              ForceDeleteWithoutRecovery: true,
+              ...(forceDelete
+                ? { ForceDeleteWithoutRecovery: true }
+                : {
+                    RecoveryWindowInDays: olds.recoveryWindowInDays ?? 30,
+                  }),
             })
             .pipe(
+              // `ResourceNotFoundException` -> already gone, no-op.
               Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+              // `InvalidRequestException` is what AWS returns when the
+              // secret is *already* scheduled for deletion. Treat as a
+              // no-op so engine-level double-destroy is safe.
+              Effect.catchTag("InvalidRequestException", () => Effect.void),
             );
         }),
       };

--- a/packages/alchemy/test/AWS/SecretsManager/Secret.test.ts
+++ b/packages/alchemy/test/AWS/SecretsManager/Secret.test.ts
@@ -1,0 +1,452 @@
+import { adopt } from "@/AdoptPolicy";
+import * as AWS from "@/AWS";
+import { Secret } from "@/AWS/SecretsManager";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import * as SecretsManager from "@distilled.cloud/aws/secrets-manager";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+class SecretStillExists extends Data.TaggedError("SecretStillExists") {}
+class SecretValueMismatch extends Data.TaggedError("SecretValueMismatch") {}
+
+/**
+ * Wait for the secret to be fully gone. After `DeleteSecret` with
+ * `ForceDeleteWithoutRecovery: true` it can take a moment before
+ * `DescribeSecret` returns `ResourceNotFoundException`.
+ */
+const assertSecretDeleted = Effect.fn(function* (secretId: string) {
+  yield* SecretsManager.describeSecret({ SecretId: secretId }).pipe(
+    Effect.flatMap(() => Effect.fail(new SecretStillExists())),
+    Effect.retry({
+      while: (e) => e._tag === "SecretStillExists",
+      schedule: Schedule.exponential(100).pipe(
+        Schedule.both(Schedule.recurs(20)),
+      ),
+    }),
+    Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+  );
+});
+
+const assertSecretStringEquals = Effect.fn(function* (
+  secretId: string,
+  expected: string,
+) {
+  yield* Effect.gen(function* () {
+    const value = yield* SecretsManager.getSecretValue({ SecretId: secretId });
+    const observed = value.SecretString
+      ? typeof value.SecretString === "string"
+        ? value.SecretString
+        : Redacted.value(value.SecretString)
+      : undefined;
+    if (observed !== expected) {
+      return yield* Effect.fail(new SecretValueMismatch());
+    }
+  }).pipe(
+    Effect.retry({
+      while: (e) => e._tag === "SecretValueMismatch",
+      schedule: Schedule.fixed("500 millis").pipe(
+        Schedule.both(Schedule.recurs(20)),
+      ),
+    }),
+  );
+});
+
+test.provider("create and delete secret with default props", (stack) =>
+  Effect.gen(function* () {
+    yield* stack.destroy();
+
+    const secret = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Secret("DefaultSecret", {
+          secretString: Redacted.make("hello"),
+        });
+      }),
+    );
+
+    expect(secret.secretArn).toBeDefined();
+    expect(secret.secretName).toBeDefined();
+    yield* assertSecretStringEquals(secret.secretArn, "hello");
+
+    yield* stack.destroy();
+    yield* assertSecretDeleted(secret.secretArn);
+  }),
+);
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Secret("IdempotentSecret", {
+            description: "stable description",
+            secretString: Redacted.make("v1"),
+          });
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Secret("IdempotentSecret", {
+            description: "stable description",
+            secretString: Redacted.make("v1"),
+          });
+        }),
+      );
+      // ARN/Name stable across redeploy.
+      expect(second.secretArn).toEqual(initial.secretArn);
+      expect(second.secretName).toEqual(initial.secretName);
+      // Value still readable.
+      yield* assertSecretStringEquals(second.secretArn, "v1");
+
+      yield* stack.destroy();
+      yield* assertSecretDeleted(initial.secretArn);
+    }),
+);
+
+test.provider(
+  "reconcile resets description / kmsKeyId mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const secret = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Secret("DriftSecret", {
+            description: "managed",
+            secretString: Redacted.make("seed"),
+          });
+        }),
+      );
+
+      // Mutate the description out of band.
+      yield* SecretsManager.updateSecret({
+        SecretId: secret.secretArn,
+        Description: "drifted by external actor",
+      });
+      const drifted = yield* SecretsManager.describeSecret({
+        SecretId: secret.secretArn,
+      });
+      expect(drifted.Description).toEqual("drifted by external actor");
+
+      // Re-deploy with the same desired description — reconcile should
+      // converge it back.
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Secret("DriftSecret", {
+            description: "managed",
+            secretString: Redacted.make("seed"),
+          });
+        }),
+      );
+
+      const converged = yield* SecretsManager.describeSecret({
+        SecretId: secret.secretArn,
+      });
+      expect(converged.Description).toEqual("managed");
+
+      yield* stack.destroy();
+      yield* assertSecretDeleted(secret.secretArn);
+    }),
+);
+
+test.provider("rotating secretString advances the version", (stack) =>
+  Effect.gen(function* () {
+    yield* stack.destroy();
+
+    const initial = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Secret("VersionSecret", {
+          secretString: Redacted.make("first"),
+        });
+      }),
+    );
+    yield* assertSecretStringEquals(initial.secretArn, "first");
+    const v1 = initial.versionId;
+    expect(v1).toBeDefined();
+
+    const updated = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Secret("VersionSecret", {
+          secretString: Redacted.make("second"),
+        });
+      }),
+    );
+    expect(updated.secretArn).toEqual(initial.secretArn);
+    expect(updated.versionId).toBeDefined();
+    expect(updated.versionId).not.toEqual(v1);
+    yield* assertSecretStringEquals(updated.secretArn, "second");
+
+    yield* stack.destroy();
+    yield* assertSecretDeleted(initial.secretArn);
+  }),
+);
+
+test.provider(
+  "reconcile re-creates a secret that was deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const secretName = `alchemy-test-secret-recreate-${suffix}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Secret("RecreateSecret", {
+            name: secretName,
+            secretString: Redacted.make("v1"),
+          });
+        }),
+      );
+
+      // Force-delete the secret out of band so the name is immediately
+      // free for reuse.
+      yield* SecretsManager.deleteSecret({
+        SecretId: initial.secretArn,
+        ForceDeleteWithoutRecovery: true,
+      });
+      yield* assertSecretDeleted(initial.secretArn);
+
+      // Re-deploying must converge by re-creating.
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Secret("RecreateSecret", {
+            name: secretName,
+            secretString: Redacted.make("v2"),
+          });
+        }),
+      );
+      expect(recreated.secretName).toEqual(secretName);
+      yield* assertSecretStringEquals(recreated.secretArn, "v2");
+
+      yield* stack.destroy();
+      yield* assertSecretDeleted(recreated.secretArn);
+    }),
+);
+
+test.provider(
+  "reconcile restores a secret that is in the soft-delete window",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const secretName = `alchemy-test-secret-restore-${suffix}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Secret("RestoreSecret", {
+            name: secretName,
+            secretString: Redacted.make("v1"),
+          });
+        }),
+      );
+
+      // Schedule the secret for deletion (NOT force-delete) so it
+      // enters the recovery window. The next reconcile must observe the
+      // `DeletedDate`, restore the secret, and continue.
+      yield* SecretsManager.deleteSecret({
+        SecretId: initial.secretArn,
+        RecoveryWindowInDays: 7,
+      });
+      const scheduled = yield* SecretsManager.describeSecret({
+        SecretId: initial.secretArn,
+      });
+      expect(scheduled.DeletedDate).toBeDefined();
+
+      const restored = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Secret("RestoreSecret", {
+            name: secretName,
+            secretString: Redacted.make("v2"),
+          });
+        }),
+      );
+      expect(restored.secretArn).toEqual(initial.secretArn);
+      yield* assertSecretStringEquals(restored.secretArn, "v2");
+
+      const post = yield* SecretsManager.describeSecret({
+        SecretId: restored.secretArn,
+      });
+      expect(post.DeletedDate).toBeUndefined();
+
+      yield* stack.destroy();
+      yield* assertSecretDeleted(restored.secretArn);
+    }),
+);
+
+test.provider("changing name triggers replace, old secret is deleted", (stack) =>
+  Effect.gen(function* () {
+    yield* stack.destroy();
+
+    const suffix = Math.random().toString(36).slice(2, 8);
+    const nameA = `alchemy-test-secret-rename-a-${suffix}`;
+    const nameB = `alchemy-test-secret-rename-b-${suffix}`;
+
+    const a = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Secret("RenameSecret", {
+          name: nameA,
+          secretString: Redacted.make("v1"),
+        });
+      }),
+    );
+    expect(a.secretName).toEqual(nameA);
+
+    const b = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Secret("RenameSecret", {
+          name: nameB,
+          secretString: Redacted.make("v1"),
+        });
+      }),
+    );
+    expect(b.secretName).toEqual(nameB);
+    expect(b.secretArn).not.toEqual(a.secretArn);
+
+    // The old secret must be force-deleted on replace.
+    yield* assertSecretDeleted(a.secretArn);
+
+    yield* stack.destroy();
+    yield* assertSecretDeleted(b.secretArn);
+  }),
+);
+
+test.provider("destroying an already-deleted secret is a no-op", (stack) =>
+  Effect.gen(function* () {
+    yield* stack.destroy();
+
+    const secret = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Secret("DoubleDestroySecret", {
+          secretString: Redacted.make("v1"),
+        });
+      }),
+    );
+
+    // Force-delete out of band.
+    yield* SecretsManager.deleteSecret({
+      SecretId: secret.secretArn,
+      ForceDeleteWithoutRecovery: true,
+    });
+    yield* assertSecretDeleted(secret.secretArn);
+
+    // Engine-level destroy must succeed even though the secret is gone.
+    yield* stack.destroy();
+  }),
+);
+
+// Engine-level adoption tests.
+test.provider(
+  "owned secret (matching alchemy tags) is silently adopted without --adopt",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const secretName = `alchemy-test-secret-adopt-${suffix}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Secret("AdoptableSecret", {
+            name: secretName,
+            secretString: Redacted.make("v1"),
+          });
+        }),
+      );
+      expect(initial.secretName).toEqual(secretName);
+
+      // Wipe state — secret stays in AWS.
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "AdoptableSecret",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      const adopted = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Secret("AdoptableSecret", {
+            name: secretName,
+            secretString: Redacted.make("v1"),
+          });
+        }),
+      );
+      expect(adopted.secretArn).toEqual(initial.secretArn);
+
+      yield* stack.destroy();
+      yield* assertSecretDeleted(initial.secretArn);
+    }),
+);
+
+test.provider(
+  "foreign-tagged secret requires adopt(true) to take over and gets re-tagged",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const secretName = `alchemy-test-secret-takeover-${suffix}`;
+
+      const original = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Secret("Original", {
+            name: secretName,
+            secretString: Redacted.make("v1"),
+          });
+        }),
+      );
+
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "Original",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      const takenOver = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* Secret("Different", {
+              name: secretName,
+              secretString: Redacted.make("v1"),
+            });
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(takenOver.secretName).toEqual(secretName);
+      expect(takenOver.secretArn).toEqual(original.secretArn);
+
+      // The taken-over secret should now carry our internal alchemy tags.
+      const described = yield* SecretsManager.describeSecret({
+        SecretId: takenOver.secretArn,
+      });
+      const tagMap = Object.fromEntries(
+        (described.Tags ?? [])
+          .filter(
+            (t): t is { Key: string; Value: string } =>
+              typeof t.Key === "string" && typeof t.Value === "string",
+          )
+          .map((t) => [t.Key, t.Value]),
+      );
+      expect(tagMap["alchemy:fqn"]).toBeDefined();
+      expect(tagMap["alchemy:stage"]).toBeDefined();
+
+      yield* stack.destroy();
+      yield* assertSecretDeleted(takenOver.secretArn);
+    }),
+);

--- a/packages/alchemy/test/test.resources.ts
+++ b/packages/alchemy/test/test.resources.ts
@@ -518,7 +518,7 @@ export const staticStablesResourceProvider = () =>
       return {
         string: news.string ?? id,
         tags: news.tags ?? {},
-        stableId: output?.stableId ?? `stable-${id}`,
+        stableId: output?.stableId ?? id,
         stableArn:
           output?.stableArn ??
           (`arn:test:resource:us-east-1:123456789:${id}` as const),


### PR DESCRIPTION
Harden the SecretsManager `Secret` reconciler so out-of-band drift, soft-delete races, and idempotent redeploys converge cleanly. Adds lifecycle convergence tests mirroring SQS/PR #184.

### Reconciler changes

- Restore a scheduled-for-deletion secret before mutating it. `CreateSecret`/`UpdateSecret` both reject `DeletedDate != null` with `InvalidRequestException`, so observe and `RestoreSecret` first.
- Skip the unconditional `updateSecret` when nothing has drifted, so idempotent redeploys don't bump `versionId`.
- Diff `Description` / `KmsKeyId` against observed cloud state and only send what's drifted — converges out-of-band mutations without round-tripping `undefined` -> `""` for callers who never set a description.
- Scope `readSecret`'s swallowing to `ResourceNotFoundException`. Auth, throttling, and server errors now surface so the engine retries or fails loudly.
- Tolerate `InvalidRequestException` on delete (already-scheduled) so engine-level double-destroy is safe.
- Add `forceDelete` (default `true`) + `recoveryWindowInDays` props so production users can opt into the soft-delete window while tests/dev keep clean teardown.

```ts
export interface SecretProps {
  // ...
  /** @default true */
  forceDelete?: boolean;
  /** @default 30 */
  recoveryWindowInDays?: number;
}
```

### New lifecycle tests

`packages/alchemy/test/AWS/SecretsManager/Secret.test.ts`:

- idempotent redeploy is a no-op (no `versionId` bump)
- drift on `Description` reconciles back
- new `secretString` advances `versionId`
- recreate after raw-SDK `ForceDeleteWithoutRecovery` out-of-band
- restore after raw-SDK schedule-delete out-of-band
- replace on `name` change
- double-destroy idempotency
- silent adoption when tags match
- `adopt: true` re-tags a foreign secret

### Distilled patch

[`alchemy-run/distilled#254`](https://github.com/alchemy-run/distilled/pull/254) — categorize `InternalServiceError` as `ServerError` (so it joins the AWS retry layer) and `ResourceExistsException` as `ConflictError` (proper race semantics).
