### PR TITLE
fix(cloudflare/apitoken): harden Account/User API tokens reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/Cloudflare/ApiToken/AccountApiToken.ts
+++ b/packages/alchemy/src/Cloudflare/ApiToken/AccountApiToken.ts
@@ -1,6 +1,7 @@
 import * as accounts from "@distilled.cloud/cloudflare/accounts";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
+import { Unowned } from "../../AdoptPolicy.ts";
 import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
@@ -10,6 +11,8 @@ import type { Providers } from "../Providers.ts";
 import {
   buildConditionPayload,
   conditionFingerprint,
+  observedCondition,
+  observedPolicyFingerprint,
   policyFingerprint,
   resolvePolicies,
   type ApiTokenProps,
@@ -29,6 +32,12 @@ export type AccountApiToken = Resource<
      */
     value: Redacted.Redacted<string>;
     accountId: string;
+    /**
+     * Opaque marker for the most recent successful `rollKey`. Persisting
+     * this lets the reconciler detect when the user has bumped `rollKey`
+     * and trigger a `putTokenValue` rotation.
+     */
+    rolledFor?: string;
   },
   never,
   Providers
@@ -70,6 +79,16 @@ export type AccountApiToken = Resource<
  *   value: token.value,
  * });
  * ```
+ *
+ * @section Rotating a Token
+ * @example Bump `rollKey` to mint a new secret value
+ * ```typescript
+ * const token = yield* Cloudflare.AccountApiToken("ci-token", {
+ *   accountId,
+ *   policies: [...],
+ *   rollKey: "2025-05-01", // change this string to rotate the secret
+ * });
+ * ```
  */
 export const AccountApiToken = Resource<AccountApiToken>(
   "Cloudflare.AccountApiToken",
@@ -91,6 +110,8 @@ export const AccountApiTokenProvider = () =>
       const updateToken = yield* accounts.updateToken;
       const deleteToken = yield* accounts.deleteToken;
       const getToken = yield* accounts.getToken;
+      const listTokens = yield* accounts.listTokens;
+      const putTokenValue = yield* accounts.putTokenValue;
 
       const buildAttributes = (
         tokenData: {
@@ -100,13 +121,36 @@ export const AccountApiTokenProvider = () =>
         },
         value: Redacted.Redacted<string>,
         accountId: string,
+        rolledFor: string | undefined,
       ): AccountApiTokenAttributes => ({
         tokenId: tokenData.id ?? "",
         name: tokenData.name ?? "",
         status: tokenData.status ?? "active",
         value,
         accountId,
+        rolledFor,
       });
+
+      // Iterate `listTokens` until the desired name is found or the pages
+      // run out. Cloudflare returns 1-based page numbers; `perPage` capped
+      // at 50 keeps individual responses small.
+      const findTokenByName = (accountId: string, name: string) =>
+        Effect.gen(function* () {
+          const perPage = 50;
+          let page = 1;
+          while (true) {
+            const response = yield* listTokens({
+              accountId,
+              page,
+              perPage,
+            });
+            const match = response.result.find((t) => t.name === name);
+            if (match) return match;
+            const total = response.resultInfo.totalCount ?? 0;
+            if (page * perPage >= total) return undefined;
+            page += 1;
+          }
+        });
 
       return {
         stables: ["tokenId", "accountId"],
@@ -118,8 +162,14 @@ export const AccountApiTokenProvider = () =>
           if (oldAccountId !== newAccountId) {
             return { action: "replace" } as const;
           }
+          // Name changes replace: a token's name is part of its identity in
+          // CI configs and audit logs. Forcing replace cleanly retires the
+          // old token and mints a new one with a fresh secret value.
           const oldName = output?.name ?? (yield* resolveName(id, olds?.name));
           const newName = yield* resolveName(id, news.name);
+          if (oldName !== newName) {
+            return { action: "replace" } as const;
+          }
           const oldPolicyFp = policyFingerprint(
             resolvePolicies(olds?.policies ?? []),
           );
@@ -127,11 +177,11 @@ export const AccountApiTokenProvider = () =>
           const oldCondFp = conditionFingerprint(olds?.condition);
           const newCondFp = conditionFingerprint(news.condition);
           if (
-            oldName !== newName ||
             oldPolicyFp !== newPolicyFp ||
             oldCondFp !== newCondFp ||
             (olds?.expiresOn ?? undefined) !== (news.expiresOn ?? undefined) ||
-            (olds?.notBefore ?? undefined) !== (news.notBefore ?? undefined)
+            (olds?.notBefore ?? undefined) !== (news.notBefore ?? undefined) ||
+            (olds?.rollKey ?? undefined) !== (news.rollKey ?? undefined)
           ) {
             return { action: "update" } as const;
           }
@@ -139,7 +189,9 @@ export const AccountApiTokenProvider = () =>
         reconcile: Effect.fn(function* ({ id, news, output }) {
           const accountId = news.accountId ?? defaultAccountId;
           const name = yield* resolveName(id, news.name);
-          const policies = resolvePolicies(news.policies);
+          const desiredPolicies = resolvePolicies(news.policies);
+          const desiredPolicyFp = policyFingerprint(desiredPolicies);
+          const desiredCondFp = conditionFingerprint(news.condition);
 
           // Observe — fetch current state if we already know the token id.
           // Cloudflare reports a deleted token as `InvalidRoute` or
@@ -149,7 +201,6 @@ export const AccountApiTokenProvider = () =>
                 accountId: output.accountId,
                 tokenId: output.tokenId,
               }).pipe(
-                Effect.map((token) => token),
                 Effect.catchTag("InvalidRoute", () =>
                   Effect.succeed(undefined),
                 ),
@@ -168,7 +219,7 @@ export const AccountApiTokenProvider = () =>
             const result = yield* createToken({
               accountId,
               name,
-              policies,
+              policies: desiredPolicies,
               condition: buildConditionPayload(news.condition),
               expiresOn: news.expiresOn,
               notBefore: news.notBefore,
@@ -182,23 +233,73 @@ export const AccountApiTokenProvider = () =>
               result,
               Redacted.make(result.value),
               accountId,
+              news.rollKey,
             );
           }
 
-          // Sync — the update API replaces all mutable fields (name,
-          // policies, condition, validity window). Cloudflare does not
-          // return the plaintext value on update, so we preserve the one
-          // captured at creation.
-          const result = yield* updateToken({
-            accountId,
-            tokenId: output!.tokenId,
-            name,
-            policies,
-            condition: buildConditionPayload(news.condition),
-            expiresOn: news.expiresOn,
-            notBefore: news.notBefore,
-          });
-          return buildAttributes(result, output!.value, accountId);
+          // Sync — diff observed cloud state against desired and call
+          // `updateToken` only if something actually drifted. The update
+          // API replaces all mutable fields, so a single call resolves
+          // any combination of name/policy/condition/window drift.
+          const observedPolicyFp = observedPolicyFingerprint(
+            observed.policies ?? null,
+          );
+          const observedCondFp = conditionFingerprint(
+            observedCondition(observed.condition ?? null),
+          );
+          const observedExpires = observed.expiresOn ?? undefined;
+          const observedNotBefore = observed.notBefore ?? undefined;
+          const desiredExpires = news.expiresOn ?? undefined;
+          const desiredNotBefore = news.notBefore ?? undefined;
+          const policyDrift = observedPolicyFp !== desiredPolicyFp;
+          const condDrift = observedCondFp !== desiredCondFp;
+          const nameDrift = (observed.name ?? "") !== name;
+          const windowDrift =
+            observedExpires !== desiredExpires ||
+            observedNotBefore !== desiredNotBefore;
+
+          let current: typeof observed = observed;
+          if (policyDrift || condDrift || nameDrift || windowDrift) {
+            current = yield* updateToken({
+              accountId,
+              tokenId: output!.tokenId,
+              name,
+              policies: desiredPolicies,
+              condition: buildConditionPayload(news.condition),
+              expiresOn: news.expiresOn,
+              notBefore: news.notBefore,
+            });
+          }
+
+          // Sync — rotate the token's secret value when `rollKey`
+          // changed since the last successful roll. Cloudflare's
+          // PUT /tokens/{id}/value endpoint mints and returns a new
+          // bearer; we replace `output.value` with the fresh Redacted.
+          let value = output!.value;
+          let rolledFor = output!.rolledFor;
+          if (
+            news.rollKey !== undefined &&
+            news.rollKey !== output!.rolledFor
+          ) {
+            const newValue = yield* putTokenValue({
+              accountId,
+              tokenId: output!.tokenId,
+              body: {},
+            });
+            if (!newValue) {
+              return yield* Effect.die(
+                `Cloudflare did not return a value when rolling token "${name}".`,
+              );
+            }
+            value = Redacted.make(newValue);
+            rolledFor = news.rollKey;
+          } else if (news.rollKey === undefined) {
+            // User cleared `rollKey`; forget the marker so a future
+            // re-introduction with the same string still rolls.
+            rolledFor = undefined;
+          }
+
+          return buildAttributes(current, value, accountId, rolledFor);
         }),
         delete: Effect.fn(function* ({ output }) {
           yield* deleteToken({
@@ -212,18 +313,58 @@ export const AccountApiTokenProvider = () =>
             Effect.catchTag("TokenNotFound", () => Effect.void),
           );
         }),
-        read: Effect.fn(function* ({ output }) {
-          if (!output?.tokenId) return undefined;
-          return yield* getToken({
-            accountId: output.accountId,
-            tokenId: output.tokenId,
-          }).pipe(
-            Effect.map((token) =>
-              buildAttributes(token, output.value, output.accountId),
-            ),
-            Effect.catchTag("InvalidRoute", () => Effect.succeed(undefined)),
-            Effect.catchTag("TokenNotFound", () => Effect.succeed(undefined)),
+        read: Effect.fn(function* ({ id, olds, output }) {
+          // Fast path — we know the token id.
+          if (output?.tokenId) {
+            return yield* getToken({
+              accountId: output.accountId,
+              tokenId: output.tokenId,
+            }).pipe(
+              Effect.map((token) =>
+                buildAttributes(
+                  token,
+                  output.value,
+                  output.accountId,
+                  output.rolledFor,
+                ),
+              ),
+              Effect.catchTag("InvalidRoute", () => Effect.succeed(undefined)),
+              Effect.catchTag("TokenNotFound", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+          }
+          // Discovery path — look up by deterministic physical name.
+          // Cloudflare tokens have no tags, so the name is the only
+          // ownership signal we have. If a token of that name exists
+          // and was minted by us (name matches engine-generated form,
+          // i.e. `olds?.name` is undefined and the auto-name resolves
+          // to it), we silently adopt; otherwise we mark `Unowned` so
+          // takeover requires `--adopt`.
+          const accountId = olds?.accountId ?? defaultAccountId;
+          const name = yield* resolveName(id, olds?.name);
+          const match = yield* findTokenByName(accountId, name);
+          if (!match) return undefined;
+          // We have no value to populate — Cloudflare won't surface a
+          // bearer for an existing token. Mark Unowned so the engine
+          // forces the operator to opt in to adoption; on the next
+          // reconcile we'll roll the secret if `rollKey` is set or
+          // surface the absence of a value otherwise.
+          const attrs = buildAttributes(
+            match,
+            // We don't have the bearer; preserve any cached value on
+            // `output` (most likely undefined here since `output.tokenId`
+            // was empty), otherwise fall back to an empty Redacted that
+            // downstream consumers can detect.
+            output?.value ?? Redacted.make(""),
+            accountId,
+            output?.rolledFor,
           );
+          // No tag-based ownership — discovered tokens are foreign by
+          // default. The engine routes silent adoption when the cached
+          // `output.tokenId` matched, so reaching this branch means the
+          // engine state lost the id and a token of that name pre-exists.
+          return Unowned(attrs);
         }),
       };
     }),

--- a/packages/alchemy/src/Cloudflare/ApiToken/Common.ts
+++ b/packages/alchemy/src/Cloudflare/ApiToken/Common.ts
@@ -62,6 +62,15 @@ export type ApiTokenProps = {
   notBefore?: string;
   /** Optional usage conditions (e.g. IP allowlist). */
   condition?: ApiTokenCondition;
+  /**
+   * Rotate the token's secret value. Cloudflare returns the plaintext value
+   * only once (on create), so to rotate it later we must call the
+   * `roll` endpoint. Provide any opaque string here (e.g. an ISO date or
+   * version label); when the value differs from the previously persisted
+   * value, the next reconcile rolls the secret and stores the new
+   * Redacted value in `output.value`.
+   */
+  rollKey?: string;
 };
 
 export type ResolvedPolicy = {
@@ -123,6 +132,68 @@ export const conditionFingerprint = (
     in: [...(condition?.requestIp?.in ?? [])].sort(),
     notIn: [...(condition?.requestIp?.notIn ?? [])].sort(),
   });
+
+/**
+ * Compute a fingerprint of an *observed* token (`getToken` response)'s
+ * policies. The observed shape is more permissive (nullable fields,
+ * extra `id`/`name` on permission groups), so normalize before hashing
+ * so we can compare with `policyFingerprint(resolvePolicies(...))`.
+ */
+export const observedPolicyFingerprint = (
+  policies:
+    | {
+        effect: "allow" | "deny";
+        permissionGroups: { id: string; meta?: unknown }[];
+        resources: Record<string, unknown>;
+      }[]
+    | null
+    | undefined,
+): string =>
+  policyFingerprint(
+    (policies ?? []).map((p) => ({
+      effect: p.effect,
+      permissionGroups: p.permissionGroups.map((g) => {
+        const meta = g.meta as
+          | { key?: string; value?: string }
+          | null
+          | undefined;
+        return meta && (meta.key !== undefined || meta.value !== undefined)
+          ? {
+              id: g.id,
+              meta: {
+                key: meta.key,
+                value: meta.value,
+              },
+            }
+          : { id: g.id };
+      }),
+      resources: p.resources ?? {},
+    })),
+  );
+
+/**
+ * Normalize an observed `condition` payload (which may have nullable
+ * inner fields) to the shape `conditionFingerprint` expects.
+ */
+export const observedCondition = (
+  condition:
+    | {
+        requestIp?:
+          | { in?: string[] | null; notIn?: string[] | null }
+          | null;
+      }
+    | null
+    | undefined,
+): ApiTokenCondition | undefined => {
+  if (!condition?.requestIp) return undefined;
+  const { in: ins, notIn } = condition.requestIp;
+  return {
+    requestIp: {
+      in: ins ?? undefined,
+      notIn: notIn ?? undefined,
+    },
+  };
+};
 
 export const buildConditionPayload = (
   condition: ApiTokenCondition | undefined,

--- a/packages/alchemy/src/Cloudflare/ApiToken/UserApiToken.ts
+++ b/packages/alchemy/src/Cloudflare/ApiToken/UserApiToken.ts
@@ -1,6 +1,7 @@
 import * as user from "@distilled.cloud/cloudflare/user";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
+import { Unowned } from "../../AdoptPolicy.ts";
 import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
@@ -9,6 +10,8 @@ import type { Providers } from "../Providers.ts";
 import {
   buildConditionPayload,
   conditionFingerprint,
+  observedCondition,
+  observedPolicyFingerprint,
   policyFingerprint,
   resolvePolicies,
   type ApiTokenProps,
@@ -26,6 +29,12 @@ export type UserApiToken = Resource<
      * creation, so we persist it here for downstream consumers.
      */
     value: Redacted.Redacted<string>;
+    /**
+     * Opaque marker for the most recent successful `rollKey`. Persisting
+     * this lets the reconciler detect when the user has bumped `rollKey`
+     * and trigger a `putTokenValue` rotation.
+     */
+    rolledFor?: string;
   },
   never,
   Providers
@@ -60,6 +69,15 @@ export type UserApiToken = Resource<
  *   ],
  * });
  * ```
