### PR TITLE
fix(github): harden Secret reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/GitHub/Secret.ts
+++ b/packages/alchemy/src/GitHub/Secret.ts
@@ -1,6 +1,8 @@
 import type { Octokit } from "@octokit/rest";
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
+import * as Schedule from "effect/Schedule";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
 import { GitHubCredentials } from "./Credentials.ts";
@@ -129,6 +131,42 @@ export interface Secret extends Resource<
  */
 export const Secret = Resource<Secret>("GitHub.Secret");
 
+/**
+ * Repository (or environment) was not found at the GitHub API. Surfaces
+ * `404` from the public-key, upsert, and delete paths. Treated as
+ * non-fatal in `delete` (the secret is already gone with the repo) and
+ * retried briefly in `reconcile` to ride out repo-create eventual
+ * consistency.
+ */
+export class GitHubSecretNotFound extends Data.TaggedError(
+  "GitHubSecretNotFound",
+)<{
+  readonly owner: string;
+  readonly repository: string;
+  readonly name: string;
+  readonly environment?: string;
+  readonly cause?: unknown;
+}> {}
+
+/**
+ * GitHub validated the request as malformed (HTTP 422) — typically a
+ * bad encrypted_value, missing key_id, or invalid secret name. This is
+ * a programming or input error, not transient, and never retried.
+ */
+export class GitHubSecretValidationError extends Data.TaggedError(
+  "GitHubSecretValidationError",
+)<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** Catch-all for unrecognised Octokit errors so they don't propagate as `unknown`. */
+export class GitHubSecretError extends Data.TaggedError("GitHubSecretError")<{
+  readonly message: string;
+  readonly status?: number;
+  readonly cause?: unknown;
+}> {}
+
 const getOctokit = Effect.gen(function* () {
   const creds = yield* GitHubCredentials;
   return creds.octokit();
@@ -150,36 +188,77 @@ async function encryptValue(
   return sodium.to_base64(encrypted, sodium.base64_variants.ORIGINAL);
 }
 
+const mapOctokitError = (
+  e: unknown,
+  ctx: { owner: string; repository: string; name: string; environment?: string },
+) => {
+  const status = (e as { status?: number } | undefined)?.status;
+  const message =
+    (e as { message?: string } | undefined)?.message ?? String(e);
+  if (status === 404) {
+    return new GitHubSecretNotFound({ ...ctx, cause: e });
+  }
+  if (status === 422) {
+    return new GitHubSecretValidationError({ message, cause: e });
+  }
+  return new GitHubSecretError({ message, status, cause: e });
+};
+
 export const SecretProvider = () =>
   Provider.succeed(Secret, {
-    reconcile: Effect.fn(function* ({ news, olds }) {
+    reconcile: Effect.fn(function* ({ news, olds, session }) {
       const octokit = yield* getOctokit;
 
-      // Observe — there's no API to read a secret's value back, so we can
-      // only observe its location (repo vs. environment, environment name).
-      // If the location changed, the previous secret is orphaned: delete
-      // it before upserting the new one, otherwise it stays in GitHub as
-      // dead state.
+      // Observe — there's no API to read a secret's value back. The most
+      // we can observe is *location* (repo-scoped vs environment-scoped)
+      // and dispose of an orphan when location changes; otherwise we re-
+      // PUT every reconcile, which is the only convergent option for a
+      // write-only resource.
       if (olds !== undefined) {
         const wasEnv = !!olds.environment;
         const isEnv = !!news.environment;
         if (wasEnv !== isEnv || olds.environment !== news.environment) {
-          yield* deleteSecret(octokit, olds);
+          yield* deleteSecret(octokit, olds).pipe(
+            // The orphan may already be gone (manual cleanup, repo
+            // deleted, etc) — that's fine, treat as success.
+            Effect.catchTag("GitHubSecretNotFound", () => Effect.void),
+          );
         }
       }
 
-      // Ensure & Sync — `createOrUpdate*Secret` is upsert-style: it
-      // creates the secret if absent and overwrites it if present. The
-      // value is encrypted client-side with the repo/environment public
-      // key, so we re-encrypt and re-upload on every reconcile (Redacted
-      // values can't be diffed across runs anyway).
-      yield* upsertSecret(octokit, news);
+      // Ensure & Sync — re-encrypt with a fresh public key and re-PUT.
+      // `createOrUpdate*Secret` is upsert-style and is the only way to
+      // converge: secret values are write-only, so we cannot diff and
+      // skip the call. A 404 here usually means the repo was created
+      // *just now* in the same plan — retry briefly to ride out repo
+      // eventual consistency.
+      yield* upsertSecret(octokit, news).pipe(
+        Effect.retry({
+          while: (e) => e._tag === "GitHubSecretNotFound",
+          schedule: Schedule.fixed(1000).pipe(
+            Schedule.tapOutput((i) =>
+              session.note(
+                `GitHub repo not found yet, retrying secret upsert... ${i + 1}s`,
+              ),
+            ),
+            // Cap at 30s — repo eventual-consistency is normally <5s.
+            // Beyond that the repo legitimately doesn't exist and the
+            // user needs to see the error.
+            Schedule.both(Schedule.recurs(30)),
+          ),
+        }),
+      );
       return { updatedAt: new Date().toISOString() };
     }),
 
     delete: Effect.fn(function* ({ olds }) {
       const octokit = yield* getOctokit;
-      yield* deleteSecret(octokit, olds);
+      // Idempotent destroy — `GitHubSecretNotFound` is success (the
+      // secret is already gone). Other errors must surface so we don't
+      // silently leak state on auth/throttling failures.
+      yield* deleteSecret(octokit, olds).pipe(
+        Effect.catchTag("GitHubSecretNotFound", () => Effect.void),
+      );
     }),
   });
 
@@ -190,45 +269,68 @@ const upsertSecret = Effect.fn(function* (
   const plaintext = Redacted.value(props.value);
   const isEnv = !!props.environment;
 
-  const publicKey = yield* Effect.tryPromise(async () => {
-    if (isEnv) {
-      const { data } = await octokit.rest.actions.getEnvironmentPublicKey({
+  const publicKey = yield* Effect.tryPromise({
+    try: async () => {
+      if (isEnv) {
+        const { data } = await octokit.rest.actions.getEnvironmentPublicKey({
+          owner: props.owner,
+          repo: props.repository,
+          environment_name: props.environment!,
+        });
+        return data;
+      }
+      const { data } = await octokit.rest.actions.getRepoPublicKey({
         owner: props.owner,
         repo: props.repository,
-        environment_name: props.environment!,
       });
       return data;
-    }
-    const { data } = await octokit.rest.actions.getRepoPublicKey({
-      owner: props.owner,
-      repo: props.repository,
-    });
-    return data;
+    },
+    catch: (e) =>
+      mapOctokitError(e, {
+        owner: props.owner,
+        repository: props.repository,
+        name: props.name,
+        environment: props.environment,
+      }),
   });
 
-  const encrypted = yield* Effect.tryPromise(() =>
-    encryptValue(plaintext, publicKey.key),
-  );
+  const encrypted = yield* Effect.tryPromise({
+    try: () => encryptValue(plaintext, publicKey.key),
+    catch: (e) =>
+      new GitHubSecretValidationError({
+        message: `Failed to encrypt secret value with libsodium for '${props.name}'`,
+        cause: e,
+      }),
+  });
 
-  yield* Effect.tryPromise(async () => {
-    if (isEnv) {
-      await octokit.rest.actions.createOrUpdateEnvironmentSecret({
+  yield* Effect.tryPromise({
+    try: async () => {
+      if (isEnv) {
+        await octokit.rest.actions.createOrUpdateEnvironmentSecret({
+          owner: props.owner,
+          repo: props.repository,
+          environment_name: props.environment!,
+          secret_name: props.name,
+          encrypted_value: encrypted,
+          key_id: publicKey.key_id,
+        });
+      } else {
+        await octokit.rest.actions.createOrUpdateRepoSecret({
+          owner: props.owner,
+          repo: props.repository,
+          secret_name: props.name,
+          encrypted_value: encrypted,
+          key_id: publicKey.key_id,
+        });
+      }
+    },
+    catch: (e) =>
+      mapOctokitError(e, {
         owner: props.owner,
-        repo: props.repository,
-        environment_name: props.environment!,
-        secret_name: props.name,
-        encrypted_value: encrypted,
-        key_id: publicKey.key_id,
-      });
-    } else {
-      await octokit.rest.actions.createOrUpdateRepoSecret({
-        owner: props.owner,
-        repo: props.repository,
-        secret_name: props.name,
-        encrypted_value: encrypted,
-        key_id: publicKey.key_id,
-      });
-    }
+        repository: props.repository,
+        name: props.name,
+        environment: props.environment,
+      }),
   });
 });
 
@@ -236,8 +338,8 @@ const deleteSecret = Effect.fn(function* (
   octokit: Octokit,
   props: SecretProps,
 ) {
-  yield* Effect.tryPromise(async () => {
-    try {
+  yield* Effect.tryPromise({
+    try: async () => {
       if (props.environment) {
         await octokit.rest.actions.deleteEnvironmentSecret({
           owner: props.owner,
@@ -252,10 +354,13 @@ const deleteSecret = Effect.fn(function* (
           secret_name: props.name,
         });
       }
-    } catch (error: any) {
-      if (error.status !== 404) {
-        throw error;
-      }
-    }
+    },
+    catch: (e) =>
+      mapOctokitError(e, {
+        owner: props.owner,
+        repository: props.repository,
+        name: props.name,
+        environment: props.environment,
+      }),
   });
 });

--- a/packages/alchemy/src/GitHub/Variable.ts
+++ b/packages/alchemy/src/GitHub/Variable.ts
@@ -1,3 +1,4 @@
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
@@ -102,10 +103,53 @@ export interface Variable extends Resource<
  */
 export const Variable = Resource<Variable>("GitHub.Variable");
 
+/** Variable was not found at the GitHub API (HTTP 404). */
+export class GitHubVariableNotFound extends Data.TaggedError(
+  "GitHubVariableNotFound",
+)<{
+  readonly owner: string;
+  readonly repository: string;
+  readonly name: string;
+  readonly cause?: unknown;
+}> {}
+
+/** GitHub returned 422 — typically the variable already exists on create. */
+export class GitHubVariableAlreadyExists extends Data.TaggedError(
+  "GitHubVariableAlreadyExists",
+)<{
+  readonly owner: string;
+  readonly repository: string;
+  readonly name: string;
+  readonly cause?: unknown;
+}> {}
+
+/** Catch-all for unrecognised Octokit errors. */
+export class GitHubVariableError extends Data.TaggedError(
+  "GitHubVariableError",
+)<{
+  readonly message: string;
+  readonly status?: number;
+  readonly cause?: unknown;
+}> {}
+
 const getOctokit = Effect.gen(function* () {
   const creds = yield* GitHubCredentials;
   return creds.octokit();
 });
+
+const mapOctokitError = (
+  e: unknown,
+  ctx: { owner: string; repository: string; name: string },
+) => {
+  const status = (e as { status?: number } | undefined)?.status;
+  const message =
+    (e as { message?: string } | undefined)?.message ?? String(e);
+  if (status === 404) return new GitHubVariableNotFound({ ...ctx, cause: e });
+  if (status === 422) {
+    return new GitHubVariableAlreadyExists({ ...ctx, cause: e });
+  }
+  return new GitHubVariableError({ message, status, cause: e });
+};
 
 export const VariableProvider = () =>
   Provider.succeed(Variable, {
@@ -113,69 +157,102 @@ export const VariableProvider = () =>
       const octokit = yield* getOctokit;
 
       // Observe — `name` is the path identifier for repo variables; ask
-      // GitHub directly for the live row. A 404 means it doesn't exist
-      // (deleted out-of-band, or never created), so we converge by
-      // creating it; otherwise we PATCH the value.
+      // GitHub directly for the live row. A typed `GitHubVariableNotFound`
+      // (404) collapses to "no live state" so we converge by creating;
+      // any other error surfaces.
       const observed = yield* Effect.tryPromise({
         try: async () => {
-          try {
-            const { data } = await octokit.rest.actions.getRepoVariable({
-              owner: news.owner,
-              repo: news.repository,
-              name: news.name,
-            });
-            return data;
-          } catch (error: any) {
-            if (error.status === 404) return undefined;
-            throw error;
-          }
-        },
-        catch: (e) => e as Error,
-      });
-
-      // Ensure — POST creates the variable.
-      if (observed === undefined) {
-        yield* Effect.tryPromise(() =>
-          octokit.rest.actions.createRepoVariable({
+          const { data } = await octokit.rest.actions.getRepoVariable({
             owner: news.owner,
             repo: news.repository,
             name: news.name,
-            value: news.value,
+          });
+          return data;
+        },
+        catch: (e) =>
+          mapOctokitError(e, {
+            owner: news.owner,
+            repository: news.repository,
+            name: news.name,
           }),
+      }).pipe(
+        Effect.catchTag("GitHubVariableNotFound", () => Effect.succeed(undefined)),
+      );
+
+      // Ensure — POST creates the variable. If a peer reconciler created
+      // the same variable between our observe and our create, GitHub
+      // returns 422; we catch that race and fall through to PATCH.
+      if (observed === undefined) {
+        const created = yield* Effect.tryPromise({
+          try: () =>
+            octokit.rest.actions.createRepoVariable({
+              owner: news.owner,
+              repo: news.repository,
+              name: news.name,
+              value: news.value,
+            }),
+          catch: (e) =>
+            mapOctokitError(e, {
+              owner: news.owner,
+              repository: news.repository,
+              name: news.name,
+            }),
+        }).pipe(
+          Effect.map(() => "created" as const),
+          Effect.catchTag("GitHubVariableAlreadyExists", () =>
+            Effect.succeed("race" as const),
+          ),
         );
+        if (created === "created") {
+          return { updatedAt: new Date().toISOString() };
+        }
+        // fall through to PATCH on the racy create
+      }
+
+      // Sync — PATCH the value. We always issue the call when we
+      // observed a live variable (so adoption converges value drift),
+      // and skip only the no-op redeploy where observe matched desired.
+      if (observed !== undefined && observed.value === news.value) {
         return { updatedAt: new Date().toISOString() };
       }
 
-      // Sync — PATCH the value if it drifted; skip the call when the
-      // observed value already matches to keep the API quiet.
-      if (observed.value !== news.value) {
-        yield* Effect.tryPromise(() =>
+      yield* Effect.tryPromise({
+        try: () =>
           octokit.rest.actions.updateRepoVariable({
             owner: news.owner,
             repo: news.repository,
             name: news.name,
             value: news.value,
           }),
-        );
-      }
+        catch: (e) =>
+          mapOctokitError(e, {
+            owner: news.owner,
+            repository: news.repository,
+            name: news.name,
+          }),
+      });
       return { updatedAt: new Date().toISOString() };
     }),
 
     delete: Effect.fn(function* ({ olds }) {
       const octokit = yield* getOctokit;
 
-      yield* Effect.tryPromise(async () => {
-        try {
-          await octokit.rest.actions.deleteRepoVariable({
+      yield* Effect.tryPromise({
+        try: () =>
+          octokit.rest.actions.deleteRepoVariable({
             owner: olds.owner,
             repo: olds.repository,
             name: olds.name,
-          });
-        } catch (error: any) {
-          if (error.status !== 404) {
-            throw error;
-          }
-        }
-      });
+          }),
+        catch: (e) =>
+          mapOctokitError(e, {
+            owner: olds.owner,
+            repository: olds.repository,
+            name: olds.name,
+          }),
+      }).pipe(
+        // Already gone is success — auth/throttling errors still surface.
+        Effect.catchTag("GitHubVariableNotFound", () => Effect.void),
+      );
     }),
   });

--- a/packages/alchemy/test/GitHub/Secret.test.ts
+++ b/packages/alchemy/test/GitHub/Secret.test.ts
@@ -1,0 +1,374 @@
+import { adopt } from "@/AdoptPolicy";
+import * as GitHub from "@/GitHub";
+import { GitHubCredentials } from "@/GitHub/Credentials";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+
+const owner = process.env.GITHUB_TEST_OWNER ?? "";
+const repository = process.env.GITHUB_TEST_REPO ?? "";
+const skip = !owner || !repository || !process.env.GITHUB_TOKEN;
+
+const { test } = Test.make({ providers: GitHub.providers() });
+
+const randomSuffix = () => Math.random().toString(36).slice(2, 8);
+
+const getOctokit = Effect.gen(function* () {
+  const creds = yield* GitHubCredentials;
+  return creds.octokit();
+});
+
+/** True iff a repo secret with `name` exists at the GitHub API. */
+const secretExists = (name: string) =>
+  Effect.gen(function* () {
+    const octokit = yield* getOctokit;
+    return yield* Effect.tryPromise({
+      try: async () => {
+        try {
+          await octokit.rest.actions.getRepoSecret({
+            owner,
+            repo: repository,
+            secret_name: name,
+          });
+          return true;
+        } catch (e: any) {
+          if (e.status === 404) return false;
+          throw e;
+        }
+      },
+      catch: (e) => e as Error,
+    });
+  });
+
+/** Read created_at/updated_at metadata for a repo secret (for rotation assertions). */
+const secretMetadata = (name: string) =>
+  Effect.gen(function* () {
+    const octokit = yield* getOctokit;
+    return yield* Effect.tryPromise(() =>
+      octokit.rest.actions
+        .getRepoSecret({
+          owner,
+          repo: repository,
+          secret_name: name,
+        })
+        .then((r) => r.data),
+    );
+  });
+
+const deleteSecretOutOfBand = (name: string) =>
+  Effect.gen(function* () {
+    const octokit = yield* getOctokit;
+    yield* Effect.tryPromise(async () => {
+      try {
+        await octokit.rest.actions.deleteRepoSecret({
+          owner,
+          repo: repository,
+          secret_name: name,
+        });
+      } catch (e: any) {
+        if (e.status !== 404) throw e;
+      }
+    });
+  });
+
+const putSecretOutOfBand = (name: string, value: string) =>
+  Effect.gen(function* () {
+    const octokit = yield* getOctokit;
+    const { data: pk } = yield* Effect.tryPromise(() =>
+      octokit.rest.actions.getRepoPublicKey({ owner, repo: repository }),
+    );
+    const encrypted = yield* Effect.tryPromise(async () => {
+      const mod = await import("libsodium-wrappers");
+      const sodium: typeof import("libsodium-wrappers") =
+        (mod as any).default ?? mod;
+      await sodium.ready;
+      const binKey = sodium.from_base64(
+        pk.key,
+        sodium.base64_variants.ORIGINAL,
+      );
+      const binMessage = sodium.from_string(value);
+      return sodium.to_base64(
+        sodium.crypto_box_seal(binMessage, binKey),
+        sodium.base64_variants.ORIGINAL,
+      );
+    });
+    yield* Effect.tryPromise(() =>
+      octokit.rest.actions.createOrUpdateRepoSecret({
+        owner,
+        repo: repository,
+        secret_name: name,
+        encrypted_value: encrypted,
+        key_id: pk.key_id,
+      }),
+    );
+  });
+
+test.provider.skipIf(skip)(
+  "create and delete repository secret",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const name = `ALCHEMY_TEST_BASIC_${randomSuffix().toUpperCase()}`;
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Secret("S", {
+            owner,
+            repository,
+            name,
+            value: Redacted.make("hello-1"),
+          });
+        }),
+      );
+      expect(yield* secretExists(name)).toBe(true);
+
+      yield* stack.destroy();
+      expect(yield* secretExists(name)).toBe(false);
+    }),
+);
+
+test.provider.skipIf(skip)(
+  "redeploy with same secret value is convergent (re-PUTs but does not throw)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const name = `ALCHEMY_TEST_NOOP_${randomSuffix().toUpperCase()}`;
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Secret("S", {
+            owner,
+            repository,
+            name,
+            value: Redacted.make("same-value"),
+          });
+        }),
+      );
+      expect(yield* secretExists(name)).toBe(true);
+
+      // Same desired state — reconcile re-PUTs (write-only resource has no
+      // value diff), but it must not error and the secret must still exist.
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Secret("S", {
+            owner,
+            repository,
+            name,
+            value: Redacted.make("same-value"),
+          });
+        }),
+      );
+      expect(yield* secretExists(name)).toBe(true);
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(skip)(
+  "rotating the value updates the secret without replace",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const name = `ALCHEMY_TEST_ROTATE_${randomSuffix().toUpperCase()}`;
+
+      const first = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Secret("S", {
+            owner,
+            repository,
+            name,
+            value: Redacted.make("v1"),
+          });
+        }),
+      );
+      const before = yield* secretMetadata(name);
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Secret("S", {
+            owner,
+            repository,
+            name,
+            value: Redacted.make("v2"),
+          });
+        }),
+      );
+      const after = yield* secretMetadata(name);
+
+      // Same logical/physical identity — created_at preserved (no replace),
+      // updated_at advances on rotation.
+      expect(before.created_at).toEqual(after.created_at);
+      expect(new Date(after.updated_at).getTime()).toBeGreaterThanOrEqual(
+        new Date(before.updated_at).getTime(),
+      );
+      expect(second.updatedAt).not.toEqual(first.updatedAt);
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(skip)(
+  "reconcile re-creates a secret deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const name = `ALCHEMY_TEST_RECREATE_${randomSuffix().toUpperCase()}`;
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Secret("S", {
+            owner,
+            repository,
+            name,
+            value: Redacted.make("v1"),
+          });
+        }),
+      );
+      expect(yield* secretExists(name)).toBe(true);
+
+      // Delete behind the engine's back.
+      yield* deleteSecretOutOfBand(name);
+      expect(yield* secretExists(name)).toBe(false);
+
+      // Re-deploy with no prop changes — reconcile must converge by
+      // re-uploading the secret (it's write-only, so the only convergent
+      // option is to PUT every time).
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Secret("S", {
+            owner,
+            repository,
+            name,
+            value: Redacted.make("v1"),
+          });
+        }),
+      );
+      expect(yield* secretExists(name)).toBe(true);
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(skip)(
+  "changing name triggers replace and old secret is deleted",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const suffix = randomSuffix().toUpperCase();
+      const oldName = `ALCHEMY_TEST_REPLACE_OLD_${suffix}`;
+      const newName = `ALCHEMY_TEST_REPLACE_NEW_${suffix}`;
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Secret("S", {
+            owner,
+            repository,
+            name: oldName,
+            value: Redacted.make("v"),
+          });
+        }),
+      );
+      expect(yield* secretExists(oldName)).toBe(true);
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Secret("S", {
+            owner,
+            repository,
+            name: newName,
+            value: Redacted.make("v"),
+          });
+        }),
+      );
+
+      // After replace, the new identity exists and the old one is gone.
+      expect(yield* secretExists(newName)).toBe(true);
+      expect(yield* secretExists(oldName)).toBe(false);
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(skip)(
+  "destroying an already-deleted secret is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const name = `ALCHEMY_TEST_DOUBLE_DESTROY_${randomSuffix().toUpperCase()}`;
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Secret("S", {
+            owner,
+            repository,
+            name,
+            value: Redacted.make("v"),
+          });
+        }),
+      );
+      expect(yield* secretExists(name)).toBe(true);
+
+      // Delete the secret out-of-band, then ask the engine to destroy.
+      // The 404 from `deleteRepoSecret` must be swallowed as success
+      // rather than propagating to the user.
+      yield* deleteSecretOutOfBand(name);
+      yield* stack.destroy();
+      expect(yield* secretExists(name)).toBe(false);
+    }),
+);
+
+test.provider.skipIf(skip)(
+  "adopt(true) re-claims a foreign secret without first destroying it",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const name = `ALCHEMY_TEST_ADOPT_${randomSuffix().toUpperCase()}`;
+
+      // Pre-create the secret out-of-band so it has no engine ownership.
+      yield* putSecretOutOfBand(name, "foreign-value");
+      expect(yield* secretExists(name)).toBe(true);
+
+      const adopted = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* GitHub.Secret("S", {
+              owner,
+              repository,
+              name,
+              value: Redacted.make("alchemy-value"),
+            });
+          }),
+        )
+        .pipe(adopt(true));
+      expect(adopted.updatedAt).toBeDefined();
+
+      // Wipe state but keep the cloud secret — re-deploying without
+      // adopt() must still converge because reconcile is unconditionally
+      // a PUT (write-only resource).
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "S",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Secret("S", {
+            owner,
+            repository,
+            name,
+            value: Redacted.make("alchemy-value"),
+          });
+        }),
+      );
+      expect(yield* secretExists(name)).toBe(true);
+
+      yield* stack.destroy();
+      expect(yield* secretExists(name)).toBe(false);
+    }),
+);


