### PR TITLE
fix(axiom): harden Monitor + Notifier reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/Axiom/Monitor.ts
+++ b/packages/alchemy/src/Axiom/Monitor.ts
@@ -117,9 +117,14 @@ export const MonitorProvider = () =>
             return yield* create(news);
           }
 
-          // Sync — the monitor exists; PATCH against its id with the
+          // Sync — the monitor exists; PUT against its id with the
           // desired props. `type` is replacement-only (handled in diff).
-          return yield* update({ ...news, id: observed.id });
+          // If the monitor disappeared between observe and update
+          // (deleted out-of-band mid-reconcile), recover by recreating
+          // instead of surfacing NotFound.
+          return yield* update({ ...news, id: observed.id }).pipe(
+            Effect.catchTag("NotFound", () => create(news)),
+          );
         }),
         delete: Effect.fn(function* ({ output }) {
           yield* del({ id: output.id }).pipe(

--- a/packages/alchemy/src/Axiom/Notifier.ts
+++ b/packages/alchemy/src/Axiom/Notifier.ts
@@ -99,10 +99,18 @@ export const NotifierProvider = () =>
             return { ...result, id: result.id ?? "" };
           }
 
-          // Sync — the notifier exists; PATCH against its id with the
+          // Sync — the notifier exists; PUT against its id with the
           // desired props. Preserve the cached id if the API response
-          // omits it.
-          const result = yield* update({ ...news, id: observed.id! });
+          // omits it. If the notifier disappeared between observe and
+          // update (deleted out-of-band mid-reconcile), recover by
+          // recreating instead of surfacing NotFound.
+          const result = yield* update({ ...news, id: observed.id! }).pipe(
+            Effect.catchTag("NotFound", () =>
+              create(news).pipe(
+                Effect.map((r) => ({ ...r, id: r.id ?? "" })),
+              ),
+            ),
+          );
           return { ...result, id: result.id ?? observed.id! };
         }),
         delete: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/test/Axiom/Monitor.test.ts
