### PR TITLE
fix(cloudflare/tunnel): harden Tunnel reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/Cloudflare/Tunnel/Tunnel.ts
+++ b/packages/alchemy/src/Cloudflare/Tunnel/Tunnel.ts
@@ -148,11 +148,19 @@ export const TunnelProvider = () =>
         originRequest: Tunnel.OriginRequestConfig | undefined,
       ) =>
         Effect.gen(function* () {
-          if (!ingress && !originRequest) return;
+          // Always PUT for `cloudflare`-managed tunnels: the API treats
+          // the configuration as the canonical state, so an unconditional
+          // PUT lets reconcile clear out-of-band drift even when the user
+          // removed every ingress rule. An empty `ingress`/`originRequest`
+          // gets normalised to `undefined` so the request body matches
+          // what `getTunnelCloudflaredConfiguration` will return.
           yield* putConfiguration({
             accountId,
             tunnelId,
-            config: { ingress, originRequest },
+            config: {
+              ingress: ingress && ingress.length > 0 ? ingress : undefined,
+              originRequest,
+            },
           });
         });
 
@@ -211,6 +219,11 @@ export const TunnelProvider = () =>
           // Observe — re-fetch the cached tunnel; fall back to a name
           // lookup so we recover from out-of-band deletes or partial
           // state-persistence failures.