+ *
+ * @section Rotating a Token
+ * @example Bump `rollKey` to mint a new secret value
+ * ```typescript
+ * const token = yield* Cloudflare.UserApiToken("personal-token", {
+ *   policies: [...],
+ *   rollKey: "2025-05-01", // change this string to rotate the secret
+ * });
+ * ```
  */
 export const UserApiToken = Resource<UserApiToken>("Cloudflare.UserApiToken");
 
@@ -78,6 +96,8 @@ export const UserApiTokenProvider = () =>
       const updateToken = yield* user.updateToken;
       const deleteToken = yield* user.deleteToken;
       const getToken = yield* user.getToken;
+      const listTokens = yield* user.listTokens;
+      const putTokenValue = yield* user.putTokenValue;
 
       const buildAttributes = (
         tokenData: {
@@ -86,12 +106,28 @@ export const UserApiTokenProvider = () =>
           status?: "active" | "disabled" | "expired" | null;
         },
         value: Redacted.Redacted<string>,
+        rolledFor: string | undefined,
       ): UserApiTokenAttributes => ({
         tokenId: tokenData.id ?? "",
         name: tokenData.name ?? "",
         status: tokenData.status ?? "active",
         value,
+        rolledFor,
       });
+
+      const findTokenByName = (name: string) =>
+        Effect.gen(function* () {
+          const perPage = 50;
+          let page = 1;
+          while (true) {
+            const response = yield* listTokens({ page, perPage });
+            const match = response.result.find((t) => t.name === name);
+            if (match) return match;
+            const total = response.resultInfo.totalCount ?? 0;
+            if (page * perPage >= total) return undefined;
+            page += 1;
+          }
+        });
 
       return {
         stables: ["tokenId"],
@@ -99,6 +135,9 @@ export const UserApiTokenProvider = () =>
           if (!isResolved(news)) return undefined;
           const oldName = output?.name ?? (yield* resolveName(id, olds?.name));
           const newName = yield* resolveName(id, news.name);
+          if (oldName !== newName) {
+            return { action: "replace" } as const;
+          }
           const oldPolicyFp = policyFingerprint(
             resolvePolicies(olds?.policies ?? []),
           );
@@ -106,26 +145,30 @@ export const UserApiTokenProvider = () =>
           const oldCondFp = conditionFingerprint(olds?.condition);
           const newCondFp = conditionFingerprint(news.condition);
           if (
-            oldName !== newName ||
             oldPolicyFp !== newPolicyFp ||
             oldCondFp !== newCondFp ||
             (olds?.expiresOn ?? undefined) !== (news.expiresOn ?? undefined) ||
-            (olds?.notBefore ?? undefined) !== (news.notBefore ?? undefined)
+            (olds?.notBefore ?? undefined) !== (news.notBefore ?? undefined) ||
+            (olds?.rollKey ?? undefined) !== (news.rollKey ?? undefined)
           ) {
             return { action: "update" } as const;
           }
         }),
         reconcile: Effect.fn(function* ({ id, news, output }) {
           const name = yield* resolveName(id, news.name);
-          const policies = resolvePolicies(news.policies);
+          const desiredPolicies = resolvePolicies(news.policies);
+          const desiredPolicyFp = policyFingerprint(desiredPolicies);
+          const desiredCondFp = conditionFingerprint(news.condition);
 
           // Observe — fetch current state if we know the token id;
           // Cloudflare reports a deleted token as `TokenNotFound`, which
           // we treat as "create from scratch".
           const observed = output?.tokenId
             ? yield* getToken({ tokenId: output.tokenId }).pipe(
-                Effect.map((token) => token),
                 Effect.catchTag("TokenNotFound", () =>
+                  Effect.succeed(undefined),
+                ),
+                Effect.catchTag("InvalidRoute", () =>
                   Effect.succeed(undefined),
                 ),
               )
@@ -138,7 +181,7 @@ export const UserApiTokenProvider = () =>
           if (observed === undefined) {
             const result = yield* createToken({
               name,
-              policies,
+              policies: desiredPolicies,
               condition: buildConditionPayload(news.condition),
               expiresOn: news.expiresOn,
               notBefore: news.notBefore,
@@ -148,33 +191,95 @@ export const UserApiTokenProvider = () =>
                 `Cloudflare did not return a value for token "${name}".`,
               );
             }
-            return buildAttributes(result, Redacted.make(result.value));
+            return buildAttributes(
+              result,
+              Redacted.make(result.value),
+              news.rollKey,
+            );
           }
 
-          // Sync — the update API replaces all mutable fields. Cloudflare
-          // does not return the plaintext value on update, so preserve
-          // the one captured at creation.
-          const result = yield* updateToken({
-            tokenId: output!.tokenId,
-            name,
-            policies,
-            condition: buildConditionPayload(news.condition),
-            expiresOn: news.expiresOn,
-            notBefore: news.notBefore,
-          });
-          return buildAttributes(result, output!.value);
+          // Sync — diff observed cloud state against desired and call
+          // `updateToken` only if something actually drifted.
+          const observedPolicyFp = observedPolicyFingerprint(
+            observed.policies ?? null,
+          );
+          const observedCondFp = conditionFingerprint(
+            observedCondition(observed.condition ?? null),
+          );
+          const observedExpires = observed.expiresOn ?? undefined;
+          const observedNotBefore = observed.notBefore ?? undefined;
+          const desiredExpires = news.expiresOn ?? undefined;
+          const desiredNotBefore = news.notBefore ?? undefined;
+          const policyDrift = observedPolicyFp !== desiredPolicyFp;
+          const condDrift = observedCondFp !== desiredCondFp;
+          const nameDrift = (observed.name ?? "") !== name;
+          const windowDrift =
+            observedExpires !== desiredExpires ||
+            observedNotBefore !== desiredNotBefore;
+
+          let current: typeof observed = observed;
+          if (policyDrift || condDrift || nameDrift || windowDrift) {
+            current = yield* updateToken({
+              tokenId: output!.tokenId,
+              name,
+              policies: desiredPolicies,
+              condition: buildConditionPayload(news.condition),
+              expiresOn: news.expiresOn,
+              notBefore: news.notBefore,
+            });
+          }
+
+          // Sync — rotate the token's secret value when `rollKey`
+          // changed since the last successful roll.
+          let value = output!.value;
+          let rolledFor = output!.rolledFor;
+          if (
+            news.rollKey !== undefined &&
+            news.rollKey !== output!.rolledFor
+          ) {
+            const newValue = yield* putTokenValue({
+              tokenId: output!.tokenId,
+            });
+            if (!newValue) {
+              return yield* Effect.die(
+                `Cloudflare did not return a value when rolling token "${name}".`,
+              );
+            }
+            value = Redacted.make(newValue);
+            rolledFor = news.rollKey;
+          } else if (news.rollKey === undefined) {
+            rolledFor = undefined;
+          }
+
+          return buildAttributes(current, value, rolledFor);
         }),
         delete: Effect.fn(function* ({ output }) {
           yield* deleteToken({ tokenId: output.tokenId }).pipe(
             Effect.catchTag("TokenNotFound", () => Effect.void),
+            Effect.catchTag("InvalidRoute", () => Effect.void),
           );
         }),
