### PR TITLE
fix(cloudflare): harden Secret + ContainerApplication reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/Cloudflare/SecretsStore/Secret.ts
+++ b/packages/alchemy/src/Cloudflare/SecretsStore/Secret.ts
@@ -230,21 +230,48 @@ export const StoreSecretProvider = () =>
               scopes: scopesChanged ? scopes : undefined,
               comment: commentChanged ? news.comment : undefined,
             }).pipe(
+              // Catch only `SecretNotFound`: between observe and patch
+              // the secret may have been deleted out-of-band. Recreate
+              // it from `news` so we converge instead of returning a
+              // stale view of a deleted secret. Other tags (auth,
+              // throttling, store-not-found) propagate.
               Effect.catchTag("SecretNotFound", () =>
-                Effect.succeed(undefined),
+                Effect.succeed("recreate" as const),
               ),
             );
-            if (patched) {
-              return {
-                secretId: observed.id,
-                secretName: observed.name,
-                storeId: observed.storeId,
+            if (patched === "recreate") {
+              const created = yield* createStoreSecret({
                 accountId,
-                status: patched.status,
+                storeId,
+                body: [
+                  {
+                    name,
+                    scopes,
+                    value: Redacted.value(news.value),
+                    comment: news.comment,
+                  },
+                ],
+              });
+              const secret = created.result[0]!;
+              return {
+                secretId: secret.id,
+                secretName: secret.name,
+                storeId: secret.storeId,
+                accountId,
+                status: secret.status,
                 scopes,
-                comment: patched.comment ?? undefined,
+                comment: secret.comment ?? undefined,
               };
             }
+            return {
+              secretId: observed.id,
+              secretName: observed.name,
+              storeId: observed.storeId,
+              accountId,
+              status: patched.status,
+              scopes,
+              comment: patched.comment ?? undefined,
+            };
           }
 
           return {
@@ -269,8 +296,20 @@ export const StoreSecretProvider = () =>
           );
         }),
         read: Effect.fn(function* ({ id, olds, output }) {
+          const lookupByName = (
+            accountId: string,
+            storeId: string,
+            name: string,
+          ) =>
+            listStoreSecrets.items({ accountId, storeId }).pipe(
+              Stream.filter((s) => s.name === name),
+              Stream.runHead,
+              Effect.catchTag("StoreNotFound", () => Effect.succeedNone),
+              Effect.map(Option.getOrUndefined),
+            );
+
           if (output?.secretId) {
-            return yield* getStoreSecret({
+            const byId = yield* getStoreSecret({
               accountId: output.accountId,
               storeId: output.storeId,
               secretId: output.secretId,
@@ -289,6 +328,26 @@ export const StoreSecretProvider = () =>
               ),
               Effect.catchTag("StoreNotFound", () => Effect.succeed(undefined)),
             );
+            if (byId) return byId;
+            // The cached id is gone (out-of-band delete or recreate).
+            // Fall through to a name-scan in the same store so we recover
+            // an existing secret with the same logical identity.
+            const name = resolveName(id, olds?.name ?? output.secretName);
+            const match = yield* lookupByName(
+              output.accountId,
+              output.storeId,
+              name,
+            );
+            if (!match) return undefined;
+            return {
+              secretId: match.id,
+              secretName: match.name,
+              storeId: match.storeId,
+              accountId: output.accountId,
+              status: match.status,
+              scopes: output.scopes,
+              comment: match.comment ?? undefined,
+            };
           }
           if (!olds?.store) return undefined;
           const name = resolveName(id, olds.name);


### PR DESCRIPTION
Two reconciler gaps in `Cloudflare/SecretsStore/Secret.ts` were silently masking out-of-band deletes — patch claimed success on a deleted secret, and read gave up when the cached id 404'd even when the secret had been recreated by name.

### Reconciler changes

```diff
   if (scopesChanged || commentChanged) {
     const patched = yield* patchStoreSecret({ ... }).pipe(
       Effect.catchTag("SecretNotFound", () =>
-        Effect.succeed(undefined),
+        Effect.succeed("recreate" as const),
       ),
     );
-    if (patched) {
-      return { secretId: observed.id, ... }; // stale: secret may be gone
+    if (patched === "recreate") {
+      const created = yield* createStoreSecret({ ... });
+      return toAttributes(created.result[0]!);
     }
+    return { secretId: observed.id, ..., status: patched.status, ... };
   }
```

```diff
 read: Effect.fn(function* ({ id, olds, output }) {
   if (output?.secretId) {
-    return yield* getStoreSecret({ ... }).pipe(
-      Effect.catchTag("SecretNotFound", () => Effect.succeed(undefined)),
-    );
+    const byId = yield* getStoreSecret({ ... }).pipe(
+      Effect.catchTag("SecretNotFound", () => Effect.succeed(undefined)),
+    );
+    if (byId) return byId;
+    // Cached id is gone — name-scan recovers an out-of-band recreate.
+    const match = yield* lookupByName(output.accountId, output.storeId, name);
+    if (!match) return undefined;
+    return { secretId: match.id, ... };
   }
```

### New lifecycle tests

None added in this PR. Authoring the convergence suite (redeploy is no-op, reconcile resets out-of-band mutation, reconcile re-creates after out-of-band delete, replace on `name` change, no-op destroy of already-deleted secret, `adopt(true)` re-claims foreign secret) requires a live Cloudflare account with an existing Secrets Store and is left as a follow-up.

`ContainerApplication` audit found no blanket-catch / observe-vs-assume gaps that the existing reconciler doesn't already handle (`getContainerApplication` then `findApplicationByName` fallback for out-of-band delete; `read` returns `Unowned(attrs)` for foreign-named applications; `delete` is idempotent on `ContainerApplicationNotFound`). No source change made there.

### Distilled patch

No patch needed. Cloudflare's distilled SDK already surfaces `SecretNotFound`/`StoreNotFound`/`SecretNameAlreadyExists`/`MaximumStoresExceeded` as discriminated tags; no `UnknownCloudflareError` surfaces in the affected paths.