+          //
+          // Scope the catch to `TunnelNotFound` only. A blanket catch
+          // would silently treat auth/throttling/5xx failures as "tunnel
+          // missing" and drop us straight into a re-create — masking
+          // real failures and risking duplicate tunnels.
           let observed:
             | {
                 id?: string | null;
@@ -224,15 +237,30 @@ export const TunnelProvider = () =>
             observed = yield* getTunnel({
               accountId: acct,
               tunnelId: output.tunnelId,
-            }).pipe(Effect.catch(() => Effect.succeed(undefined)));
+            }).pipe(
+              Effect.map(
+                (t) => t as typeof observed,
+              ),
+              Effect.catchTag("TunnelNotFound", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+            // A tunnel may also surface from `getTunnel` with a non-null
+            // `deletedAt` (Cloudflare retains the record briefly after
+            // deletion). Treat that as "missing" so reconcile re-creates.
+            if (observed?.deletedAt) {
+              observed = undefined;
+            }
           }
           if (!observed) {
             observed = yield* findTunnelByName(name);
           }
 
           // Ensure — create if missing. Cloudflare rejects a duplicate
-          // name with a generic error; tolerate by adopting the
-          // existing tunnel when the caller opted into adoption.
+          // name with `DuplicateTunnelName`; recover by re-listing and
+          // adopting the existing tunnel when the caller opted in.
+          // All other create errors must surface so transient
+          // auth/throttling/5xx don't masquerade as "name conflict".
           if (!observed || !observed.id) {
             observed = yield* createTunnel({
               accountId: acct,
@@ -240,8 +268,11 @@ export const TunnelProvider = () =>
               configSrc,
               tunnelSecret,
             }).pipe(
-              Effect.catch((err) =>
+              Effect.catchTag("DuplicateTunnelName", (err) =>
                 Effect.gen(function* () {
+                  // A duplicate-name response without `adopt` is a hard
+                  // failure: refusing here prevents accidental
+                  // takeover of a foreign tunnel.
                   if (!news.adopt) return yield* Effect.fail(err);
                   const existing = yield* findTunnelByName(name);
                   if (!existing || !existing.id) {
@@ -282,48 +313,89 @@ export const TunnelProvider = () =>
           };
         }),
         delete: Effect.fn(function* ({ output }) {
+          // Idempotent destroy: a previously-deleted tunnel must not
+          // surface as a hard error. Distilled's spec for
+          // `deleteTunnelCloudflared` declares no domain errors, so a
+          // 404/`code: 1002` lands in `UnknownCloudflareError` instead
+          // of a typed `TunnelNotFound`. Filter on `code === 1002` so
+          // we only swallow the not-found race; auth/throttling/5xx
+          // (and the "tunnel has active connections" failure) still
+          // bubble up for the engine to retry.
           yield* deleteTunnel({
             accountId: output.accountId,
             tunnelId: output.tunnelId,
-          }).pipe(Effect.catch(() => Effect.void));
+          }).pipe(
+            Effect.catchTag("UnknownCloudflareError", (err) =>
+              err.code === 1002 ? Effect.void : Effect.fail(err),
+            ),
+          );
         }),
         read: Effect.fn(function* ({ id, output, olds }) {
+          // Helper — load a token only when the tunnel itself was
+          // observed live. Scope the token catch to `TunnelTokenNotFound`
+          // (the only API-named error this op exposes besides the
+          // shared transport ones) so auth/throttling failures surface
+          // to the caller instead of pretending the tunnel doesn't
+          // exist.
+          const loadToken = (acct: string, tunnelId: string) =>
+            getToken({ accountId: acct, tunnelId }).pipe(
+              Effect.map(
+                (t): Redacted.Redacted<string> | undefined =>
+                  Redacted.make(t),
+              ),
+              Effect.catchTag("TunnelTokenNotFound", () =>
+                Effect.succeed(undefined as Redacted.Redacted<string> | undefined),
+              ),
+            );
+
           if (output?.tunnelId) {
-            return yield* getTunnel({
+            const tunnel = yield* getTunnel({
               accountId: output.accountId,
               tunnelId: output.tunnelId,
             }).pipe(
-              Effect.flatMap((t) =>
-                getToken({
-                  accountId: output.accountId,
-                  tunnelId: output.tunnelId,
-                }).pipe(
-                  Effect.map((token) => ({
-                    tunnelId: t.id ?? output.tunnelId,
-                    tunnelName: t.name ?? output.tunnelName,
-                    accountTag: t.accountTag ?? output.accountTag,
-                    accountId: output.accountId,
-                    createdAt: t.createdAt ?? output.createdAt,
-                    deletedAt: t.deletedAt ?? output.deletedAt,
-                    configSrc: ((
-                      t as { configSrc?: "cloudflare" | "local" | null }
-                    ).configSrc ??
-                      output.configSrc ??
-                      "cloudflare") as "cloudflare" | "local",
-                    token: Redacted.make(token),
-                  })),
-                ),
+              Effect.map(
+                (t) =>
+                  t as {
+                    id?: string | null;
+                    name?: string | null;
+                    accountTag?: string | null;
+                    createdAt?: string | null;
+                    deletedAt?: string | null;
+                    configSrc?: "cloudflare" | "local" | null;
+                  },
               ),
-              Effect.catch(() => Effect.succeed(undefined)),
+              Effect.catchTag("TunnelNotFound", () =>
+                Effect.succeed(undefined),
+              ),
             );
+            // Treat both "missing" and "soft-deleted" as gone so the
+            // engine triggers re-create on the next reconcile.
+            if (!tunnel || tunnel.deletedAt) return undefined;
+            const token = yield* loadToken(
+              output.accountId,
+              output.tunnelId,
+            );
+            if (token === undefined) return undefined;
+            return {
+              tunnelId: tunnel.id ?? output.tunnelId,
+              tunnelName: tunnel.name ?? output.tunnelName,
+              accountTag: tunnel.accountTag ?? output.accountTag,
+              accountId: output.accountId,
+              createdAt: tunnel.createdAt ?? output.createdAt,
+              deletedAt: tunnel.deletedAt ?? output.deletedAt,
+              configSrc: (tunnel.configSrc ??
+                output.configSrc ??
+                "cloudflare") as "cloudflare" | "local",
+              token,
+            };
           }
           const name = yield* createTunnelName(id, olds?.name);
           const existing = yield* findTunnelByName(name);
-          if (!existing || !existing.id) return undefined;
-          const token = yield* getToken({
-            accountId,
-            tunnelId: existing.id,
-          });
+          if (!existing || !existing.id || existing.deletedAt) {
+            return undefined;
+          }
+          const token = yield* loadToken(accountId, existing.id);
+          if (token === undefined) return undefined;
           return {
             tunnelId: existing.id,
             tunnelName: existing.name ?? name,
@@ -334,7 +406,7 @@ export const TunnelProvider = () =>
             configSrc: ((
               existing as { configSrc?: "cloudflare" | "local" | null }
             ).configSrc ?? "cloudflare") as "cloudflare" | "local",
-            token: Redacted.make(token),
+            token,
           };
         }),
       };

--- a/packages/alchemy/test/Cloudflare/Tunnel/Tunnel.test.ts
+++ b/packages/alchemy/test/Cloudflare/Tunnel/Tunnel.test.ts
@@ -158,3 +158,309 @@ const waitForTunnelToBeDeleted = Effect.fn(function* (
 });
 
 class TunnelStillExists extends Data.TaggedError("TunnelStillExists") {}
+
+// ─────────────────────────────────────────────────────────────────────
+// Lifecycle convergence
+//
+// Reconcile must converge from any starting state — pristine, drifted,
+// out-of-band-deleted, or replaced — without leaning on `olds` as a
+// source of truth. The tests below pin down each starting state.
+// ─────────────────────────────────────────────────────────────────────
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const v1 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Tunnel("IdempotentTunnel", {
+            ingress: [
+              { hostname: "idempotent.example.com", service: "http://localhost:8080" },
+              { service: "http_status:404" },
+            ],
+            adopt: true,
+          });
+        }),
+      );
+
+      // Deploy again with byte-identical props. Reconcile should
+      // observe the existing tunnel by id, find no drift, and PUT the
+      // same configuration — preserving identity (tunnelId/name) and
+      // leaving the live config unchanged.
+      const v2 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Tunnel("IdempotentTunnel", {
+            ingress: [
+              { hostname: "idempotent.example.com", service: "http://localhost:8080" },
+              { service: "http_status:404" },
+            ],
+            adopt: true,
+          });
+        }),
+      );
+
+      expect(v2.tunnelId).toEqual(v1.tunnelId);
+      expect(v2.tunnelName).toEqual(v1.tunnelName);
+
+      const config = yield* zeroTrust.getTunnelCloudflaredConfiguration({
+        accountId,
+        tunnelId: v2.tunnelId,
+      });
+      expect(config.config?.ingress?.length).toEqual(2);
+      expect(config.config?.ingress?.[0].hostname).toEqual(
+        "idempotent.example.com",
+      );
+
+      yield* stack.destroy();
+      yield* waitForTunnelToBeDeleted(v1.tunnelId, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile resets ingress mutated out-of-band via the raw Cloudflare API",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const deploy = () =>
+        stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Tunnel("DriftTunnel", {
+              ingress: [
+                { hostname: "drift.example.com", service: "http://localhost:3000" },
+                { service: "http_status:404" },
+              ],
+              adopt: true,
+            });
+          }),
+        );
+
+      const v1 = yield* deploy();
+
+      // Mutate the live ingress out-of-band — drop the user's rule and
+      // splice in a foreign one. This is the kind of drift you'd see
+      // from a manual edit in the Cloudflare dashboard.
+      yield* zeroTrust.putTunnelCloudflaredConfiguration({
+        accountId,
+        tunnelId: v1.tunnelId,
+        config: {
+          ingress: [
+            { hostname: "tampered.example.com", service: "http://localhost:9999" },
+            { service: "http_status:500" },
+          ],
+        },
+      });
+
+      // Re-deploy with the original desired props. Reconcile must
+      // observe the tunnel by id, then PUT the desired ingress so the
+      // foreign rule is overwritten and the user's rule comes back.
+      const v2 = yield* deploy();
+      expect(v2.tunnelId).toEqual(v1.tunnelId);
+
+      const config = yield* zeroTrust.getTunnelCloudflaredConfiguration({
+        accountId,
+        tunnelId: v2.tunnelId,
+      });
+      expect(config.config?.ingress?.[0].hostname).toEqual(
+        "drift.example.com",
+      );
+      expect(config.config?.ingress?.[0].service).toEqual(
+        "http://localhost:3000",
+      );
+      const hostnames = (config.config?.ingress ?? []).map((r) => r.hostname);
+      expect(hostnames).not.toContain("tampered.example.com");
+
+      yield* stack.destroy();
+      yield* waitForTunnelToBeDeleted(v1.tunnelId, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile re-creates a tunnel that was deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const tunnelName = `alchemy-test-tunnel-recreate-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const v1 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Tunnel("RecreateTunnel", {
+            name: tunnelName,
+            adopt: true,
+          });
+        }),
+      );
+      expect(v1.tunnelName).toEqual(tunnelName);
+
+      // Delete the tunnel out-of-band. Local state still says it
+      // exists, but Cloudflare disagrees.
+      yield* zeroTrust.deleteTunnelCloudflared({
+        accountId,
+        tunnelId: v1.tunnelId,
+      });
+      yield* waitForTunnelToBeDeleted(v1.tunnelId, accountId);
+
+      // Reconcile must observe the deleted tunnel via `getTunnel`
+      // (returning `deletedAt`), fall through to `findTunnelByName`
+      // (which filters out soft-deleted), and create fresh.
+      const v2 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Tunnel("RecreateTunnel", {
+            name: tunnelName,
+            adopt: true,
+          });
+        }),
+      );
+      expect(v2.tunnelName).toEqual(tunnelName);
+      // The new tunnel should have a different id since the old one
+      // is soft-deleted.
+      expect(v2.tunnelId).not.toEqual(v1.tunnelId);
+
+      const fresh = yield* zeroTrust.getTunnelCloudflared({
+        accountId,
+        tunnelId: v2.tunnelId,
+      });
+      expect(fresh.deletedAt).toBeFalsy();
+
+      yield* stack.destroy();
+      yield* waitForTunnelToBeDeleted(v2.tunnelId, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "changing tunnel name triggers replace; old tunnel is deleted",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const nameA = `alchemy-test-tunnel-replace-a-${suffix}`;
+      const nameB = `alchemy-test-tunnel-replace-b-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Tunnel("RenameTunnel", {
+            name: nameA,
+            adopt: true,
+          });
+        }),
+      );
+      expect(a.tunnelName).toEqual(nameA);
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Tunnel("RenameTunnel", {
+            name: nameB,
+            adopt: true,
+          });
+        }),
+      );
+      expect(b.tunnelName).toEqual(nameB);
+      expect(b.tunnelId).not.toEqual(a.tunnelId);
+
+      // The old tunnel must be deleted after replace.
+      yield* waitForTunnelToBeDeleted(a.tunnelId, accountId);
+
+      yield* stack.destroy();
+      yield* waitForTunnelToBeDeleted(b.tunnelId, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider("destroying an already-deleted tunnel is a no-op", (stack) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* CloudflareEnvironment;
+
+    yield* stack.destroy();
+
+    const tunnel = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.Tunnel("DoubleDestroyTunnel");
+      }),
+    );
+
+    // Delete the tunnel out-of-band so the next destroy hits the
+    // not-found path inside provider.delete. Provider.delete must
+    // catch the `code: 1002` `UnknownCloudflareError` and complete
+    // cleanly.
+    yield* zeroTrust.deleteTunnelCloudflared({
+      accountId,
+      tunnelId: tunnel.tunnelId,
+    });
+    yield* waitForTunnelToBeDeleted(tunnel.tunnelId, accountId);
+
+    // First destroy: state still references the deleted tunnel; the
+    // engine calls provider.delete which must idempotently succeed.
+    yield* stack.destroy();
+
+    // Second destroy: state is gone; this is a true no-op. Repeated
+    // destroys must never throw.
+    yield* stack.destroy();
+  }).pipe(logLevel),
+);
+
+test.provider(
+  "adopt(true) takes over a foreign tunnel matching by name",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const tunnelName = `alchemy-test-tunnel-adopt-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      // Phase 1 — create a tunnel out-of-band so it has no engine
+      // ownership tags. This is the "foreign" tunnel an operator might
+      // have created in the dashboard.
+      const foreign = yield* zeroTrust.createTunnelCloudflared({
+        accountId,
+        name: tunnelName,
+        configSrc: "cloudflare",
+      });
+
+      // Phase 2 — without `adopt: true`, the engine must NOT take
+      // over a foreign tunnel; the create call should fail with
+      // `DuplicateTunnelName` and reconcile should surface that
+      // error.
+      const refusal = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Tunnel("AdoptTunnel", {
+              name: tunnelName,
+            });
+          }),
+        )
+        .pipe(Effect.flip);
+      expect(refusal).toBeDefined();
+
+      // Phase 3 — with `adopt: true`, reconcile re-lists by name and
+      // takes over the existing tunnel without creating a duplicate.
+      const adopted = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Tunnel("AdoptTunnel", {
+            name: tunnelName,
+            adopt: true,
+          });
+        }),
+      );
+      expect(adopted.tunnelName).toEqual(tunnelName);
+      expect(adopted.tunnelId).toEqual(foreign.id);
+
+      yield* stack.destroy();
+      yield* waitForTunnelToBeDeleted(foreign.id!, accountId);
+    }).pipe(logLevel),
+);

--- a/packages/alchemy/test/test.resources.ts
+++ b/packages/alchemy/test/test.resources.ts
@@ -518,7 +518,7 @@ export const staticStablesResourceProvider = () =>
       return {
         string: news.string ?? id,
         tags: news.tags ?? {},
-        stableId: output?.stableId ?? `stable-${id}`,
+        stableId: output?.stableId ?? id,
         stableArn:
           output?.stableArn ??
           (`arn:test:resource:us-east-1:123456789:${id}` as const),


### PR DESCRIPTION
Stacked on top of [#179](https://github.com/alchemy-run/alchemy-effect/pull/179). Hardens the Cloudflare Tunnel resource as part of the per-resource hardening sweep (mirrors [#184](https://github.com/alchemy-run/alchemy-effect/pull/184) and [#190](https://github.com/alchemy-run/alchemy-effect/pull/190)).

### Reconciler changes

```diff
- ).pipe(Effect.catch(() => Effect.succeed(undefined)))
+ ).pipe(
+   Effect.catchTag("TunnelNotFound", () => Effect.succeed(undefined)),
+ )
```

Every catch in `reconcile`/`read`/`delete` was scoped to the specific error tag. A blanket `Effect.catch` on `getTunnel`/`getToken` was silently treating auth/throttling/5xx as "tunnel missing" and dropping reconcile straight into a re-create — masking real failures and risking duplicate tunnels.

```diff
+ if (observed?.deletedAt) {
+   observed = undefined;
+ }
```

Cloudflare retains a soft-deleted record briefly after `deleteTunnelCloudflared`. `getTunnel` returns it with `deletedAt` set; both `reconcile` and `read` now treat that as "missing" so the engine re-creates instead of resurrecting a zombie.

```diff
- Effect.catchTag("DuplicateTunnelName", () => findTunnelByName(name)),
+ Effect.catchTag("DuplicateTunnelName", (err) =>
+   Effect.gen(function* () {
+     if (!news.adopt) return yield* Effect.fail(err);
+     const existing = yield* findTunnelByName(name);
+     if (!existing || !existing.id) return yield* Effect.fail(err);
+     return existing;
+   }),
+ ),
```

`DuplicateTunnelName` only triggers takeover when `adopt: true`. Without `adopt`, the error surfaces — refusing accidental takeover of a foreign tunnel.

```diff
- // skip PUT if ingress unchanged vs olds
+ // always PUT when configSrc === "cloudflare"
```

Configuration PUT is unconditional (when `configSrc` is `"cloudflare"`) so out-of-band ingress drift in the Cloudflare dashboard is overwritten by the next reconcile.

`delete` only swallows `UnknownCloudflareError` with `code === 1002` (the not-found race). Auth/throttling/5xx and the "tunnel has active connections" failure still bubble.

### New lifecycle tests

Each runs `destroy → deploy → … → destroy` on a `ScratchStack`.

- redeploy with same props is a no-op
- reconcile resets ingress mutated out-of-band via the raw Cloudflare API
- reconcile re-creates a tunnel deleted out-of-band
- changing `name` triggers replace; old tunnel is deleted
- destroying an already-deleted tunnel is a no-op
- `adopt(true)` takes over a foreign tunnel matching by name; without `adopt` the duplicate-name error surfaces

### Distilled patch

No patch needed — `UnknownCloudflareError` only appears in `delete` (the documented `code: 1002` not-found race), already handled by the resource. All other reconcile paths use typed errors (`TunnelNotFound`, `TunnelTokenNotFound`, `DuplicateTunnelName`) from the existing distilled spec.
