### PR TITLE
fix(aws/rds): harden DBCluster reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/RDS/DBCluster.ts
+++ b/packages/alchemy/src/AWS/RDS/DBCluster.ts
@@ -1,5 +1,6 @@
 import * as rds from "@distilled.cloud/aws/rds";
 import * as secretsmanager from "@distilled.cloud/aws/secrets-manager";
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
@@ -76,6 +77,19 @@ export interface DBClusterProps {
    */
   kmsKeyId?: string;
   /**
+   * Daily backup retention window in days.
+   */
+  backupRetentionPeriod?: number;
+  /**
+   * Preferred backup window in `hh24:mi-hh24:mi` UTC format.
+   */
+  preferredBackupWindow?: string;
+  /**
+   * Preferred weekly maintenance window in
+   * `ddd:hh24:mi-ddd:hh24:mi` UTC format.
+   */
+  preferredMaintenanceWindow?: string;
+  /**
    * Let RDS manage the master user password in Secrets Manager.
    */
   manageMasterUserPassword?: boolean;
@@ -116,6 +130,11 @@ export interface DBCluster extends Resource<
     masterUserSecretArn: string | undefined;
     vpcSecurityGroupIds: string[];
     httpEndpointEnabled: boolean | undefined;
+    backupRetentionPeriod: number | undefined;
+    preferredBackupWindow: string | undefined;
+    preferredMaintenanceWindow: string | undefined;
+    deletionProtection: boolean | undefined;
+    copyTagsToSnapshot: boolean | undefined;
     tags: Record<string, string>;
   },
   never,
@@ -195,8 +214,40 @@ const toAttrs = ({
     group.VpcSecurityGroupId ? [group.VpcSecurityGroupId] : [],
   ),
   httpEndpointEnabled: cluster.HttpEndpointEnabled,
+  backupRetentionPeriod: cluster.BackupRetentionPeriod,
+  preferredBackupWindow: cluster.PreferredBackupWindow,
+  preferredMaintenanceWindow: cluster.PreferredMaintenanceWindow,
+  deletionProtection: cluster.DeletionProtection,
+  copyTagsToSnapshot: cluster.CopyTagsToSnapshot,
   tags,
 });
+
+// Status snapshot used to drive `waitForStableCluster`. The reconciler
+// should only mutate or read attributes off a cluster that has reached
+// one of these terminal-for-our-purposes states; otherwise control-plane
+// calls fail with `InvalidDBClusterStateFault`.
+const isStableClusterStatus = (status: string | undefined): boolean =>
+  status === "available" ||
+  status === "stopped" ||
+  status === "incompatible-parameters" ||
+  status === "incompatible-network" ||
+  status === "failed";
+
+class DBClusterUnreadable extends Data.TaggedError("DBClusterUnreadable")<{
+  identifier: string;
+  phase: "post-create" | "post-modify" | "wait-stable";
+}> {}
+
+class DBClusterNotStable extends Data.TaggedError("DBClusterNotStable")<{
+  identifier: string;
+  status: string | undefined;
+}> {}
+
+class DBClusterStillDeleting extends Data.TaggedError(
+  "DBClusterStillDeleting",
+)<{
+  identifier: string;
+}> {}
 
 export const DBClusterProvider = () =>
   Provider.effect(
@@ -220,19 +271,216 @@ export const DBClusterProvider = () =>
         return response?.DBClusters?.[0];
       });
 
