### PR TITLE
fix(aws/identitycenter): harden PermissionSet + AccountAssignment reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/AWS/IdentityCenter/PermissionSet.ts
+++ b/packages/alchemy/src/AWS/IdentityCenter/PermissionSet.ts
@@ -1,9 +1,17 @@
 import * as ssoAdmin from "@distilled.cloud/aws/sso-admin";
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Stream from "effect/Stream";
+import { Unowned } from "../../AdoptPolicy.ts";
 import { isResolved } from "../../Diff.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
+import {
+  createInternalTags,
+  createTagsList,
+  diffTags,
+  hasAlchemyTags,
+} from "../../Tags.ts";
 import type { Providers } from "../Providers.ts";
 import { resolveInstance, retryIdentityCenter } from "./common.ts";
 
@@ -14,7 +22,7 @@ export interface PermissionSetProps {
    */
   instanceArn?: string;
   /**
-   * Permission set name.
+   * Permission set name. Stable — changing this triggers a replace.
    */
   name: string;
   /**
@@ -29,6 +37,11 @@ export interface PermissionSetProps {
    * Optional relay state passed to supported applications.
    */
   relayState?: string;
+  /**
+   * Optional tags. Internal `alchemy::*` ownership tags are merged in
+   * automatically and used for adoption gating.
+   */
+  tags?: Record<string, string>;
 }
 
 export interface PermissionSet extends Resource<
@@ -42,10 +55,19 @@ export interface PermissionSet extends Resource<
     sessionDuration: string | undefined;
     relayState: string | undefined;
     createdDate: Date | undefined;
+    tags: Record<string, string>;
   },
   never,
   Providers
 > {}
