### PR TITLE
fix(kubernetes): harden Deployment + Namespace reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/Kubernetes/client.ts
+++ b/packages/alchemy/src/Kubernetes/client.ts
@@ -4,6 +4,7 @@ import { AwsClient } from "aws4fetch";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
+import * as Schedule from "effect/Schedule";
 import * as https from "node:https";
 import {
   buildKubernetesObjectPath,
@@ -15,11 +16,96 @@ import {
   type KubernetesObjectRef,
 } from "./types.ts";
 
+/**
+ * Generic Kubernetes API error — returned for any non-2xx status the more
+ * specific tagged errors below don't cover (4xx auth/validation, 5xx).
+ */
 export class KubernetesApiError extends Data.TaggedError("KubernetesApiError")<{
   method: string;
   path: string;
   statusCode: number;
   body: string;
+}> {}
+
+/**
+ * The server replied 404 — the requested resource does not exist. Callers
+ * decide whether that's terminal (delete is a no-op) or whether reconcile
+ * should fall through to create.
+ */
+export class KubernetesNotFound extends Data.TaggedError("KubernetesNotFound")<{
+  method: string;
+  path: string;
+  body: string;
+}> {}
+
+/**
+ * The server replied 409 Conflict. Two common shapes:
+ *   - resourceVersion changed underneath us (optimistic concurrency)
+ *   - "object is being deleted" / "namespace is being terminated"
+ * Both shapes are retryable in bounded fashion: the second resolves only
+ * after the prior delete completes, so we cap retries to avoid looping
+ * forever when the cluster genuinely refuses (e.g. namespace stuck
+ * terminating).
+ */
+export class KubernetesConflict extends Data.TaggedError("KubernetesConflict")<{
+  method: string;
+  path: string;
+  body: string;
+}> {}
+
+/**
+ * The server replied 429 Too Many Requests. Always safe to retry with
+ * backoff — the API server is asking us to slow down.
+ */
+export class KubernetesThrottled extends Data.TaggedError(
+  "KubernetesThrottled",
+)<{
+  method: string;
+  path: string;
+  body: string;
+}> {}
+
+/**
+ * Transport-level failure (TCP reset, TLS handshake, DNS, etc.) before we
+ * got an HTTP status. Always retryable, since by definition the request
+ * never reached the API server's decision logic.
+ */
+export class KubernetesNetworkError extends Data.TaggedError(
+  "KubernetesNetworkError",
+)<{
+  method: string;
+  path: string;
+  cause: string;
+}> {}
+
+/**
+ * Bounded wait for a `Deployment` to converge to ready. Surfaces if it
+ * never does, so callers get a real failure instead of silently returning
+ * before pods come up.
+ */
+export class KubernetesDeploymentNotReady extends Data.TaggedError(
+  "KubernetesDeploymentNotReady",
+)<{
+  namespace: string;
+  name: string;
+  observedGeneration: number | undefined;
+  generation: number | undefined;
+  readyReplicas: number | undefined;
+  updatedReplicas: number | undefined;
+  desiredReplicas: number | undefined;
+}> {}
+
+/**
+ * Bounded wait for a delete to fully clear (finalizers run, tombstone
+ * removed). Surfaces if it doesn't.
+ */
+export class KubernetesDeleteNotComplete extends Data.TaggedError(
+  "KubernetesDeleteNotComplete",
+)<{
+  apiVersion: string;
+  kind: string;
+  namespace: string | undefined;
+  name: string;
 }> {}
 
 export interface KubernetesClusterConnection {
@@ -116,6 +202,38 @@ const requestJson = Effect.fn(function* ({
               const statusCode = response.statusCode ?? 500;
 
               if (statusCode < 200 || statusCode >= 300) {
+                // Narrow the error so callers can `catchTag` precisely
+                // instead of inspecting `statusCode` on a generic envelope.
+                if (statusCode === 404) {
+                  reject(
+                    new KubernetesNotFound({
+                      method,
+                      path,
+                      body: responseBody,
+                    }),
+                  );
+                  return;
+                }
+                if (statusCode === 409) {
+                  reject(
+                    new KubernetesConflict({
+                      method,
+                      path,
+                      body: responseBody,
+                    }),
+                  );
+                  return;
+                }
+                if (statusCode === 429) {
+                  reject(
+                    new KubernetesThrottled({
+                      method,
+                      path,
+                      body: responseBody,
+                    }),
+                  );
+                  return;
+                }
                 reject(
                   new KubernetesApiError({
                     method,
@@ -147,14 +265,54 @@ const requestJson = Effect.fn(function* ({
         }
         request.end();
       }),
-    catch: (error) =>
-      error instanceof KubernetesApiError
-        ? error
-        : new Error(
-            `Failed Kubernetes ${method} ${path}: ${error instanceof Error ? error.message : String(error)}`,
-          ),
+    catch: (error) => {
+      // Pass typed API errors through untouched.
+      if (
+        error instanceof KubernetesApiError ||
+        error instanceof KubernetesNotFound ||
+        error instanceof KubernetesConflict ||
+        error instanceof KubernetesThrottled
+      ) {
+        return error;
+      }
+      // Anything else — TLS, ECONNRESET, DNS, socket hangup — is a
+      // transport-level failure that never reached the API server's
+      // decision logic. Always retryable.
+      return new KubernetesNetworkError({
+        method,
+        path,
+        cause: error instanceof Error ? error.message : String(error),
+      });
+    },
   });
 });
+
+/**
+ * 429 throttling and transport hiccups are universally retryable; cap to
+ * keep CLI deploys bounded if the cluster is genuinely down.
+ */
+const transientRetrySchedule = Schedule.exponential("1 second").pipe(
+  Schedule.both(Schedule.recurs(8)),
+);
+
+const retryTransient = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  Effect.retry(effect, {
+    while: (e: E) => {
+      const tag = (e as { _tag?: string })._tag;
+      return tag === "KubernetesThrottled" || tag === "KubernetesNetworkError";
+    },
+    schedule: transientRetrySchedule,
+  });
+
+/**
+ * 409 retry budget for apply. Conflicts here are usually:
+ *   - resourceVersion races (resolves on next read)
+ *   - "namespace is being terminated" (resolves once the namespace is gone)
+ * Bounded so a stuck namespace fails the deploy instead of looping forever.
+ */
+const conflictRetrySchedule = Schedule.exponential("1 second").pipe(
+  Schedule.both(Schedule.recurs(10)),
+);
 
 export const readObject = Effect.fn(function* ({
   connection,
@@ -167,7 +325,7 @@ export const readObject = Effect.fn(function* ({
     connection,
     method: "GET",
     path: buildKubernetesObjectPath(object),
-  });
+  }).pipe(retryTransient);
 });
 
 export const applyObject = Effect.fn(function* ({
@@ -179,31 +337,167 @@ export const applyObject = Effect.fn(function* ({
 }) {
   const path = `${buildKubernetesObjectPath(toKubernetesObjectRef(object))}?fieldManager=${fieldManager}&force=true`;
 
-  return yield* requestJson({
+  const result = yield* requestJson({
     connection,
     method: "PATCH",
     path,
     body: object,
-  });
+  }).pipe(
+    retryTransient,
+    // 409 on apply means a concurrent writer or a namespace mid-delete.
+    // Both resolve on retry; we cap so a permanently-stuck namespace
+    // surfaces instead of looping forever.
+    Effect.retry({
+      while: (e) => (e as { _tag?: string })._tag === "KubernetesConflict",
+      schedule: conflictRetrySchedule,
+    }),
+  );
+
+  // For Deployments specifically, wait until the rollout converges so
+  // downstream resources don't see a half-deployed app. We compare
+  // status.observedGeneration against metadata.generation and check
+  // readyReplicas — the canonical kubectl rollout-status check.
+  if (object.apiVersion === "apps/v1" && object.kind === "Deployment") {
+    yield* waitForDeploymentReady({
+      connection,
+      object: toKubernetesObjectRef(object),
+    });
+  }
+
+  return result;
 });
 
-export const deleteObject = Effect.fn(function* ({
+export interface DeploymentLike {
+  metadata?: {
+    generation?: number;
+  };
+  spec?: {
+    replicas?: number;
+  };
+  status?: {
+    observedGeneration?: number;
+    readyReplicas?: number;
+    updatedReplicas?: number;
+    availableReplicas?: number;
+    replicas?: number;
+  };
+}
+
+export const isDeploymentReady = (deployment: DeploymentLike): boolean => {
+  const generation = deployment.metadata?.generation;
+  const observed = deployment.status?.observedGeneration;
+  // Controller hasn't seen our update yet.
+  if (generation !== undefined && observed !== undefined && observed < generation) {
+    return false;
+  }
+  const desired = deployment.spec?.replicas ?? 1;
+  const ready = deployment.status?.readyReplicas ?? 0;
+  const updated = deployment.status?.updatedReplicas ?? 0;
+  return ready >= desired && updated >= desired;
+};
+
+/**
+ * Bounded poll for `availableReplicas`/`readyReplicas` to catch up to
+ * `spec.replicas` after an apply. We give the rollout 5 minutes (enough
+ * for an image pull on a cold node, well short of a hung deploy).
+ */
+const waitForDeploymentReady = Effect.fn(function* ({
   connection,
   object,
 }: {
   connection: KubernetesClusterConnection;
   object: KubernetesObjectRef;
 }) {
+  const deployment = yield* readObject({
+    connection,
+    object,
+  }).pipe(
+    Effect.flatMap((d) => {
+      const dep = d as DeploymentLike;
+      if (isDeploymentReady(dep)) {
+        return Effect.succeed(dep);
+      }
+      return Effect.fail(
+        new KubernetesDeploymentNotReady({
+          namespace: object.namespace ?? "",
+          name: object.name,
+          observedGeneration: dep.status?.observedGeneration,
+          generation: dep.metadata?.generation,
+          readyReplicas: dep.status?.readyReplicas,
+          updatedReplicas: dep.status?.updatedReplicas,
+          desiredReplicas: dep.spec?.replicas,
+        }),
+      );
+    }),
+    Effect.retry({
+      while: (e) =>
+        (e as { _tag?: string })._tag === "KubernetesDeploymentNotReady",
+      schedule: Schedule.fixed("2 seconds").pipe(
+        Schedule.both(Schedule.recurs(150)),
+      ),
+    }),
+  );
+  return deployment;
+});
+
+export const deleteObject = Effect.fn(function* ({
+  connection,
+  object,
+  waitForRemoval = false,
+}: {
+  connection: KubernetesClusterConnection;
+  object: KubernetesObjectRef;
+  /**
+   * If true, poll until the object returns 404 (finalizers complete).
+   * Useful for namespaces and other finalizer-heavy resources where the
+   * server returns 200 immediately but the object lingers with a
+   * deletionTimestamp until controllers run.
+   */
+  waitForRemoval?: boolean;
+}) {
+  // The DELETE itself is idempotent on 404 (already gone) and bounded-
+  // retryable on 409 (conflicts during finalization).
   yield* requestJson({
     connection,
     method: "DELETE",
     path: buildKubernetesObjectPath(object),
   }).pipe(
-    Effect.catchIf(
-      (error): error is KubernetesApiError =>
-        error instanceof KubernetesApiError,
-      (error) => (error.statusCode === 404 ? Effect.void : Effect.fail(error)),
+    retryTransient,
+    Effect.catchTag("KubernetesNotFound", () => Effect.void),
+    Effect.retry({
+      while: (e) => (e as { _tag?: string })._tag === "KubernetesConflict",
+      schedule: conflictRetrySchedule,
+    }),
+  );
+
+  if (!waitForRemoval) {
+    return;
+  }
+
+  // Poll GET until we get a 404. Bounded — a hung namespace finalizer
+  // surfaces as KubernetesDeleteNotComplete instead of a silent timeout.
+  yield* readObject({
+    connection,
+    object,
+  }).pipe(
+    Effect.flatMap(() =>
+      Effect.fail(
+        new KubernetesDeleteNotComplete({
+          apiVersion: object.apiVersion,
+          kind: object.kind,
+          namespace: object.namespace,
+          name: object.name,
+        }),
+      ),
     ),
+    Effect.catchTag("KubernetesNotFound", () => Effect.void),
+    Effect.retry({
+      while: (e) =>
+        (e as { _tag?: string })._tag === "KubernetesDeleteNotComplete",
+      schedule: Schedule.fixed("2 seconds").pipe(
+        Schedule.both(Schedule.recurs(150)),
+      ),
+    }),
   );
 });
 
@@ -224,9 +518,14 @@ export const reconcileObjects = Effect.fn(function* ({
   );
 
   for (const object of sortRefsForDelete(removedObjects)) {
+    // Wait for namespaces to finish terminating before we move on, so a
+    // subsequent apply that recreates an object in that namespace doesn't
+    // race with the namespace's finalizer and 409.
+    const waitForRemoval = object.kind === "Namespace";
     yield* deleteObject({
       connection,
       object,
+      waitForRemoval,
     });
   }
 
@@ -255,9 +554,11 @@ export const deleteObjects = Effect.fn(function* ({
   objects: ReadonlyArray<KubernetesObjectRef>;
 }) {
   for (const object of sortRefsForDelete(objects)) {
+    const waitForRemoval = object.kind === "Namespace";
     yield* deleteObject({
       connection,
       object,
+      waitForRemoval,
     });
   }
 });

--- a/packages/alchemy/test/Kubernetes/client.test.ts
+++ b/packages/alchemy/test/Kubernetes/client.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, test } from "@effect/vitest";
+import {
+  isDeploymentReady,
+  type DeploymentLike,
+} from "../../src/Kubernetes/client.ts";
+import {
+  buildKubernetesObjectPath,
+  chunkByApplyRank,
+  kubernetesObjectKey,
+  sortRefsForDelete,
+  toKubernetesObjectRef,
+  type KubernetesObjectDefinition,
+} from "../../src/Kubernetes/types.ts";
+
+describe("Kubernetes/types", () => {
+  describe("buildKubernetesObjectPath", () => {
+    test("namespaced core resource uses /api/v1 prefix", () => {
+      expect(
+        buildKubernetesObjectPath({
+          apiVersion: "v1",
+          kind: "ConfigMap",
+          name: "cfg",
+          namespace: "demo",
+        }),
+      ).toBe("/api/v1/namespaces/demo/configmaps/cfg");
+    });
+
+    test("namespaced apps/v1 Deployment uses /apis prefix", () => {
+      expect(
+        buildKubernetesObjectPath({
+          apiVersion: "apps/v1",
+          kind: "Deployment",
+          name: "api",
+          namespace: "demo",
+        }),
+      ).toBe("/apis/apps/v1/namespaces/demo/deployments/api");
+    });
+
+    test("cluster-scoped Namespace omits /namespaces/ segment", () => {
+      expect(
+        buildKubernetesObjectPath({
+          apiVersion: "v1",
+          kind: "Namespace",
+          name: "demo",
+        }),
+      ).toBe("/api/v1/namespaces/demo");
+    });
+
+    test("namespaced kind without namespace throws", () => {
+      expect(() =>
+        buildKubernetesObjectPath({
+          apiVersion: "apps/v1",
+          kind: "Deployment",
+          name: "api",
+        }),
+      ).toThrow(/requires a namespace/);
+    });
+  });
+
+  describe("kubernetesObjectKey", () => {
+    test("encodes apiVersion/kind/namespace/name", () => {
+      expect(
+        kubernetesObjectKey({
+          apiVersion: "apps/v1",
+          kind: "Deployment",
+          name: "api",
+          namespace: "demo",
+        }),
+      ).toBe("apps/v1/Deployment/demo/api");
+    });
+
+    test("uses _cluster sentinel for cluster-scoped objects", () => {
+      expect(
+        kubernetesObjectKey({
+          apiVersion: "v1",
+          kind: "Namespace",
+          name: "demo",
+        }),
+      ).toBe("v1/Namespace/_cluster/demo");
+    });
+  });
+
+  describe("chunkByApplyRank", () => {
+    const make = (
+      apiVersion: string,
+      kind: string,
+      name: string,
+      namespace?: string,
+    ): KubernetesObjectDefinition => ({
+      apiVersion,
+      kind,
+      metadata: { name, namespace },
+    });
+
+    test("groups objects by applyRank so namespaces apply before deps", () => {
+      const objs = [
+        make("apps/v1", "Deployment", "api", "demo"),
+        make("v1", "Namespace", "demo"),
+        make("v1", "ConfigMap", "cfg", "demo"),
+      ];
+      const chunks = chunkByApplyRank(objs);
+      expect(chunks.length).toBe(3);
+      expect(chunks[0]?.[0]?.kind).toBe("Namespace");
+      expect(chunks[1]?.[0]?.kind).toBe("ConfigMap");
+      expect(chunks[2]?.[0]?.kind).toBe("Deployment");
+    });
+
+    test("collapses same-rank kinds into a single concurrent chunk", () => {
+      const objs = [
+        make("v1", "ConfigMap", "a", "demo"),
+        make("v1", "ConfigMap", "b", "demo"),
+      ];
+      const chunks = chunkByApplyRank(objs);
+      expect(chunks.length).toBe(1);
+      expect(chunks[0]?.length).toBe(2);
+    });
+  });
+
+  describe("sortRefsForDelete", () => {
+    test("deletes in reverse apply order (Deployment before Namespace)", () => {
+      const refs = [
+        { apiVersion: "v1", kind: "Namespace", name: "demo" },
+        {
+          apiVersion: "apps/v1",
+          kind: "Deployment",
+          name: "api",
+          namespace: "demo",
+        },
+        {
+          apiVersion: "v1",
+          kind: "ConfigMap",
+          name: "cfg",
+          namespace: "demo",
+        },
+      ];
+      const sorted = sortRefsForDelete(refs);
+      expect(sorted.map((r) => r.kind)).toEqual([
+        "Deployment",
+        "ConfigMap",
+        "Namespace",
+      ]);
+    });
+  });
+
+  describe("toKubernetesObjectRef", () => {
+    test("strips body and keeps only identity fields", () => {
+      const obj: KubernetesObjectDefinition = {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: { name: "api", namespace: "demo", labels: { a: "b" } },
+        spec: { replicas: 3 },
+      };
+      expect(toKubernetesObjectRef(obj)).toEqual({
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        name: "api",
+        namespace: "demo",
+      });
+    });
+  });
+});
+
+describe("isDeploymentReady", () => {
+  const dep = (overrides: DeploymentLike): DeploymentLike => overrides;
+
+  test("ready when observedGeneration === generation and replicas converged", () => {
+    expect(
+      isDeploymentReady(
+        dep({
+          metadata: { generation: 3 },
+          spec: { replicas: 2 },
+          status: {
+            observedGeneration: 3,
+            readyReplicas: 2,
+            updatedReplicas: 2,
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("not ready when controller hasn't observed latest generation", () => {
+    expect(
+      isDeploymentReady(
+        dep({
+          metadata: { generation: 4 },
+          spec: { replicas: 2 },
+          status: {
+            observedGeneration: 3,
+            readyReplicas: 2,
+            updatedReplicas: 2,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("not ready when readyReplicas lags desired", () => {
+    expect(
+      isDeploymentReady(
+        dep({
+          metadata: { generation: 1 },
+          spec: { replicas: 3 },
+          status: {
+            observedGeneration: 1,
+            readyReplicas: 1,
+            updatedReplicas: 3,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("not ready when updatedReplicas lags desired (rolling)", () => {
+    expect(
+      isDeploymentReady(
+        dep({
+          metadata: { generation: 2 },
+          spec: { replicas: 3 },
+          status: {
+            observedGeneration: 2,
+            readyReplicas: 3,
+            updatedReplicas: 1,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("not ready on a fresh deployment with empty status", () => {
+    expect(
+      isDeploymentReady(
+        dep({
+          metadata: { generation: 1 },
+          spec: { replicas: 1 },
+          status: {},
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("defaults to replicas=1 when spec omits replicas", () => {
+    expect(
+      isDeploymentReady(
+        dep({
+          metadata: { generation: 1 },
+          spec: {},
+          status: {
+            observedGeneration: 1,
+            readyReplicas: 1,
+            updatedReplicas: 1,
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+});
+
+// Live-cluster lifecycle tests. These exercise the reconcile flow against a
+// real EKS cluster — redeploy no-op, OOB drift recovery, OOB delete recovery,
+// rename-triggers-replace, and double-destroy idempotency. Skipped by default
+// because there is no kind/minikube fixture in this repo; flip the suite on
+// once an EKS test cluster is provisioned.
+describe.skip("Deployment lifecycle (requires EKS cluster)", () => {
+  test("redeploy with same spec is a no-op", () => {});
+  test("reconcile resets replicas mutated out-of-band", () => {});
+  test("reconcile resets image mutated out-of-band", () => {});
+  test("reconcile resets env mutated out-of-band", () => {});
+  test("reconcile re-creates a deployment deleted out-of-band", () => {});
+  test("changing name triggers replace", () => {});
+  test("destroying an already-deleted deployment is a no-op", () => {});
+});
+
+describe.skip("Namespace lifecycle (requires EKS cluster)", () => {
+  test("redeploy is a no-op", () => {});
+  test("recreate after OOB delete", () => {});
+  test("rename triggers replace", () => {});
+  test("double-destroy is idempotent", () => {});
+});


### PR DESCRIPTION
Replace the single `KubernetesApiError` envelope with status-specific tagged errors so retries are scoped instead of blanket-catching auth/validation failures, wait for Deployment rollouts to converge, and wait for Namespace finalizers before recreating downstream objects.

### Reconciler changes

```ts
// status-specific tagged errors — callers can catchTag precisely
KubernetesNotFound       // 404
KubernetesConflict       // 409  (resourceVersion race / namespace terminating)
KubernetesThrottled      // 429
KubernetesNetworkError   // transport (TLS, ECONNRESET, DNS)
KubernetesDeploymentNotReady
KubernetesDeleteNotComplete
```

- 429 + transport errors retry with bounded exponential backoff (8 retries).
- 409 on apply retries with bounded backoff (10 retries) — covers both `resourceVersion` races and `namespace is being terminated`.
- After applying a `Deployment`, poll until `status.observedGeneration === metadata.generation` and `readyReplicas`/`updatedReplicas` reach `spec.replicas` (5 minute cap). Surfaces `KubernetesDeploymentNotReady` instead of returning before pods come up.
- After deleting a `Namespace`, poll GET until 404 so a subsequent apply doesn't race the finalizer. Surfaces `KubernetesDeleteNotComplete` if the namespace stays stuck.
- `DELETE` is idempotent on 404 (already gone) and bounded-retry on 409.

### New lifecycle tests

`packages/alchemy/test/Kubernetes/client.test.ts` — pure unit coverage:

- `buildKubernetesObjectPath` — core vs `apis` group, cluster-scoped vs namespaced, missing-namespace throws
- `kubernetesObjectKey` / `toKubernetesObjectRef` — identity encoding, `_cluster` sentinel
- `chunkByApplyRank` / `sortRefsForDelete` — Namespace before Deployment on apply, reverse on delete
- `isDeploymentReady` — covers `observedGeneration` lag, `readyReplicas` lag, `updatedReplicas` lag (rolling), fresh-status, and `spec.replicas` default

Live-cluster lifecycle scenarios (redeploy no-op, OOB drift recovery for `replicas`/`image`/`env`, OOB-delete recovery, rename-triggers-replace, double-destroy idempotency for both Deployment and Namespace) are stubbed as `describe.skip` blocks; this repo has no kind/minikube fixture yet, so they wire up once an EKS test cluster lands.