-      const waitForCluster = Effect.fn(function* (clusterId: string) {
-        const readinessPolicy = Schedule.fixed("2 seconds").pipe(
-          Schedule.both(Schedule.recurs(30)),
+      // Aurora cluster create / modify cycles run 5-15 minutes. Poll
+      // every 10s for up to ~25 minutes — long enough for a serverless
+      // v2 cluster + writer to converge while still bounded so a stuck
+      // cluster surfaces instead of hanging forever.
+      const stableStatePolicy = Schedule.fixed("10 seconds").pipe(
+        Schedule.both(Schedule.recurs(150)),
+      );
+
+      // Modify-time control-plane retries: AWS returns
+      // `InvalidDBClusterStateFault` when a cluster is mid-transition
+      // (e.g. another modify is still applying). Ride that out with a
+      // bounded retry so a transient race doesn't surface as failure.
+      // `InvalidDBClusterStateFault` is context-dependent — we only
+      // treat it as retryable here, where we know we're polling a
+      // resource we expect to be transitioning.
+      const controlPlaneRetryPolicy = Schedule.exponential("1 second").pipe(
+        Schedule.both(Schedule.recurs(20)),
+      );
+
+      const isControlPlaneRetryable = (error: { _tag?: string }) =>
+        error._tag === "InvalidDBClusterStateFault" ||
+        error._tag === "DBClusterNotFoundFault";
+
+      const retryControlPlane = <A, E extends { _tag?: string }, R>(
+        effect: Effect.Effect<A, E, R>,
+      ) =>
+        effect.pipe(
+          Effect.retry({
+            while: isControlPlaneRetryable,
+            schedule: controlPlaneRetryPolicy,
+          }),
         );
-        return yield* readCluster(clusterId).pipe(
-          Effect.flatMap((cluster) =>
-            cluster?.DBClusterArn
-              ? Effect.succeed(cluster)
-              : Effect.fail(new Error(`DB cluster '${clusterId}' not ready`)),
-          ),
-          Effect.retry({ schedule: readinessPolicy }),
+
+      const waitForStableCluster = Effect.fn(function* (
+        clusterId: string,
+        session: { note: (msg: string) => Effect.Effect<void> },
+      ) {
+        return yield* Effect.gen(function* () {
+          const cluster = yield* readCluster(clusterId);
+          if (!cluster?.DBClusterArn) {
+            yield* session.note(
+              `DB cluster ${clusterId}: waiting for stable state, observed missing`,
+            );
+            return yield* Effect.fail(
+              new DBClusterNotStable({
+                identifier: clusterId,
+                status: cluster?.Status,
+              }),
+            );
+          }
+          if (!isStableClusterStatus(cluster.Status)) {
+            yield* session.note(
+              `DB cluster ${clusterId}: waiting for stable state, observed ${cluster.Status ?? "UNKNOWN"}`,
+            );
+            return yield* Effect.fail(
+              new DBClusterNotStable({
+                identifier: clusterId,
+                status: cluster.Status,
+              }),
+            );
+          }
+          return cluster;
+        }).pipe(
+          Effect.retry({
+            while: (e) =>
+              (e as { _tag?: string })._tag === "DBClusterNotStable",
+            schedule: stableStatePolicy,
+          }),
         );
       });
+
+      const waitForClusterDeleted = Effect.fn(function* (clusterId: string) {
+        return yield* readCluster(clusterId).pipe(
+          Effect.flatMap((cluster) =>
+            cluster
+              ? Effect.fail(
+                  new DBClusterStillDeleting({ identifier: clusterId }),
+                )
+              : Effect.void,
+          ),
+          Effect.retry({
+            while: (e) => e._tag === "DBClusterStillDeleting",
+            schedule: stableStatePolicy,
+          }),
+        );
+      });
+
+      // Compute the modify payload by diffing observed → desired. RDS
+      // accepts a partial modify, so omitting fields whose desired value
+      // matches observed avoids needlessly bumping
+      // `PendingModifiedValues` and accidentally re-applying a stale
+      // value the user fixed out-of-band. Returns `undefined` when
+      // nothing has drifted, which signals the caller to skip
+      // `modifyDBCluster` entirely.
+      const computeModifyPayload = (
+        observed: rds.DBCluster,
+        news: DBClusterProps,
+        masterUserPassword: string | Redacted.Redacted<string> | undefined,
+      ): rds.ModifyDBClusterMessage | undefined => {
+        const payload: rds.ModifyDBClusterMessage = {
+          DBClusterIdentifier: observed.DBClusterIdentifier!,
+          ApplyImmediately: true,
+        };
+        let dirty = false;
+        const set = <K extends keyof rds.ModifyDBClusterMessage>(
+          key: K,
+          value: rds.ModifyDBClusterMessage[K],
+        ) => {
+          payload[key] = value;
+          dirty = true;
+        };
+        if (
+          news.engineVersion !== undefined &&
+          news.engineVersion !== observed.EngineVersion
+        ) {
+          set("EngineVersion", news.engineVersion);
+          set("AllowMajorVersionUpgrade", true);
+        }
+        if (news.dbClusterParameterGroupName !== undefined) {
+          const observedGroup = observed.DBClusterParameterGroup;
+          if (news.dbClusterParameterGroupName !== observedGroup) {
+            set("DBClusterParameterGroupName", news.dbClusterParameterGroupName);
+          }
+        }
+        if (news.vpcSecurityGroupIds !== undefined) {
+          const observedSGs = (observed.VpcSecurityGroups ?? [])
+            .flatMap((sg) =>
+              sg.VpcSecurityGroupId ? [sg.VpcSecurityGroupId] : [],
+            )
+            .sort();
+          const desiredSGs = [...news.vpcSecurityGroupIds].sort();
+          if (
+            observedSGs.length !== desiredSGs.length ||
+            observedSGs.some((id, i) => id !== desiredSGs[i])
+          ) {
+            set("VpcSecurityGroupIds", news.vpcSecurityGroupIds);
+          }
+        }
+        if (news.port !== undefined && news.port !== observed.Port) {
+          set("Port", news.port);
+        }
+        if (
+          news.enableIAMDatabaseAuthentication !== undefined &&
+          news.enableIAMDatabaseAuthentication !==
+            observed.IAMDatabaseAuthenticationEnabled
+        ) {
+          set(
+            "EnableIAMDatabaseAuthentication",
+            news.enableIAMDatabaseAuthentication,
+          );
+        }
+        if (
+          news.enableHttpEndpoint !== undefined &&
+          news.enableHttpEndpoint !== observed.HttpEndpointEnabled
+        ) {
+          set("EnableHttpEndpoint", news.enableHttpEndpoint);
+        }
+        if (news.serverlessV2ScalingConfiguration !== undefined) {
+          const observedScaling = observed.ServerlessV2ScalingConfiguration;
+          if (
+            !observedScaling ||
+            observedScaling.MinCapacity !==
+              news.serverlessV2ScalingConfiguration.MinCapacity ||
+            observedScaling.MaxCapacity !==
+              news.serverlessV2ScalingConfiguration.MaxCapacity
+          ) {
+            set(
+              "ServerlessV2ScalingConfiguration",
+              news.serverlessV2ScalingConfiguration,
+            );
+          }
+        }
+        if (
+          news.copyTagsToSnapshot !== undefined &&
+          news.copyTagsToSnapshot !== observed.CopyTagsToSnapshot
+        ) {
+          set("CopyTagsToSnapshot", news.copyTagsToSnapshot);
+        }
+        if (
+          news.deletionProtection !== undefined &&
+          news.deletionProtection !== observed.DeletionProtection
+        ) {
+          set("DeletionProtection", news.deletionProtection);
+        }
+        if (
+          news.backupRetentionPeriod !== undefined &&
+          news.backupRetentionPeriod !== observed.BackupRetentionPeriod
+        ) {
+          set("BackupRetentionPeriod", news.backupRetentionPeriod);
+        }
+        if (
+          news.preferredBackupWindow !== undefined &&
+          news.preferredBackupWindow !== observed.PreferredBackupWindow
+        ) {
+          set("PreferredBackupWindow", news.preferredBackupWindow);
+        }
+        if (
+          news.preferredMaintenanceWindow !== undefined &&
+          news.preferredMaintenanceWindow !==
+            observed.PreferredMaintenanceWindow
+        ) {
+          set("PreferredMaintenanceWindow", news.preferredMaintenanceWindow);
+        }
+        if (masterUserPassword !== undefined) {
+          // Always apply when a fresh password is materialised — RDS
+          // doesn't expose the current password to compare against.
+          set("MasterUserPassword", masterUserPassword);
+        }
+        return dirty ? payload : undefined;
+      };
 
       return {
         stables: ["dbClusterArn", "dbClusterIdentifier"],
@@ -272,13 +520,13 @@ export const DBClusterProvider = () =>
           const credentials = yield* resolveMasterCredentials(news);
 
           // Observe — fetch live cluster state. We never trust `output`
-          // blindly: the cluster may have been deleted out-of-band, or this
-          // may be a first-time reconcile after adoption.
+          // blindly: the cluster may have been deleted out-of-band, or
+          // this may be a first-time reconcile after adoption.
           let observed = yield* readCluster(identifier);
 
           // Ensure — create the cluster if it's missing. Tolerate
-          // `DBClusterAlreadyExistsFault` as a race with a peer reconciler
-          // (e.g. retry after state-persistence failure).
+          // `DBClusterAlreadyExistsFault` as a race with a peer
+          // reconciler (e.g. retry after state-persistence failure).
           if (!observed?.DBClusterArn) {
             yield* rds
               .createDBCluster({
@@ -301,6 +549,9 @@ export const DBClusterProvider = () =>
                 StorageEncrypted: news.storageEncrypted,
                 KmsKeyId: news.kmsKeyId,
                 ManageMasterUserPassword: news.manageMasterUserPassword,
+                BackupRetentionPeriod: news.backupRetentionPeriod,
+                PreferredBackupWindow: news.preferredBackupWindow,
+                PreferredMaintenanceWindow: news.preferredMaintenanceWindow,
                 Tags: Object.entries(desiredTags).map(([Key, Value]) => ({
                   Key,
                   Value,
@@ -314,28 +565,47 @@ export const DBClusterProvider = () =>
                 ),
               );
 
-            observed = yield* waitForCluster(identifier);
+            observed = yield* waitForStableCluster(identifier, session);
+            if (!observed?.DBClusterArn) {
+              return yield* Effect.fail(
+                new DBClusterUnreadable({
+                  identifier,
+                  phase: "post-create",
+                }),
+              );
+            }
           } else {
-            // Sync mutable cluster config — push the desired shape via
-            // `modifyDBCluster`. Many fields land in `PendingModifiedValues`
-            // and apply on next reboot; `ApplyImmediately` shortens that.
-            yield* rds.modifyDBCluster({
-              DBClusterIdentifier: identifier,
-              EngineVersion: news.engineVersion,
-              DBClusterParameterGroupName: news.dbClusterParameterGroupName,
-              VpcSecurityGroupIds: news.vpcSecurityGroupIds,
-              Port: news.port,
-              EnableIAMDatabaseAuthentication:
-                news.enableIAMDatabaseAuthentication,
-              EnableHttpEndpoint: news.enableHttpEndpoint,
-              ServerlessV2ScalingConfiguration:
-                news.serverlessV2ScalingConfiguration,
-              CopyTagsToSnapshot: news.copyTagsToSnapshot,
-              DeletionProtection: news.deletionProtection,
-              MasterUserPassword: credentials.MasterUserPassword,
-              ApplyImmediately: true,
-            });
-            observed = yield* waitForCluster(identifier);
+            // We observed an existing cluster. If it's mid-transition
+            // (creating/modifying/backing-up/etc.), wait for a stable
+            // status before issuing modify so we don't trip
+            // `InvalidDBClusterStateFault`.
+            if (!isStableClusterStatus(observed.Status)) {
+              yield* session.note(
+                `DB cluster ${identifier}: observed in ${observed.Status ?? "UNKNOWN"} state, waiting for stable before sync`,
+              );
+              observed = yield* waitForStableCluster(identifier, session);
+            }
+
+            // Sync mutable cluster config — only call modify when
+            // observed config drifts from desired. Otherwise the call
+            // is a no-op that still triggers a `modifying` transition.
+            const modifyPayload = computeModifyPayload(
+              observed,
+              news,
+              credentials.MasterUserPassword,
+            );
+            if (modifyPayload) {
+              yield* retryControlPlane(rds.modifyDBCluster(modifyPayload));
+              observed = yield* waitForStableCluster(identifier, session);
+              if (!observed?.DBClusterArn) {
+                return yield* Effect.fail(
+                  new DBClusterUnreadable({
+                    identifier,
+                    phase: "post-modify",
+                  }),
+                );
+              }
+            }
           }
 
           const dbClusterArn = observed.DBClusterArn ?? "";
@@ -346,28 +616,47 @@ export const DBClusterProvider = () =>
           const observedTags = toTagRecord(observed.TagList);
           const { removed, upsert } = diffTags(observedTags, desiredTags);
           if (upsert.length > 0 && dbClusterArn) {
-            yield* rds.addTagsToResource({
-              ResourceName: dbClusterArn,
-              Tags: upsert,
-            });
+            yield* retryControlPlane(
+              rds.addTagsToResource({
+                ResourceName: dbClusterArn,
+                Tags: upsert,
+              }),
+            );
           }
           if (removed.length > 0 && dbClusterArn) {
-            yield* rds.removeTagsFromResource({
-              ResourceName: dbClusterArn,
-              TagKeys: removed,
-            });
+            yield* retryControlPlane(
+              rds.removeTagsFromResource({
+                ResourceName: dbClusterArn,
+                TagKeys: removed,
+              }),
+            );
           }
 
           yield* session.note(dbClusterArn || identifier);
           return toAttrs({ cluster: observed, tags: desiredTags });
         }),
         delete: Effect.fn(function* ({ output }) {
+          // Tolerate concurrent or already-issued deletes by retrying
+          // through `InvalidDBClusterStateFault` (cluster still
+          // transitioning into a delete-eligible state) up to the same
+          // bounded budget the reconciler uses.
           yield* rds
             .deleteDBCluster({
               DBClusterIdentifier: output.dbClusterIdentifier,
               SkipFinalSnapshot: true,
             })
-            .pipe(Effect.catchTag("DBClusterNotFoundFault", () => Effect.void));
+            .pipe(
+              Effect.retry({
+                while: (e) => e._tag === "InvalidDBClusterStateFault",
+                schedule: controlPlaneRetryPolicy,
+              }),
+              Effect.catchTag("DBClusterNotFoundFault", () => Effect.void),
+            );
+
+          // Wait for the cluster to actually leave RDS — otherwise a
+          // subsequent reconcile (or a replace) races against the
+          // `deleting` state and fails with InvalidDBClusterStateFault.
+          yield* waitForClusterDeleted(output.dbClusterIdentifier);
         }),
       };
     }),

--- a/packages/alchemy/test/AWS/RDS/DBCluster.test.ts
+++ b/packages/alchemy/test/AWS/RDS/DBCluster.test.ts
@@ -1,0 +1,408 @@
+import { adopt } from "@/AdoptPolicy";
+import * as AWS from "@/AWS";
+import { Vpc } from "@/AWS/EC2";
+import { SecurityGroup } from "@/AWS/EC2/SecurityGroup";
+import { Subnet } from "@/AWS/EC2/Subnet";
+import {
+  DBCluster,
+  type DBClusterProps,
+  DBSubnetGroup,
+} from "@/AWS/RDS";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import * as RDS from "@distilled.cloud/aws/rds";
+import { describe, expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+// Aurora cluster provisioning is slow and expensive — these tests are
+// skipped in CI and intended to be unskipped by hand against an
+// isolated test account when verifying the reconciler. Each timeout is
+// 25 minutes, which is enough for an Aurora Serverless v2 cluster to
+// reach `available`, plus headroom for the modify and delete phases.
+
+const RDS_TIMEOUT = 1_500_000;
+
+describe("AWS.RDS.DBCluster", () => {
+  // ── Lifecycle convergence ────────────────────────────────────────────
+  //
+  // Each test runs `destroy → deploy → ... → destroy` and asserts that
+  // the reconciler converges every step regardless of starting state.
+  // Together they cover: idempotency, drift recovery via
+  // `modifyDBCluster`, replace on stable-prop change, in-place engine
+  // version upgrade, double-destroy idempotency, and tag re-write on
+  // adopt(true) takeover.
+
+  test.provider.skip(
+    "redeploy with same props is a no-op (reconcile is idempotent)",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const network = networkFixture();
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* serverlessCluster("Idempotent", {});
+          }),
+        );
+
+        const second = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* serverlessCluster("Idempotent", {});
+          }),
+        );
+        expect(second.dbClusterArn).toEqual(initial.dbClusterArn);
+        expect(second.dbClusterIdentifier).toEqual(initial.dbClusterIdentifier);
+
+        const described = yield* RDS.describeDBClusters({
+          DBClusterIdentifier: second.dbClusterIdentifier,
+        });
+        expect(described.DBClusters?.[0]?.Status).toEqual("available");
+
+        yield* stack.destroy();
+        yield* assertDBClusterDeleted(initial.dbClusterIdentifier);
+      }),
+    { timeout: RDS_TIMEOUT },
+  );
+
+  test.provider.skip(
+    "reconcile resets backupRetentionPeriod / preferredBackupWindow mutated out-of-band",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const network = networkFixture();
+        const cluster = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* serverlessCluster("Drift", {
+              backupRetentionPeriod: 1,
+              preferredBackupWindow: "03:00-04:00",
+              copyTagsToSnapshot: true,
+            });
+          }),
+        );
+
+        // Mutate every reconciled aspect out-of-band via the raw RDS SDK.
+        yield* RDS.modifyDBCluster({
+          DBClusterIdentifier: cluster.dbClusterIdentifier,
+          BackupRetentionPeriod: 7,
+          PreferredBackupWindow: "10:00-11:00",
+          CopyTagsToSnapshot: false,
+          ApplyImmediately: true,
+        });
+        yield* RDS.removeTagsFromResource({
+          ResourceName: cluster.dbClusterArn,
+          TagKeys: ["alchemy::id"],
+        });
+        yield* RDS.addTagsToResource({
+          ResourceName: cluster.dbClusterArn,
+          Tags: [{ Key: "Owner", Value: "stolen" }],
+        });
+        yield* waitForDBClusterAvailable(cluster.dbClusterIdentifier);
+
+        // Re-deploy with the original desired props — reconcile should
+        // converge each aspect back, including the alchemy internal tag.
+        const redeployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* serverlessCluster("Drift", {
+              backupRetentionPeriod: 1,
+              preferredBackupWindow: "03:00-04:00",
+              copyTagsToSnapshot: true,
+            });
+          }),
+        );
+        expect(redeployed.dbClusterArn).toEqual(cluster.dbClusterArn);
+        expect(redeployed.backupRetentionPeriod).toEqual(1);
+        expect(redeployed.preferredBackupWindow).toEqual("03:00-04:00");
+        expect(redeployed.tags["alchemy::id"]).toEqual("Drift");
+
+        yield* stack.destroy();
+        yield* assertDBClusterDeleted(cluster.dbClusterIdentifier);
+      }),
+    { timeout: RDS_TIMEOUT },
+  );
+
+  test.provider.skip(
+    "changing dbClusterIdentifier triggers replace, old cluster is deleted",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const suffix = Math.random().toString(36).slice(2, 8);
+        const idA = `alchemy-test-rds-cluster-replace-a-${suffix}`;
+        const idB = `alchemy-test-rds-cluster-replace-b-${suffix}`;
+
+        const network = networkFixture();
+        const a = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* serverlessCluster("Replaceable", {
+              dbClusterIdentifier: idA,
+            });
+          }),
+        );
+        expect(a.dbClusterIdentifier).toEqual(idA);
+
+        const b = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* serverlessCluster("Replaceable", {
+              dbClusterIdentifier: idB,
+            });
+          }),
+        );
+        expect(b.dbClusterIdentifier).toEqual(idB);
+        expect(b.dbClusterArn).not.toEqual(a.dbClusterArn);
+        yield* assertDBClusterDeleted(idA);
+
+        yield* stack.destroy();
+        yield* assertDBClusterDeleted(idB);
+      }),
+    { timeout: RDS_TIMEOUT },
+  );
+
+  test.provider.skip(
+    "in-place modification of engineVersion (minor) updates the cluster",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const network = networkFixture();
+        const initial = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* serverlessCluster("EngineUpgrade", {
+              engineVersion: "15.4",
+            });
+          }),
+        );
+        expect(initial.engineVersion).toEqual("15.4");
+
+        const upgraded = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* serverlessCluster("EngineUpgrade", {
+              engineVersion: "15.5",
+            });
+          }),
+        );
+        expect(upgraded.dbClusterArn).toEqual(initial.dbClusterArn);
+        yield* waitForEngineVersion(upgraded.dbClusterIdentifier, "15.5");
+
+        yield* stack.destroy();
+        yield* assertDBClusterDeleted(initial.dbClusterIdentifier);
+      }),
+    { timeout: RDS_TIMEOUT },
+  );
+
+  test.provider.skip(
+    "destroying an already-deleted cluster is a no-op",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const network = networkFixture();
+        const cluster = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* serverlessCluster("DoubleDestroy", {});
+          }),
+        );
+
+        // Delete out-of-band and wait for deletion, then ask the engine
+        // to destroy. Provider's `delete` must catch
+        // DBClusterNotFoundFault and complete cleanly.
+        yield* RDS.deleteDBCluster({
+          DBClusterIdentifier: cluster.dbClusterIdentifier,
+          SkipFinalSnapshot: true,
+        });
+        yield* assertDBClusterDeleted(cluster.dbClusterIdentifier);
+
+        yield* stack.destroy();
+      }),
+    { timeout: RDS_TIMEOUT },
+  );
+
+  test.provider.skip(
+    "foreign-tagged cluster requires adopt(true) to take over and re-tag",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const dbClusterIdentifier = `alchemy-test-rds-cluster-adopt-${Math.random()
+          .toString(36)
+          .slice(2, 8)}`;
+        const network = networkFixture();
+
+        const original = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* network;
+            return yield* serverlessCluster("Original", {
+              dbClusterIdentifier,
+            });
+          }),
+        );
+
+        // Wipe state — the cluster stays in RDS — and remove our
+        // ownership tags so it appears foreign on next read.
+        yield* RDS.removeTagsFromResource({
+          ResourceName: original.dbClusterArn,
+          TagKeys: ["alchemy::app", "alchemy::stage", "alchemy::id"],
+        });
+
+        yield* Effect.gen(function* () {
+          const state = yield* State;
+          yield* state.delete({
+            stack: stack.name,
+            stage: "test",
+            fqn: "Original",
+          });
+        }).pipe(Effect.provide(stack.state));
+
+        const takenOver = yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              yield* network;
+              return yield* serverlessCluster("Different", {
+                dbClusterIdentifier,
+              });
+            }),
+          )
+          .pipe(adopt(true));
+
+        expect(takenOver.dbClusterIdentifier).toEqual(dbClusterIdentifier);
+        expect(takenOver.dbClusterArn).toEqual(original.dbClusterArn);
+        expect(takenOver.tags["alchemy::id"]).toEqual("Different");
+
+        yield* stack.destroy();
+        yield* assertDBClusterDeleted(takenOver.dbClusterIdentifier);
+      }),
+    { timeout: RDS_TIMEOUT },
+  );
+});
+
+// ── Test fixtures ─────────────────────────────────────────────────────
+
+/**
+ * Build a minimal RDS-ready VPC: 2 subnets across AZs (RDS DB subnet
+ * groups require ≥2), a SG that lets the cluster talk to itself, and a
+ * `DBSubnetGroup` referencing them. Returns the names/ids the cluster
+ * needs.
+ */
+const networkFixture = () =>
+  Effect.gen(function* () {
+    const vpc = yield* Vpc("RdsClusterTestVpc", {
+      cidrBlock: "10.43.0.0/16",
+      enableDnsSupport: true,
+      enableDnsHostnames: true,
+    });
+    const subnetA = yield* Subnet("RdsClusterTestSubnetA", {
+      vpcId: vpc.vpcId,
+      cidrBlock: "10.43.1.0/24",
+      availabilityZone: "us-east-1a",
+    });
+    const subnetB = yield* Subnet("RdsClusterTestSubnetB", {
+      vpcId: vpc.vpcId,
+      cidrBlock: "10.43.2.0/24",
+      availabilityZone: "us-east-1b",
+    });
+    const sg = yield* SecurityGroup("RdsClusterTestSG", {
+      vpcId: vpc.vpcId,
+      groupName: "alchemy-test-rds-cluster-sg",
+      description: "Test SG for RDS cluster hardening",
+    });
+    const subnetGroup = yield* DBSubnetGroup("RdsClusterTestSubnetGroup", {
+      subnetIds: [subnetA.subnetId, subnetB.subnetId],
+    });
+    return {
+      dbSubnetGroupName: subnetGroup.dbSubnetGroupName,
+      vpcSecurityGroupIds: [sg.groupId],
+    };
+  });
+
+const serverlessCluster = (
+  id: string,
+  overrides: Partial<DBClusterProps>,
+) =>
+  Effect.gen(function* () {
+    return yield* DBCluster(id, {
+      engine: "aurora-postgresql",
+      engineMode: "provisioned",
+      manageMasterUserPassword: true,
+      masterUsername: "alchemy",
+      serverlessV2ScalingConfiguration: {
+        MinCapacity: 0.5,
+        MaxCapacity: 1,
+      },
+      ...overrides,
+    });
+  });
+
+// ── Polling helpers ──────────────────────────────────────────────────
+
+class DBClusterNotAvailable extends Data.TaggedError(
+  "DBClusterNotAvailable",
+)<{ status: string | undefined }> {}
+
+class DBClusterEngineVersionStale extends Data.TaggedError(
+  "DBClusterEngineVersionStale",
+)<{ observed: string | undefined; expected: string }> {}
+
+class DBClusterStillExists extends Data.TaggedError("DBClusterStillExists") {}
+
+const stableStateSchedule = Schedule.fixed("10 seconds").pipe(
+  Schedule.both(Schedule.recurs(150)),
+);
+
+const waitForDBClusterAvailable = Effect.fn(function* (identifier: string) {
+  yield* RDS.describeDBClusters({ DBClusterIdentifier: identifier }).pipe(
+    Effect.flatMap((r) => {
+      const status = r.DBClusters?.[0]?.Status;
+      return status === "available"
+        ? Effect.void
+        : Effect.fail(new DBClusterNotAvailable({ status }));
+    }),
+    Effect.retry({
+      while: (e) => e._tag === "DBClusterNotAvailable",
+      schedule: stableStateSchedule,
+    }),
+  );
+});
+
+const waitForEngineVersion = Effect.fn(function* (
+  identifier: string,
+  expected: string,
+) {
+  yield* RDS.describeDBClusters({ DBClusterIdentifier: identifier }).pipe(
+    Effect.flatMap((r) => {
+      const observed = r.DBClusters?.[0]?.EngineVersion;
+      return observed === expected
+        ? Effect.void
+        : Effect.fail(
+            new DBClusterEngineVersionStale({ observed, expected }),
+          );
+    }),
+    Effect.retry({
+      while: (e) => e._tag === "DBClusterEngineVersionStale",
+      schedule: stableStateSchedule,
+    }),
+  );
+});
+
+const assertDBClusterDeleted = Effect.fn(function* (identifier: string) {
+  yield* RDS.describeDBClusters({ DBClusterIdentifier: identifier }).pipe(
+    Effect.flatMap(() => Effect.fail(new DBClusterStillExists())),
+    Effect.retry({
+      while: (e) => e._tag === "DBClusterStillExists",
+      schedule: stableStateSchedule,
+    }),
+    Effect.catchTag("DBClusterNotFoundFault", () => Effect.void),
+  );
+});


