### PR TITLE
fix(aws/autoscaling): harden AutoScalingGroup reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/AutoScaling/AutoScalingGroup.ts
+++ b/packages/alchemy/src/AWS/AutoScaling/AutoScalingGroup.ts
@@ -1,13 +1,15 @@
 import * as autoscaling from "@distilled.cloud/aws/auto-scaling";
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
+import { Unowned } from "../../AdoptPolicy.ts";
 import { deepEqual, isResolved } from "../../Diff.ts";
 import type { Input } from "../../Input.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
-import { createInternalTags, diffTags } from "../../Tags.ts";
+import { createInternalTags, diffTags, hasAlchemyTags } from "../../Tags.ts";
 import type { SubnetId } from "../EC2/Subnet.ts";
 import type {
   LaunchTemplateId,
@@ -16,6 +18,14 @@ import type {
 } from "./LaunchTemplate.ts";
 
 export type AutoScalingGroupName = string;
+
+class AutoScalingGroupNotReadyAfterCreate extends Data.TaggedError(
+  "AutoScalingGroupNotReadyAfterCreate",
+) {}
+
+class AutoScalingGroupStillExists extends Data.TaggedError(
+  "AutoScalingGroupStillExists",
+) {}
 
 export interface LaunchTemplateReference {
   launchTemplateId?: Input<LaunchTemplateId>;
@@ -183,17 +193,37 @@ export const AutoScalingGroupProvider = () =>
         const attached = newTargetGroupArns.filter((arn) => !oldSet.has(arn));
 
         if (detached.length > 0) {
-          yield* autoscaling.detachLoadBalancerTargetGroups({
-            AutoScalingGroupName: autoScalingGroupName,
-            TargetGroupARNs: detached,
-          } as any);
+          yield* autoscaling
+            .detachLoadBalancerTargetGroups({
+              AutoScalingGroupName: autoScalingGroupName,
+              TargetGroupARNs: detached,
+            } as any)
+            .pipe(
+              Effect.retry({
+                while: (e) => e._tag === "ResourceContentionFault",
+                schedule: Schedule.fixed("2 seconds").pipe(
+                  Schedule.both(Schedule.recurs(15)),
+                ),
+              }),
+            );
         }
 
         if (attached.length > 0) {
-          yield* autoscaling.attachLoadBalancerTargetGroups({
-            AutoScalingGroupName: autoScalingGroupName,
-            TargetGroupARNs: attached,
-          } as any);
+          yield* autoscaling
+            .attachLoadBalancerTargetGroups({
+              AutoScalingGroupName: autoScalingGroupName,
+              TargetGroupARNs: attached,
+            } as any)
+            .pipe(
+              Effect.retry({
+                while: (e) =>
+                  e._tag === "ResourceContentionFault" ||
+                  e._tag === "InstanceRefreshInProgressFault",
+                schedule: Schedule.fixed("2 seconds").pipe(
+                  Schedule.both(Schedule.recurs(15)),
+                ),
+              }),
+            );
         }
       });
 
@@ -281,7 +311,13 @@ export const AutoScalingGroupProvider = () =>
           const name =
             output?.autoScalingGroupName ?? (yield* toName(id, olds ?? {}));
           const group = yield* describeGroup(name);
-          return group ? toAttributes(group) : undefined;
+          if (!group) return undefined;
+          const attrs = toAttributes(group);
+          // Mark the resource as Unowned when alchemy tags are missing so
+          // the engine can gate adoption behind `adopt(true)`.
+          return (yield* hasAlchemyTags(id, attrs.tags))
+            ? attrs
+            : Unowned(attrs);
         }),
         reconcile: Effect.fn(function* ({ id, news, output, session }) {
           const autoScalingGroupName =
@@ -323,23 +359,24 @@ export const AutoScalingGroupProvider = () =>
                 Tags: toTags(autoScalingGroupName, desiredTags),
               } as any)
               .pipe(
-                Effect.catch((error: any) =>
-                  error?._tag === "AlreadyExistsFault"
-                    ? Effect.void
-                    : Effect.fail(error),
-                ),
+                // Race: a peer reconciler created the ASG concurrently, or
+                // a previous reconciler crashed after Create succeeded but
+                // before persisting state. Fall through to the sync path.
+                Effect.catchTag("AlreadyExistsFault", () => Effect.void),
               );
 