-        read: Effect.fn(function* ({ output }) {
-          if (!output?.tokenId) return undefined;
-          return yield* getToken({ tokenId: output.tokenId }).pipe(
-            Effect.map((token) => buildAttributes(token, output.value)),
-            Effect.catchTag("TokenNotFound", () => Effect.succeed(undefined)),
+        read: Effect.fn(function* ({ id, olds, output }) {
+          if (output?.tokenId) {
+            return yield* getToken({ tokenId: output.tokenId }).pipe(
+              Effect.map((token) =>
+                buildAttributes(token, output.value, output.rolledFor),
+              ),
+              Effect.catchTag("TokenNotFound", () =>
+                Effect.succeed(undefined),
+              ),
+              Effect.catchTag("InvalidRoute", () => Effect.succeed(undefined)),
+            );
+          }
+          const name = yield* resolveName(id, olds?.name);
+          const match = yield* findTokenByName(name);
+          if (!match) return undefined;
+          const attrs = buildAttributes(
+            match,
+            output?.value ?? Redacted.make(""),
+            output?.rolledFor,
           );
+          return Unowned(attrs);
         }),
       };
     }),

--- a/packages/alchemy/test/Cloudflare/ApiToken/AccountApiToken.test.ts
+++ b/packages/alchemy/test/Cloudflare/ApiToken/AccountApiToken.test.ts
@@ -1,5 +1,7 @@
+import { adopt } from "@/AdoptPolicy";
 import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import { State } from "@/State";
 import * as Test from "@/Test/Vitest";
 import * as accounts from "@distilled.cloud/cloudflare/accounts";
 import { expect } from "@effect/vitest";