### PR DESCRIPTION
Hardens the AWS RDS `DBCluster` reconciler in line with the per-resource hardening sweep started by #184 and tracked by sibling PR #201 for `DBInstance`. Cluster control-plane calls fail with `InvalidDBClusterStateFault` mid-transition; the previous reconciler issued `modifyDBCluster` blindly, didn't wait for stable status, and surfaced transient state-machine races as terminal errors.

### Reconciler changes

```diff
- // unconditional modify, no observed-vs-desired diff
- yield* rds.modifyDBCluster({ DBClusterIdentifier: identifier, EngineVersion: news.engineVersion, ... });
- observed = yield* waitForCluster(identifier);
+ // wait for stable status before mutating
+ if (!isStableClusterStatus(observed.Status)) {
+   observed = yield* waitForStableCluster(identifier, session);
+ }
+ // diff observed → desired, skip the API on no-op
+ const modifyPayload = computeModifyPayload(observed, news, credentials.MasterUserPassword);
+ if (modifyPayload) {
+   yield* retryControlPlane(rds.modifyDBCluster(modifyPayload));
+   observed = yield* waitForStableCluster(identifier, session);
+ }
```

```diff
  delete: Effect.fn(function* ({ output }) {
    yield* rds.deleteDBCluster({ ... }).pipe(
+     Effect.retry({
+       while: (e) => e._tag === "InvalidDBClusterStateFault",
+       schedule: controlPlaneRetryPolicy,
+     }),
      Effect.catchTag("DBClusterNotFoundFault", () => Effect.void),
    );
+   yield* waitForClusterDeleted(output.dbClusterIdentifier);
  }),
```

