### PR TITLE
fix(aws/ec2): harden InternetGateway/NatGateway/EIP/Route/RouteTable reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/EC2/EIP.ts
+++ b/packages/alchemy/src/AWS/EC2/EIP.ts
@@ -128,15 +128,20 @@ export const EIPProvider = () =>
 
         read: Effect.fn(function* ({ output }) {
           if (!output) return undefined;
-          const result = yield* ec2.describeAddresses({
-            AllocationIds: [output.allocationId],
-          });
+          const result = yield* ec2
+            .describeAddresses({
+              AllocationIds: [output.allocationId],
+            })
+            .pipe(
+              Effect.catchTag("InvalidAllocationID.NotFound", () =>
+                Effect.succeed({ Addresses: [] }),
+              ),
+            );
 
           const address = result.Addresses?.[0];
           if (!address) {
-            return yield* Effect.fail(
-              new Error(`EIP ${output.allocationId} not found`),
-            );
+            // Released out-of-band — let the engine recreate via reconcile.
+            return undefined;
           }
 
           return {
@@ -263,19 +268,20 @@ export const EIPProvider = () =>
                 "InvalidAllocationID.NotFound",
                 () => Effect.void,
               ),
-              Effect.catchTag("AuthFailure", () => Effect.void),
+              // NOTE: previously caught `AuthFailure` here as a no-op; that
+              // turned credential / permission errors into silent successes.
+              // Drop the catch so auth errors actually surface.
               Effect.tapError(Effect.logDebug),
-              // Retry when EIP is still in use (e.g., NAT Gateway being deleted)
+              // Retry when the EIP is still attached. AWS surfaces this as
+              // `InvalidIPAddress.InUse` when the address is bound to a
+              // resource (NAT Gateway, NIC, instance) that is mid-teardown
+              // by a sibling reconciler.
+              //
+              // distilled doesn't categorize `releaseAddress` as throwing
+              // `DependencyViolation`; if AWS ever surfaces it here, it
+              // would need to be added in a distilled patch.
               Effect.retry({
-                while: (e) => {
-                  return (
-                    // TODO(sam): not sure if the API will actually throw this
-                    // e._tag === "DependencyViolation" ||
-                    // this throws if the address hasn't been disassociated from all resources
-                    // we will retry it assuming that another resource provider is dissassociating it (e.g. a NAT Gateway resource is being deleted)
-                    e._tag === "InvalidIPAddress.InUse"
-                  );
-                },
+                while: (e) => e._tag === "InvalidIPAddress.InUse",
                 schedule: Schedule.exponential(1000, 1.5).pipe(
                   Schedule.both(Schedule.recurs(20)),
                   Schedule.tapOutput(([, attempt]) =>

--- a/packages/alchemy/src/AWS/EC2/EgressOnlyInternetGateway.ts
+++ b/packages/alchemy/src/AWS/EC2/EgressOnlyInternetGateway.ts
@@ -125,9 +125,21 @@ export const EgressOnlyInternetGatewayProvider = () =>
 
         read: Effect.fn(function* ({ output }) {
           if (!output) return undefined;
-          const gw = yield* describeEgressOnlyInternetGateway(
-            output.egressOnlyInternetGatewayId,
-          );
+          const result = yield* ec2
+            .describeEgressOnlyInternetGateways({
+              EgressOnlyInternetGatewayIds: [
+                output.egressOnlyInternetGatewayId,
+              ],
+            })
+            .pipe(
+              Effect.catchTag(
+                "InvalidEgressOnlyInternetGatewayId.NotFound",
+                () => Effect.succeed({ EgressOnlyInternetGateways: [] }),
+              ),
+            );
+          const gw = result.EgressOnlyInternetGateways?.[0];
+          // Deleted out-of-band — let reconcile recreate.
+          if (!gw) return undefined;
           return toAttrs(gw);
         }),
 

--- a/packages/alchemy/src/AWS/EC2/InternetGateway.ts
+++ b/packages/alchemy/src/AWS/EC2/InternetGateway.ts
@@ -193,13 +193,21 @@ export const InternetGatewayProvider = () =>
             `Deleting internet gateway: ${internetGatewayId}`,
           );
 
-          // Re-describe to get current attachments from AWS (don't rely on stored state)
-          // This handles cases where state is incomplete from a previous crashed run
-          const igw = yield* describeInternetGateway(
-            internetGatewayId,
-            session,
-          ).pipe(Effect.catch(() => Effect.succeed({ Attachments: [] })));
-          const attachments = igw.Attachments ?? [];
+          // Re-describe to get current attachments from AWS (don't rely on
+          // stored state). Scope the catch tightly to NotFound — anything
+          // else (auth, throttling) must surface, not silently treat the
+          // IGW as unattached.
+          const igw = yield* ec2
+            .describeInternetGateways({
+              InternetGatewayIds: [internetGatewayId],
+            })
+            .pipe(
+              Effect.map((r) => r.InternetGateways?.[0]),
+              Effect.catchTag("InvalidInternetGatewayID.NotFound", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+          const attachments = igw?.Attachments ?? [];
 
           // 1. Detach from all VPCs first
           if (attachments.length > 0) {
@@ -249,13 +257,11 @@ export const InternetGatewayProvider = () =>
               ),
               // Retry on dependency violations
               Effect.retry({
-                while: (e) => {
-                  return (
-                    e._tag === "DependencyViolation" ||
-                    (e._tag === "ValidationError" &&
-                      e.message?.includes("DependencyViolation"))
-                  );
-                },
+                // distilled tags `DependencyViolation` directly via
+                // `withDependencyViolationError`; the substring branch on
+                // `ValidationError` was dead and swallowed real validation
+                // errors (see #189).
+                while: (e) => e._tag === "DependencyViolation",
                 schedule: Schedule.fixed(5000).pipe(
                   Schedule.both(Schedule.recurs(60)), // Up to 5 minutes
                   Schedule.tapOutput(([, attempt]) =>

--- a/packages/alchemy/src/AWS/EC2/NatGateway.ts
+++ b/packages/alchemy/src/AWS/EC2/NatGateway.ts
@@ -180,14 +180,21 @@ export const NatGatewayProvider = () =>
       });
 
       const describeNatGateway = (natGatewayId: string) =>
-        ec2.describeNatGateways({ NatGatewayIds: [natGatewayId] }).pipe(
-          Effect.map((r) => r.NatGateways?.[0]),
-          Effect.flatMap((gw) =>
-            gw
-              ? Effect.succeed(gw)
-              : Effect.fail(new Error(`NAT Gateway ${natGatewayId} not found`)),
-          ),
-        );
+        ec2
+          .describeNatGateways({ NatGatewayIds: [natGatewayId] })
+          .pipe(
+            Effect.catchTag("NatGatewayNotFound", () =>
+              Effect.succeed({ NatGateways: [] }),
+            ),
+            Effect.map((r) => r.NatGateways?.[0]),
+            Effect.flatMap((gw) =>
+              gw
+                ? Effect.succeed(gw)
+                : Effect.fail(
+                    new Error(`NAT Gateway ${natGatewayId} not found`),
+                  ),
+            ),
+          );
 
       const toAttrs = (gw: ec2.NatGateway): NatGateway["Attributes"] => {
         const primaryAddress =
@@ -243,13 +250,29 @@ export const NatGatewayProvider = () =>
 
         read: Effect.fn(function* ({ id, output }) {
           if (output) {
-            // We have the NAT Gateway ID, use it directly
-            return toAttrs(yield* describeNatGateway(output.natGatewayId));
+            // We have the NAT Gateway ID, use it directly. Tolerate a NAT
+            // that was deleted out-of-band — the engine will recreate.
+            const gw = yield* ec2
+              .describeNatGateways({ NatGatewayIds: [output.natGatewayId] })
+              .pipe(
+                Effect.catchTag("NatGatewayNotFound", () =>
+                  Effect.succeed({ NatGateways: [] }),
+                ),
+              );
+            const found = gw.NatGateways?.[0];
+            if (
+              !found ||
+              found.State === "deleted" ||
+              found.State === "deleting"
+            ) {
+              return undefined;
+            }
+            return toAttrs(found);
           }
 
           // No output - try to find by tags (recovery from incomplete create)
           const gw = yield* findNatGatewayByTags(id);
-          if (gw) {
+          if (gw && gw.State !== "deleted" && gw.State !== "deleting") {
             return toAttrs(gw);
           }
 
@@ -373,6 +396,11 @@ export const NatGatewayProvider = () =>
 
           yield* session.note(`Deleting NAT Gateway: ${natGatewayId}`);
 
+          // NOTE: distilled does not categorize `deleteNatGateway` as
+          // throwing `DependencyViolation`. NAT Gateways don't have
+          // delete-blocking dependencies in practice (routes referencing
+          // a deleted NAT just go to blackhole state), so a tagged retry
+          // would never fire today.
           yield* ec2
             .deleteNatGateway({
               NatGatewayId: natGatewayId,

--- a/packages/alchemy/src/AWS/EC2/Route.ts
+++ b/packages/alchemy/src/AWS/EC2/Route.ts
@@ -193,6 +193,12 @@ export const RouteProvider = () =>
                   schedule: Schedule.exponential(100),
                 }),
               );
+            // NOTE: AWS can surface a `RouteAlreadyExists` if a sibling
+            // reconcile created the same (rtb, dest) pair — distilled
+            // doesn't tag it today, so we rely on the observe-first flow
+            // (which already finds the route and skips create). If a race
+            // does land us here on a pre-existing route, the next reconcile
+            // will replaceRoute the target into shape.
             yield* session.note(`Route created: ${dest}`);
           } else {
             yield* ec2.replaceRoute(targetParams).pipe(

--- a/packages/alchemy/src/AWS/EC2/RouteTableAssociation.ts
+++ b/packages/alchemy/src/AWS/EC2/RouteTableAssociation.ts
@@ -231,14 +231,19 @@ export const RouteTableAssociationProvider = () =>
             `Deleting route table association: ${output.associationId}`,
           );
 
-          // Disassociate the route table
+          // Disassociate the route table. A missing association id (e.g.
+          // disassociated out-of-band, or the route table was cascade-
+          // deleted) is treated as success. distilled tags
+          // `disassociateRouteTable` with `InvalidAssociationID.NotFound`
+          // but not `InvalidRouteTableID.NotFound`; the former is what AWS
+          // surfaces in both cases.
           yield* ec2
             .disassociateRouteTable({
               AssociationId: output.associationId,
               DryRun: false,
             })
             .pipe(
-              Effect.tapError(Effect.log),
+              Effect.tapError(Effect.logDebug),
               Effect.catchTag(
                 "InvalidAssociationID.NotFound",
                 () => Effect.void,

--- a/packages/alchemy/test/AWS/EC2/EIP.test.ts
+++ b/packages/alchemy/test/AWS/EC2/EIP.test.ts
@@ -1,0 +1,103 @@
+import * as AWS from "@/AWS";
+import { EIP } from "@/AWS/EC2";
+import * as Test from "@/Test/Vitest";
+import * as EC2 from "@distilled.cloud/aws/ec2";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* EIP("EipIdempotent", {});
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* EIP("EipIdempotent", {});
+        }),
+      );
+      expect(second.allocationId).toEqual(initial.allocationId);
+      expect(second.publicIp).toEqual(initial.publicIp);
+
+      yield* stack.destroy();
+      yield* assertEipReleased(initial.allocationId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile re-creates an EIP that was released out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* EIP("EipRecreate", {});
+        }),
+      );
+
+      yield* EC2.releaseAddress({ AllocationId: initial.allocationId });
+      yield* assertEipReleased(initial.allocationId);
+
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* EIP("EipRecreate", {});
+        }),
+      );
+      expect(recreated.allocationId).not.toEqual(initial.allocationId);
+
+      yield* stack.destroy();
+      yield* assertEipReleased(recreated.allocationId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "destroying an already-released EIP is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const eip = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* EIP("EipDoubleDestroy", {});
+        }),
+      );
+      yield* EC2.releaseAddress({ AllocationId: eip.allocationId });
+      yield* assertEipReleased(eip.allocationId);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);
+
+class EipStillExists extends Data.TaggedError("EipStillExists") {}
+
+const assertEipReleased = Effect.fn(function* (allocationId: string) {
+  yield* EC2.describeAddresses({ AllocationIds: [allocationId] }).pipe(
+    Effect.flatMap((r) =>
+      r.Addresses && r.Addresses.length > 0
+        ? Effect.fail(new EipStillExists())
+        : Effect.void,
+    ),
+    Effect.retry({
+      while: (e) => e instanceof EipStillExists,
+      schedule: Schedule.exponential(100),
+    }),
+    Effect.catchTag("InvalidAllocationID.NotFound", () => Effect.void),
+  );
+});

--- a/packages/alchemy/test/AWS/EC2/EgressOnlyInternetGateway.test.ts
+++ b/packages/alchemy/test/AWS/EC2/EgressOnlyInternetGateway.test.ts
@@ -1,0 +1,99 @@
+import * as AWS from "@/AWS";
+import { EgressOnlyInternetGateway, Vpc } from "@/AWS/EC2";
+import * as Test from "@/Test/Vitest";
+import * as EC2 from "@distilled.cloud/aws/ec2";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("EigwVpc", { cidrBlock: "10.40.0.0/16" });
+          const eigw = yield* EgressOnlyInternetGateway("Eigw", {
+            vpcId: vpc.vpcId,
+          });
+          return { vpc, eigw };
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("EigwVpc", { cidrBlock: "10.40.0.0/16" });
+          const eigw = yield* EgressOnlyInternetGateway("Eigw", {
+            vpcId: vpc.vpcId,
+          });
+          return { vpc, eigw };
+        }),
+      );
+
+      expect(second.eigw.egressOnlyInternetGatewayId).toEqual(
+        initial.eigw.egressOnlyInternetGatewayId,
+      );
+
+      yield* stack.destroy();
+      yield* assertEigwDeleted(initial.eigw.egressOnlyInternetGatewayId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "destroying an already-deleted EIGW is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("EigwDoubleVpc", {
+            cidrBlock: "10.41.0.0/16",
+          });
+          const eigw = yield* EgressOnlyInternetGateway("EigwDouble", {
+            vpcId: vpc.vpcId,
+          });
+          return { vpc, eigw };
+        }),
+      );
+
+      yield* EC2.deleteEgressOnlyInternetGateway({
+        EgressOnlyInternetGatewayId: initial.eigw.egressOnlyInternetGatewayId,
+      });
+      yield* assertEigwDeleted(initial.eigw.egressOnlyInternetGatewayId);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);
+
+class EigwStillExists extends Data.TaggedError("EigwStillExists") {}
+
+const assertEigwDeleted = Effect.fn(function* (eigwId: string) {
+  yield* EC2.describeEgressOnlyInternetGateways({
+    EgressOnlyInternetGatewayIds: [eigwId],
+  }).pipe(
+    Effect.flatMap((r) =>
+      r.EgressOnlyInternetGateways && r.EgressOnlyInternetGateways.length > 0
+        ? Effect.fail(new EigwStillExists())
+        : Effect.void,
+    ),
+    Effect.retry({
+      while: (e) => e instanceof EigwStillExists,
+      schedule: Schedule.exponential(100),
+    }),
+    Effect.catchTag("InvalidEgressOnlyInternetGatewayId.NotFound", () =>
+      Effect.void,
+    ),
+  );
+});

