### PR TITLE
fix(github): harden Variable + Comment reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/GitHub/Comment.ts
+++ b/packages/alchemy/src/GitHub/Comment.ts
@@ -1,5 +1,6 @@
 import { Octokit } from "@octokit/rest";
 import * as Effect from "effect/Effect";
+import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
 import { dedent } from "../Util/dedent.ts";
@@ -163,6 +164,21 @@ export const CommentProvider = () =>
   Provider.succeed(Comment, {
     stables: ["commentId"],
 
+    // The `(owner, repository, issueNumber)` tuple identifies the
+    // host issue/PR. A comment can't be moved between issues — change
+    // any of them and we must replace.
+    diff: Effect.fn(function* ({ news, olds }) {
+      if (!isResolved(news)) return undefined;
+      if (
+        news.owner !== olds.owner ||
+        news.repository !== olds.repository ||
+        news.issueNumber !== olds.issueNumber
+      ) {
+        return { action: "replace" } as const;
+      }
+      return undefined;
+    }),
+
     reconcile: Effect.fn(function* ({ news, output }) {
       const octokit = createClient(news);
       const body = dedent(news.body);
@@ -171,7 +187,7 @@ export const CommentProvider = () =>
       // state via the cached id; a 404 (deleted out-of-band, or never
       // created) collapses to "no observed comment" so we converge by
       // posting a fresh one.
-      const observedId = output?.commentId
+      const observed = output?.commentId
         ? yield* Effect.tryPromise({
             try: async () => {
               try {
@@ -180,7 +196,12 @@ export const CommentProvider = () =>
                   repo: news.repository,
                   comment_id: output.commentId,
                 });
-                return data.id;
+                return {
+                  id: data.id,
+                  body: data.body ?? "",
+                  htmlUrl: data.html_url,
+                  updatedAt: data.updated_at,
+                };
               } catch (error: any) {
                 if (error.status === 404) return undefined;
                 throw error;
@@ -191,7 +212,7 @@ export const CommentProvider = () =>
         : undefined;
 
       // Ensure — when no live comment exists, POST creates one.
-      if (observedId === undefined) {
+      if (observed === undefined) {
         const { data } = yield* Effect.tryPromise(() =>
           octokit.rest.issues.createComment({
             owner: news.owner,
@@ -207,21 +228,28 @@ export const CommentProvider = () =>
         };
       }
 
-      // Sync — PATCH the existing comment with the desired body. GitHub's
-      // updateComment is idempotent for identical bodies (returns same
-      // updatedAt), so we always issue the call rather than diffing.
-      const { data } = yield* Effect.tryPromise(() =>
-        octokit.rest.issues.updateComment({
-          owner: news.owner,
-          repo: news.repository,
-          comment_id: observedId,
-          body,
-        }),
-      );
+      // Sync — PATCH the existing comment only when the observed body
+      // drifted from desired. Skipping the call on no-op keeps redeploys
+      // with unchanged props quiet and preserves the prior `updatedAt`.
+      if (observed.body !== body) {
+        const { data } = yield* Effect.tryPromise(() =>
+          octokit.rest.issues.updateComment({
+            owner: news.owner,
+            repo: news.repository,
+            comment_id: observed.id,
+            body,
+          }),
+        );
+        return {
+          commentId: data.id,
+          htmlUrl: data.html_url,
+          updatedAt: data.updated_at,
+        };
+      }
       return {
-        commentId: data.id,
-        htmlUrl: data.html_url,
-        updatedAt: data.updated_at,
+        commentId: observed.id,
+        htmlUrl: observed.htmlUrl,
+        updatedAt: observed.updatedAt,
       };
     }),
 
@@ -232,6 +260,8 @@ export const CommentProvider = () =>
 
       const octokit = createClient(olds);
 
+      // Idempotent delete: 404 = already gone (deleted in the GitHub UI
+      // or by another process), which matches the desired terminal state.
       yield* Effect.tryPromise(async () => {
         try {
           await octokit.rest.issues.deleteComment({

--- a/packages/alchemy/src/GitHub/Variable.ts
+++ b/packages/alchemy/src/GitHub/Variable.ts
@@ -1,4 +1,5 @@
 import * as Effect from "effect/Effect";
+import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
 import { GitHubCredentials } from "./Credentials.ts";
@@ -109,7 +110,22 @@ const getOctokit = Effect.gen(function* () {
 
 export const VariableProvider = () =>
   Provider.succeed(Variable, {
-    reconcile: Effect.fn(function* ({ news }) {
+    // `(owner, repository, name)` is the GitHub-side identifier for a
+    // repo variable. Mutating any of them isn't an in-place rename —
+    // GitHub will refuse, so the engine must replace.
+    diff: Effect.fn(function* ({ news, olds }) {
+      if (!isResolved(news)) return undefined;
+      if (
+        news.owner !== olds.owner ||
+        news.repository !== olds.repository ||
+        news.name !== olds.name
+      ) {
+        return { action: "replace" } as const;
+      }
+      return undefined;
+    }),
+
+    reconcile: Effect.fn(function* ({ news, output }) {
       const octokit = yield* getOctokit;
 
       // Observe — `name` is the path identifier for repo variables; ask
@@ -133,22 +149,40 @@ export const VariableProvider = () =>
         catch: (e) => e as Error,
       });
 
-      // Ensure — POST creates the variable.
+      // Ensure — POST creates the variable. Tolerate a 422 race: another
+      // caller (or a concurrent reconcile) may have created the variable
+      // between our observe and ensure; in that case we fall through to
+      // the sync step below to make the value match.
       if (observed === undefined) {
-        yield* Effect.tryPromise(() =>
-          octokit.rest.actions.createRepoVariable({
-            owner: news.owner,
-            repo: news.repository,
-            name: news.name,
-            value: news.value,
-          }),
-        );
-        return { updatedAt: new Date().toISOString() };
+        const created = yield* Effect.tryPromise({
+          try: async () => {
+            try {
+              await octokit.rest.actions.createRepoVariable({
+                owner: news.owner,
+                repo: news.repository,
+                name: news.name,
+                value: news.value,
+              });
+              return true as const;
+            } catch (error: any) {
+              // 422 = "variable already exists" race. Anything else is
+              // a real error (auth, validation on name format, …).
+              if (error.status === 422) return false as const;
+              throw error;
+            }
+          },
+          catch: (e) => e as Error,
+        });
+        if (created) {
+          return { updatedAt: new Date().toISOString() };
+        }
       }
 
-      // Sync — PATCH the value if it drifted; skip the call when the
-      // observed value already matches to keep the API quiet.
-      if (observed.value !== news.value) {
+      // Sync — PATCH the value when the observed cloud value drifted
+      // from desired (or when we just lost the create race above). Skip
+      // the API call on a no-op so the timestamp doesn't churn — this
+      // keeps redeploys with the same props as a true no-op.
+      if (observed === undefined || observed.value !== news.value) {
         yield* Effect.tryPromise(() =>
           octokit.rest.actions.updateRepoVariable({
             owner: news.owner,
@@ -157,13 +191,21 @@ export const VariableProvider = () =>
             value: news.value,
           }),
         );
+        return { updatedAt: new Date().toISOString() };
       }
-      return { updatedAt: new Date().toISOString() };
+      // Observed value already matches — preserve prior timestamp so
+      // a redeploy with unchanged props is a true no-op for downstream
+      // consumers reading `updatedAt`.
+      return {
+        updatedAt: output?.updatedAt ?? new Date().toISOString(),
+      };
     }),
 
     delete: Effect.fn(function* ({ olds }) {
       const octokit = yield* getOctokit;
 
+      // Idempotent delete: 404 = already gone (deleted out-of-band or
+      // never created), which is the desired terminal state.
       yield* Effect.tryPromise(async () => {
         try {
           await octokit.rest.actions.deleteRepoVariable({

--- a/packages/alchemy/test/GitHub/Comment.test.ts
+++ b/packages/alchemy/test/GitHub/Comment.test.ts
@@ -1,0 +1,246 @@
+import { Octokit } from "@octokit/rest";
+import * as GitHub from "@/GitHub";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+const TEST_OWNER = process.env.GITHUB_TEST_OWNER;
+const TEST_REPO = process.env.GITHUB_TEST_REPO;
+const TEST_ISSUE = process.env.GITHUB_TEST_ISSUE_NUMBER
+  ? Number(process.env.GITHUB_TEST_ISSUE_NUMBER)
+  : undefined;
+const TEST_ISSUE_2 = process.env.GITHUB_TEST_ISSUE_NUMBER_2
+  ? Number(process.env.GITHUB_TEST_ISSUE_NUMBER_2)
+  : undefined;
+const TEST_TOKEN =
+  process.env.GITHUB_ACCESS_TOKEN ?? process.env.GITHUB_TOKEN;
+
+const skip = !TEST_OWNER || !TEST_REPO || !TEST_ISSUE || !TEST_TOKEN;
+const skipReplace = skip || !TEST_ISSUE_2;
+
+const { test } = Test.make({ providers: GitHub.providers() });
+
+const octokit = () => new Octokit({ auth: TEST_TOKEN });
+
+const tag = (suffix: string) =>
+  `<!-- alchemy-test ${suffix} ${Math.random()
+    .toString(36)
+    .slice(2, 8)} -->`;
+
+const readComment = (commentId: number) =>
+  Effect.tryPromise(async () => {
+    try {
+      const { data } = await octokit().rest.issues.getComment({
+        owner: TEST_OWNER!,
+        repo: TEST_REPO!,
+        comment_id: commentId,
+      });
+      return data;
+    } catch (e: any) {
+      if (e.status === 404) return undefined;
+      throw e;
+    }
+  });
+
+const deleteComment = (commentId: number) =>
+  Effect.tryPromise(async () => {
+    try {
+      await octokit().rest.issues.deleteComment({
+        owner: TEST_OWNER!,
+        repo: TEST_REPO!,
+        comment_id: commentId,
+      });
+    } catch (e: any) {
+      if (e.status !== 404) throw e;
+    }
+  });
+
+test.provider.skipIf(skip)(
+  "redeploy with same props is a no-op (updatedAt preserved)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const body = `${tag("noop")} hello`;
+
+      const first = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Comment("C", {
+            owner: TEST_OWNER!,
+            repository: TEST_REPO!,
+            issueNumber: TEST_ISSUE!,
+            body,
+            allowDelete: true,
+          });
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Comment("C", {
+            owner: TEST_OWNER!,
+            repository: TEST_REPO!,
+            issueNumber: TEST_ISSUE!,
+            body,
+            allowDelete: true,
+          });
+        }),
+      );
+      expect(second.commentId).toEqual(first.commentId);
+      expect(second.updatedAt).toEqual(first.updatedAt);
+
+      yield* stack.destroy();
+      const after = yield* readComment(first.commentId);
+      expect(after).toBeUndefined();
+    }),
+);
+
+test.provider.skipIf(skip)(
+  "reconcile resets body mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const marker = tag("drift");
+      const desired = `${marker} desired`;
+
+      const c = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Comment("C", {
+            owner: TEST_OWNER!,
+            repository: TEST_REPO!,
+            issueNumber: TEST_ISSUE!,
+            body: desired,
+            allowDelete: true,
+          });
+        }),
+      );
+
+      // Mutate out-of-band.
+      yield* Effect.tryPromise(() =>
+        octokit().rest.issues.updateComment({
+          owner: TEST_OWNER!,
+          repo: TEST_REPO!,
+          comment_id: c.commentId,
+          body: `${marker} drifted`,
+        }),
+      );
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Comment("C", {
+            owner: TEST_OWNER!,
+            repository: TEST_REPO!,
+            issueNumber: TEST_ISSUE!,
+            body: desired,
+            allowDelete: true,
+          });
+        }),
+      );
+
+      const observed = yield* readComment(c.commentId);
+      expect(observed?.body).toContain("desired");
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(skip)(
+  "reconcile re-creates a comment deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const body = `${tag("recreate")} hello`;
+
+      const first = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Comment("C", {
+            owner: TEST_OWNER!,
+            repository: TEST_REPO!,
+            issueNumber: TEST_ISSUE!,
+            body,
+            allowDelete: true,
+          });
+        }),
+      );
+      yield* deleteComment(first.commentId);
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Comment("C", {
+            owner: TEST_OWNER!,
+            repository: TEST_REPO!,
+            issueNumber: TEST_ISSUE!,
+            body,
+            allowDelete: true,
+          });
+        }),
+      );
+      expect(second.commentId).not.toEqual(first.commentId);
+      const observed = yield* readComment(second.commentId);
+      expect(observed?.id).toEqual(second.commentId);
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(skipReplace)(
+  "changing issueNumber (target) triggers replace",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const body = `${tag("replace")} hello`;
+
+      const first = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Comment("C", {
+            owner: TEST_OWNER!,
+            repository: TEST_REPO!,
+            issueNumber: TEST_ISSUE!,
+            body,
+            allowDelete: true,
+          });
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Comment("C", {
+            owner: TEST_OWNER!,
+            repository: TEST_REPO!,
+            issueNumber: TEST_ISSUE_2!,
+            body,
+            allowDelete: true,
+          });
+        }),
+      );
+      expect(second.commentId).not.toEqual(first.commentId);
+      // Old comment was destroyed as part of replace.
+      const oldCheck = yield* readComment(first.commentId);
+      expect(oldCheck).toBeUndefined();
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(skip)(
+  "destroying an already-deleted comment is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const body = `${tag("gone")} hello`;
+
+      const c = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Comment("C", {
+            owner: TEST_OWNER!,
+            repository: TEST_REPO!,
+            issueNumber: TEST_ISSUE!,
+            body,
+            allowDelete: true,
+          });
+        }),
+      );
+
+      yield* deleteComment(c.commentId);
+      yield* stack.destroy();
+    }),
+);

--- a/packages/alchemy/test/GitHub/Variable.test.ts
+++ b/packages/alchemy/test/GitHub/Variable.test.ts
@@ -1,0 +1,302 @@
+import { Octokit } from "@octokit/rest";
+import { adopt } from "@/AdoptPolicy";
+import * as GitHub from "@/GitHub";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+const TEST_OWNER = process.env.GITHUB_TEST_OWNER;
+const TEST_REPO = process.env.GITHUB_TEST_REPO;
+const TEST_TOKEN =
+  process.env.GITHUB_ACCESS_TOKEN ?? process.env.GITHUB_TOKEN;
+
+const skip = !TEST_OWNER || !TEST_REPO || !TEST_TOKEN;
+
+const { test } = Test.make({ providers: GitHub.providers() });
+
+const octokit = () => new Octokit({ auth: TEST_TOKEN });
+
+const variableName = (suffix: string) =>
+  `ALCHEMY_TEST_VAR_${suffix.replace(/[^A-Z0-9_]/gi, "_").toUpperCase()}`;
+
+const cleanupVariable = Effect.fn(function* (name: string) {
+  yield* Effect.tryPromise(async () => {
+    try {
+      await octokit().rest.actions.deleteRepoVariable({
+        owner: TEST_OWNER!,
+        repo: TEST_REPO!,
+        name,
+      });
+    } catch (e: any) {
+      if (e.status !== 404) throw e;
+    }
+  });
+});
+
+const readVariable = (name: string) =>
+  Effect.tryPromise(async () => {
+    try {
+      const { data } = await octokit().rest.actions.getRepoVariable({
+        owner: TEST_OWNER!,
+        repo: TEST_REPO!,
+        name,
+      });
+      return data;
+    } catch (e: any) {
+      if (e.status === 404) return undefined;
+      throw e;
+    }
+  });
+
+test.provider.skipIf(skip)(
+  "redeploy with same props is a no-op (updatedAt preserved)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const name = variableName(
+        `noop_${Math.random().toString(36).slice(2, 8)}`,
+      );
+      yield* cleanupVariable(name);
+
+      const first = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Variable("Var", {
+            owner: TEST_OWNER!,
+            repository: TEST_REPO!,
+            name,
+            value: "v1",
+          });
+        }),
+      );
+      // Tiny delay so `updatedAt` would change if we hit the API again.
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Variable("Var", {
+            owner: TEST_OWNER!,
+            repository: TEST_REPO!,
+            name,
+            value: "v1",
+          });
+        }),
+      );
+      expect(second.updatedAt).toEqual(first.updatedAt);
+
+      yield* stack.destroy();
+      const after = yield* readVariable(name);
+      expect(after).toBeUndefined();
+    }),
+);
+
+test.provider.skipIf(skip)(
+  "reconcile resets value mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const name = variableName(
+        `drift_${Math.random().toString(36).slice(2, 8)}`,
+      );
+      yield* cleanupVariable(name);
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Variable("Var", {
+            owner: TEST_OWNER!,
+            repository: TEST_REPO!,
+            name,
+            value: "desired",
+          });
+        }),
+      );
+
+      // Mutate out-of-band via the raw SDK.
+      yield* Effect.tryPromise(() =>
+        octokit().rest.actions.updateRepoVariable({
+          owner: TEST_OWNER!,
+          repo: TEST_REPO!,
+          name,
+          value: "drifted",
+        }),
+      );
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Variable("Var", {
+            owner: TEST_OWNER!,
+            repository: TEST_REPO!,
+            name,
+            value: "desired",
+          });
+        }),
+      );
+
+      const observed = yield* readVariable(name);
+      expect(observed?.value).toEqual("desired");
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(skip)(
+  "reconcile re-creates a variable deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const name = variableName(
+        `recreate_${Math.random().toString(36).slice(2, 8)}`,
+      );
+      yield* cleanupVariable(name);
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Variable("Var", {
+            owner: TEST_OWNER!,
+            repository: TEST_REPO!,
+            name,
+            value: "v1",
+          });
+        }),
+      );
+
+      // Delete out-of-band.
+      yield* cleanupVariable(name);
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Variable("Var", {
+            owner: TEST_OWNER!,
+            repository: TEST_REPO!,
+            name,
+            value: "v2",
+          });
+        }),
+      );
+
+      const observed = yield* readVariable(name);
+      expect(observed?.value).toEqual("v2");
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(skip)(
+  "changing variable name triggers replace (old deleted, new created)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const oldName = variableName(
+        `old_${Math.random().toString(36).slice(2, 8)}`,
+      );
+      const newName = variableName(
+        `new_${Math.random().toString(36).slice(2, 8)}`,
+      );
+      yield* cleanupVariable(oldName);
+      yield* cleanupVariable(newName);
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Variable("Var", {
+            owner: TEST_OWNER!,
+            repository: TEST_REPO!,
+            name: oldName,
+            value: "v",
+          });
+        }),
+      );
+      expect((yield* readVariable(oldName))?.value).toEqual("v");
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Variable("Var", {
+            owner: TEST_OWNER!,
+            repository: TEST_REPO!,
+            name: newName,
+            value: "v",
+          });
+        }),
+      );
+
+      expect(yield* readVariable(oldName)).toBeUndefined();
+      expect((yield* readVariable(newName))?.value).toEqual("v");
+
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(skip)(
+  "destroying an already-deleted variable is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const name = variableName(
+        `gone_${Math.random().toString(36).slice(2, 8)}`,
+      );
+      yield* cleanupVariable(name);
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Variable("Var", {
+            owner: TEST_OWNER!,
+            repository: TEST_REPO!,
+            name,
+            value: "v",
+          });
+        }),
+      );
+
+      // Delete out-of-band, then ask the engine to destroy.
+      yield* cleanupVariable(name);
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(skip)(
+  "adopt(true) re-claims a foreign variable",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const name = variableName(
+        `adopt_${Math.random().toString(36).slice(2, 8)}`,
+      );
+      yield* cleanupVariable(name);
+
+      // Create a foreign variable directly via the SDK.
+      yield* Effect.tryPromise(() =>
+        octokit().rest.actions.createRepoVariable({
+          owner: TEST_OWNER!,
+          repo: TEST_REPO!,
+          name,
+          value: "foreign",
+        }),
+      );
+
+      const adopted = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* GitHub.Variable("Var", {
+              owner: TEST_OWNER!,
+              repository: TEST_REPO!,
+              name,
+              value: "owned",
+            });
+          }),
+        )
+        .pipe(adopt(true));
+      expect(adopted.updatedAt).toBeDefined();
+
+      const observed = yield* readVariable(name);
+      expect(observed?.value).toEqual("owned");
+
+      // Wipe state — variable stays in GitHub.
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "Var",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      yield* cleanupVariable(name);
+    }),
+);