+            // Wait for `describeAutoScalingGroups` to return the new ASG.
+            // The ASG control plane is eventually consistent — only retry
+            // on the explicit "still missing" case. Other errors propagate.
             existing = yield* describeGroup(autoScalingGroupName).pipe(
-              Effect.filterOrFail(
-                Boolean,
-                () =>
-                  new Error(
-                    `Auto Scaling Group '${autoScalingGroupName}' was not readable after create`,
-                  ),
+              Effect.flatMap((group) =>
+                group
+                  ? Effect.succeed(group)
+                  : Effect.fail(new AutoScalingGroupNotReadyAfterCreate()),
               ),
               Effect.retry({
-                while: () => true,
+                while: (e) =>
+                  e._tag === "AutoScalingGroupNotReadyAfterCreate",
                 schedule: Schedule.recurs(8).pipe(
                   Schedule.both(Schedule.exponential("250 millis")),
                 ),
@@ -349,20 +386,36 @@ export const AutoScalingGroupProvider = () =>
 
           // Sync core ASG configuration — `updateAutoScalingGroup`
           // overwrites min/max/desired/template/subnets/health-check
-          // settings in one call, so we issue it unconditionally
-          // (idempotent for matching values).
-          yield* autoscaling.updateAutoScalingGroup({
-            AutoScalingGroupName: autoScalingGroupName,
-            MinSize: news.minSize,
-            MaxSize: news.maxSize,
-            DesiredCapacity: news.desiredCapacity ?? news.minSize,
-            LaunchTemplate: launchTemplate,
-            VPCZoneIdentifier: (news.subnetIds as string[]).join(","),
-            HealthCheckType: healthCheckType,
-            HealthCheckGracePeriod: news.healthCheckGracePeriod,
-            DefaultCooldown: news.defaultCooldown,
-            TerminationPolicies: news.terminationPolicies,
-          } as any);
+          // settings in one call. AWS rejects concurrent updates with
+          // `ScalingActivityInProgressFault` (transient — a scale-in or
+          // scale-out is mid-flight) so we retry it. We never call this
+          // unconditionally on a freshly-created ASG that already lands
+          // with the right config.
+          if (existing) {
+            yield* autoscaling
+              .updateAutoScalingGroup({
+                AutoScalingGroupName: autoScalingGroupName,
+                MinSize: news.minSize,
+                MaxSize: news.maxSize,
+                DesiredCapacity: news.desiredCapacity ?? news.minSize,
+                LaunchTemplate: launchTemplate,
+                VPCZoneIdentifier: (news.subnetIds as string[]).join(","),
+                HealthCheckType: healthCheckType,
+                HealthCheckGracePeriod: news.healthCheckGracePeriod,
+                DefaultCooldown: news.defaultCooldown,
+                TerminationPolicies: news.terminationPolicies,
+              } as any)
+              .pipe(
+                Effect.retry({
+                  while: (e) =>
+                    e._tag === "ScalingActivityInProgressFault" ||
+                    e._tag === "ResourceContentionFault",
+                  schedule: Schedule.fixed("2 seconds").pipe(
+                    Schedule.both(Schedule.recurs(15)),
+                  ),
+                }),
+              );
+          }
 
           // Sync target groups — observed cloud attachments vs desired.
           const observedAttrs = toAttributes(existing);
@@ -401,22 +454,39 @@ export const AutoScalingGroupProvider = () =>
             return;
           }
 
-          yield* autoscaling.deleteAutoScalingGroup({
-            AutoScalingGroupName: output.autoScalingGroupName,
-            ForceDelete: true,
-          } as any);
+          // `ForceDelete=true` lets AWS terminate any in-flight instances
+          // instead of refusing the call. `ScalingActivityInProgressFault`
+          // is transient — a scale activity raced our delete; retry.
+          yield* autoscaling
+            .deleteAutoScalingGroup({
+              AutoScalingGroupName: output.autoScalingGroupName,
+              ForceDelete: true,
+            } as any)
+            .pipe(
+              Effect.retry({
+                while: (e) =>
+                  e._tag === "ScalingActivityInProgressFault" ||
+                  e._tag === "ResourceInUseFault" ||
+                  e._tag === "ResourceContentionFault",
+                schedule: Schedule.fixed("2 seconds").pipe(
+                  Schedule.both(Schedule.recurs(30)),
+                ),
+              }),
+            );
 
+          // Wait for the ASG to disappear from `describeAutoScalingGroups`
+          // — deletion is asynchronous (instances drain before the group
+          // record is removed). Bound the wait so we don't loop forever.
           yield* describeGroup(output.autoScalingGroupName).pipe(
             Effect.flatMap((group) =>
               group
-                ? Effect.fail(new Error("AutoScalingGroupStillExists"))
+                ? Effect.fail(new AutoScalingGroupStillExists())
                 : Effect.void,
             ),
             Effect.retry({
-              while: (error) =>
-                (error as Error).message === "AutoScalingGroupStillExists",
-              schedule: Schedule.recurs(12).pipe(
-                Schedule.both(Schedule.exponential("250 millis")),
+              while: (e) => e._tag === "AutoScalingGroupStillExists",
+              schedule: Schedule.fixed("2 seconds").pipe(
+                Schedule.both(Schedule.recurs(60)),
               ),
             }),
           );

--- a/packages/alchemy/test/AWS/AutoScaling/AutoScalingGroup.test.ts
+++ b/packages/alchemy/test/AWS/AutoScaling/AutoScalingGroup.test.ts
@@ -1,0 +1,299 @@
+import { adopt } from "@/AdoptPolicy";
+import * as AWS from "@/AWS";
+import { AutoScalingGroup } from "@/AWS/AutoScaling";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import * as autoscaling from "@distilled.cloud/aws/auto-scaling";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+// ASG tests require pre-existing infrastructure: a launch template and
+// at least one VPC subnet ID. Gate the suite behind env vars so CI doesn't
+// try to spin up real EC2 instances.
+//
+//   TEST_LAUNCH_TEMPLATE_ID=lt-xxxxxxxx
+//   TEST_SUBNET_IDS=subnet-aaaa,subnet-bbbb
+const TEST_LAUNCH_TEMPLATE_ID = process.env.TEST_LAUNCH_TEMPLATE_ID as
+  | `lt-${string}`
+  | undefined;
+const TEST_SUBNET_IDS = (process.env.TEST_SUBNET_IDS?.split(",") ??
+  []) as `subnet-${string}`[];
+const skip = !TEST_LAUNCH_TEMPLATE_ID || TEST_SUBNET_IDS.length === 0;
+
+const launchTemplate = () => ({
+  launchTemplateId: TEST_LAUNCH_TEMPLATE_ID!,
+});
+
+test.provider.skipIf(skip)("redeploy with same props is a no-op", (stack) =>
+  Effect.gen(function* () {
+    yield* stack.destroy();
+
+    const first = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* AutoScalingGroup("Asg", {
+          launchTemplate: launchTemplate(),
+          subnetIds: TEST_SUBNET_IDS,
+          minSize: 0,
+          maxSize: 1,
+          desiredCapacity: 0,
+        });
+      }),
+    );
+
+    const second = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* AutoScalingGroup("Asg", {
+          launchTemplate: launchTemplate(),
+          subnetIds: TEST_SUBNET_IDS,
+          minSize: 0,
+          maxSize: 1,
+          desiredCapacity: 0,
+        });
+      }),
+    );
+
+    expect(second.autoScalingGroupArn).toEqual(first.autoScalingGroupArn);
+    expect(second.minSize).toEqual(0);
+    expect(second.maxSize).toEqual(1);
+    expect(second.desiredCapacity).toEqual(0);
+
+    yield* stack.destroy();
+    yield* assertGroupDeleted(first.autoScalingGroupName);
+  }),
+);
+
+test.provider.skipIf(skip)(
+  "reconcile resets desiredCapacity mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const created = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AutoScalingGroup("AsgDrift", {
+            launchTemplate: launchTemplate(),
+            subnetIds: TEST_SUBNET_IDS,
+            minSize: 0,
+            maxSize: 2,
+            desiredCapacity: 0,
+          });
+        }),
+      );
+
+      // Mutate desiredCapacity out-of-band via the raw SDK.
+      yield* autoscaling.setDesiredCapacity({
+        AutoScalingGroupName: created.autoScalingGroupName,
+        DesiredCapacity: 1,
+        HonorCooldown: false,
+      } as any);
+
+      const reconverged = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AutoScalingGroup("AsgDrift", {
+            launchTemplate: launchTemplate(),
+            subnetIds: TEST_SUBNET_IDS,
+            minSize: 0,
+            maxSize: 2,
+            desiredCapacity: 0,
+          });
+        }),
+      );
+
+      expect(reconverged.desiredCapacity).toEqual(0);
+
+      yield* stack.destroy();
+      yield* assertGroupDeleted(created.autoScalingGroupName);
+    }),
+);
+
+test.provider.skipIf(skip)(
+  "changing autoScalingGroupName triggers replace",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const original = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AutoScalingGroup("AsgReplace", {
+            autoScalingGroupName: "alchemy-asg-replace-a",
+            launchTemplate: launchTemplate(),
+            subnetIds: TEST_SUBNET_IDS,
+            minSize: 0,
+            maxSize: 1,
+          });
+        }),
+      );
+
+      const replaced = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AutoScalingGroup("AsgReplace", {
+            autoScalingGroupName: "alchemy-asg-replace-b",
+            launchTemplate: launchTemplate(),
+            subnetIds: TEST_SUBNET_IDS,
+            minSize: 0,
+            maxSize: 1,
+          });
+        }),
+      );
+
+      expect(replaced.autoScalingGroupName).not.toEqual(
+        original.autoScalingGroupName,
+      );
+      yield* assertGroupDeleted(original.autoScalingGroupName);
+
+      yield* stack.destroy();
+      yield* assertGroupDeleted(replaced.autoScalingGroupName);
+    }),
+);
+
+test.provider.skipIf(skip)(
+  "in-place modification of minSize/maxSize",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const before = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AutoScalingGroup("AsgSize", {
+            launchTemplate: launchTemplate(),
+            subnetIds: TEST_SUBNET_IDS,
+            minSize: 0,
+            maxSize: 1,
+            desiredCapacity: 0,
+          });
+        }),
+      );
+
+      const after = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AutoScalingGroup("AsgSize", {
+            launchTemplate: launchTemplate(),
+            subnetIds: TEST_SUBNET_IDS,
+            minSize: 1,
+            maxSize: 3,
+            desiredCapacity: 1,
+          });
+        }),
+      );
+
+      expect(after.autoScalingGroupArn).toEqual(before.autoScalingGroupArn);
+      expect(after.minSize).toEqual(1);
+      expect(after.maxSize).toEqual(3);
+      expect(after.desiredCapacity).toEqual(1);
+
+      yield* stack.destroy();
+      yield* assertGroupDeleted(before.autoScalingGroupName);
+    }),
+);
+
+test.provider.skipIf(skip)(
+  "destroying an already-deleted ASG is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const created = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* AutoScalingGroup("AsgPreDel", {
+            launchTemplate: launchTemplate(),
+            subnetIds: TEST_SUBNET_IDS,
+            minSize: 0,
+            maxSize: 1,
+            desiredCapacity: 0,
+          });
+        }),
+      );
+
+      // Out-of-band delete using the raw SDK.
+      yield* autoscaling
+        .deleteAutoScalingGroup({
+          AutoScalingGroupName: created.autoScalingGroupName,
+          ForceDelete: true,
+        } as any)
+        .pipe(Effect.catch(() => Effect.void));
+      yield* assertGroupDeleted(created.autoScalingGroupName);
+
+      // stack.destroy() now must succeed without raising.
+      yield* stack.destroy();
+    }),
+);
+
+test.provider.skipIf(skip)("adopt(true) re-tags a foreign ASG", (stack) =>
+  Effect.gen(function* () {
+    yield* stack.destroy();
+
+    const groupName = `alchemy-asg-adopt-${Math.random()
+      .toString(36)
+      .slice(2, 8)}`;
+
+    const original = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* AutoScalingGroup("Original", {
+          autoScalingGroupName: groupName,
+          launchTemplate: launchTemplate(),
+          subnetIds: TEST_SUBNET_IDS,
+          minSize: 0,
+          maxSize: 1,
+          desiredCapacity: 0,
+        });
+      }),
+    );
+
+    // Wipe state so the engine sees the ASG as foreign.
+    yield* Effect.gen(function* () {
+      const state = yield* State;
+      yield* state.delete({
+        stack: stack.name,
+        stage: "test",
+        fqn: "Original",
+      });
+    }).pipe(Effect.provide(stack.state));
+
+    const adopted = yield* stack
+      .deploy(
+        Effect.gen(function* () {
+          return yield* AutoScalingGroup("Different", {
+            autoScalingGroupName: groupName,
+            launchTemplate: launchTemplate(),
+            subnetIds: TEST_SUBNET_IDS,
+            minSize: 0,
+            maxSize: 1,
+            desiredCapacity: 0,
+          });
+        }),
+      )
+      .pipe(adopt(true));
+
+    expect(adopted.autoScalingGroupArn).toEqual(original.autoScalingGroupArn);
+    expect(adopted.tags["alchemy::id"]).toEqual("Different");
+
+    yield* stack.destroy();
+    yield* assertGroupDeleted(groupName);
+  }),
+);
+
+class AutoScalingGroupStillExists extends Data.TaggedError(
+  "AutoScalingGroupStillExists",
+) {}
+
+const assertGroupDeleted = Effect.fn(function* (name: string) {
+  yield* autoscaling
+    .describeAutoScalingGroups({ AutoScalingGroupNames: [name] })
+    .pipe(
+      Effect.flatMap((result) =>
+        (result.AutoScalingGroups ?? []).length === 0
+          ? Effect.void
+          : Effect.fail(new AutoScalingGroupStillExists()),
+      ),
+      Effect.retry({
+        while: (e) => e._tag === "AutoScalingGroupStillExists",
+        schedule: Schedule.fixed("2 seconds").pipe(
+          Schedule.both(Schedule.recurs(60)),
+        ),
+      }),
+    );
+});