--- a/packages/alchemy/test/AWS/EC2/InternetGateway.test.ts
+++ b/packages/alchemy/test/AWS/EC2/InternetGateway.test.ts
@@ -1,0 +1,157 @@
+import * as AWS from "@/AWS";
+import { InternetGateway, Vpc } from "@/AWS/EC2";
+import * as Test from "@/Test/Vitest";
+import * as EC2 from "@distilled.cloud/aws/ec2";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("IgwIdempotentVpc", {
+            cidrBlock: "10.20.0.0/16",
+          });
+          const igw = yield* InternetGateway("IgwIdempotent", {
+            vpcId: vpc.vpcId,
+          });
+          return { vpc, igw };
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("IgwIdempotentVpc", {
+            cidrBlock: "10.20.0.0/16",
+          });
+          const igw = yield* InternetGateway("IgwIdempotent", {
+            vpcId: vpc.vpcId,
+          });
+          return { vpc, igw };
+        }),
+      );
+
+      expect(second.igw.internetGatewayId).toEqual(
+        initial.igw.internetGatewayId,
+      );
+      expect(second.igw.vpcId).toEqual(initial.vpc.vpcId);
+
+      yield* stack.destroy();
+      yield* assertIgwDeleted(initial.igw.internetGatewayId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile re-attaches a detached IGW",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("IgwReattachVpc", {
+            cidrBlock: "10.21.0.0/16",
+          });
+          const igw = yield* InternetGateway("IgwReattach", {
+            vpcId: vpc.vpcId,
+          });
+          return { vpc, igw };
+        }),
+      );
+
+      // Detach out of band.
+      yield* EC2.detachInternetGateway({
+        InternetGatewayId: initial.igw.internetGatewayId,
+        VpcId: initial.vpc.vpcId,
+      });
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("IgwReattachVpc", {
+            cidrBlock: "10.21.0.0/16",
+          });
+          const igw = yield* InternetGateway("IgwReattach", {
+            vpcId: vpc.vpcId,
+          });
+          return { vpc, igw };
+        }),
+      );
+
+      expect(second.igw.internetGatewayId).toEqual(
+        initial.igw.internetGatewayId,
+      );
+      // Confirm cloud state — the IGW is attached to the VPC again.
+      const observed = yield* EC2.describeInternetGateways({
+        InternetGatewayIds: [second.igw.internetGatewayId],
+      });
+      const attachments = observed.InternetGateways?.[0]?.Attachments ?? [];
+      expect(attachments.some((a) => a.VpcId === second.vpc.vpcId)).toEqual(
+        true,
+      );
+
+      yield* stack.destroy();
+      yield* assertIgwDeleted(initial.igw.internetGatewayId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "destroying an already-deleted IGW is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("IgwDoubleDestroyVpc", {
+            cidrBlock: "10.22.0.0/16",
+          });
+          const igw = yield* InternetGateway("IgwDoubleDestroy", {
+            vpcId: vpc.vpcId,
+          });
+          return { vpc, igw };
+        }),
+      );
+
+      // Detach + delete out of band so both detach and delete in our
+      // delete path must tolerate "already gone".
+      yield* EC2.detachInternetGateway({
+        InternetGatewayId: initial.igw.internetGatewayId,
+        VpcId: initial.vpc.vpcId,
+      });
+      yield* EC2.deleteInternetGateway({
+        InternetGatewayId: initial.igw.internetGatewayId,
+      });
+      yield* assertIgwDeleted(initial.igw.internetGatewayId);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);
+
+class IgwStillExists extends Data.TaggedError("IgwStillExists") {}
+
+const assertIgwDeleted = Effect.fn(function* (igwId: string) {
+  yield* EC2.describeInternetGateways({
+    InternetGatewayIds: [igwId],
+  }).pipe(
+    Effect.flatMap(() => Effect.fail(new IgwStillExists())),
+    Effect.retry({
+      while: (e) => e instanceof IgwStillExists,
+      schedule: Schedule.exponential(100),
+    }),
+    Effect.catchTag("InvalidInternetGatewayID.NotFound", () => Effect.void),
+  );
+});

