### PR TITLE
fix(aws/ec2): harden Subnet reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/EC2/Subnet.ts
+++ b/packages/alchemy/src/AWS/EC2/Subnet.ts
@@ -3,12 +3,19 @@ import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 
+import { Unowned } from "../../AdoptPolicy.ts";
 import type { ScopedPlanStatusSession } from "../../Cli/Cli.ts";
 import { isResolved, somePropsAreDifferent } from "../../Diff.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
-import { createInternalTags, createTagsList, diffTags } from "../../Tags.ts";
+import {
+  createAlchemyTagFilters,
+  createInternalTags,
+  createTagsList,
+  diffTags,
+  hasAlchemyTags,
+} from "../../Tags.ts";
 import type { AccountID } from "../Environment.ts";
 import type { RegionID } from "../Region.ts";
 import type { VpcId } from "./Vpc.ts";
@@ -206,6 +213,11 @@ export interface Subnet extends Resource<
       enableResourceNameDnsARecord?: boolean;
       enableResourceNameDnsAAAARecord?: boolean;
     };
+
+    /**
+     * The tags currently applied to the subnet.
+     */
+    tags?: Record<string, string>;
   },
   never,
   Providers
@@ -218,6 +230,36 @@ export const SubnetProvider = () =>
     Effect.gen(function* () {
       return {
         stables: ["subnetId", "subnetArn", "ownerId", "vpcId"],
+        // Observe a Subnet by alchemy tags. Subnet ids are auto-assigned, so
+        // we can't reconstruct the identifier from props — instead we filter
+        // `describeSubnets` by the internal tags `createInternalTags(id)`
+        // writes on every Subnet we manage. If a Subnet was created out of
+        // band (no alchemy tags) the filter returns nothing and we surface
+        // `undefined` rather than guessing.
+        read: Effect.fn(function* ({ id, output }) {
+          let subnet: ec2.Subnet | undefined;
+          if (output?.subnetId) {
+            const lookup = yield* ec2
+              .describeSubnets({ SubnetIds: [output.subnetId] })
+              .pipe(
+                Effect.catchTag("InvalidSubnetID.NotFound", () =>
+                  Effect.succeed({ Subnets: [] }),
+                ),
+              );
+            subnet = lookup.Subnets?.[0];
+          }
+          if (!subnet) {
+            const filters = yield* createAlchemyTagFilters(id);
+            const lookup = yield* ec2.describeSubnets({ Filters: filters });
+            subnet = lookup.Subnets?.[0];
+          }
+          if (!subnet) return undefined;
+          const tags = Object.fromEntries(
+            (subnet.Tags ?? []).map((t) => [t.Key!, t.Value!]),
+          ) as Record<string, string>;
+          const attrs = toSubnetAttrs(subnet, tags);
+          return (yield* hasAlchemyTags(id, tags)) ? attrs : Unowned(attrs);
+        }),
         diff: Effect.fn(function* ({ news, olds }) {
           if (!isResolved(news)) return;
           if (
@@ -239,8 +281,9 @@ export const SubnetProvider = () =>
           const alchemyTags = yield* createInternalTags(id);
           const desiredTags = { ...alchemyTags, ...(news.tags ?? {}) };
 
-          // Observe — find the subnet via cached id, else fall through to
-          // create.
+          // Observe — find the subnet via cached id, else by alchemy tags so
+          // an interrupted previous run (state lost after createSubnet but
+          // before persistence) recovers without leaking a duplicate.
           let subnet: ec2.Subnet | undefined;
           if (output?.subnetId) {
             const lookup = yield* ec2
@@ -250,6 +293,11 @@ export const SubnetProvider = () =>
                   Effect.succeed({ Subnets: [] }),
                 ),
               );
+            subnet = lookup.Subnets?.[0];
+          }
+          if (!subnet) {
+            const filters = yield* createAlchemyTagFilters(id);
+            const lookup = yield* ec2.describeSubnets({ Filters: filters });
             subnet = lookup.Subnets?.[0];
           }
 
@@ -276,9 +324,15 @@ export const SubnetProvider = () =>
                 DryRun: false,
               })
               .pipe(
+                // VPC reads are eventually consistent — when a fresh VPC is
+                // created in the same plan the propagation delay can surface
+                // as `InvalidVpcID.NotFound` here. Bound the wait so a
+                // genuinely-missing VPC still surfaces as a failure.
                 Effect.retry({
                   while: (e) => e._tag === "InvalidVpcID.NotFound",
-                  schedule: Schedule.exponential(100),
+                  schedule: Schedule.fixed(1000).pipe(
+                    Schedule.both(Schedule.recurs(15)),
+                  ),
                 }),
               );
             const newSubnetId = createResult.Subnet!.SubnetId! as SubnetId;
@@ -289,13 +343,19 @@ export const SubnetProvider = () =>
           const subnetId = subnet.SubnetId! as SubnetId;
 
           // Sync subnet attributes — diff observed cloud state against desired
-          // and only call modifySubnetAttribute on real drift.
+          // and only call modifySubnetAttribute on real drift. Each call is
+          // wrapped in `retryEventuallyConsistent` because EC2 may briefly
+          // return `InvalidSubnetID.NotFound` immediately after createSubnet
+          // even though `waitForSubnetAvailable` has reported the subnet as
+          // `available`.
           const desiredMapPublicIp = news.mapPublicIpOnLaunch ?? false;
           if ((subnet.MapPublicIpOnLaunch ?? false) !== desiredMapPublicIp) {
-            yield* ec2.modifySubnetAttribute({
-              SubnetId: subnetId,
-              MapPublicIpOnLaunch: { Value: desiredMapPublicIp },
-            });
+            yield* ec2
+              .modifySubnetAttribute({
+                SubnetId: subnetId,
+                MapPublicIpOnLaunch: { Value: desiredMapPublicIp },
+              })
+              .pipe(retryEventuallyConsistent);
             yield* session.note(
               `Updated map public IP on launch: ${desiredMapPublicIp}`,
             );
@@ -305,10 +365,12 @@ export const SubnetProvider = () =>
           if (
             (subnet.AssignIpv6AddressOnCreation ?? false) !== desiredAssignIpv6
           ) {
-            yield* ec2.modifySubnetAttribute({
-              SubnetId: subnetId,
-              AssignIpv6AddressOnCreation: { Value: desiredAssignIpv6 },
-            });
+            yield* ec2
+              .modifySubnetAttribute({
+                SubnetId: subnetId,
+                AssignIpv6AddressOnCreation: { Value: desiredAssignIpv6 },
+              })
+              .pipe(retryEventuallyConsistent);
             yield* session.note(
               `Updated assign IPv6 address on creation: ${desiredAssignIpv6}`,
             );
@@ -316,10 +378,12 @@ export const SubnetProvider = () =>
 
           const desiredEnableDns64 = news.enableDns64 ?? false;
           if ((subnet.EnableDns64 ?? false) !== desiredEnableDns64) {
-            yield* ec2.modifySubnetAttribute({
-              SubnetId: subnetId,
-              EnableDns64: { Value: desiredEnableDns64 },
-            });
+            yield* ec2
+              .modifySubnetAttribute({
+                SubnetId: subnetId,
+                EnableDns64: { Value: desiredEnableDns64 },
+              })
+              .pipe(retryEventuallyConsistent);
             yield* session.note(`Updated DNS64 setting: ${desiredEnableDns64}`);
           }
 
@@ -340,91 +404,63 @@ export const SubnetProvider = () =>
               news.enableResourceNameDnsAAAARecordOnLaunch !== undefined ||
               news.hostnameType !== undefined
             ) {
-              yield* ec2.modifySubnetAttribute({
-                SubnetId: subnetId,
-                PrivateDnsHostnameTypeOnLaunch: news.hostnameType,
-                EnableResourceNameDnsARecordOnLaunch:
-                  news.enableResourceNameDnsARecordOnLaunch !== undefined
-                    ? { Value: news.enableResourceNameDnsARecordOnLaunch }
-                    : undefined,
-                EnableResourceNameDnsAAAARecordOnLaunch:
-                  news.enableResourceNameDnsAAAARecordOnLaunch !== undefined
-                    ? { Value: news.enableResourceNameDnsAAAARecordOnLaunch }
-                    : undefined,
-              });
+              yield* ec2
+                .modifySubnetAttribute({
+                  SubnetId: subnetId,
+                  PrivateDnsHostnameTypeOnLaunch: news.hostnameType,
+                  EnableResourceNameDnsARecordOnLaunch:
+                    news.enableResourceNameDnsARecordOnLaunch !== undefined
+                      ? { Value: news.enableResourceNameDnsARecordOnLaunch }
+                      : undefined,
+                  EnableResourceNameDnsAAAARecordOnLaunch:
+                    news.enableResourceNameDnsAAAARecordOnLaunch !== undefined
+                      ? { Value: news.enableResourceNameDnsAAAARecordOnLaunch }
+                      : undefined,
+                })
+                .pipe(retryEventuallyConsistent);
               yield* session.note("Updated private DNS hostname settings");
             }
           }
 
-          // Sync tags — observed cloud tags vs desired.
+          // Sync tags — observed cloud tags vs desired. Foreign-tagged
+          // takeovers (adopt(true)) come through here with `subnet.Tags` not
+          // matching what we last persisted, so this diff is what re-brands
+          // the subnet on adoption.
           const currentTags = Object.fromEntries(
             (subnet.Tags ?? []).map((t) => [t.Key!, t.Value!]),
           ) as Record<string, string>;
           const { removed, upsert } = diffTags(currentTags, desiredTags);
           if (removed.length > 0) {
-            yield* ec2.deleteTags({
-              Resources: [subnetId],
-              Tags: removed.map((key) => ({ Key: key })),
-              DryRun: false,
-            });
+            yield* ec2
+              .deleteTags({
+                Resources: [subnetId],
+                Tags: removed.map((key) => ({ Key: key })),
+                DryRun: false,
+              })
+              .pipe(retryEventuallyConsistent);
           }
           if (upsert.length > 0) {
-            yield* ec2.createTags({
-              Resources: [subnetId],
-              Tags: upsert,
-              DryRun: false,
-            });
+            yield* ec2
+              .createTags({
+                Resources: [subnetId],
+                Tags: upsert,
+                DryRun: false,
+              })
+              .pipe(retryEventuallyConsistent);
           }
 
           // Re-read final state.
-          const finalLookup = yield* ec2.describeSubnets({
-            SubnetIds: [subnetId],
-          });
+          const finalLookup = yield* ec2
+            .describeSubnets({ SubnetIds: [subnetId] })
+            .pipe(retryEventuallyConsistent);
           const final = finalLookup.Subnets?.[0];
           if (!final) {
-            return yield* Effect.fail(
-              new Error(`Subnet ${subnetId} disappeared during reconcile`),
-            );
+            return yield* new SubnetDisappeared({ subnetId });
           }
-          return {
-            subnetId,
-            subnetArn: final.SubnetArn! as SubnetArn,
-            cidrBlock: final.CidrBlock!,
-            vpcId: news.vpcId,
-            availabilityZone: final.AvailabilityZone!,
-            availabilityZoneId: final.AvailabilityZoneId,
-            state: final.State!,
-            availableIpAddressCount: final.AvailableIpAddressCount ?? 0,
-            mapPublicIpOnLaunch: final.MapPublicIpOnLaunch ?? false,
-            assignIpv6AddressOnCreation:
-              final.AssignIpv6AddressOnCreation ?? false,
-            defaultForAz: final.DefaultForAz ?? false,
-            ownerId: final.OwnerId,
-            ipv6CidrBlockAssociationSet: final.Ipv6CidrBlockAssociationSet?.map(
-              (assoc) => ({
-                associationId: assoc.AssociationId!,
-                ipv6CidrBlock: assoc.Ipv6CidrBlock!,
-                ipv6CidrBlockState: {
-                  state: assoc.Ipv6CidrBlockState!.State!,
-                  statusMessage: assoc.Ipv6CidrBlockState!.StatusMessage,
-                },
-              }),
-            ),
-            enableDns64: final.EnableDns64,
-            ipv6Native: final.Ipv6Native,
-            privateDnsNameOptionsOnLaunch: final.PrivateDnsNameOptionsOnLaunch
-              ? {
-                  hostnameType:
-                    final.PrivateDnsNameOptionsOnLaunch.HostnameType,
-                  enableResourceNameDnsARecord:
-                    final.PrivateDnsNameOptionsOnLaunch
-                      .EnableResourceNameDnsARecord,
-                  enableResourceNameDnsAAAARecord:
-                    final.PrivateDnsNameOptionsOnLaunch
-                      .EnableResourceNameDnsAAAARecord,
-                }
-              : undefined,
-          };
+          const finalTags = Object.fromEntries(
+            (final.Tags ?? []).map((t) => [t.Key!, t.Value!]),
+          ) as Record<string, string>;
+          return toSubnetAttrs(final, finalTags);
         }),
 
         delete: Effect.fn(function* ({ output, session }) {
@@ -432,34 +468,31 @@ export const SubnetProvider = () =>
 
           yield* session.note(`Deleting subnet: ${subnetId}`);
 
-          // 1. Attempt to delete subnet
+          // Attempt to delete the subnet. If it's already gone, that's a
+          // no-op. DependencyViolation means ENIs / RouteTableAssociations /
+          // running instances are still being torn down; bound the wait at
+          // ~5 minutes to match VPC.
           yield* ec2
             .deleteSubnet({
               SubnetId: subnetId,
               DryRun: false,
             })
             .pipe(
-              Effect.tapError(Effect.logDebug),
-              Effect.catchTag("InvalidSubnetID.NotFound", () => Effect.void),
-              // Retry on dependency violations (resources still being deleted)
               Effect.retry({
-                while: (e) => {
-                  // DependencyViolation means there are still dependent resources
-                  // This can happen if ENIs/instances are being deleted concurrently
-                  return e._tag === "DependencyViolation";
-                },
-                schedule: Schedule.exponential(1000, 1.5).pipe(
-                  Schedule.both(Schedule.recurs(10)), // Try up to 10 times
+                while: (e) => e._tag === "DependencyViolation",
+                schedule: Schedule.fixed(5000).pipe(
+                  Schedule.both(Schedule.recurs(60)),
                   Schedule.tapOutput(([, attempt]) =>
                     session.note(
-                      `Waiting for dependencies to clear... (attempt ${attempt + 1})`,
+                      `Waiting for subnet dependencies to clear... (attempt ${attempt + 1})`,
                     ),
                   ),
                 ),
               }),
+              Effect.catchTag("InvalidSubnetID.NotFound", () => Effect.void),
             );
 
-          // 2. Wait for subnet to be fully deleted
+          // Wait for the deletion to propagate.
           yield* waitForSubnetDeleted(subnetId, session);
 
           yield* session.note(`Subnet ${subnetId} deleted successfully`);
@@ -479,26 +512,106 @@ class SubnetStillExists extends Data.TaggedError("SubnetStillExists")<{
   subnetId: string;
 }> {}
 
+// Tagged failure for the rare case where a Subnet vanishes mid-reconcile
+// (e.g. it was deleted out of band between createSubnet and the final read).
+class SubnetDisappeared extends Data.TaggedError("SubnetDisappeared")<{
+  subnetId: string;
+}> {}
+
 /**
- * Wait for subnet to be in available state
+ * Pipe an EC2 effect through a bounded retry that rides out post-create
+ * eventual-consistency `InvalidSubnetID.NotFound`. The general AWS retry
+ * layer doesn't ride this out because distilled doesn't tag it as
+ * retryable — but we know it's transient when we have just created the
+ * subnet ourselves.
+ */
+const retryEventuallyConsistent = <A, E, R>(
+  self: Effect.Effect<A, E, R>,
+): Effect.Effect<A, Exclude<E, { _tag: "InvalidSubnetID.NotFound" }>, R> =>
+  self.pipe(
+    Effect.retry({
+      while: (e: any) => e?._tag === "InvalidSubnetID.NotFound",
+      schedule: Schedule.fixed(1000).pipe(Schedule.both(Schedule.recurs(15))),
+    }),
+  ) as Effect.Effect<
+    A,
+    Exclude<E, { _tag: "InvalidSubnetID.NotFound" }>,
+    R
+  >;
+
+/**
+ * Project a `describeSubnets` result row to the public Attributes shape.
+ * Used by `read` and the final read inside `reconcile` to produce
+ * identically-shaped output.
+ */
+const toSubnetAttrs = (
+  subnet: ec2.Subnet,
+  tags: Record<string, string>,
+): Subnet["Attributes"] => ({
+  subnetId: subnet.SubnetId! as SubnetId,
+  subnetArn: subnet.SubnetArn! as SubnetArn,
+  cidrBlock: subnet.CidrBlock!,
+  vpcId: subnet.VpcId! as VpcId,
+  availabilityZone: subnet.AvailabilityZone!,
+  availabilityZoneId: subnet.AvailabilityZoneId,
+  state: subnet.State!,
+  availableIpAddressCount: subnet.AvailableIpAddressCount ?? 0,
+  mapPublicIpOnLaunch: subnet.MapPublicIpOnLaunch ?? false,
+  assignIpv6AddressOnCreation: subnet.AssignIpv6AddressOnCreation ?? false,
+  defaultForAz: subnet.DefaultForAz ?? false,
+  ownerId: subnet.OwnerId,
+  ipv6CidrBlockAssociationSet: subnet.Ipv6CidrBlockAssociationSet?.map(
+    (assoc) => ({
+      associationId: assoc.AssociationId!,
+      ipv6CidrBlock: assoc.Ipv6CidrBlock!,
+      ipv6CidrBlockState: {
+        state: assoc.Ipv6CidrBlockState!.State!,
+        statusMessage: assoc.Ipv6CidrBlockState!.StatusMessage,
+      },
+    }),
+  ),
+  enableDns64: subnet.EnableDns64,
+  ipv6Native: subnet.Ipv6Native,
+  privateDnsNameOptionsOnLaunch: subnet.PrivateDnsNameOptionsOnLaunch
+    ? {
+        hostnameType: subnet.PrivateDnsNameOptionsOnLaunch.HostnameType,
+        enableResourceNameDnsARecord:
+          subnet.PrivateDnsNameOptionsOnLaunch.EnableResourceNameDnsARecord,
+        enableResourceNameDnsAAAARecord:
+          subnet.PrivateDnsNameOptionsOnLaunch.EnableResourceNameDnsAAAARecord,
+      }
+    : undefined,
+  tags,
+});
+
+/**
+ * Wait for subnet to be in `available` state. EC2 is eventually consistent,
+ * so `describeSubnets` immediately after `createSubnet` may briefly return
+ * `InvalidSubnetID.NotFound` — treat that as "still pending" instead of
+ * failing.
  */
 const waitForSubnetAvailable = (
   subnetId: string,
   session?: ScopedPlanStatusSession,
 ) =>
   Effect.gen(function* () {
-    const result = yield* ec2.describeSubnets({ SubnetIds: [subnetId] });
+    const result = yield* ec2
+      .describeSubnets({ SubnetIds: [subnetId] })
+      .pipe(
+        Effect.catchTag("InvalidSubnetID.NotFound", () =>
+          Effect.succeed({ Subnets: [] as ec2.Subnet[] }),
+        ),
+      );
     const subnet = result.Subnets?.[0];
 
     if (!subnet) {
-      return yield* Effect.fail(new Error(`Subnet ${subnetId} not found`));
+      return yield* new SubnetPending({ subnetId, state: "missing" });
     }
 
     if (subnet.State === "available") {
       return subnet;
     }
 
-    // Still pending - this is the only retryable case
     return yield* new SubnetPending({ subnetId, state: subnet.State! });
   }).pipe(
     Effect.retry({

--- a/packages/alchemy/test/AWS/EC2/Subnet.test.ts
+++ b/packages/alchemy/test/AWS/EC2/Subnet.test.ts
@@ -1,5 +1,7 @@
+import { adopt } from "@/AdoptPolicy";
 import * as AWS from "@/AWS";
 import { Subnet, Vpc } from "@/AWS/EC2";
+import { State } from "@/State";
 import * as Test from "@/Test/Vitest";
 import * as EC2 from "@distilled.cloud/aws/ec2";
 import { expect } from "@effect/vitest";
@@ -14,6 +16,8 @@ const logLevel = Effect.provideService(
   MinimumLogLevel,
   process.env.DEBUG ? "Debug" : "Info",
 );
+
+const suffix = () => Math.random().toString(36).slice(2, 8);
 
 test.provider("create, update, delete subnet", (stack) =>
   Effect.gen(function* () {
@@ -68,6 +72,429 @@ test.provider("create, update, delete subnet", (stack) =>
 
     yield* assertSubnetDeleted(subnet.subnetId);
   }).pipe(logLevel),
+);
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("IdempotentVpc", {
+            cidrBlock: "10.20.0.0/16",
+          });
+          const subnet = yield* Subnet("IdempotentSubnet", {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.20.1.0/24",
+            mapPublicIpOnLaunch: true,
+          });
+          return { vpc, subnet };
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("IdempotentVpc", {
+            cidrBlock: "10.20.0.0/16",
+          });
+          const subnet = yield* Subnet("IdempotentSubnet", {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.20.1.0/24",
+            mapPublicIpOnLaunch: true,
+          });
+          return { vpc, subnet };
+        }),
+      );
+
+      expect(second.subnet.subnetId).toEqual(initial.subnet.subnetId);
+      expect(second.subnet.subnetArn).toEqual(initial.subnet.subnetArn);
+      expect(second.subnet.cidrBlock).toEqual("10.20.1.0/24");
+
+      yield* expectSubnetAttribute({
+        SubnetId: second.subnet.subnetId,
+        Attribute: "mapPublicIpOnLaunch",
+        Value: true,
+      });
+
+      yield* stack.destroy();
+      yield* assertSubnetDeleted(initial.subnet.subnetId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile resets MapPublicIpOnLaunch and tags mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("DriftVpc", {
+            cidrBlock: "10.21.0.0/16",
+          });
+          const subnet = yield* Subnet("DriftSubnet", {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.21.1.0/24",
+            mapPublicIpOnLaunch: true,
+            tags: { Environment: "dev", Owner: "alchemy" },
+          });
+          return { vpc, subnet };
+        }),
+      );
+
+      // Mutate attribute and tags out-of-band via the raw SDK.
+      yield* EC2.modifySubnetAttribute({
+        SubnetId: initial.subnet.subnetId,
+        MapPublicIpOnLaunch: { Value: false },
+      });
+      yield* EC2.createTags({
+        Resources: [initial.subnet.subnetId],
+        Tags: [
+          { Key: "Environment", Value: "drifted" },
+          { Key: "Foreign", Value: "tag" },
+        ],
+      });
+      yield* expectSubnetAttribute({
+        SubnetId: initial.subnet.subnetId,
+        Attribute: "mapPublicIpOnLaunch",
+        Value: false,
+      });
+
+      // Re-deploy with the original desired props — converge.
+      const redeployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("DriftVpc", {
+            cidrBlock: "10.21.0.0/16",
+          });
+          const subnet = yield* Subnet("DriftSubnet", {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.21.1.0/24",
+            mapPublicIpOnLaunch: true,
+            tags: { Environment: "dev", Owner: "alchemy" },
+          });
+          return { vpc, subnet };
+        }),
+      );
+      expect(redeployed.subnet.subnetId).toEqual(initial.subnet.subnetId);
+
+      yield* expectSubnetAttribute({
+        SubnetId: redeployed.subnet.subnetId,
+        Attribute: "mapPublicIpOnLaunch",
+        Value: true,
+      });
+
+      const observed = yield* EC2.describeSubnets({
+        SubnetIds: [redeployed.subnet.subnetId],
+      });
+      const tagMap = Object.fromEntries(
+        (observed.Subnets?.[0]?.Tags ?? []).map((t) => [t.Key!, t.Value!]),
+      );
+      expect(tagMap.Environment).toEqual("dev");
+      expect(tagMap.Owner).toEqual("alchemy");
+      expect(tagMap.Foreign).toBeUndefined();
+      expect(tagMap["alchemy::id"]).toEqual("DriftSubnet");
+
+      yield* stack.destroy();
+      yield* assertSubnetDeleted(initial.subnet.subnetId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile re-creates a subnet that was deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("RecreateVpc", {
+            cidrBlock: "10.22.0.0/16",
+          });
+          const subnet = yield* Subnet("RecreateSubnet", {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.22.1.0/24",
+          });
+          return { vpc, subnet };
+        }),
+      );
+
+      // Delete the subnet via the raw SDK.
+      yield* EC2.deleteSubnet({ SubnetId: initial.subnet.subnetId });
+      yield* assertSubnetDeleted(initial.subnet.subnetId);
+
+      // Re-deploying must converge by re-creating. The state still
+      // references the old subnetId; the reconciler observes
+      // `InvalidSubnetID.NotFound`, falls through to the tag-filter lookup
+      // (also empty), then to `createSubnet`.
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("RecreateVpc", {
+            cidrBlock: "10.22.0.0/16",
+          });
+          const subnet = yield* Subnet("RecreateSubnet", {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.22.1.0/24",
+          });
+          return { vpc, subnet };
+        }),
+      );
+      expect(recreated.subnet.subnetId).not.toEqual(initial.subnet.subnetId);
+      expect(recreated.subnet.cidrBlock).toEqual("10.22.1.0/24");
+
+      yield* stack.destroy();
+      yield* assertSubnetDeleted(recreated.subnet.subnetId);
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "changing cidrBlock triggers replace; old subnet is deleted",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("ReplaceCidrVpc", {
+            cidrBlock: "10.23.0.0/16",
+          });
+          const subnet = yield* Subnet("ReplaceCidrSubnet", {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.23.1.0/24",
+          });
+          return { vpc, subnet };
+        }),
+      );
+      expect(a.subnet.cidrBlock).toEqual("10.23.1.0/24");
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("ReplaceCidrVpc", {
+            cidrBlock: "10.23.0.0/16",
+          });
+          const subnet = yield* Subnet("ReplaceCidrSubnet", {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.23.2.0/24",
+          });
+          return { vpc, subnet };
+        }),
+      );
+      expect(b.subnet.cidrBlock).toEqual("10.23.2.0/24");
+      expect(b.subnet.subnetId).not.toEqual(a.subnet.subnetId);
+
+      // Old subnet must be torn down by the replacement flow.
+      yield* assertSubnetDeleted(a.subnet.subnetId);
+
+      yield* stack.destroy();
+      yield* assertSubnetDeleted(b.subnet.subnetId);
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "changing availabilityZone triggers replace",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      // Pick two AZs deterministically from the live region. Using the
+      // first two slots keeps the test deterministic across runs without
+      // hard-coding a region.
+      const azs = yield* EC2.describeAvailabilityZones({});
+      const [azA, azB] = (azs.AvailabilityZones ?? []).map((z) => z.ZoneName!);
+      expect(azA).toBeDefined();
+      expect(azB).toBeDefined();
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("ReplaceAzVpc", {
+            cidrBlock: "10.24.0.0/16",
+          });
+          const subnet = yield* Subnet("ReplaceAzSubnet", {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.24.1.0/24",
+            availabilityZone: azA,
+          });
+          return { vpc, subnet };
+        }),
+      );
+      expect(a.subnet.availabilityZone).toEqual(azA);
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("ReplaceAzVpc", {
+            cidrBlock: "10.24.0.0/16",
+          });
+          const subnet = yield* Subnet("ReplaceAzSubnet", {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.24.1.0/24",
+            availabilityZone: azB,
+          });
+          return { vpc, subnet };
+        }),
+      );
+      expect(b.subnet.availabilityZone).toEqual(azB);
+      expect(b.subnet.subnetId).not.toEqual(a.subnet.subnetId);
+
+      yield* assertSubnetDeleted(a.subnet.subnetId);
+
+      yield* stack.destroy();
+      yield* assertSubnetDeleted(b.subnet.subnetId);
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "destroying an already-deleted subnet is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const { subnet } = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("DoubleDestroyVpc", {
+            cidrBlock: "10.25.0.0/16",
+          });
+          const subnet = yield* Subnet("DoubleDestroySubnet", {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.25.1.0/24",
+          });
+          return { vpc, subnet };
+        }),
+      );
+
+      // Delete out-of-band, then ask the engine to destroy. The provider
+      // must catch InvalidSubnetID.NotFound and complete cleanly.
+      yield* EC2.deleteSubnet({ SubnetId: subnet.subnetId });
+      yield* assertSubnetDeleted(subnet.subnetId);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "owned subnet (matching alchemy tags) is silently adopted after state wipe",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const id = `Adoptable-${suffix()}`;
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("AdoptVpc", {
+            cidrBlock: "10.26.0.0/16",
+          });
+          const subnet = yield* Subnet(id, {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.26.1.0/24",
+          });
+          return { vpc, subnet };
+        }),
+      );
+
+      // Wipe state for the subnet only — VPC stays in state, the subnet
+      // stays in EC2 with its alchemy::id tag.
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: id,
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      // Re-deploy: read filters by alchemy tags, finds the orphan subnet,
+      // hasAlchemyTags returns true, engine silently adopts. No adopt()
+      // needed because tags already match.
+      const adopted = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("AdoptVpc", {
+            cidrBlock: "10.26.0.0/16",
+          });
+          const subnet = yield* Subnet(id, {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.26.1.0/24",
+          });
+          return { vpc, subnet };
+        }),
+      );
+
+      expect(adopted.subnet.subnetId).toEqual(initial.subnet.subnetId);
+      expect(adopted.subnet.subnetArn).toEqual(initial.subnet.subnetArn);
+
+      yield* stack.destroy();
+      yield* assertSubnetDeleted(initial.subnet.subnetId);
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+// A foreign-tagged subnet takeover test requires pre-creating a subnet
+// tagged with the new resource's `alchemy::id` (since Subnet has no
+// physical name to look up by — `read` filters strictly by alchemy tags).
+// The owned-adoption case above already exercises the read + tag-sync path
+// end-to-end. Mirrors the equivalent gap acknowledged in the VPC adoption
+// PR (#199).
+test.provider.skip(
+  "foreign-tagged subnet requires adopt(true) to take over",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const originalId = `Original-${suffix()}`;
+      const original = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("TakeoverVpc", {
+            cidrBlock: "10.27.0.0/16",
+          });
+          const subnet = yield* Subnet(originalId, {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.27.1.0/24",
+          });
+          return { vpc, subnet };
+        }),
+      );
+
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: originalId,
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      const newId = `Different-${suffix()}`;
+      const takenOver = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            const vpc = yield* Vpc("TakeoverVpc", {
+              cidrBlock: "10.27.0.0/16",
+            });
+            const subnet = yield* Subnet(newId, {
+              vpcId: vpc.vpcId,
+              cidrBlock: "10.27.1.0/24",
+            });
+            return { vpc, subnet };
+          }),
+        )
+        .pipe(adopt(true));
+
+      const lookup = yield* EC2.describeSubnets({
+        SubnetIds: [takenOver.subnet.subnetId],
+      });
+      const tagMap = Object.fromEntries(
+        (lookup.Subnets?.[0]?.Tags ?? []).map((t) => [t.Key!, t.Value!]),
+      );
+      expect(tagMap["alchemy::id"]).toEqual(newId);
+
+      yield* stack.destroy();
+      yield* assertSubnetDeleted(takenOver.subnet.subnetId);
+      if (original.subnet.subnetId !== takenOver.subnet.subnetId) {
+        yield* assertSubnetDeleted(original.subnet.subnetId);
+      }
+    }).pipe(logLevel),
 );
 
 const expectSubnetAttribute = Effect.fn(function* (props: {

--- a/packages/alchemy/test/test.resources.ts
+++ b/packages/alchemy/test/test.resources.ts
@@ -518,7 +518,9 @@ export const staticStablesResourceProvider = () =>
       return {
         string: news.string ?? id,
         tags: news.tags ?? {},
-        stableId: output?.stableId ?? `stable-${id}`,
+        stableId:
+          output?.stableId ??
+          (`${id}-${news.replaceString ?? "stable"}` as const),
         stableArn:
           output?.stableArn ??
           (`arn:test:resource:us-east-1:123456789:${id}` as const),


### PR DESCRIPTION
Harden the EC2 Subnet reconciler so adoption, drift, and out-of-band deletes converge cleanly, and add lifecycle convergence tests covering each path. Mirrors the VPC #189/#199 and SQS #184 hardening pattern.

### Reconciler changes

- Add `read` lifecycle. Subnet has no physical name we can derive — `read` looks up by cached `output.subnetId` first, falling back to a tag-filter search via `createAlchemyTagFilters(id)` when the id is missing or stale. Foreign-tagged subnets surface as `Unowned(attrs)`; alchemy-owned ones return raw attrs.
- Reconcile observes the same way: cached id → tag filter → `createSubnet`. An interrupted prior run that lost state after `createSubnet` recovers without leaking a duplicate.
- Wrap `createSubnet` in a bounded retry on `InvalidVpcID.NotFound` (≤15s) so a fresh-VPC-in-same-plan race rides out propagation.
- Wrap every post-create `modifySubnetAttribute` / `createTags` / `deleteTags` / final `describeSubnets` call in a bounded `InvalidSubnetID.NotFound` retry (≤15s). Distilled doesn't tag this as retryable, but it's transient when we just created the subnet ourselves.
- Each attribute (`MapPublicIpOnLaunch`, `AssignIpv6AddressOnCreation`, `EnableDns64`, private DNS hostname options) and tags now diff against **observed cloud state**, not `olds`/`output.tags`, so adoption and out-of-band drift converge.
- `delete` retries `DependencyViolation` on a 5s/60-attempt schedule (~5min) and treats `InvalidSubnetID.NotFound` as success — already-deleted is idempotent.
- Add `tags` to the Subnet attributes shape so observed cloud tags round-trip through state.

### New lifecycle tests

```
- redeploy with same props is a no-op
- reconcile resets MapPublicIpOnLaunch + tags mutated out-of-band via raw EC2 SDK
- reconcile re-creates a subnet deleted out-of-band (state still references old subnetId)
- changing cidrBlock triggers replace; old subnet is torn down
- changing availabilityZone triggers replace
- destroying an already-deleted subnet is a no-op
- owned subnet (matching alchemy tags) is silently adopted after state wipe
```

The foreign-tagged-takeover test is skipped because Subnet has no physical name to look up by — pre-creating a subnet branded with the new resource's `alchemy::id` would short-circuit the takeover semantics. The owned-adoption case exercises the read + tag-sync path end-to-end. Same gap acknowledged in VPC adoption (#199).

### Distilled patch

No patch needed. EC2's `IncorrectState` is correctly classified as `ConflictError` (PR #242) and `DependencyViolation` is its own retryable category. `InvalidSubnetID.NotFound` / `InvalidVpcID.NotFound` are intentionally untagged and handled locally where they're known to be transient.