### PR DESCRIPTION
Hardens the GitHub `Variable` and `Comment` resources, mirroring the per-resource sweep started in #184. Single GitHub scope; `Secret` is being hardened separately.

### Reconciler changes

`Variable` — tolerate the create race and skip the PATCH on a true no-op so `updatedAt` doesn't churn:

```diff
- yield* Effect.tryPromise(() => octokit.rest.actions.createRepoVariable({ … }));
- return { updatedAt: new Date().toISOString() };
+ const created = yield* Effect.tryPromise({
+   try: async () => {
+     try { await octokit.rest.actions.createRepoVariable({ … }); return true; }
+     catch (e: any) { if (e.status === 422) return false; throw e; }
+   },
+   catch: (e) => e as Error,
+ });
+ if (created) return { updatedAt: new Date().toISOString() };
+ // … fall through to the PATCH path below
```

```diff
- if (observed.value !== news.value) { /* PATCH */ }
- return { updatedAt: new Date().toISOString() };
+ if (observed === undefined || observed.value !== news.value) {
+   /* PATCH */ ; return { updatedAt: new Date().toISOString() };
+ }
+ return { updatedAt: output?.updatedAt ?? new Date().toISOString() };
```

`Comment` — only PATCH when the observed body drifts from desired (instead of always issuing the call), so a redeploy with the same `body` is a true no-op:

```diff
- // always PATCH (idempotent on the server, but churns updatedAt)
- const { data } = yield* Effect.tryPromise(() => octokit.rest.issues.updateComment({ … }));
+ if (observed.body !== body) {
+   const { data } = yield* Effect.tryPromise(() => octokit.rest.issues.updateComment({ … }));
+   return { commentId: data.id, htmlUrl: data.html_url, updatedAt: data.updated_at };
+ }
+ return { commentId: observed.id, htmlUrl: observed.htmlUrl, updatedAt: observed.updatedAt };
```

Both resources gain a `diff` that triggers `replace` when the GitHub-side identity changes — `(owner, repository, name)` for `Variable`, `(owner, repository, issueNumber)` for `Comment`. Previously a name/target change would silently create a second resource and orphan the old one.

```ts
diff: Effect.fn(function* ({ news, olds }) {
  if (!isResolved(news)) return undefined;
  if (
    news.owner !== olds.owner ||
    news.repository !== olds.repository ||
    news.name !== olds.name // issueNumber for Comment
  ) {
    return { action: "replace" } as const;
  }
  return undefined;
}),
```

### New lifecycle tests

Each test runs `destroy → deploy → … → destroy` on a `ScratchStack` and asserts convergence at every step. Gated on `GITHUB_TEST_OWNER` / `GITHUB_TEST_REPO` / `GITHUB_TEST_ISSUE_NUMBER` (+ `GITHUB_TEST_ISSUE_NUMBER_2` for the Comment replace test); skipped otherwise.

`Variable`:

- redeploy with same props is a no-op (`updatedAt` preserved)
- reconcile resets a value mutated out-of-band via the raw Octokit SDK
- reconcile re-creates a variable deleted out-of-band
- changing `name` triggers replace; old variable is deleted
- destroying an already-deleted variable is a no-op
- `adopt(true)` re-claims a foreign variable

`Comment`:

- redeploy with same props is a no-op (`commentId` and `updatedAt` preserved)
- reconcile resets a body mutated out-of-band
- reconcile re-creates a comment deleted out-of-band (new `commentId`)
- changing `issueNumber` triggers replace
- destroying an already-deleted comment is a no-op