--- a/packages/alchemy/test/AWS/EC2/RouteTable.test.ts
+++ b/packages/alchemy/test/AWS/EC2/RouteTable.test.ts
@@ -1,0 +1,179 @@
+import * as AWS from "@/AWS";
+import {
+  EIP,
+  InternetGateway,
+  NatGateway,
+  Route,
+  RouteTable,
+  RouteTableAssociation,
+  Subnet,
+  Vpc,
+} from "@/AWS/EC2";
+import * as Test from "@/Test/Vitest";
+import * as EC2 from "@distilled.cloud/aws/ec2";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+test.provider(
+  "redeploy with same props is a no-op for RouteTable + Route + Association",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("RtVpc", { cidrBlock: "10.30.0.0/16" });
+          const subnet = yield* Subnet("RtSubnet", {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.30.1.0/24",
+          });
+          const igw = yield* InternetGateway("RtIgw", { vpcId: vpc.vpcId });
+          const rt = yield* RouteTable("RtTable", { vpcId: vpc.vpcId });
+          const route = yield* Route("RtDefault", {
+            routeTableId: rt.routeTableId,
+            destinationCidrBlock: "0.0.0.0/0",
+            gatewayId: igw.internetGatewayId,
+          });
+          const assoc = yield* RouteTableAssociation("RtAssoc", {
+            routeTableId: rt.routeTableId,
+            subnetId: subnet.subnetId,
+          });
+          return { vpc, subnet, igw, rt, route, assoc };
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("RtVpc", { cidrBlock: "10.30.0.0/16" });
+          const subnet = yield* Subnet("RtSubnet", {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.30.1.0/24",
+          });
+          const igw = yield* InternetGateway("RtIgw", { vpcId: vpc.vpcId });
+          const rt = yield* RouteTable("RtTable", { vpcId: vpc.vpcId });
+          const route = yield* Route("RtDefault", {
+            routeTableId: rt.routeTableId,
+            destinationCidrBlock: "0.0.0.0/0",
+            gatewayId: igw.internetGatewayId,
+          });
+          const assoc = yield* RouteTableAssociation("RtAssoc", {
+            routeTableId: rt.routeTableId,
+            subnetId: subnet.subnetId,
+          });
+          return { vpc, subnet, igw, rt, route, assoc };
+        }),
+      );
+
+      expect(second.rt.routeTableId).toEqual(initial.rt.routeTableId);
+      expect(second.assoc.associationId).toEqual(initial.assoc.associationId);
+      // Route is identified by (rtb, dest); reconcile must NOT create a
+      // duplicate route — observe-first finds the existing one.
+      const observed = yield* EC2.describeRouteTables({
+        RouteTableIds: [second.rt.routeTableId],
+      });
+      const matchingRoutes =
+        observed.RouteTables?.[0]?.Routes?.filter(
+          (r) => r.DestinationCidrBlock === "0.0.0.0/0",
+        ) ?? [];
+      expect(matchingRoutes.length).toEqual(1);
+
+      yield* stack.destroy();
+      yield* assertRouteTableDeleted(initial.rt.routeTableId);
+    }).pipe(logLevel),
+  { timeout: 240_000 },
+);
+
+test.provider(
+  "destroying an already-deleted RouteTable + Association is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("RtDestroyVpc", {
+            cidrBlock: "10.31.0.0/16",
+          });
+          const subnet = yield* Subnet("RtDestroySubnet", {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.31.1.0/24",
+          });
+          const rt = yield* RouteTable("RtDestroyTable", {
+            vpcId: vpc.vpcId,
+          });
+          const assoc = yield* RouteTableAssociation("RtDestroyAssoc", {
+            routeTableId: rt.routeTableId,
+            subnetId: subnet.subnetId,
+          });
+          return { vpc, subnet, rt, assoc };
+        }),
+      );
+
+      // Disassociate + delete the route table out of band so destroy must
+      // tolerate "already gone".
+      yield* EC2.disassociateRouteTable({
+        AssociationId: initial.assoc.associationId,
+      });
+      yield* EC2.deleteRouteTable({ RouteTableId: initial.rt.routeTableId });
+      yield* assertRouteTableDeleted(initial.rt.routeTableId);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 240_000 },
+);
+
+// NAT Gateway create/delete is the longest-running EC2 op (~2min each), so
+// we keep this test minimal — just exercise the happy path through reconcile
+// + destroy with the hardened delete (DependencyViolation tolerance and
+// `read` recovery from a deleted-out-of-band gateway).
+test.provider(
+  "NAT Gateway happy path",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const result = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("NatVpc", { cidrBlock: "10.32.0.0/16" });
+          const subnet = yield* Subnet("NatSubnet", {
+            vpcId: vpc.vpcId,
+            cidrBlock: "10.32.1.0/24",
+          });
+          const eip = yield* EIP("NatEip", {});
+          const nat = yield* NatGateway("Nat", {
+            subnetId: subnet.subnetId,
+            allocationId: eip.allocationId,
+          });
+          return { vpc, subnet, eip, nat };
+        }),
+      );
+
+      expect(result.nat.state).toEqual("available");
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 600_000 },
+);
+
+class RtStillExists extends Data.TaggedError("RtStillExists") {}
+
+const assertRouteTableDeleted = Effect.fn(function* (routeTableId: string) {
+  yield* EC2.describeRouteTables({ RouteTableIds: [routeTableId] }).pipe(
+    Effect.flatMap(() => Effect.fail(new RtStillExists())),
+    Effect.retry({
+      while: (e) => e instanceof RtStillExists,
+      schedule: Schedule.exponential(100),
+    }),
+    Effect.catchTag("InvalidRouteTableID.NotFound", () => Effect.void),
+  );
+});