@@ -16,6 +18,8 @@ const logLevel = Effect.provideService(
   MinimumLogLevel,
   process.env.DEBUG ? "Debug" : "Info",
 );
+
+const randomSuffix = () => Math.random().toString(36).slice(2, 8);
 
 describe.skip("AccountApiToken", () => {
   test.provider("create and delete account token with default props", (stack) =>
@@ -58,70 +62,7 @@ describe.skip("AccountApiToken", () => {
     }).pipe(logLevel),
   );
 
-  test.provider("create, update, delete account token", (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* CloudflareEnvironment;
-
-      yield* stack.destroy();
-
-      const token = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.AccountApiToken("UpdateToken", {
-            name: "alchemy-test-acct-update-initial",
-            policies: [
-              {
-                effect: "allow",
-                permissionGroups: ["Workers Scripts Read"],
-                resources: {
-                  [`com.cloudflare.api.account.${accountId}`]: "*",
-                },
-              },
-            ],
-          });
-        }),
-      );
-
-      expect(token.name).toEqual("alchemy-test-acct-update-initial");
-      const initialValue = Redacted.value(token.value);
-
-      const updated = yield* stack.deploy(
-        Effect.gen(function* () {
-          return yield* Cloudflare.AccountApiToken("UpdateToken", {
-            name: "alchemy-test-acct-update-renamed",
-            policies: [
-              {
-                effect: "allow",
-                permissionGroups: [
-                  "Workers Scripts Read",
-                  "Workers KV Storage Read",
-                ],
-                resources: {
-                  [`com.cloudflare.api.account.${accountId}`]: "*",
-                },
-              },
-            ],
-          });
-        }),
-      );
-
-      expect(updated.tokenId).toEqual(token.tokenId);
-      expect(updated.name).toEqual("alchemy-test-acct-update-renamed");
-      expect(Redacted.value(updated.value)).toEqual(initialValue);
-
-      const actual = yield* accounts.getToken({
-        accountId,
-        tokenId: updated.tokenId,
-      });
-      expect(actual.name).toEqual("alchemy-test-acct-update-renamed");
-      expect(actual.policies?.[0]?.permissionGroups.length).toEqual(2);
-
-      yield* stack.destroy();
-
-      yield* waitForTokenToBeDeleted(token.tokenId, accountId);
-    }).pipe(logLevel),
-  );
-
-  test.provider("noop when account token props unchanged", (stack) =>
+  test.provider("redeploy with same props is a no-op", (stack) =>
     Effect.gen(function* () {
       const { accountId } = yield* CloudflareEnvironment;
 
@@ -152,10 +93,384 @@ describe.skip("AccountApiToken", () => {
         }),
       );
 
+      // Same id, same secret value — confirms diff returned undefined
+      // and reconcile didn't re-roll.
       expect(second.tokenId).toEqual(first.tokenId);
       expect(Redacted.value(second.value)).toEqual(Redacted.value(first.value));
 
       yield* stack.destroy();
+    }).pipe(logLevel),
+  );
+
+  test.provider("update changes name and policies", (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const token = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AccountApiToken("UpdateToken", {
+            name: "alchemy-test-acct-update-initial",
+            policies: [
+              {
+                effect: "allow",
+                permissionGroups: ["Workers Scripts Read"],
+                resources: {
+                  [`com.cloudflare.api.account.${accountId}`]: "*",
+                },
+              },
+            ],
+          });
+        }),
+      );
+
+      const initialValue = Redacted.value(token.value);
+
+      // Name change forces replace; policies change is a regular update.
+      // We exercise policies-only here so the secret value is preserved
+      // (replace would mint a new one).
+      const updated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AccountApiToken("UpdateToken", {
+            name: "alchemy-test-acct-update-initial",
+            policies: [
+              {
+                effect: "allow",
+                permissionGroups: [
+                  "Workers Scripts Read",
+                  "Workers KV Storage Read",
+                ],
+                resources: {
+                  [`com.cloudflare.api.account.${accountId}`]: "*",
+                },
+              },
+            ],
+          });
+        }),
+      );
+
+      expect(updated.tokenId).toEqual(token.tokenId);
+      expect(Redacted.value(updated.value)).toEqual(initialValue);
+
+      const actual = yield* accounts.getToken({
+        accountId,
+        tokenId: updated.tokenId,
+      });
+      expect(actual.policies?.[0]?.permissionGroups.length).toEqual(2);
+
+      yield* stack.destroy();
+
+      yield* waitForTokenToBeDeleted(token.tokenId, accountId);
+    }).pipe(logLevel),
+  );
+
+  test.provider(
+    "reconcile resets permissions mutated out-of-band",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        const desiredPolicies = [
+          {
+            effect: "allow" as const,
+            permissionGroups: ["Workers Scripts Read" as const],
+            resources: {
+              [`com.cloudflare.api.account.${accountId}`]: "*",
+            },
+          },
+        ];
+
+        const token = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.AccountApiToken("DriftToken", {
+              name: `alchemy-test-acct-drift-${randomSuffix()}`,
+              policies: desiredPolicies,
+            });
+          }),
+        );
+
+        // Mutate the token out-of-band: add an extra permission group.
+        yield* accounts.updateToken({
+          accountId,
+          tokenId: token.tokenId,
+          name: token.name,
+          policies: [
+            {
+              effect: "allow",
+              permissionGroups: [
+                { id: "82e64a83756745bbbb1c9c2701bf816b" }, // Workers Scripts Read
+                { id: "f7f0eda5697f475c90846e879bab8666" }, // KV Read
+              ],
+              resources: {
+                [`com.cloudflare.api.account.${accountId}`]: "*",
+              },
+            },
+          ],
+        });
+
+        // Redeploy with the *same* desired props. Reconcile observes
+        // the drifted live state and converges back to one permission.
+        const reconciled = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.AccountApiToken("DriftToken", {
+              name: token.name,
+              policies: desiredPolicies,
+            });
+          }),
+        );
+
+        expect(reconciled.tokenId).toEqual(token.tokenId);
+        const actual = yield* accounts.getToken({
+          accountId,
+          tokenId: token.tokenId,
+        });
+        expect(actual.policies?.[0]?.permissionGroups.length).toEqual(1);
+
+        yield* stack.destroy();
+        yield* waitForTokenToBeDeleted(token.tokenId, accountId);
+      }).pipe(logLevel),
+  );
+
+  test.provider("rollKey rotation advances the secret value", (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const baseProps = {
+        name: `alchemy-test-acct-roll-${randomSuffix()}`,
+        policies: [
+          {
+            effect: "allow" as const,
+            permissionGroups: ["Workers Scripts Read" as const],
+            resources: {
+              [`com.cloudflare.api.account.${accountId}`]: "*",
+            },
+          },
+        ],
+      };
+
+      const before = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AccountApiToken("RollToken", {
+            ...baseProps,
+            rollKey: "v1",
+          });
+        }),
+      );
+      const beforeValue = Redacted.value(before.value);
+
+      const after = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AccountApiToken("RollToken", {
+            ...baseProps,
+            rollKey: "v2",
+          });
+        }),
+      );
+
+      expect(after.tokenId).toEqual(before.tokenId);
+      expect(Redacted.value(after.value)).not.toEqual(beforeValue);
+
+      yield* stack.destroy();
+      yield* waitForTokenToBeDeleted(before.tokenId, accountId);
+    }).pipe(logLevel),
+  );
+
+  test.provider("reconcile re-creates a token deleted out-of-band", (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const physicalName = `alchemy-test-acct-recreate-${randomSuffix()}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AccountApiToken("RecreateToken", {
+            name: physicalName,
+            policies: [
+              {
+                effect: "allow",
+                permissionGroups: ["Workers Scripts Read"],
+                resources: {
+                  [`com.cloudflare.api.account.${accountId}`]: "*",
+                },
+              },
+            ],
+          });
+        }),
+      );
+
+      // Delete out-of-band.
+      yield* accounts.deleteToken({
+        accountId,
+        tokenId: initial.tokenId,
+      });
+
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AccountApiToken("RecreateToken", {
+            name: physicalName,
+            policies: [
+              {
+                effect: "allow",
+                permissionGroups: ["Workers Scripts Read"],
+                resources: {
+                  [`com.cloudflare.api.account.${accountId}`]: "*",
+                },
+              },
+            ],
+          });
+        }),
+      );
+
+      expect(recreated.tokenId).not.toEqual(initial.tokenId);
+      expect(recreated.name).toEqual(physicalName);
+
+      yield* stack.destroy();
+      yield* waitForTokenToBeDeleted(recreated.tokenId, accountId);
+    }).pipe(logLevel),
+  );
+
+  test.provider("changing name triggers replace", (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const policies = [
+        {
+          effect: "allow" as const,
+          permissionGroups: ["Workers Scripts Read" as const],
+          resources: {
+            [`com.cloudflare.api.account.${accountId}`]: "*",
+          },
+        },
+      ];
+
+      const before = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AccountApiToken("RenameToken", {
+            name: `alchemy-test-acct-before-${randomSuffix()}`,
+            policies,
+          });
+        }),
+      );
+
+      const after = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AccountApiToken("RenameToken", {
+            name: `alchemy-test-acct-after-${randomSuffix()}`,
+            policies,
+          });
+        }),
+      );
+
+      expect(after.tokenId).not.toEqual(before.tokenId);
+      // Old token gone (replace deletes after creating new).
+      yield* waitForTokenToBeDeleted(before.tokenId, accountId);
+
+      yield* stack.destroy();
+      yield* waitForTokenToBeDeleted(after.tokenId, accountId);
+    }).pipe(logLevel),
+  );
+
+  test.provider("destroying an already-deleted token is a no-op", (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const token = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AccountApiToken("DoubleDestroyToken", {
+            name: `alchemy-test-acct-double-${randomSuffix()}`,
+            policies: [
+              {
+                effect: "allow",
+                permissionGroups: ["Workers Scripts Read"],
+                resources: {
+                  [`com.cloudflare.api.account.${accountId}`]: "*",
+                },
+              },
+            ],
+          });
+        }),
+      );
+
+      // Delete out-of-band, then destroy via engine — should not raise.
+      yield* accounts.deleteToken({
+        accountId,
+        tokenId: token.tokenId,
+      });
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  );
+
+  test.provider("adopt(true) re-claims a foreign token", (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const physicalName = `alchemy-test-acct-adopt-${randomSuffix()}`;
+
+      // Phase 1: normal deploy creates the cloud token.
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AccountApiToken("AdoptableToken", {
+            name: physicalName,
+            policies: [
+              {
+                effect: "allow",
+                permissionGroups: ["Workers Scripts Read"],
+                resources: {
+                  [`com.cloudflare.api.account.${accountId}`]: "*",
+                },
+              },
+            ],
+          });
+        }),
+      );
+
+      // Phase 2: wipe local state — the token survives on Cloudflare.
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "AdoptableToken",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      // Phase 3: redeploy with `adopt(true)` so the engine takes over
+      // the foreign-by-tags token discovered via `findTokenByName`.
+      const adopted = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.AccountApiToken("AdoptableToken", {
+            name: physicalName,
+            policies: [
+              {
+                effect: "allow",
+                permissionGroups: ["Workers Scripts Read"],
+                resources: {
+                  [`com.cloudflare.api.account.${accountId}`]: "*",
+                },
+              },
+            ],
+          }).pipe(adopt(true));
+        }),
+      );
+
+      expect(adopted.tokenId).toEqual(initial.tokenId);
+
+      yield* stack.destroy();
+      yield* waitForTokenToBeDeleted(initial.tokenId, accountId);
     }).pipe(logLevel),
   );
 

--- a/packages/alchemy/test/Cloudflare/ApiToken/UserApiToken.test.ts
+++ b/packages/alchemy/test/Cloudflare/ApiToken/UserApiToken.test.ts
@@ -1,5 +1,7 @@
+import { adopt } from "@/AdoptPolicy";
 import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import { State } from "@/State";
 import * as Test from "@/Test/Vitest";
 import * as user from "@distilled.cloud/cloudflare/user";
 import { describe, expect } from "@effect/vitest";
@@ -15,6 +17,9 @@ const logLevel = Effect.provideService(
   MinimumLogLevel,
   process.env.DEBUG ? "Debug" : "Info",
 );
+
+const randomSuffix = () => Math.random().toString(36).slice(2, 8);
+
 describe.skip("UserApiToken", () => {
   test.provider("create and delete user token with default props", (stack) =>
     Effect.gen(function* () {
@@ -53,7 +58,45 @@ describe.skip("UserApiToken", () => {
     }).pipe(logLevel),
   );
 
-  test.provider("create, update, delete user token", (stack) =>
+  test.provider("redeploy with same props is a no-op", (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const props = {
+        name: "alchemy-test-user-noop",
+        policies: [
+          {
+            effect: "allow" as const,
+            permissionGroups: ["Workers Scripts Read" as const],
+            resources: {
+              [`com.cloudflare.api.account.${accountId}`]: "*",
+            },
+          },
+        ],
+      };
+
+      const first = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.UserApiToken("UserNoopToken", props);
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.UserApiToken("UserNoopToken", props);
+        }),
+      );
+
+      expect(second.tokenId).toEqual(first.tokenId);
+      expect(Redacted.value(second.value)).toEqual(Redacted.value(first.value));
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  );
+
+  test.provider("update changes policies", (stack) =>
     Effect.gen(function* () {
       const { accountId } = yield* CloudflareEnvironment;
 
@@ -76,13 +119,12 @@ describe.skip("UserApiToken", () => {
         }),
       );
 
-      expect(token.name).toEqual("alchemy-test-user-update-initial");
       const initialValue = Redacted.value(token.value);
 
       const updated = yield* stack.deploy(
         Effect.gen(function* () {
           return yield* Cloudflare.UserApiToken("UpdateUserToken", {
-            name: "alchemy-test-user-update-renamed",
+            name: "alchemy-test-user-update-initial",
             policies: [
               {
                 effect: "allow",
@@ -100,16 +142,303 @@ describe.skip("UserApiToken", () => {
       );
 
       expect(updated.tokenId).toEqual(token.tokenId);
-      expect(updated.name).toEqual("alchemy-test-user-update-renamed");
       expect(Redacted.value(updated.value)).toEqual(initialValue);
 
       const actual = yield* user.getToken({ tokenId: updated.tokenId });
-      expect(actual.name).toEqual("alchemy-test-user-update-renamed");
       expect(actual.policies?.[0]?.permissionGroups.length).toEqual(2);
 
       yield* stack.destroy();
 
       yield* waitForTokenToBeDeleted(token.tokenId);
+    }).pipe(logLevel),
+  );
+
+  test.provider(
+    "reconcile resets permissions mutated out-of-band",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        const desiredPolicies = [
+          {
+            effect: "allow" as const,
+            permissionGroups: ["Workers Scripts Read" as const],
+            resources: {
+              [`com.cloudflare.api.account.${accountId}`]: "*",
+            },
+          },
+        ];
+
+        const token = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.UserApiToken("UserDriftToken", {
+              name: `alchemy-test-user-drift-${randomSuffix()}`,
+              policies: desiredPolicies,
+            });
+          }),
+        );
+
+        yield* user.updateToken({
+          tokenId: token.tokenId,
+          name: token.name,
+          policies: [
+            {
+              effect: "allow",
+              permissionGroups: [
+                { id: "82e64a83756745bbbb1c9c2701bf816b" },
+                { id: "f7f0eda5697f475c90846e879bab8666" },
+              ],
+              resources: {
+                [`com.cloudflare.api.account.${accountId}`]: "*",
+              },
+            },
+          ],
+        });
+
+        const reconciled = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.UserApiToken("UserDriftToken", {
+              name: token.name,
+              policies: desiredPolicies,
+            });
+          }),
+        );
+
+        expect(reconciled.tokenId).toEqual(token.tokenId);
+        const actual = yield* user.getToken({ tokenId: token.tokenId });
+        expect(actual.policies?.[0]?.permissionGroups.length).toEqual(1);
+
+        yield* stack.destroy();
+        yield* waitForTokenToBeDeleted(token.tokenId);
+      }).pipe(logLevel),
+  );
+
+  test.provider("rollKey rotation advances the secret value", (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const baseProps = {
+        name: `alchemy-test-user-roll-${randomSuffix()}`,
+        policies: [
+          {
+            effect: "allow" as const,
+            permissionGroups: ["Workers Scripts Read" as const],
+            resources: {
+              [`com.cloudflare.api.account.${accountId}`]: "*",
+            },
+          },
+        ],
+      };
+
+      const before = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.UserApiToken("UserRollToken", {
+            ...baseProps,
+            rollKey: "v1",
+          });
+        }),
+      );
+      const beforeValue = Redacted.value(before.value);
+
+      const after = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.UserApiToken("UserRollToken", {
+            ...baseProps,
+            rollKey: "v2",
+          });
+        }),
+      );
+
+      expect(after.tokenId).toEqual(before.tokenId);
+      expect(Redacted.value(after.value)).not.toEqual(beforeValue);
+
+      yield* stack.destroy();
+      yield* waitForTokenToBeDeleted(before.tokenId);
+    }).pipe(logLevel),
+  );
+
+  test.provider("reconcile re-creates a token deleted out-of-band", (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const physicalName = `alchemy-test-user-recreate-${randomSuffix()}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.UserApiToken("UserRecreateToken", {
+            name: physicalName,
+            policies: [
+              {
+                effect: "allow",
+                permissionGroups: ["Workers Scripts Read"],
+                resources: {
+                  [`com.cloudflare.api.account.${accountId}`]: "*",
+                },
+              },
+            ],
+          });
+        }),
+      );
+
+      yield* user.deleteToken({ tokenId: initial.tokenId });
+
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.UserApiToken("UserRecreateToken", {
+            name: physicalName,
+            policies: [
+              {
+                effect: "allow",
+                permissionGroups: ["Workers Scripts Read"],
+                resources: {
+                  [`com.cloudflare.api.account.${accountId}`]: "*",
+                },
+              },
+            ],
+          });
+        }),
+      );
+
+      expect(recreated.tokenId).not.toEqual(initial.tokenId);
+      expect(recreated.name).toEqual(physicalName);
+
+      yield* stack.destroy();
+      yield* waitForTokenToBeDeleted(recreated.tokenId);
+    }).pipe(logLevel),
+  );
+
+  test.provider("changing name triggers replace", (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const policies = [
+        {
+          effect: "allow" as const,
+          permissionGroups: ["Workers Scripts Read" as const],
+          resources: {
+            [`com.cloudflare.api.account.${accountId}`]: "*",
+          },
+        },
+      ];
+
+      const before = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.UserApiToken("UserRenameToken", {
+            name: `alchemy-test-user-before-${randomSuffix()}`,
+            policies,
+          });
+        }),
+      );
+
+      const after = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.UserApiToken("UserRenameToken", {
+            name: `alchemy-test-user-after-${randomSuffix()}`,
+            policies,
+          });
+        }),
+      );
+
+      expect(after.tokenId).not.toEqual(before.tokenId);
+      yield* waitForTokenToBeDeleted(before.tokenId);
+
+      yield* stack.destroy();
+      yield* waitForTokenToBeDeleted(after.tokenId);
+    }).pipe(logLevel),
+  );
+
+  test.provider("destroying an already-deleted token is a no-op", (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const token = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.UserApiToken("UserDoubleDestroyToken", {
+            name: `alchemy-test-user-double-${randomSuffix()}`,
+            policies: [
+              {
+                effect: "allow",
+                permissionGroups: ["Workers Scripts Read"],
+                resources: {
+                  [`com.cloudflare.api.account.${accountId}`]: "*",
+                },
+              },
+            ],
+          });
+        }),
+      );
+
+      yield* user.deleteToken({ tokenId: token.tokenId });
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  );
+
+  test.provider("adopt(true) re-claims a foreign token", (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const physicalName = `alchemy-test-user-adopt-${randomSuffix()}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.UserApiToken("UserAdoptableToken", {
+            name: physicalName,
+            policies: [
+              {
+                effect: "allow",
+                permissionGroups: ["Workers Scripts Read"],
+                resources: {
+                  [`com.cloudflare.api.account.${accountId}`]: "*",
+                },
+              },
+            ],
+          });
+        }),
+      );
+
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "UserAdoptableToken",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      const adopted = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.UserApiToken("UserAdoptableToken", {
+            name: physicalName,
+            policies: [
+              {
+                effect: "allow",
+                permissionGroups: ["Workers Scripts Read"],
+                resources: {
+                  [`com.cloudflare.api.account.${accountId}`]: "*",
+                },
+              },
+            ],
+          }).pipe(adopt(true));
+        }),
+      );
+
+      expect(adopted.tokenId).toEqual(initial.tokenId);
+
+      yield* stack.destroy();
+      yield* waitForTokenToBeDeleted(initial.tokenId);
     }).pipe(logLevel),
   );
 


### PR DESCRIPTION
Hardens the `Cloudflare.AccountApiToken` and `Cloudflare.UserApiToken` reconcilers as the next pass of the per-resource hardening sweep on top of the reconcile migration. Both tokens get observe-vs-desired drift detection, an explicit `rollKey` for secret rotation, name-as-replace, and a `read` that discovers by name and brands as `Unowned`.

### Reconciler changes

```diff
  reconcile: Effect.fn(function* ({ id, news, output }) {
    ...
    const observed = output?.tokenId
      ? yield* getToken({ ... }).pipe(
          Effect.catchTag("TokenNotFound", () => Effect.succeed(undefined)),
          Effect.catchTag("InvalidRoute", () => Effect.succeed(undefined)),
        )
      : undefined;

    if (observed === undefined) { /* create */ }

-   // Always call updateToken on reconcile.
-   const result = yield* updateToken({ ... });
+   // Diff observed cloud state against desired and update only on drift.
+   const policyDrift = observedPolicyFingerprint(observed.policies) !== desiredPolicyFp;
+   const condDrift   = conditionFingerprint(observedCondition(observed.condition)) !== desiredCondFp;
+   const nameDrift   = (observed.name ?? "") !== name;
+   const windowDrift = ...;
+   if (policyDrift || condDrift || nameDrift || windowDrift) {
+     current = yield* updateToken({ ... });
+   }
```

Reconcile previously trusted `diff` (which only compares `olds` vs `news`) and unconditionally called `updateToken` on every reconcile. An out-of-band permission mutation never showed up in `olds`, so subsequent deploys with unchanged props left the drift in place. The new flow makes `getToken` the source of truth.

```diff
+ if (news.rollKey !== undefined && news.rollKey !== output!.rolledFor) {
+   const newValue = yield* putTokenValue({ ... });
+   value = Redacted.make(newValue);
+   rolledFor = news.rollKey;
+ }
```

New `rollKey` prop drives `PUT /tokens/{id}/value` (account + user variants). The new bearer is captured into a fresh `Redacted` and persisted as `output.value`; `output.rolledFor` records the marker so subsequent reconciles with the same `rollKey` are no-ops.

```diff
  diff: Effect.fn(function* ({ id, olds, news, output }) {
-   if (oldName !== newName || ... ) { return { action: "update" }; }
+   if (oldName !== newName) { return { action: "replace" }; }
+   if (oldPolicyFp !== newPolicyFp || oldCondFp !== newCondFp || ...) {
+     return { action: "update" };
+   }
  }),
```

Name now forces replace — name is part of token identity for audit/CI consumers and a clean cycle (mint new + retire old) is preferable to renaming in place.

```diff
  read: Effect.fn(function* ({ id, olds, output }) {
    if (output?.tokenId) { /* fast path: getToken */ }
+   const name = yield* resolveName(id, olds?.name);
+   const match = yield* findTokenByName(name);   // paginated listTokens
+   if (!match) return undefined;
+   return Unowned(buildAttributes(match, ...));
  }),
```

Tokens have no tag-based ownership signal, so a discovered token is always `Unowned`. Engine routes silent adoption only when `output.tokenId` round-trips through `getToken`; foreign discovery requires `adopt(true)` / `--adopt`.

### New lifecycle tests

Each test runs `destroy → deploy → … → destroy` on a `ScratchStack` and asserts convergence at every step. Same set for both `AccountApiToken` and `UserApiToken`:

- redeploy with same props is a no-op (token id and secret value preserved)
- update changes policies in place (id and secret value preserved)
- reconcile resets permissions mutated out-of-band via the raw SDK
- `rollKey` rotation: bumping the marker advances the secret value but keeps the id
- reconcile re-creates a token deleted out-of-band
- changing `name` triggers replace; old token is gone
- destroying an already-deleted token is a no-op
- `adopt(true)` re-claims a token after a state-store wipe

### Distilled patch

No patch needed. `accounts.{getToken,createToken,updateToken,deleteToken,listTokens,putTokenValue}` and the matching `user.*` operations already surface `TokenNotFound` and `InvalidRoute` as tagged errors (verified against `/Users/samgoodwin/workspaces/distilled/packages/cloudflare/src/services/{accounts,user}.ts`); no `UnknownCloudflareError` paths surface in the reconciler.