### PR DESCRIPTION
Hardens the AutoScalingGroup resource as part of the per-resource hardening sweep on top of the reconcile migration.

### Reconciler changes

```diff
- Effect.catch((error: any) =>
-   error?._tag === "AlreadyExistsFault"
-     ? Effect.void
-     : Effect.fail(error),
- ),
+ Effect.catchTag("AlreadyExistsFault", () => Effect.void),
```

Blanket `Effect.catch` swallowed every error. Scoped to `AlreadyExistsFault` only — race / restart-after-crash recovery — so auth, throttling, and validation errors propagate.

```diff
  existing = yield* describeGroup(autoScalingGroupName).pipe(
-   Effect.filterOrFail(Boolean, () => new Error(...)),
+   Effect.flatMap((group) =>
+     group ? Effect.succeed(group)
+           : Effect.fail(new AutoScalingGroupNotReadyAfterCreate()),
+   ),
    Effect.retry({
-     while: () => true,
+     while: (e) => e._tag === "AutoScalingGroupNotReadyAfterCreate",
      schedule: Schedule.recurs(8).pipe(...),
    }),
  );
```

The post-create read previously retried on *any* error including auth/validation. Now retries only the actual "still missing in describe" case.

```diff
+ .pipe(
+   Effect.retry({
+     while: (e) =>
+       e._tag === "ScalingActivityInProgressFault" ||
+       e._tag === "ResourceContentionFault",
+     schedule: Schedule.fixed("2 seconds").pipe(
+       Schedule.both(Schedule.recurs(15)),
+     ),
+   }),
+ );
```