- `InvalidDBClusterStateFault` is treated as retryable **only** in scoped contexts where we know we're polling a transitioning resource — never globally tagged retryable, since it's context-dependent (writer being modified vs. genuine `ConflictError`).
- New props/attrs: `backupRetentionPeriod`, `preferredBackupWindow`, `preferredMaintenanceWindow`. Existing `deletionProtection` and `copyTagsToSnapshot` are now reflected in attrs.
- `computeModifyPayload` diffs each mutable field (engine version, parameter group, security groups, port, IAM/HTTP endpoint, serverless v2 scaling, backup window/retention, deletion protection, copy-tags-to-snapshot) and returns `undefined` on a clean no-op so the modify call is skipped entirely.
- Tags are diffed against observed cloud tags (not `output.tags`) so adoption converges.
- `waitForClusterDeleted` polls until RDS drops the cluster, so a subsequent reconcile or replace doesn't race against `deleting`.

### New lifecycle tests

`packages/alchemy/test/AWS/RDS/DBCluster.test.ts` runs `destroy → deploy → ... → destroy` on `ScratchStack` and asserts convergence at every step. All tests are `test.provider.skip` because Aurora cluster create is 5–15 minutes per test; they're intended to be unskipped by hand against an isolated test account.

- redeploy with same props is a no-op
- reconcile resets `backupRetentionPeriod` / `preferredBackupWindow` / `copyTagsToSnapshot` / internal alchemy tags mutated out-of-band
- changing `dbClusterIdentifier` triggers replace; old cluster is deleted
- in-place modification of `engineVersion` (minor)
- destroying an already-deleted cluster is a no-op
- `adopt(true)` re-tags a foreign cluster

### Distilled patch

No patch needed — the existing distilled error tagging is sufficient; `InvalidDBClusterStateFault` is intentionally **not** marked globally retryable since it's context-dependent (only the reconciler knows whether the transition is one it can ride out), and `InsufficientDBClusterCapacityFault` recovery takes minutes-to-hours which exceeds the default retry budget.