### PR DESCRIPTION
Hardens the GitHub `Secret` and `Variable` reconcilers as the GitHub pass of the per-resource hardening sweep. Octokit errors (which arrive as `unknown`) are now mapped to typed `Data.TaggedError` shapes so individual cases can be caught precisely instead of via blanket `try/catch (error: any)` blocks.

### Reconciler changes

```diff
- } catch (error: any) {
-   if (error.status !== 404) throw error;
- }
+ Effect.tryPromise({
+   try: ...,
+   catch: (e) => mapOctokitError(e, ctx),
+ }).pipe(Effect.catchTag("GitHubSecretNotFound", () => Effect.void))
```

`mapOctokitError` translates Octokit `status` → `GitHubSecretNotFound` (404), `GitHubSecretValidationError` (422), or a typed `GitHubSecretError` fallback so 422s from libsodium/key-id mistakes never get retried as if they were transient, and arbitrary error shapes never escape as `unknown`.

```diff
+ yield* upsertSecret(octokit, news).pipe(
+   Effect.retry({
+     while: (e) => e._tag === "GitHubSecretNotFound",
+     schedule: Schedule.fixed(1000).pipe(
+       Schedule.both(Schedule.recurs(30)),
+     ),
+   }),
+ );
```

Repo creation in the same plan is eventually consistent — a 404 from `getRepoPublicKey`/`createOrUpdate*Secret` right after the repo lands is a race, not a permanent failure. Capped at 30s so a genuinely missing repo still surfaces.

`Variable` gets the same Octokit-error mapping plus a `GitHubVariableAlreadyExists` (422) catch around `createRepoVariable`, so a peer reconciler racing the create falls through to `PATCH` instead of failing the whole stack.

### New lifecycle tests

`packages/alchemy/test/GitHub/Secret.test.ts` runs `destroy → deploy → … → destroy` against a real test repo (gated on `GITHUB_TEST_OWNER` / `GITHUB_TEST_REPO` / `GITHUB_TOKEN`):

- create + delete a repository secret
- redeploy with same value is convergent (re-PUT, no error)
- rotating value updates in place — `created_at` preserved, `updated_at` advances
- reconcile re-creates a secret deleted out-of-band
- changing `name` triggers replace; old secret is deleted
- destroying an already-deleted secret is a no-op
- `adopt(true)` re-claims a foreign secret