+++ b/packages/alchemy/test/Axiom/Monitor.test.ts
@@ -1,0 +1,397 @@
+import * as Axiom from "@/Axiom";
+import * as Test from "@/Test/Vitest";
+import * as AxiomSdk from "@distilled.cloud/axiom";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+
+const { test } = Test.make({ providers: Axiom.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const randomSuffix = () => Math.random().toString(36).slice(2, 8);
+
+const getMonitor = (id: string) =>
+  AxiomSdk.getMonitor({ id }).pipe(
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
+  );
+
+const assertMonitorDeleted = Effect.fn(function* (id: string) {
+  const found = yield* getMonitor(id);
+  expect(found).toBeUndefined();
+});
+
+const monitorAplFor = (datasetName: string) =>
+  `['${datasetName}'] | summarize count() by bin_auto(_time)`;
+
+test.provider(
+  "create and delete monitor with default props",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const datasetName = `alchemy-test-monitor-default-${suffix}`;
+      const monitorName = `alchemy-test-monitor-default-${suffix}`;
+
+      const monitor = yield* stack.deploy(
+        Effect.gen(function* () {
+          const ds = yield* Axiom.Dataset("DefaultDS", { name: datasetName });
+          return yield* Axiom.Monitor("DefaultMonitor", {
+            name: monitorName,
+            description: "default-test",
+            type: "Threshold",
+            aplQuery: monitorAplFor(datasetName),
+            operator: "Above",
+            threshold: 100,
+            intervalMinutes: 5,
+            rangeMinutes: 5,
+            alertOnNoData: false,
+            resolvable: true,
+            notifierIds: [],
+          });
+        }),
+      );
+
+      expect(monitor.id).toBeDefined();
+      expect(monitor.name).toEqual(monitorName);
+      expect(monitor.threshold).toEqual(100);
+
+      const observed = yield* getMonitor(monitor.id);
+      expect(observed?.name).toEqual(monitorName);
+
+      const monitorId = monitor.id;
+      yield* stack.destroy();
+      yield* assertMonitorDeleted(monitorId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "redeploy monitor with same props is a no-op (id stable)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const datasetName = `alchemy-test-monitor-idem-${suffix}`;
+      const monitorName = `alchemy-test-monitor-idem-${suffix}`;
+
+      const props = (apl: string) => ({
+        name: monitorName,
+        description: "stable",
+        type: "Threshold" as const,
+        aplQuery: apl,
+        operator: "Above" as const,
+        threshold: 50,
+        intervalMinutes: 5,
+        rangeMinutes: 5,
+        alertOnNoData: false,
+        resolvable: true,
+        notifierIds: [] as string[],
+      });
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          const ds = yield* Axiom.Dataset("IdemDS", { name: datasetName });
+          return yield* Axiom.Monitor(
+            "IdemMonitor",
+            props(monitorAplFor(datasetName)),
+          );
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          const ds = yield* Axiom.Dataset("IdemDS", { name: datasetName });
+          return yield* Axiom.Monitor(
+            "IdemMonitor",
+            props(monitorAplFor(datasetName)),
+          );
+        }),
+      );
+
+      expect(second.id).toEqual(initial.id);
+      expect(second.name).toEqual(initial.name);
+      expect(second.threshold).toEqual(50);
+
+      const monitorId = initial.id;
+      yield* stack.destroy();
+      yield* assertMonitorDeleted(monitorId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile resets monitor settings mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const datasetName = `alchemy-test-monitor-drift-${suffix}`;
+      const monitorName = `alchemy-test-monitor-drift-${suffix}`;
+
+      const desired = (apl: string) => ({
+        name: monitorName,
+        description: "managed",
+        type: "Threshold" as const,
+        aplQuery: apl,
+        operator: "Above" as const,
+        threshold: 100,
+        intervalMinutes: 5,
+        rangeMinutes: 5,
+        alertOnNoData: false,
+        resolvable: true,
+        notifierIds: [] as string[],
+      });
+
+      const monitor = yield* stack.deploy(
+        Effect.gen(function* () {
+          const ds = yield* Axiom.Dataset("DriftDS", { name: datasetName });
+          return yield* Axiom.Monitor(
+            "DriftMonitor",
+            desired(monitorAplFor(datasetName)),
+          );
+        }),
+      );
+
+      // Mutate threshold + description out-of-band.
+      yield* AxiomSdk.updateMonitor({
+        ...desired(monitorAplFor(datasetName)),
+        id: monitor.id,
+        description: "drifted",
+        threshold: 999,
+      });
+
+      const drifted = yield* getMonitor(monitor.id);
+      expect(drifted?.threshold).toEqual(999);
+      expect(drifted?.description).toEqual("drifted");
+
+      // Re-deploy with original props — reconcile must converge it back.
+      const redeployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const ds = yield* Axiom.Dataset("DriftDS", { name: datasetName });
+          return yield* Axiom.Monitor(
+            "DriftMonitor",
+            desired(monitorAplFor(datasetName)),
+          );
+        }),
+      );
+
+      expect(redeployed.id).toEqual(monitor.id);
+      const reconverged = yield* getMonitor(monitor.id);
+      expect(reconverged?.threshold).toEqual(100);
+      expect(reconverged?.description).toEqual("managed");
+
+      const monitorId = monitor.id;
+      yield* stack.destroy();
+      yield* assertMonitorDeleted(monitorId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile re-creates a monitor deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const datasetName = `alchemy-test-monitor-recreate-${suffix}`;
+      const monitorName = `alchemy-test-monitor-recreate-${suffix}`;
+
+      const desired = (apl: string) => ({
+        name: monitorName,
+        description: "recreate",
+        type: "Threshold" as const,
+        aplQuery: apl,
+        operator: "Above" as const,
+        threshold: 10,
+        intervalMinutes: 5,
+        rangeMinutes: 5,
+        alertOnNoData: false,
+        resolvable: true,
+        notifierIds: [] as string[],
+      });
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          const ds = yield* Axiom.Dataset("RecreateDS", { name: datasetName });
+          return yield* Axiom.Monitor(
+            "RecreateMonitor",
+            desired(monitorAplFor(datasetName)),
+          );
+        }),
+      );
+
+      yield* AxiomSdk.deleteMonitor({ id: initial.id });
+      yield* assertMonitorDeleted(initial.id);
+
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          const ds = yield* Axiom.Dataset("RecreateDS", { name: datasetName });
+          return yield* Axiom.Monitor(
+            "RecreateMonitor",
+            desired(monitorAplFor(datasetName)),
+          );
+        }),
+      );
+
+      // New server-assigned id since the old one is gone.
+      expect(recreated.id).toBeDefined();
+      expect(recreated.name).toEqual(monitorName);
+      const live = yield* getMonitor(recreated.id);
+      expect(live?.name).toEqual(monitorName);
+
+      const recreatedId = recreated.id;
+      yield* stack.destroy();
+      yield* assertMonitorDeleted(recreatedId);
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "changing monitor name updates in place",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const datasetName = `alchemy-test-monitor-rename-${suffix}`;
+      const nameA = `alchemy-test-monitor-rename-a-${suffix}`;
+      const nameB = `alchemy-test-monitor-rename-b-${suffix}`;
+
+      const desired = (apl: string, name: string) => ({
+        name,
+        description: "rename",
+        type: "Threshold" as const,
+        aplQuery: apl,
+        operator: "Above" as const,
+        threshold: 10,
+        intervalMinutes: 5,
+        rangeMinutes: 5,
+        alertOnNoData: false,
+        resolvable: true,
+        notifierIds: [] as string[],
+      });
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          const ds = yield* Axiom.Dataset("RenameDS", { name: datasetName });
+          return yield* Axiom.Monitor(
+            "RenameMonitor",
+            desired(monitorAplFor(datasetName), nameA),
+          );
+        }),
+      );
+      expect(a.name).toEqual(nameA);
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          const ds = yield* Axiom.Dataset("RenameDS", { name: datasetName });
+          return yield* Axiom.Monitor(
+            "RenameMonitor",
+            desired(monitorAplFor(datasetName), nameB),
+          );
+        }),
+      );
+
+      // Rename is in-place — id stays stable, server takes the new name.
+      expect(b.id).toEqual(a.id);
+      expect(b.name).toEqual(nameB);
+
+      const monitorId = b.id;
+      yield* stack.destroy();
+      yield* assertMonitorDeleted(monitorId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "changing monitor type triggers replace",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const datasetName = `alchemy-test-monitor-replace-${suffix}`;
+      const monitorName = `alchemy-test-monitor-replace-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          const ds = yield* Axiom.Dataset("ReplaceDS", { name: datasetName });
+          return yield* Axiom.Monitor("ReplaceMonitor", {
+            name: monitorName,
+            type: "Threshold",
+            aplQuery: monitorAplFor(datasetName),
+            operator: "Above",
+            threshold: 10,
+            intervalMinutes: 5,
+            rangeMinutes: 5,
+            notifierIds: [],
+          });
+        }),
+      );
+      expect(a.type).toEqual("Threshold");
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          const ds = yield* Axiom.Dataset("ReplaceDS", { name: datasetName });
+          return yield* Axiom.Monitor("ReplaceMonitor", {
+            name: monitorName,
+            type: "MatchEvent",
+            aplQuery: monitorAplFor(datasetName),
+            intervalMinutes: 1,
+            rangeMinutes: 1,
+            notifierIds: [],
+          });
+        }),
+      );
+
+      expect(b.type).toEqual("MatchEvent");
+      expect(b.id).not.toEqual(a.id);
+
+      // Old monitor (different id) is deleted as part of the replacement.
+      const oldId = a.id;
+      yield* assertMonitorDeleted(oldId);
+
+      const newId = b.id;
+      yield* stack.destroy();
+      yield* assertMonitorDeleted(newId);
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "destroying an already-deleted monitor is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const datasetName = `alchemy-test-monitor-doubledel-${suffix}`;
+      const monitorName = `alchemy-test-monitor-doubledel-${suffix}`;
+
+      const monitor = yield* stack.deploy(
+        Effect.gen(function* () {
+          const ds = yield* Axiom.Dataset("DoubleDelDS", { name: datasetName });
+          return yield* Axiom.Monitor("DoubleDelMonitor", {
+            name: monitorName,
+            type: "Threshold",
+            aplQuery: monitorAplFor(datasetName),
+            operator: "Above",
+            threshold: 1,
+            intervalMinutes: 5,
+            rangeMinutes: 5,
+            notifierIds: [],
+          });
+        }),
+      );
+
+      yield* AxiomSdk.deleteMonitor({ id: monitor.id });
+      yield* assertMonitorDeleted(monitor.id);
+
+      // Provider's delete must catch NotFound and complete cleanly.
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);

--- a/packages/alchemy/test/Axiom/Notifier.test.ts
+++ b/packages/alchemy/test/Axiom/Notifier.test.ts
@@ -1,0 +1,242 @@
+import * as Axiom from "@/Axiom";
+import * as Test from "@/Test/Vitest";
+import * as AxiomSdk from "@distilled.cloud/axiom";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+
+const { test } = Test.make({ providers: Axiom.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const randomSuffix = () => Math.random().toString(36).slice(2, 8);
+
+const getNotifier = (id: string) =>
+  AxiomSdk.getNotifier({ id }).pipe(
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
+  );
+
+const assertNotifierDeleted = Effect.fn(function* (id: string) {
+  const found = yield* getNotifier(id);
+  expect(found).toBeUndefined();
+});
+
+test.provider(
+  "create and delete notifier with default props",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const notifierName = `alchemy-test-notifier-default-${randomSuffix()}`;
+
+      const notifier = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Notifier("DefaultNotifier", {
+            name: notifierName,
+            properties: {
+              email: { emails: ["alchemy-test@example.com"] },
+            },
+          });
+        }),
+      );
+
+      expect(notifier.id).toBeDefined();
+      expect(notifier.name).toEqual(notifierName);
+
+      const observed = yield* getNotifier(notifier.id);
+      expect(observed?.name).toEqual(notifierName);
+
+      const notifierId = notifier.id;
+      yield* stack.destroy();
+      yield* assertNotifierDeleted(notifierId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "redeploy notifier with same props is a no-op (id stable)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const notifierName = `alchemy-test-notifier-idem-${randomSuffix()}`;
+      const props = {
+        name: notifierName,
+        properties: {
+          email: { emails: ["a@example.com", "b@example.com"] },
+        },
+      };
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Notifier("IdemNotifier", props);
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Notifier("IdemNotifier", props);
+        }),
+      );
+
+      expect(second.id).toEqual(initial.id);
+      expect(second.name).toEqual(initial.name);
+
+      const notifierId = initial.id;
+      yield* stack.destroy();
+      yield* assertNotifierDeleted(notifierId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile resets notifier settings mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const notifierName = `alchemy-test-notifier-drift-${randomSuffix()}`;
+      const desired = {
+        name: notifierName,
+        properties: {
+          email: { emails: ["managed@example.com"] },
+        },
+      };
+
+      const notifier = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Notifier("DriftNotifier", desired);
+        }),
+      );
+
+      // Mutate emails out-of-band.
+      yield* AxiomSdk.updateNotifier({
+        id: notifier.id,
+        name: notifierName,
+        properties: { email: { emails: ["drifted@example.com"] } },
+      });
+
+      const drifted = yield* getNotifier(notifier.id);
+      expect(drifted?.properties.email?.emails).toEqual(["drifted@example.com"]);
+
+      const redeployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Notifier("DriftNotifier", desired);
+        }),
+      );
+
+      expect(redeployed.id).toEqual(notifier.id);
+      const reconverged = yield* getNotifier(notifier.id);
+      expect(reconverged?.properties.email?.emails).toEqual([
+        "managed@example.com",
+      ]);
+
+      const notifierId = notifier.id;
+      yield* stack.destroy();
+      yield* assertNotifierDeleted(notifierId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile re-creates a notifier deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const notifierName = `alchemy-test-notifier-recreate-${randomSuffix()}`;
+      const desired = {
+        name: notifierName,
+        properties: {
+          email: { emails: ["x@example.com"] },
+        },
+      };
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Notifier("RecreateNotifier", desired);
+        }),
+      );
+
+      yield* AxiomSdk.deleteNotifier({ id: initial.id });
+      yield* assertNotifierDeleted(initial.id);
+
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Notifier("RecreateNotifier", desired);
+        }),
+      );
+
+      expect(recreated.name).toEqual(notifierName);
+      const live = yield* getNotifier(recreated.id);
+      expect(live?.name).toEqual(notifierName);
+
+      const recreatedId = recreated.id;
+      yield* stack.destroy();
+      yield* assertNotifierDeleted(recreatedId);
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "changing notifier name updates in place",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const nameA = `alchemy-test-notifier-rename-a-${suffix}`;
+      const nameB = `alchemy-test-notifier-rename-b-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Notifier("RenameNotifier", {
+            name: nameA,
+            properties: { email: { emails: ["a@example.com"] } },
+          });
+        }),
+      );
+      expect(a.name).toEqual(nameA);
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Notifier("RenameNotifier", {
+            name: nameB,
+            properties: { email: { emails: ["a@example.com"] } },
+          });
+        }),
+      );
+
+      // In-place rename — id stays stable.
+      expect(b.id).toEqual(a.id);
+      expect(b.name).toEqual(nameB);
+
+      const notifierId = b.id;
+      yield* stack.destroy();
+      yield* assertNotifierDeleted(notifierId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "destroying an already-deleted notifier is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const notifierName = `alchemy-test-notifier-doubledel-${randomSuffix()}`;
+
+      const notifier = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Notifier("DoubleDelNotifier", {
+            name: notifierName,
+            properties: { email: { emails: ["x@example.com"] } },
+          });
+        }),
+      );
+
+      yield* AxiomSdk.deleteNotifier({ id: notifier.id });
+      yield* assertNotifierDeleted(notifier.id);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);


