### PR TITLE
fix(aws/organizations): harden Organizations resources reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/Organizations/Account.ts
+++ b/packages/alchemy/src/AWS/Organizations/Account.ts
@@ -301,10 +301,14 @@ const waitForCreateAccount = (requestId: string) =>
 
     return status;
   }).pipe(
+    // Account creation is asynchronous on AWS's side. Typical completion is
+    // ~90s but it can extend past 5 minutes under load or when CloudTrail /
+    // billing setup is slow. Cap at ~10 minutes (300 polls × 2s) so a stuck
+    // request eventually surfaces.
     Effect.retry({
       while: (error: any) => error?._tag === "CreateAccountInProgress",
       schedule: Schedule.spaced("2 seconds").pipe(
-        Schedule.both(Schedule.recurs(120)),
+        Schedule.both(Schedule.recurs(300)),
       ),
     }),
   );

--- a/packages/alchemy/src/AWS/Organizations/Organization.ts
+++ b/packages/alchemy/src/AWS/Organizations/Organization.ts
@@ -3,7 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
-import { retryOrganizations } from "./common.ts";
+import { retryDeleteEmptiness, retryOrganizations } from "./common.ts";
 
 export type OrganizationId = string;
 export type OrganizationArn = string;
@@ -108,7 +108,13 @@ export const OrganizationProvider = () =>
           return toAttrs(org);
         }),
         delete: Effect.fn(function* () {
-          yield* retryOrganizations(
+          // `OrganizationNotEmptyException` is permanent in the sense that we
+          // can't retry our way out of unrelated children, but immediately
+          // after the engine removes child accounts/OUs the listing is
+          // eventually consistent and can briefly still report the org as
+          // non-empty. `retryDeleteEmptiness` caps the retry window so a
+          // genuine dependency surfaces instead of hanging.
+          yield* retryDeleteEmptiness(
             organizations
               .deleteOrganization({})
               .pipe(

--- a/packages/alchemy/src/AWS/Organizations/OrganizationResourcePolicy.ts
+++ b/packages/alchemy/src/AWS/Organizations/OrganizationResourcePolicy.ts
@@ -4,7 +4,7 @@ import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
 import type { PolicyDocument } from "../IAM/Policy.ts";
-import { retryOrganizations } from "./common.ts";
+import { retryOrganizations, stableStringify } from "./common.ts";
 
 export interface OrganizationResourcePolicyProps {
   /**
@@ -64,6 +64,10 @@ export const OrganizationResourcePolicyProvider = () =>
         }),
         reconcile: Effect.fn(function* ({ news, session }) {
           const desiredContent = JSON.stringify(news.document);
+          // AWS doesn't preserve object key order on round-trip; compare
+          // documents through a stable stringifier so reconcile doesn't flap
+          // and re-`putResourcePolicy` on every run.
+          const desiredContentForCompare = stableStringify(news.document);
 
           // Observe — fetch the live resource policy (or absence).
           let state = yield* readResourcePolicy();
@@ -72,12 +76,12 @@ export const OrganizationResourcePolicyProvider = () =>
           // first-create and update. We diff observed content against
           // desired so the call only fires when there's drift. Reading by
           // ID isn't possible (resource is a singleton with a server-issued
-          // ID), so we compare the JSON-stringified document.
+          // ID), so we compare key-order-stable serializations.
           const observedContent = state
-            ? JSON.stringify(state.document)
+            ? stableStringify(state.document)
             : undefined;
 
-          if (observedContent !== desiredContent) {
+          if (observedContent !== desiredContentForCompare) {
             yield* retryOrganizations(
               organizations.putResourcePolicy({
                 Content: desiredContent,

--- a/packages/alchemy/src/AWS/Organizations/OrganizationalUnit.ts
+++ b/packages/alchemy/src/AWS/Organizations/OrganizationalUnit.ts
@@ -10,6 +10,7 @@ import {
   collectPages,
   createName,
   readResourceTags,
+  retryDeleteEmptiness,
   retryOrganizations,
   updateResourceTags,
 } from "./common.ts";
@@ -175,7 +176,11 @@ export const OrganizationalUnitProvider = () =>
           };
         }),
         delete: Effect.fn(function* ({ output }) {
-          yield* retryOrganizations(
+          // `OrganizationalUnitNotEmptyException` is a true dependency
+          // violation, but the engine deletes children first and the OU's
+          // child listing can lag for a short window. `retryDeleteEmptiness`
+          // bounds the retry; a stuck reference still surfaces.
+          yield* retryDeleteEmptiness(
             organizations
               .deleteOrganizationalUnit({
                 OrganizationalUnitId: output.ouId,

--- a/packages/alchemy/src/AWS/Organizations/Policy.ts
+++ b/packages/alchemy/src/AWS/Organizations/Policy.ts
@@ -11,7 +11,9 @@ import {
   collectPages,
   createName,
   readResourceTags,
+  retryDeleteEmptiness,
   retryOrganizations,
+  stableStringify,
   updateResourceTags,
 } from "./common.ts";
 
@@ -99,6 +101,11 @@ export const PolicyProvider = () =>
         reconcile: Effect.fn(function* ({ id, news, output, session }) {
           const name = yield* toName(id, news);
           const desiredDescription = news.description ?? "";
+          // The AWS API stores the policy document but doesn't preserve key
+          // order on round-trip. Comparing `stableStringify` outputs avoids
+          // a flap where reconcile thinks the doc has drifted just because
+          // keys came back in a different order.
+          const desiredContentForCompare = stableStringify(news.document);
           const desiredContent = JSON.stringify(news.document);
 
           // Observe — locate the policy by ID if known, else by type+name.
@@ -145,10 +152,10 @@ export const PolicyProvider = () =>
           // desired. `updatePolicy` requires `Name`; we keep the existing
           // policy name (rename triggers replacement at the diff level).
           const observedDescription = state.description ?? "";
-          const observedContent = JSON.stringify(state.document);
+          const observedContent = stableStringify(state.document);
           if (
             observedDescription !== desiredDescription ||
-            observedContent !== desiredContent
+            observedContent !== desiredContentForCompare
           ) {
             yield* retryOrganizations(
               organizations.updatePolicy({
@@ -184,7 +191,12 @@ export const PolicyProvider = () =>
           };
         }),
         delete: Effect.fn(function* ({ output }) {
-          yield* retryOrganizations(
+          // `PolicyInUseException` fires when the policy is still attached to
+          // any target. The engine should have detached attachments first via
+          // dependency ordering, but the listing is eventually consistent.
+          // `retryDeleteEmptiness` bounds the retry window; a real persistent
+          // attachment still surfaces.
+          yield* retryDeleteEmptiness(
             organizations
               .deletePolicy({ PolicyId: output.policyId })
               .pipe(

--- a/packages/alchemy/src/AWS/Organizations/common.ts
+++ b/packages/alchemy/src/AWS/Organizations/common.ts
@@ -47,19 +47,72 @@ export const collectPages = <Page extends { NextToken?: string }, Item, E, R>(
     return items;
   });
 
+/**
+ * The Organizations control plane serializes mutating calls per-org and
+ * surfaces a small set of genuinely transient errors when two writes overlap
+ * or the org is mid-finalize. Anything in this list is safe to retry without
+ * additional context.
+ */
+const isRetryableOrganizationsError = (error: any) =>
+  error?._tag === "ConcurrentModificationException" ||
+  error?._tag === "TooManyRequestsException" ||
+  error?._tag === "ServiceException" ||
+  error?._tag === "FinalizingOrganizationException" ||
+  error?._tag === "PolicyChangesInProgressException";
+
 export const retryOrganizations = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   effect.pipe(
     Effect.retry({
-      while: (error: any) =>
-        error?._tag === "ConcurrentModificationException" ||
-        error?._tag === "TooManyRequestsException" ||
-        error?._tag === "ServiceException" ||
-        error?._tag === "FinalizingOrganizationException",
-      schedule: Schedule.exponential(200).pipe(
-        Schedule.both(Schedule.recurs(8)),
+      while: isRetryableOrganizationsError,
+      schedule: Schedule.exponential(250).pipe(
+        Schedule.both(Schedule.recurs(12)),
       ),
     }),
   );
+
+/**
+ * Bounded retry for delete-time "container is not empty" errors. After the
+ * engine deletes child resources, the parent delete can still see them for a
+ * short eventual-consistency window. We cap the retry so a genuine, persistent
+ * dependency surfaces as a real error instead of hanging indefinitely.
+ */
+export const retryDeleteEmptiness = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  effect.pipe(
+    Effect.retry({
+      while: (error: any) =>
+        isRetryableOrganizationsError(error) ||
+        error?._tag === "OrganizationNotEmptyException" ||
+        error?._tag === "OrganizationalUnitNotEmptyException" ||
+        error?._tag === "PolicyInUseException",
+      schedule: Schedule.exponential(500).pipe(
+        Schedule.both(Schedule.recurs(10)),
+      ),
+    }),
+  );
+
+/**
+ * Deterministic JSON stringifier for comparing policy documents. Object key
+ * order isn't preserved by AWS round-trips, so the naive `JSON.stringify`
+ * comparison can flap and trigger needless `updatePolicy` calls (or, worse,
+ * mask real drift in the other direction).
+ */
+export const stableStringify = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const keys = Object.keys(value as Record<string, unknown>).sort();
+    return `{${keys
+      .map(
+        (key) =>
+          `${JSON.stringify(key)}:${stableStringify(
+            (value as Record<string, unknown>)[key],
+          )}`,
+      )
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+};
 
 export const createManagedTags = Effect.fn(function* (
   id: string,


### PR DESCRIPTION
Per-resource hardening sweep for AWS Organizations. No live integration tests added — they require a real management account and consume a non-renewable account-creation quota; flagged as outstanding.

### Reconciler changes

Add `PolicyChangesInProgressException` to the transient set and bump the retry budget. AWS Organizations serializes policy changes per-org and surfaces this tag mid-apply; it's genuinely transient.

```diff
 const isRetryableOrganizationsError = (error: any) =>
   error?._tag === "ConcurrentModificationException" ||
   error?._tag === "TooManyRequestsException" ||
   error?._tag === "ServiceException" ||
-  error?._tag === "FinalizingOrganizationException";
+  error?._tag === "FinalizingOrganizationException" ||
+  error?._tag === "PolicyChangesInProgressException";
```

Bound `retryDeleteEmptiness` for `*NotEmptyException` / `PolicyInUseException` on delete. These are genuine dependency violations, but right after the engine deletes children the parent's listing is eventually consistent and can briefly still report non-empty. Caps at ~10 attempts of exponential backoff so a real persistent reference still surfaces.

```ts
export const retryDeleteEmptiness = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
  effect.pipe(
    Effect.retry({
      while: (error: any) =>
        isRetryableOrganizationsError(error) ||
        error?._tag === "OrganizationNotEmptyException" ||
        error?._tag === "OrganizationalUnitNotEmptyException" ||
        error?._tag === "PolicyInUseException",
      schedule: Schedule.exponential(500).pipe(
        Schedule.both(Schedule.recurs(10)),
      ),
    }),
  );
```

Wrap `Organization.delete`, `OrganizationalUnit.delete`, `Policy.delete` with `retryDeleteEmptiness`.

Stable-stringify policy documents in `Policy` and `OrganizationResourcePolicy` reconcilers. AWS doesn't preserve object key order on round-trip, so the naive `JSON.stringify` comparison flapped and re-issued `updatePolicy` / `putResourcePolicy` on every reconcile.

```diff
- const observedContent = JSON.stringify(state.document);
+ const observedContent = stableStringify(state.document);
```

Bump `Account` create-status poll cap from 240s (120 × 2s) to 600s (300 × 2s). Account creation typically completes in ~90s but can extend past 5 minutes; the old cap surfaced spurious failures.

### New lifecycle tests

None. Organizations reconcile/delete tests need a real management account, can only run sequentially, and exhaust the non-renewable account-creation quota. Flagged as outstanding — running them requires an opted-in test account.

### Distilled patch

No patch needed. The relevant errors (`PolicyChangesInProgressException`, `*NotEmptyException`, `PolicyInUseException`, `ConcurrentModificationException`) already carry the right base categories in distilled (`ConflictError`); the per-call retry helpers handle the context-specific transience that the AWS retry layer can't infer.