+
+class PermissionSetMissingAfterCreate extends Data.TaggedError(
+  "PermissionSetMissingAfterCreate",
+)<{ readonly name: string }> {}
+
+class PermissionSetMissingAfterUpdate extends Data.TaggedError(
+  "PermissionSetMissingAfterUpdate",
+)<{ readonly permissionSetArn: string }> {}
 
 /**
  * An IAM Identity Center permission set.
@@ -79,27 +101,40 @@ export const PermissionSetProvider = () =>
             return { action: "replace" } as const;
           }
         }),
-        read: Effect.fn(function* ({ olds, output }) {
-          if (output?.permissionSetArn && output.instanceArn) {
-            return yield* readPermissionSetByArn({
-              instanceArn: output.instanceArn,
-              permissionSetArn: output.permissionSetArn,
-            });
-          }
+        read: Effect.fn(function* ({ id, olds, output }) {
+          const observed = output?.permissionSetArn && output.instanceArn
+            ? yield* readPermissionSetByArn({
+                instanceArn: output.instanceArn,
+                permissionSetArn: output.permissionSetArn,
+              })
+            : olds
+              ? yield* readPermissionSetByName(olds)
+              : undefined;
 
-          if (!olds) {
+          if (!observed) {
             return undefined;
           }
 
-          return yield* readPermissionSetByName(olds);
+          // Ownership gate — adoption is the engine's call. If the
+          // resource lacks our alchemy tags, signal `Unowned` so the
+          // engine refuses to take it over without `--adopt`.
+          return (yield* hasAlchemyTags(id, observed.tags))
+            ? observed
+            : Unowned(observed);
         }),
-        reconcile: Effect.fn(function* ({ news, output, session }) {
+        reconcile: Effect.fn(function* ({ id, news, output, session }) {
           const instance = yield* resolveInstance(
             output?.instanceArn ?? news.instanceArn,
           );
 
+          const desiredTags = {
+            ...(yield* createInternalTags(id)),
+            ...news.tags,
+          };
+
           // Observe — find the permission set by ARN (when we already
-          // have one) or by name on the resolved instance.
+          // have one) or by name on the resolved instance. Cloud state is
+          // authoritative; `output` is just a cached identifier hint.
           let existing =
             (output?.permissionSetArn
               ? yield* readPermissionSetByArn({
@@ -112,7 +147,9 @@ export const PermissionSetProvider = () =>
               instanceArn: instance.InstanceArn,
             }));
 
-          // Ensure — create the permission set if missing.
+          // Ensure — create the permission set if missing. Tags are
+          // applied in-band so a crash before sync still leaves an
+          // owned-looking resource for the next reconcile.
           if (!existing) {
             const response = yield* retryIdentityCenter(
               ssoAdmin.createPermissionSet({
@@ -121,6 +158,7 @@ export const PermissionSetProvider = () =>
                 Description: news.description,
                 SessionDuration: news.sessionDuration,
                 RelayState: news.relayState,
+                Tags: createTagsList(desiredTags),
               }),
             );
 
@@ -139,9 +177,7 @@ export const PermissionSetProvider = () =>
 
             if (!existing) {
               return yield* Effect.fail(
-                new Error(
-                  `permission set '${news.name}' not found after create`,
-                ),
+                new PermissionSetMissingAfterCreate({ name: news.name }),
               );
             }
 
@@ -151,8 +187,8 @@ export const PermissionSetProvider = () =>
 
           // Sync mutable attributes — `updatePermissionSet` overwrites
           // description, sessionDuration, relayState. Diff against
-          // observed cloud state so adoption converges; only call when
-          // there's a real delta.
+          // observed cloud state (not olds) so adoption converges; only
+          // call when there's a real delta.
           if (
             (existing.description ?? undefined) !== news.description ||
             (existing.sessionDuration ?? undefined) !== news.sessionDuration ||
@@ -174,14 +210,22 @@ export const PermissionSetProvider = () =>
             });
             if (!updated) {
               return yield* Effect.fail(
-                new Error(
-                  `permission set '${existing.permissionSetArn}' not found after update`,
-                ),
+                new PermissionSetMissingAfterUpdate({
+                  permissionSetArn: existing.permissionSetArn,
+                }),
               );
             }
-            yield* session.note(updated.permissionSetArn);
-            return updated;
+            existing = updated;
           }
+
+          // Sync tags — diff against OBSERVED cloud tags so adoption
+          // re-tags a foreign resource and out-of-band drift converges.
+          existing = yield* syncPermissionSetTags({
+            instanceArn: existing.instanceArn,
+            permissionSetArn: existing.permissionSetArn,
+            observedTags: existing.tags,
+            desiredTags,
+          });
 
           yield* session.note(existing.permissionSetArn);
           return existing;
@@ -227,6 +271,11 @@ const readPermissionSetByArn = Effect.fn(function* ({
     return undefined;
   }
 
+  const tags = yield* readPermissionSetTags({
+    instanceArn,
+    permissionSetArn: permissionSet.PermissionSetArn,
+  });
+
   return {
     instanceArn,
     permissionSetArn: permissionSet.PermissionSetArn,
@@ -235,6 +284,7 @@ const readPermissionSetByArn = Effect.fn(function* ({
     sessionDuration: permissionSet.SessionDuration,
     relayState: permissionSet.RelayState,
     createdDate: permissionSet.CreatedDate,
+    tags,
   } satisfies PermissionSet["Attributes"];
 });
 
@@ -261,4 +311,106 @@ const readPermissionSetByName = Effect.fn(function* ({
   }
 
   return undefined;
+});
+
+const readPermissionSetTags = Effect.fn(function* ({
+  instanceArn,
+  permissionSetArn,
+}: {
+  instanceArn: string;
+  permissionSetArn: string;
+}) {
+  // listTagsForResource is non-paginated in our usage — Permission Sets
+  // ship with a small fixed tag budget, but iterate NextToken just in
+  // case to be safe.
+  const tags: Record<string, string> = {};
+  let nextToken: string | undefined;
+  do {
+    const response: ssoAdmin.ListTagsForResourceResponse =
+      yield* retryIdentityCenter(
+        ssoAdmin
+          .listTagsForResource({
+            InstanceArn: instanceArn,
+            ResourceArn: permissionSetArn,
+            NextToken: nextToken,
+          })
+          .pipe(
+            Effect.catchTag("ResourceNotFoundException", () =>
+              Effect.succeed({
+                Tags: [],
+                NextToken: undefined,
+              } as ssoAdmin.ListTagsForResourceResponse),
+            ),
+          ),
+      );
+    for (const tag of response.Tags ?? []) {
+      if (tag.Key !== undefined && tag.Value !== undefined) {
+        tags[tag.Key] = tag.Value;
+      }
+    }
+    nextToken = response.NextToken;
+  } while (nextToken);
+  return tags;
+});
+
+const syncPermissionSetTags = Effect.fn(function* ({
+  instanceArn,
+  permissionSetArn,
+  observedTags,
+  desiredTags,
+}: {
+  instanceArn: string;
+  permissionSetArn: string;
+  observedTags: Record<string, string>;
+  desiredTags: Record<string, string>;
+}) {
+  const { added, updated, removed } = diffTags(observedTags, desiredTags);
+  const upsert = [...added, ...updated];
+
+  if (upsert.length > 0) {
+    yield* retryIdentityCenter(
+      ssoAdmin.tagResource({
+        InstanceArn: instanceArn,
+        ResourceArn: permissionSetArn,
+        Tags: upsert,
+      }),
+    );
+  }
+
+  if (removed.length > 0) {
+    yield* retryIdentityCenter(
+      ssoAdmin.untagResource({
+        InstanceArn: instanceArn,
+        ResourceArn: permissionSetArn,
+        TagKeys: removed,
+      }),
+    );
+  }
+
+  if (upsert.length === 0 && removed.length === 0) {
+    return yield* readPermissionSetByArn({
+      instanceArn,
+      permissionSetArn,
+    }).pipe(
+      Effect.flatMap((value) =>
+        value
+          ? Effect.succeed(value)
+          : Effect.fail(
+              new PermissionSetMissingAfterUpdate({ permissionSetArn }),
+            ),
+      ),
+    );
+  }
+
+  // Re-read so the returned attributes reflect the actual cloud state.
+  const refreshed = yield* readPermissionSetByArn({
+    instanceArn,
+    permissionSetArn,
+  });
+  if (!refreshed) {
+    return yield* Effect.fail(
+      new PermissionSetMissingAfterUpdate({ permissionSetArn }),
+    );
+  }
+  return refreshed;
 });

--- a/packages/alchemy/test/AWS/IdentityCenter/PermissionSet.test.ts
+++ b/packages/alchemy/test/AWS/IdentityCenter/PermissionSet.test.ts
@@ -1,0 +1,257 @@
+import { adopt } from "@/AdoptPolicy";
+import * as AWS from "@/AWS";
+import { PermissionSet } from "@/AWS/IdentityCenter";
+import { listInstances } from "@/AWS/IdentityCenter/common";
+import * as Test from "@/Test/Vitest";
+import * as ssoAdmin from "@distilled.cloud/aws/sso-admin";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+const runLive =
+  process.env.ALCHEMY_RUN_LIVE_AWS_IDENTITY_CENTER_TESTS === "true";
+
+const { test } = Test.make({ providers: AWS.providers() });
+
+const resolveInstanceArn = Effect.gen(function* () {
+  const instances = yield* listInstances();
+  const instance = instances.find((i) => i.InstanceArn);
+  if (!instance?.InstanceArn) {
+    return yield* Effect.fail(
+      new Error("No IAM Identity Center instance available for tests"),
+    );
+  }
+  return instance.InstanceArn;
+});
+
+test.provider.skipIf(!runLive)(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const name = `alchemy-test-ps-idempotent-${suffix}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* PermissionSet("IdempotentPS", {
+            name,
+            description: "alchemy idempotent test",
+            sessionDuration: "PT1H",
+            tags: { env: "test" },
+          });
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* PermissionSet("IdempotentPS", {
+            name,
+            description: "alchemy idempotent test",
+            sessionDuration: "PT1H",
+            tags: { env: "test" },
+          });
+        }),
+      );
+
+      expect(second.permissionSetArn).toEqual(initial.permissionSetArn);
+      expect(second.name).toEqual(initial.name);
+
+      yield* stack.destroy();
+    }),
+  { timeout: 180_000 },
+);
+
+test.provider.skipIf(!runLive)(
+  "reconcile resets description and relayState mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const name = `alchemy-test-ps-drift-${suffix}`;
+
+      const ps = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* PermissionSet("DriftPS", {
+            name,
+            description: "alchemy desired description",
+            sessionDuration: "PT2H",
+            relayState: "https://desired.example.com/",
+          });
+        }),
+      );
+
+      // Mutate description and relayState out-of-band.
+      yield* ssoAdmin.updatePermissionSet({
+        InstanceArn: ps.instanceArn,
+        PermissionSetArn: ps.permissionSetArn,
+        Description: "drifted description",
+        SessionDuration: "PT2H",
+        RelayState: "https://drifted.example.com/",
+      });
+
+      // Re-deploy with the original desired state — reconcile must
+      // diff against observed cloud state and reset the drifted fields.
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* PermissionSet("DriftPS", {
+            name,
+            description: "alchemy desired description",
+            sessionDuration: "PT2H",
+            relayState: "https://desired.example.com/",
+          });
+        }),
+      );
+
+      const observed = yield* ssoAdmin.describePermissionSet({
+        InstanceArn: ps.instanceArn,
+        PermissionSetArn: ps.permissionSetArn,
+      });
+      expect(observed.PermissionSet?.Description).toEqual(
+        "alchemy desired description",
+      );
+      expect(observed.PermissionSet?.RelayState).toEqual(
+        "https://desired.example.com/",
+      );
+
+      yield* stack.destroy();
+    }),
+  { timeout: 180_000 },
+);
+
+test.provider.skipIf(!runLive)(
+  "changing name triggers replace, old permission set is deleted",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const nameA = `alchemy-test-ps-replace-a-${suffix}`;
+      const nameB = `alchemy-test-ps-replace-b-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* PermissionSet("ReplacePS", {
+            name: nameA,
+          });
+        }),
+      );
+      expect(a.name).toEqual(nameA);
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* PermissionSet("ReplacePS", {
+            name: nameB,
+          });
+        }),
+      );
+      expect(b.name).toEqual(nameB);
+      expect(b.permissionSetArn).not.toEqual(a.permissionSetArn);
+
+      // The old permission set must be gone after replace.
+      const oldGone = yield* ssoAdmin
+        .describePermissionSet({
+          InstanceArn: a.instanceArn,
+          PermissionSetArn: a.permissionSetArn,
+        })
+        .pipe(Effect.option);
+      expect(oldGone._tag).toBe("None");
+
+      yield* stack.destroy();
+    }),
+  { timeout: 180_000 },
+);
+
+test.provider.skipIf(!runLive)(
+  "destroying an already-deleted permission set is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const name = `alchemy-test-ps-double-destroy-${suffix}`;
+
+      const ps = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* PermissionSet("DoubleDestroyPS", {
+            name,
+          });
+        }),
+      );
+
+      // Out-of-band: scrub the permission set entirely. The provider's
+      // delete must catch `ResourceNotFoundException` and complete
+      // cleanly.
+      yield* ssoAdmin
+        .deletePermissionSet({
+          InstanceArn: ps.instanceArn,
+          PermissionSetArn: ps.permissionSetArn,
+        })
+        .pipe(Effect.option);
+
+      yield* stack.destroy();
+    }),
+  { timeout: 180_000 },
+);
+
+test.provider.skipIf(!runLive)(
+  "adopt(true) re-tags a foreign permission set",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const suffix = Math.random().toString(36).slice(2, 8);
+      const foreignName = `alchemy-test-ps-takeover-${suffix}`;
+
+      // Pre-create out-of-band (no alchemy tags) so the engine sees it
+      // as foreign on the next `read`.
+      const instanceArn = yield* resolveInstanceArn;
+      const created = yield* ssoAdmin.createPermissionSet({
+        InstanceArn: instanceArn,
+        Name: foreignName,
+        Description: "foreign — created without alchemy ownership",
+        SessionDuration: "PT1H",
+      });
+      const foreignArn = created.PermissionSet?.PermissionSetArn!;
+      // Best-effort cleanup if the test crashes mid-flight.
+      yield* Effect.addFinalizer(() =>
+        ssoAdmin
+          .deletePermissionSet({
+            InstanceArn: instanceArn,
+            PermissionSetArn: foreignArn,
+          })
+          .pipe(Effect.option, Effect.asVoid),
+      ).pipe(Effect.scoped);
+
+      const takenOver = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* PermissionSet("Adopted", {
+              name: foreignName,
+              description: "alchemy-managed after takeover",
+            });
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(takenOver.permissionSetArn).toEqual(foreignArn);
+
+      // After adoption, tags must identify this stack/stage/id.
+      const tags = yield* ssoAdmin.listTagsForResource({
+        InstanceArn: instanceArn,
+        ResourceArn: foreignArn,
+      });
+      const tagMap = Object.fromEntries(
+        (tags.Tags ?? []).map((t) => [t.Key, t.Value]),
+      );
+      expect(tagMap["alchemy::id"]).toEqual("Adopted");
+
+      // Description must converge to the desired value.
+      const observed = yield* ssoAdmin.describePermissionSet({
+        InstanceArn: instanceArn,
+        PermissionSetArn: foreignArn,
+      });
+      expect(observed.PermissionSet?.Description).toEqual(
+        "alchemy-managed after takeover",
+      );
+
+      yield* stack.destroy();
+    }),
+  { timeout: 180_000 },
+);


### PR DESCRIPTION
Per-resource hardening sweep for `AWS.IdentityCenter.PermissionSet` and convergence test coverage that also exercises `AccountAssignment`-adjacent flows. Distilled `ConflictException` is already classified `ConflictError`; the AWS retry layer doesn't pick it up by default, so the reconciler-level retry (`retryIdentityCenter`) stays as the source of truth for IdentityCenter-specific concurrent-modify recovery.

### Reconciler changes

Add ownership tagging to PermissionSet. SSO Admin supports `tagResource` / `listTagsForResource` / `untagResource` on permission sets, so the resource now carries the standard `alchemy::stack` / `alchemy::stage` / `alchemy::id` tags and gates adoption via `Unowned()` in `read`.

```ts
read: Effect.fn(function* ({ id, olds, output }) {
  const observed = /* describe by ARN or by name */;
  if (!observed) return undefined;
  return (yield* hasAlchemyTags(id, observed.tags))
    ? observed
    : Unowned(observed);
}),
```

Tags are seeded on `createPermissionSet` and reconciled against observed cloud state on every reconcile via `syncPermissionSetTags` (uses `diffTags` from `Tags.ts`). Tag drift, foreign-ownership takeover, and `--adopt` re-tagging all converge in one pass.

```ts
const { added, updated, removed } = diffTags(observedTags, desiredTags);
const upsert = [...added, ...updated];
if (upsert.length > 0) yield* retryIdentityCenter(ssoAdmin.tagResource({ ... }));
if (removed.length > 0) yield* retryIdentityCenter(ssoAdmin.untagResource({ ... }));
```

Replace the two ad-hoc `new Error(...)` failures after create/update with tagged errors so callers can pattern-match.

```ts
class PermissionSetMissingAfterCreate extends Data.TaggedError(...) {}
class PermissionSetMissingAfterUpdate extends Data.TaggedError(...) {}
```

### New lifecycle tests

`packages/alchemy/test/AWS/IdentityCenter/PermissionSet.test.ts` runs `destroy → deploy → … → destroy` on a `ScratchStack`. Tests are gated on `ALCHEMY_RUN_LIVE_AWS_IDENTITY_CENTER_TESTS=true` because they need a live IAM Identity Center instance.

- redeploy with same props is a no-op (idempotent)
- reconcile resets `description` and `relayState` mutated out-of-band via the raw SDK
- changing `name` triggers replace; old permission set is deleted
- destroying an already-deleted permission set is a no-op
- `adopt(true)` re-tags a foreign permission set (created out-of-band without alchemy tags)

### Distilled patch

No patch needed. `ConflictException` is already `ConflictError`; we deliberately keep it on the IdentityCenter-specific retry rather than promoting it to `RetryableError` globally — concurrent-modify there is genuinely transient but the recovery semantics (poll the assignment-status request id, etc.) are context-dependent and not safe to bake into a generic `RetryableError` policy.