### PR DESCRIPTION
Hardens the Axiom Monitor and Notifier reconcile paths the same way [#184](https://github.com/alchemy-run/alchemy-effect/pull/184) (SQS) and [#197](https://github.com/alchemy-run/alchemy-effect/pull/197) (Axiom Dataset) did for their resources.

### Reconciler changes

`updateMonitor` and `updateNotifier` both declare `NotFound` as an error — if a peer reconciler / human deletes the resource between our `get` and our `update`, the engine would surface a hard failure instead of converging. Catch `NotFound` and re-create.

```diff
- return yield* update({ ...news, id: observed.id });
+ return yield* update({ ...news, id: observed.id }).pipe(
+   Effect.catchTag("NotFound", () => create(news)),
+ );
```

```diff
- const result = yield* update({ ...news, id: observed.id! });
+ const result = yield* update({ ...news, id: observed.id! }).pipe(
+   Effect.catchTag("NotFound", () =>
+     create(news).pipe(Effect.map((r) => ({ ...r, id: r.id ?? "" }))),
+   ),
+ );
```

### New lifecycle tests

Each test runs `destroy -> deploy -> ... -> destroy` on a `ScratchStack` and asserts convergence at every step.

For Monitor:
- redeploy with same props is a no-op (id stable)
- reconcile resets `threshold` / `description` mutated out-of-band via `AxiomSdk.updateMonitor`
- reconcile re-creates a monitor deleted out-of-band via `AxiomSdk.deleteMonitor`
- changing `name` updates in place (id stays stable)
- changing `type` triggers replace; old monitor id is gone
- destroying an already-deleted monitor is a no-op (delete catches `NotFound`)

For Notifier:
- redeploy with same props is a no-op (id stable)
- reconcile resets `properties.email.emails` mutated out-of-band via `AxiomSdk.updateNotifier`
- reconcile re-creates a notifier deleted out-of-band via `AxiomSdk.deleteNotifier`
- changing `name` updates in place
- destroying an already-deleted notifier is a no-op

`adopt(true)` re-claim is intentionally omitted: Monitor / Notifier identifiers are server-assigned with no name uniqueness or ownership marker, so after a state wipe the engine has no way to discover the prior cloud resource by logical id — adoption is N/A for these resources today.

### Distilled patch

No patch needed. The Axiom client already routes HTTP status to typed errors via `HTTP_STATUS_MAP` and `updateMonitor` / `updateNotifier` already declare `NotFound` in their error channel; the reconciler change is purely about catching the right shape alchemy-side.