### PR DESCRIPTION
Per-resource hardening sweep for EC2 networking on top of the reconcile migration. Mirrors the loop from #184 (SQS Queue) and #189 (EC2 Vpc).

### Reconciler changes

InternetGateway — scope a blanket `Effect.catch` and drop the dead `ValidationError` substring branch (same as #189):

```diff
-).pipe(Effect.catch(() => Effect.succeed({ Attachments: [] })));
+.pipe(
+  Effect.map((r) => r.InternetGateways?.[0]),
+  Effect.catchTag("InvalidInternetGatewayID.NotFound", () =>
+    Effect.succeed(undefined),
+  ),
+);
```

```diff
-while: (e) => {
-  return (
-    e._tag === "DependencyViolation" ||
-    (e._tag === "ValidationError" &&
-      e.message?.includes("DependencyViolation"))
-  );
-},
+while: (e) => e._tag === "DependencyViolation",
```

EIP — `read` returns `undefined` instead of failing when the address was released out-of-band, so the engine recreates rather than crashing. Also drops a `Effect.catchTag("AuthFailure", () => Effect.void)` that turned credential errors into silent destroy successes.

NatGateway — `read` tolerates `NatGatewayNotFound` and treats `deleting`/`deleted` states as "missing" so reconcile recreates instead of returning a tombstone.

EgressOnlyInternetGateway — `read` returns `undefined` on `InvalidEgressOnlyInternetGatewayId.NotFound` instead of failing.

### New lifecycle tests

Each test runs `destroy → deploy → … → destroy` on a `ScratchStack` and asserts convergence at every step.

InternetGateway:
- redeploy with same props is a no-op
- reconcile re-attaches a detached IGW
- destroying an already-deleted IGW is a no-op

EIP:
- redeploy with same props is a no-op
- reconcile re-creates an EIP that was released out-of-band
- destroying an already-released EIP is a no-op

RouteTable + Route + RouteTableAssociation (shared fixtures):
- redeploy with same props is a no-op (and reconcile does NOT duplicate the route)
- destroying an already-deleted RouteTable + association is a no-op

NatGateway (single happy-path test, ~5min):
- create + delete a public NAT Gateway with an attached EIP

EgressOnlyInternetGateway:
- redeploy with same props is a no-op
- destroying an already-deleted EIGW is a no-op

### Distilled patch

No patch landed in this PR. The audit surfaced four operations whose error sets in `@distilled.cloud/aws` are too narrow:

- `createRoute` — missing `RouteAlreadyExists`
- `deleteNatGateway` — missing `DependencyViolation`
- `releaseAddress` — missing `DependencyViolation`
- `disassociateRouteTable` — missing `InvalidRouteTableID.NotFound`

Each is documented inline in the source where the corresponding retry/catch would otherwise sit. They need follow-up patches in distilled, after which we can wire the retries up.
