### PR TITLE
fix(aws/scheduler): harden ScheduleGroup reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/Scheduler/ScheduleGroup.ts
+++ b/packages/alchemy/src/AWS/Scheduler/ScheduleGroup.ts
@@ -1,16 +1,18 @@
 import * as scheduler from "@distilled.cloud/aws/scheduler";
 import * as Effect from "effect/Effect";
+import * as Schedule_ from "effect/Schedule";
+import { Unowned } from "../../AdoptPolicy.ts";
 import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
-import type { Providers } from "../Providers.ts";
 import {
   createInternalTags,
   createTagsList,
   diffTags,
-  hasTags,
+  hasAlchemyTags,
 } from "../../Tags.ts";
+import type { Providers } from "../Providers.ts";
 
 export interface ScheduleGroupProps {
   /**
@@ -28,6 +30,10 @@ export interface ScheduleGroupProps {
  *
  * Schedule groups provide a namespace for schedules so higher-level helpers can
  * organize recurring jobs separately from one-shot or operational schedules.
+ *
+ * Unlike individual schedules, schedule groups DO support tagging, so alchemy
+ * brands its groups with internal tags and uses tag presence to decide whether
+ * a foreign group can be adopted (with `--adopt`/`adopt(true)`).
  *
  * @section Creating Schedule Groups
  * @example Basic Group
@@ -55,6 +61,26 @@ export const ScheduleGroup = Resource<ScheduleGroup>(
   "AWS.Scheduler.ScheduleGroup",
 );
 
+/**
+ * Bounded-retry on `ConflictException`. EventBridge Scheduler returns
+ * `ConflictException` when a group is in the transient `DELETING` /
+ * `CREATING` state or when a concurrent mutation is in flight; the API
+ * itself does not classify the error as retryable, so the provider retries
+ * locally rather than tagging the distilled error as `RetryableError`
+ * (which would also cover genuine name-collision conflicts).
+ */
+const conflictRetry = <A, E extends { _tag: string }, R>(
+  eff: Effect.Effect<A, E, R>,
+) =>
+  eff.pipe(
+    Effect.retry({
+      while: (e) => e._tag === "ConflictException",
+      schedule: Schedule_.spaced("2 seconds").pipe(
+        Schedule_.both(Schedule_.recurs(15)),
+      ),
+    }),
+  );
+
 export const ScheduleGroupProvider = () =>
   Provider.effect(
     ScheduleGroup,
@@ -79,9 +105,7 @@ export const ScheduleGroupProvider = () =>
           const scheduleGroupName =
             output?.scheduleGroupName ?? (yield* toName(id, olds));
           const described = yield* scheduler
-            .getScheduleGroup({
-              Name: scheduleGroupName,
-            })
+            .getScheduleGroup({ Name: scheduleGroupName })
             .pipe(
               Effect.catchTag("ResourceNotFoundException", () =>
                 Effect.succeed(undefined),
@@ -92,11 +116,32 @@ export const ScheduleGroupProvider = () =>
             return undefined;
           }
 
-          return {
+          const attrs = {
             scheduleGroupArn: described.Arn,
             scheduleGroupName: described.Name,
             state: described.State,
           };
+
+          // Probe tags. Schedule groups support tagging, so a foreign
+          // group can be detected by absence of our internal brand. If
+          // tagging is unavailable (rare — `ResourceNotFoundException`
+          // race), conservatively treat as unowned.
+          const tagsResp = yield* scheduler
+            .listTagsForResource({ ResourceArn: described.Arn })
+            .pipe(
+              Effect.map((r) =>
+                Object.fromEntries(
+                  (r.Tags ?? []).map((t) => [t.Key, t.Value]),
+                ),
+              ),
+              Effect.catchTag("ResourceNotFoundException", () =>
+                Effect.succeed({} as Record<string, string>),
+              ),
+            );
+
+          return (yield* hasAlchemyTags(id, tagsResp))
+            ? attrs
+            : Unowned(attrs);
         }),
         reconcile: Effect.fn(function* ({ id, news, output, session }) {
           const scheduleGroupName =
@@ -105,7 +150,7 @@ export const ScheduleGroupProvider = () =>
           const desiredTags = { ...internalTags, ...news.tags };
 
           // Observe — fetch live group; gracefully handle missing.
-          let observed = yield* scheduler
+          const observed = yield* scheduler
             .getScheduleGroup({ Name: scheduleGroupName })
             .pipe(
               Effect.catchTag("ResourceNotFoundException", () =>
@@ -113,62 +158,45 @@ export const ScheduleGroupProvider = () =>
               ),
             );
 
-          // Ensure — create if missing. Tolerate `ConflictException` as a
-          // race or adoption case: verify ownership via tags before
-          // continuing.
-          if (!observed?.Arn) {
-            yield* scheduler
+          // Ensure — create if missing. Bounded-retry `ConflictException`
+          // because a concurrent destroy may have left the group in
+          // `DELETING` and AWS rejects re-creation until the deletion
+          // completes. After a `ConflictException` window expires, the
+          // create attempt itself succeeds.
+          let groupArn: string | undefined = observed?.Arn;
+          if (!groupArn) {
+            groupArn = yield* scheduler
               .createScheduleGroup({
                 Name: scheduleGroupName,
                 Tags: createTagsList(desiredTags),
               })
               .pipe(
-                Effect.catchTag("ConflictException", () =>
-                  scheduler.getScheduleGroup({ Name: scheduleGroupName }).pipe(
-                    Effect.flatMap((existing) =>
-                      existing.Arn
-                        ? scheduler
-                            .listTagsForResource({ ResourceArn: existing.Arn })
-                            .pipe(
-                              Effect.filterOrFail(
-                                ({ Tags }) => hasTags(internalTags, Tags),
-                                () =>
-                                  new Error(
-                                    `ScheduleGroup '${scheduleGroupName}' already exists and is not managed by alchemy`,
-                                  ),
-                              ),
-                              Effect.asVoid,
-                            )
-                        : Effect.fail(
-                            new Error(
-                              `ScheduleGroup '${scheduleGroupName}' already exists but could not be described`,
-                            ),
-                          ),
-                    ),
-                  ),
-                ),
+                conflictRetry,
+                Effect.map((r) => r.ScheduleGroupArn),
               );
-            observed = yield* scheduler
+          }
+
+          if (!groupArn) {
+            // Re-read in case the create response did not echo the ARN.
+            const reread = yield* scheduler
               .getScheduleGroup({ Name: scheduleGroupName })
               .pipe(
                 Effect.catchTag("ResourceNotFoundException", () =>
                   Effect.succeed(undefined),
                 ),
               );
+            if (!reread?.Arn) {
+              return yield* Effect.fail(
+                new Error(
+                  `Failed to read created ScheduleGroup '${scheduleGroupName}'`,
+                ),
+              );
+            }
+            groupArn = reread.Arn;
           }
 
-          if (!observed?.Arn) {
-            return yield* Effect.fail(
-              new Error(
-                `Failed to read created ScheduleGroup '${scheduleGroupName}'`,
-              ),
-            );
-          }
-
-          const groupArn = observed.Arn;
-
-          // Sync tags — diff observed cloud tags against desired so
-          // adoption rewrites ownership tags.
+          // Sync tags — diff against observed cloud tags so adoption
+          // rewrites ownership tags and out-of-band tag drift converges.
           const observedTagsResp = yield* scheduler
             .listTagsForResource({ ResourceArn: groupArn })
             .pipe(
@@ -182,32 +210,46 @@ export const ScheduleGroupProvider = () =>
           const { removed, upsert } = diffTags(observedTags, desiredTags);
 
           if (removed.length > 0) {
-            yield* scheduler.untagResource({
-              ResourceArn: groupArn,
-              TagKeys: removed,
-            });
+            yield* scheduler
+              .untagResource({
+                ResourceArn: groupArn,
+                TagKeys: removed,
+              })
+              .pipe(conflictRetry);
           }
           if (upsert.length > 0) {
-            yield* scheduler.tagResource({
-              ResourceArn: groupArn,
-              Tags: upsert,
-            });
+            yield* scheduler
+              .tagResource({
+                ResourceArn: groupArn,
+                Tags: upsert,
+              })
+              .pipe(conflictRetry);
           }
+
+          // Re-read final state so we return the cloud's authoritative
+          // `State` (e.g. `ACTIVE`) rather than guess.
+          const finalState = yield* scheduler
+            .getScheduleGroup({ Name: scheduleGroupName })
+            .pipe(
+              Effect.map((r) => r.State),
+              Effect.catchTag("ResourceNotFoundException", () =>
+                Effect.succeed(undefined),
+              ),
+            );
 
           yield* session.note(groupArn);
 
           return {
             scheduleGroupArn: groupArn,
             scheduleGroupName,
-            state: observed?.State,
+            state: finalState,
           };
         }),
         delete: Effect.fn(function* ({ output }) {
           yield* scheduler
-            .deleteScheduleGroup({
-              Name: output.scheduleGroupName,
-            })
+            .deleteScheduleGroup({ Name: output.scheduleGroupName })
             .pipe(
+              conflictRetry,
               Effect.catchTag("ResourceNotFoundException", () => Effect.void),
             );
         }),

--- a/packages/alchemy/test/AWS/Scheduler/ScheduleGroup.test.ts
+++ b/packages/alchemy/test/AWS/Scheduler/ScheduleGroup.test.ts
@@ -1,0 +1,337 @@
+import { adopt } from "@/AdoptPolicy";
+import * as AWS from "@/AWS";
+import { ScheduleGroup } from "@/AWS/Scheduler";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import * as scheduler from "@distilled.cloud/aws/scheduler";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Schedule_ from "effect/Schedule";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+class GroupStillExists extends Data.TaggedError("GroupStillExists") {}
+class GroupTagsNotReady extends Data.TaggedError("GroupTagsNotReady") {}
+
+const assertGroupDeleted = Effect.fn(function* (groupName: string) {
+  yield* scheduler
+    .getScheduleGroup({ Name: groupName })
+    .pipe(
+      Effect.flatMap(() => Effect.fail(new GroupStillExists())),
+      Effect.catchTag("ResourceNotFoundException", () => Effect.void),
+      Effect.retry({
+        while: (e) => (e as { _tag: string })._tag === "GroupStillExists",
+        schedule: Schedule_.exponential(200).pipe(
+          Schedule_.both(Schedule_.recurs(10)),
+        ),
+      }),
+    );
+});
+
+const fetchGroupTags = Effect.fn(function* (arn: string) {
+  const r = yield* scheduler.listTagsForResource({ ResourceArn: arn });
+  return Object.fromEntries((r.Tags ?? []).map((t) => [t.Key, t.Value]));
+});
+
+/** Poll until tag set on the group matches `expected` (subset match). */
+const waitForTagsMatch = Effect.fn(function* (
+  arn: string,
+  expected: Record<string, string>,
+) {
+  yield* Effect.gen(function* () {
+    const tags = yield* fetchGroupTags(arn);
+    const ok = Object.entries(expected).every(([k, v]) => tags[k] === v);
+    if (!ok) {
+      return yield* Effect.fail(new GroupTagsNotReady());
+    }
+  }).pipe(
+    Effect.retry({
+      while: (e) => (e as { _tag: string })._tag === "GroupTagsNotReady",
+      schedule: Schedule_.fixed("500 millis").pipe(
+        Schedule_.both(Schedule_.recurs(40)),
+      ),
+    }),
+  );
+});
+
+test.provider(
+  "create and delete schedule group with default props",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const group = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* ScheduleGroup("DefaultGroup", {
+            tags: { domain: "ops" },
+          });
+        }),
+      );
+
+      expect(group.scheduleGroupArn).toBeDefined();
+      expect(group.scheduleGroupName).toBeDefined();
+
+      const described = yield* scheduler.getScheduleGroup({
+        Name: group.scheduleGroupName,
+      });
+      expect(described.Arn).toEqual(group.scheduleGroupArn);
+      expect(described.State).toEqual("ACTIVE");
+
+      const tags = yield* fetchGroupTags(group.scheduleGroupArn);
+      expect(tags.domain).toEqual("ops");
+
+      yield* stack.destroy();
+      yield* assertGroupDeleted(group.scheduleGroupName);
+    }),
+  { timeout: 240_000 },
+);
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* ScheduleGroup("IdempotentGroup", {
+            tags: { layer: "ops" },
+          });
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* ScheduleGroup("IdempotentGroup", {
+            tags: { layer: "ops" },
+          });
+        }),
+      );
+
+      expect(second.scheduleGroupArn).toEqual(initial.scheduleGroupArn);
+      expect(second.scheduleGroupName).toEqual(initial.scheduleGroupName);
+
+      const tags = yield* fetchGroupTags(second.scheduleGroupArn);
+      expect(tags.layer).toEqual("ops");
+
+      yield* stack.destroy();
+      yield* assertGroupDeleted(second.scheduleGroupName);
+    }),
+  { timeout: 240_000 },
+);
+
+test.provider(
+  "reconcile resets tags mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* ScheduleGroup("DriftGroup", {
+            tags: { domain: "ops", env: "prod" },
+          });
+        }),
+      );
+
+      // Mutate tags out-of-band: drop `env`, change `domain`, add `intruder`.
+      yield* scheduler.untagResource({
+        ResourceArn: initial.scheduleGroupArn,
+        TagKeys: ["env", "domain"],
+      });
+      yield* scheduler.tagResource({
+        ResourceArn: initial.scheduleGroupArn,
+        Tags: [
+          { Key: "domain", Value: "drifted" },
+          { Key: "intruder", Value: "yes" },
+        ],
+      });
+      yield* waitForTagsMatch(initial.scheduleGroupArn, {
+        domain: "drifted",
+        intruder: "yes",
+      });
+
+      // Re-deploy with original props — reconcile must reset the tag set.
+      const redeployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* ScheduleGroup("DriftGroup", {
+            tags: { domain: "ops", env: "prod" },
+          });
+        }),
+      );
+
+      expect(redeployed.scheduleGroupArn).toEqual(initial.scheduleGroupArn);
+
+      const tags = yield* fetchGroupTags(initial.scheduleGroupArn);
+      expect(tags.domain).toEqual("ops");
+      expect(tags.env).toEqual("prod");
+      expect(tags.intruder).toBeUndefined();
+
+      yield* stack.destroy();
+      yield* assertGroupDeleted(initial.scheduleGroupName);
+    }),
+  { timeout: 240_000 },
+);
+
+test.provider(
+  "reconcile re-creates a schedule group deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const groupName = `alchemy-test-grp-recreate-${suffix}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* ScheduleGroup("RecreateGroup", {
+            name: groupName,
+            tags: { layer: "ops" },
+          });
+        }),
+      );
+      expect(initial.scheduleGroupName).toEqual(groupName);
+
+      // Delete out-of-band. The group enters `DELETING` and removal is
+      // eventually consistent.
+      yield* scheduler.deleteScheduleGroup({ Name: groupName });
+      yield* assertGroupDeleted(groupName);
+
+      // Re-deploy. The reconciler must create a fresh group with the
+      // same name, riding the bounded `ConflictException` retry through
+      // any residual `DELETING` window.
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* ScheduleGroup("RecreateGroup", {
+            name: groupName,
+            tags: { layer: "ops" },
+          });
+        }),
+      );
+
+      expect(recreated.scheduleGroupName).toEqual(groupName);
+      const described = yield* scheduler.getScheduleGroup({ Name: groupName });
+      expect(described.Arn).toBeDefined();
+      const tags = yield* fetchGroupTags(described.Arn!);
+      expect(tags.layer).toEqual("ops");
+
+      yield* stack.destroy();
+      yield* assertGroupDeleted(groupName);
+    }),
+  { timeout: 360_000 },
+);
+
+test.provider(
+  "changing schedule group name triggers replace",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const nameA = `alchemy-test-grp-replace-a-${suffix}`;
+      const nameB = `alchemy-test-grp-replace-b-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* ScheduleGroup("RenameGroup", { name: nameA });
+        }),
+      );
+      expect(a.scheduleGroupName).toEqual(nameA);
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* ScheduleGroup("RenameGroup", { name: nameB });
+        }),
+      );
+      expect(b.scheduleGroupName).toEqual(nameB);
+      expect(b.scheduleGroupArn).not.toEqual(a.scheduleGroupArn);
+
+      yield* assertGroupDeleted(nameA);
+
+      yield* stack.destroy();
+      yield* assertGroupDeleted(nameB);
+    }),
+  { timeout: 360_000 },
+);
+
+test.provider(
+  "destroying an already-deleted schedule group is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const result = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* ScheduleGroup("DoubleDestroyGroup", {});
+        }),
+      );
+
+      // Delete out-of-band, then ask the engine to destroy the stack.
+      yield* scheduler.deleteScheduleGroup({
+        Name: result.scheduleGroupName,
+      });
+      yield* assertGroupDeleted(result.scheduleGroupName);
+
+      yield* stack.destroy();
+    }),
+  { timeout: 240_000 },
+);
+
+test.provider(
+  "foreign-tagged schedule group requires adopt(true) to take over",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const groupName = `alchemy-test-grp-adopt-${suffix}`;
+
+      const original = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* ScheduleGroup("Original", {
+            name: groupName,
+            tags: { phase: "before" },
+          });
+        }),
+      );
+
+      // Wipe engine state — group remains in AWS with the old logical
+      // ID's internal tags. A subsequent deploy under a different
+      // logical ID has no engine-state record and the tags don't match,
+      // so adoption requires `adopt(true)`.
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "Original",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      const takenOver = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* ScheduleGroup("Different", {
+              name: groupName,
+              tags: { phase: "after" },
+            });
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(takenOver.scheduleGroupName).toEqual(groupName);
+      expect(takenOver.scheduleGroupArn).toEqual(original.scheduleGroupArn);
+
+      // Adoption must rewrite the internal alchemy::id tag and the user
+      // tag set so the group is now branded for the new logical ID.
+      yield* waitForTagsMatch(takenOver.scheduleGroupArn, {
+        phase: "after",
+        "alchemy::id": "Different",
+      });
+
+      yield* stack.destroy();
+      yield* assertGroupDeleted(groupName);
+    }),
+  { timeout: 360_000 },
+);


### PR DESCRIPTION
Following the SQS hardening template from [#184](https://github.com/alchemy-run/alchemy-effect/pull/184) and the sibling Schedule PR [#200](https://github.com/alchemy-run/alchemy-effect/pull/200). Hardens the EventBridge Scheduler `ScheduleGroup` resource. Unlike `Schedule`, schedule groups DO support tagging — so ownership detection, adoption gating, and tag-drift convergence are all in scope here.

### Reconciler changes

```diff
- if (!observed?.Arn) {
-   yield* scheduler.createScheduleGroup({ Name, Tags })
-     .pipe(Effect.catchTag("ConflictException", () => …listTagsForResource…hasTags…throw…))
-   observed = yield* scheduler.getScheduleGroup({ Name })
- }
- // tag sync diffed against observedTagsResp — kept
+ const arn = observed?.Arn
+   ?? yield* scheduler.createScheduleGroup({ Name, Tags })
+        .pipe(conflictRetry, Effect.map(r => r.ScheduleGroupArn));
```

- `read` now returns `Unowned(attrs)` when the group lacks the alchemy internal tag set, so first-touch adoption requires `--adopt` / `adopt(true)` instead of being silently taken over. Subsequent reconciles trust the persisted output.
- Drop the bespoke `ConflictException` ownership check on `createScheduleGroup`. The previous code fetched tags, called `hasTags`, and threw a plain `Error` if they didn't match — duplicating ownership logic that now lives entirely in `read` + the engine's `--adopt` gate.
- Replace it with a bounded `ConflictException` retry (15 × 2s) on `createScheduleGroup`, `tagResource`, `untagResource`, and `deleteScheduleGroup`. EventBridge Scheduler returns `ConflictException` while a group is in the transient `DELETING`/`CREATING` state, so re-creating a name through a residual `DELETING` window now converges instead of failing.
- Re-read the final `State` from the cloud after reconcile rather than echoing `observed?.State` (which may be stale by one round-trip).

`ConflictException` is intentionally NOT tagged `RetryableError` in distilled — it's context-dependent (`DELETING` race vs. genuine name collision). The reconciler-level bounded retry stays scoped.

### New lifecycle tests

`packages/alchemy/test/AWS/Scheduler/ScheduleGroup.test.ts` — each test runs `destroy → deploy → … → destroy` on a `ScratchStack` and asserts convergence at every step:

- create + delete with default props
- redeploy with same props is a no-op
- reconcile resets tags mutated out-of-band via the raw Scheduler SDK
- reconcile re-creates a group deleted out-of-band (rides the `DELETING` window)
- changing `name` triggers replace; old group is deleted
- destroying an already-deleted group is a no-op
- foreign-tagged group requires `adopt(true)` to take over and rewrites internal alchemy tags

### Distilled patch

No patch needed — `packages/aws/patches/scheduler.json` (per the existing process) already covers `ConflictException`, and tagging it `RetryableError` would over-broaden coverage. The reconciler-level bounded retry handles the genuinely transient cases.