`updateAutoScalingGroup` and `deleteAutoScalingGroup` now retry on transient `ScalingActivityInProgressFault` and `ResourceContentionFault`. Delete also retries on `ResourceInUseFault`. Attach/Detach LB target groups retry on the errors their distilled unions actually carry (`ResourceContention`, `InstanceRefreshInProgress`).

```diff
+ const attrs = toAttributes(group);
+ return (yield* hasAlchemyTags(id, attrs.tags))
+   ? attrs
+   : Unowned(attrs);
```

`read` now marks foreign ASGs as `Unowned`, gating takeover behind `adopt(true)` instead of silently re-tagging.

### New lifecycle tests

`packages/alchemy/test/AWS/AutoScaling/AutoScalingGroup.test.ts`. Skipped unless `TEST_LAUNCH_TEMPLATE_ID` and `TEST_SUBNET_IDS` are set (real EC2 fleet required).

- redeploy with same props is a no-op
- reconcile resets `desiredCapacity` mutated out-of-band via `setDesiredCapacity`
- changing `autoScalingGroupName` triggers replace
- in-place modification of `minSize`/`maxSize`/`desiredCapacity`
- destroying an already-deleted ASG is a no-op
- `adopt(true)` re-tags a foreign ASG

### Distilled patch

No patch needed for this pass. `ScalingActivityInProgressFault` is genuinely transient and a candidate for `withRetryableError` in distilled, but the reconciler-level retry handles it for now without depending on the AWS retry layer. `InvalidInstanceLifecycleStateException` is context-dependent and stays `BadRequestError + ConflictError` only.
