### PR TITLE
fix(axiom): harden Dashboard/View/VirtualField/Annotation/ApiToken reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/Axiom/Annotation.ts
+++ b/packages/alchemy/src/Axiom/Annotation.ts
@@ -1,8 +1,36 @@
 import * as Axiom from "@distilled.cloud/axiom";
 import * as Effect from "effect/Effect";
+import { Unowned } from "../AdoptPolicy.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
+import { Stack } from "../Stack.ts";
+import { Stage } from "../Stage.ts";
 import type { Providers } from "./Providers.ts";
+
+const MARKER_RE = /\s*\[alchemy:stack=([^;]+);stage=([^;]+);id=([^\]]+)\]\s*$/;
+
+const buildMarker = (stack: string, stage: string, id: string) =>
+  `[alchemy:stack=${stack};stage=${stage};id=${id}]`;
+
+const stripMarker = (description: string | undefined) =>
+  (description ?? "").replace(MARKER_RE, "").trimEnd();
+
+const augmentDescription = (
+  description: string | undefined,
+  marker: string,
+) => {
+  const base = stripMarker(description);
+  return base.length > 0 ? `${base}\n${marker}` : marker;
+};
+
+const parseMarker = (
+  description: string | undefined,
+): { stack: string; stage: string; id: string } | undefined => {
+  if (!description) return undefined;
+  const m = description.match(MARKER_RE);
+  if (!m) return undefined;
+  return { stack: m[1], stage: m[2], id: m[3] };
+};
 
 export type AnnotationProps = Axiom.CreateAnnotationInput;
 
@@ -67,7 +95,15 @@ export const AnnotationProvider = () =>
 
       return {
         stables: ["id"],
-        reconcile: Effect.fn(function* ({ news, output }) {
+        reconcile: Effect.fn(function* ({ id, news, output }) {
+          const stack = yield* Stack;
+          const stage = yield* Stage;
+          const marker = buildMarker(stack.name, stage, id);
+          const desired = {
+            ...news,
+            description: augmentDescription(news.description, marker),
+          };
+
           // Observe — Axiom assigns the annotation id server-side, so the
           // only handle to a previously-created annotation is the cached
           // `output.id`. Probe for live state with that id; treat NotFound
@@ -81,15 +117,18 @@ export const AnnotationProvider = () =>
           // Ensure — when no observed annotation exists, POST creates one
           // and Axiom assigns the id.
           if (observed === undefined) {
-            return yield* create(news);
+            return yield* create(desired);
           }
 
           // Sync — the annotation exists; apply desired props with PUT and
-          // preserve the stable id and original time as fallbacks.
-          const result = yield* update({ ...news, id: observed.id! });
+          // preserve the stable id and original time as fallbacks. If it
+          // disappeared between observe and update, recreate.
+          const result = yield* update({ ...desired, id: observed.id! }).pipe(
+            Effect.catchTag("NotFound", () => create(desired)),
+          );
           return {
             ...result,
-            id: observed.id!,
+            id: result.id ?? observed.id!,
             time: result.time ?? output?.time ?? news.time,
           };
         }),
@@ -98,16 +137,26 @@ export const AnnotationProvider = () =>
             Effect.catchTag("NotFound", () => Effect.void),
           );
         }),
-        read: Effect.fn(function* ({ output }) {
+        read: Effect.fn(function* ({ id, output }) {
           if (!output?.id) return undefined;
-          return yield* get({ id: output.id }).pipe(
-            Effect.map((current) => ({
-              ...current,
-              id: current.id ?? output.id,
-              time: current.time ?? output.time,
-            })),
+          const stack = yield* Stack;
+          const stage = yield* Stage;
+          const existing = yield* get({ id: output.id }).pipe(
             Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
           );
+          if (!existing) return undefined;
+          const ownership = parseMarker(existing.description);
+          const isOurs =
+            ownership !== undefined &&
+            ownership.stack === stack.name &&
+            ownership.stage === stage &&
+            ownership.id === id;
+          const attrs = {
+            ...existing,
+            id: existing.id ?? output.id,
+            time: existing.time ?? output.time,
+          };
+          return isOurs ? attrs : Unowned(attrs);
         }),
       };
     }),

--- a/packages/alchemy/src/Axiom/ApiToken.ts
+++ b/packages/alchemy/src/Axiom/ApiToken.ts
@@ -108,7 +108,7 @@ export const ApiTokenProvider = () =>
           // once; capture it into Redacted state for downstream consumers.
           const result = yield* create(news);
           if (!result.token) {
-            return yield* Effect.die(
+            return yield* Effect.fail(
               new Error("Axiom did not return a token on create"),
             );
           }

--- a/packages/alchemy/src/Axiom/Dashboard.ts
+++ b/packages/alchemy/src/Axiom/Dashboard.ts
@@ -1,7 +1,10 @@
 import * as Axiom from "@distilled.cloud/axiom";
 import * as Effect from "effect/Effect";
+import { Unowned } from "../AdoptPolicy.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
+import { Stack } from "../Stack.ts";
+import { Stage } from "../Stage.ts";
 import type { Chart, LayoutCell } from "./Chart.ts";
 import type { Providers } from "./Providers.ts";
 
@@ -131,6 +134,38 @@ export type Dashboard = Resource<
  */
 export const Dashboard = Resource<Dashboard>("Axiom.Dashboard");
 
+/**
+ * Axiom dashboards have no tags/labels API. The only writable field we can
+ * use to mark ownership is `description`. We append a deterministic marker
+ * so that on a re-apply (e.g. state was wiped) we can identify a dashboard
+ * we previously created and adopt it idempotently — without hijacking a
+ * dashboard created by someone else with the same uid.
+ */
+const MARKER_RE = /\s*\[alchemy:stack=([^;]+);stage=([^;]+);id=([^\]]+)\]\s*$/;
+
+const buildMarker = (stack: string, stage: string, id: string) =>
+  `[alchemy:stack=${stack};stage=${stage};id=${id}]`;
+
+const stripMarker = (description: string | undefined) =>
+  (description ?? "").replace(MARKER_RE, "").trimEnd();
+
+const augmentDescription = (
+  description: string | undefined,
+  marker: string,
+) => {
+  const base = stripMarker(description);
+  return base.length > 0 ? `${base}\n${marker}` : marker;
+};
+
+const parseMarker = (
+  description: string | undefined,
+): { stack: string; stage: string; id: string } | undefined => {
+  if (!description) return undefined;
+  const m = description.match(MARKER_RE);
+  if (!m) return undefined;
+  return { stack: m[1], stage: m[2], id: m[3] };
+};
+
 export const DashboardProvider = () =>
   Provider.effect(
     Dashboard,
@@ -159,9 +194,28 @@ export const DashboardProvider = () =>
         dashboard: current.dashboard,
       });
 
+      const augmentInput = (
+        input: Axiom.CreateDashboardInput,
+        marker: string,
+      ): Axiom.CreateDashboardInput => ({
+        ...input,
+        dashboard: {
+          ...input.dashboard,
+          description: augmentDescription(
+            input.dashboard.description,
+            marker,
+          ),
+        },
+      });
+
       return {
         stables: ["uid", "id", "createdAt", "createdBy"],
-        reconcile: Effect.fn(function* ({ news, output }) {
+        reconcile: Effect.fn(function* ({ id, news, output }) {
+          const stack = yield* Stack;
+          const stage = yield* Stage;
+          const marker = buildMarker(stack.name, stage, id);
+          const desired = augmentInput(news, marker);
+
           // Observe — `uid` is server-assigned at create time. We probe
           // Axiom for the dashboard via the cached uid; treat NotFound
           // (deleted out-of-band) as "no observed state" so we converge
@@ -174,14 +228,27 @@ export const DashboardProvider = () =>
 
           // Ensure — POST mints a new dashboard with a fresh uid.
           if (observed === undefined) {
-            return toAttrsFromCreate(yield* create(news));
+            return toAttrsFromCreate(yield* create(desired));
           }
 
           // Sync — `overwrite: true` short-circuits Axiom's optimistic-
           // concurrency check (otherwise the API requires the caller to
           // echo back the server-side `version`, which we don't track).
+          // If the dashboard disappeared between observe and update
+          // (deleted out-of-band mid-reconcile), the SDK routes a 404 to
+          // `NotFound` via `HTTP_STATUS_MAP`; `updateDashboard` does not
+          // declare it so we narrow on `_tag` and recover by re-creating.
           return toAttrsFromCreate(
-            yield* update({ ...news, uid: observed.uid, overwrite: true }),
+            yield* update({
+              ...desired,
+              uid: observed.uid,
+              overwrite: true,
+            }).pipe(
+              Effect.catch((e: { readonly _tag?: string }) => {
+                if (e._tag === "NotFound") return create(desired);
+                return Effect.fail(e);
+              }),
+            ),
           );
         }),
         delete: Effect.fn(function* ({ output }) {
@@ -189,12 +256,22 @@ export const DashboardProvider = () =>
             Effect.catchTag("NotFound", () => Effect.void),
           );
         }),
-        read: Effect.fn(function* ({ output }) {
+        read: Effect.fn(function* ({ id, output }) {
           if (!output?.uid) return undefined;
-          return yield* get({ uid: output.uid }).pipe(
-            Effect.map(toAttrsFromGet),
+          const stack = yield* Stack;
+          const stage = yield* Stage;
+          const existing = yield* get({ uid: output.uid }).pipe(
             Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
           );
+          if (!existing) return undefined;
+          const ownership = parseMarker(existing.dashboard.description);
+          const isOurs =
+            ownership !== undefined &&
+            ownership.stack === stack.name &&
+            ownership.stage === stage &&
+            ownership.id === id;
+          const attrs = toAttrsFromGet(existing);
+          return isOurs ? attrs : Unowned(attrs);
         }),
       };
     }),

--- a/packages/alchemy/src/Axiom/View.ts
+++ b/packages/alchemy/src/Axiom/View.ts
@@ -1,9 +1,37 @@
 import * as Axiom from "@distilled.cloud/axiom";
 import * as Effect from "effect/Effect";
+import { Unowned } from "../AdoptPolicy.ts";
 import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
+import { Stack } from "../Stack.ts";
+import { Stage } from "../Stage.ts";
 import type { Providers } from "./Providers.ts";
+
+const MARKER_RE = /\s*\[alchemy:stack=([^;]+);stage=([^;]+);id=([^\]]+)\]\s*$/;
+
+const buildMarker = (stack: string, stage: string, id: string) =>
+  `[alchemy:stack=${stack};stage=${stage};id=${id}]`;
+
+const stripMarker = (description: string | undefined) =>
+  (description ?? "").replace(MARKER_RE, "").trimEnd();
+
+const augmentDescription = (
+  description: string | undefined,
+  marker: string,
+) => {
+  const base = stripMarker(description);
+  return base.length > 0 ? `${base}\n${marker}` : marker;
+};
+
+const parseMarker = (
+  description: string | undefined,
+): { stack: string; stage: string; id: string } | undefined => {
+  if (!description) return undefined;
+  const m = description.match(MARKER_RE);
+  if (!m) return undefined;
+  return { stack: m[1], stage: m[2], id: m[3] };
+};
 
 export type ViewProps = Axiom.CreateViewInput;
 
@@ -81,7 +109,16 @@ export const ViewProvider = () =>
           }
           return undefined;
         }),
-        reconcile: Effect.fn(function* ({ news, output }) {
+        reconcile: Effect.fn(function* ({ id, news, output }) {
+          const stack = yield* Stack;
+          const stage = yield* Stage;
+          const marker = buildMarker(stack.name, stage, id);
+          const desiredDescription = augmentDescription(
+            news.description,
+            marker,
+          );
+          const desired = { ...news, description: desiredDescription };
+
           // Observe — `name` is the path identifier for views. Renames are
           // forced to a replacement by `diff` above, so the cached
           // `output.id` (set to `news.name` on first create) and the
@@ -91,15 +128,53 @@ export const ViewProvider = () =>
             Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
           );
 
-          // Ensure — POST creates the view under `news.name`.
+          // Ensure — POST creates the view under `news.name`. Axiom's
+          // `createView` declares `UnprocessableEntity` for name reuse;
+          // 409s fall through `HTTP_STATUS_MAP` to `Conflict` (typed) or
+          // `UnknownAxiomError` (fallback). On any of those, re-observe
+          // and either update if we own it or surface the foreign-owner
+          // error so the engine's adoption gate fires.
           if (observed === undefined) {
-            const result = yield* create(news);
+            const result = yield* create(desired).pipe(
+              Effect.catch((e: { readonly _tag?: string }) => {
+                const tag = e._tag;
+                if (
+                  tag === "UnprocessableEntity" ||
+                  tag === "Conflict" ||
+                  tag === "UnknownAxiomError"
+                ) {
+                  return Effect.gen(function* () {
+                    const existing = yield* get({ id: news.name }).pipe(
+                      Effect.catchTag("NotFound", () =>
+                        Effect.succeed(undefined),
+                      ),
+                    );
+                    if (existing === undefined) {
+                      return yield* Effect.fail(e);
+                    }
+                    const ownership = parseMarker(existing.description);
+                    const isOurs =
+                      ownership === undefined ||
+                      (ownership.stack === stack.name &&
+                        ownership.stage === stage &&
+                        ownership.id === id);
+                    if (!isOurs) {
+                      return yield* Effect.fail(e);
+                    }
+                    return yield* update({ ...desired, id: news.name });
+                  });
+                }
+                return Effect.fail(e);
+              }),
+            );
             return { ...result, id: news.name };
           }
 
           // Sync — the view exists; PUT against its id with the desired
-          // props.
-          const result = yield* update({ ...news, id: viewId });
+          // props. If the view disappeared mid-reconcile, recreate.
+          const result = yield* update({ ...desired, id: viewId }).pipe(
+            Effect.catchTag("NotFound", () => create(desired)),
+          );
           return { ...result, id: viewId };
         }),
         delete: Effect.fn(function* ({ output }) {
@@ -107,12 +182,22 @@ export const ViewProvider = () =>
             Effect.catchTag("NotFound", () => Effect.void),
           );
         }),
-        read: Effect.fn(function* ({ output }) {
+        read: Effect.fn(function* ({ id, output }) {
           if (!output?.id) return undefined;
-          return yield* get({ id: output.id }).pipe(
-            Effect.map((current) => ({ ...current, id: output.id })),
+          const stack = yield* Stack;
+          const stage = yield* Stage;
+          const existing = yield* get({ id: output.id }).pipe(
             Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
           );
+          if (!existing) return undefined;
+          const ownership = parseMarker(existing.description);
+          const isOurs =
+            ownership !== undefined &&
+            ownership.stack === stack.name &&
+            ownership.stage === stage &&
+            ownership.id === id;
+          const attrs = { ...existing, id: output.id };
+          return isOurs ? attrs : Unowned(attrs);
         }),
       };
     }),

--- a/packages/alchemy/src/Axiom/VirtualField.ts
+++ b/packages/alchemy/src/Axiom/VirtualField.ts
@@ -1,9 +1,37 @@
 import * as Axiom from "@distilled.cloud/axiom";
 import * as Effect from "effect/Effect";
+import { Unowned } from "../AdoptPolicy.ts";
 import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
+import { Stack } from "../Stack.ts";
+import { Stage } from "../Stage.ts";
 import type { Providers } from "./Providers.ts";
+
+const MARKER_RE = /\s*\[alchemy:stack=([^;]+);stage=([^;]+);id=([^\]]+)\]\s*$/;
+
+const buildMarker = (stack: string, stage: string, id: string) =>
+  `[alchemy:stack=${stack};stage=${stage};id=${id}]`;
+
+const stripMarker = (description: string | undefined) =>
+  (description ?? "").replace(MARKER_RE, "").trimEnd();
+
+const augmentDescription = (
+  description: string | undefined,
+  marker: string,
+) => {
+  const base = stripMarker(description);
+  return base.length > 0 ? `${base}\n${marker}` : marker;
+};
+
+const parseMarker = (
+  description: string | undefined,
+): { stack: string; stage: string; id: string } | undefined => {
+  if (!description) return undefined;
+  const m = description.match(MARKER_RE);
+  if (!m) return undefined;
+  return { stack: m[1], stage: m[2], id: m[3] };
+};
 
 export type VirtualFieldProps = Axiom.CreateVirtualFieldInput;
 
@@ -68,7 +96,15 @@ export const VirtualFieldProvider = () =>
           }
           return undefined;
         }),
-        reconcile: Effect.fn(function* ({ news, output }) {
+        reconcile: Effect.fn(function* ({ id, news, output }) {
+          const stack = yield* Stack;
+          const stage = yield* Stage;
+          const marker = buildMarker(stack.name, stage, id);
+          const desired = {
+            ...news,
+            description: augmentDescription(news.description, marker),
+          };
+
           // Observe — Axiom assigns the virtual-field id server-side, so
           // the only handle to a previously-created field is the cached
           // `output.id`. Probe for live state with that id; treat NotFound
@@ -82,23 +118,36 @@ export const VirtualFieldProvider = () =>
 
           // Ensure — POST mints a new virtual field with a fresh id.
           if (observed === undefined) {
-            return yield* create(news);
+            return yield* create(desired);
           }
 
           // Sync — the field exists; PUT against its id with the desired
-          // props. `dataset` is replacement-only (handled in diff).
-          return yield* update({ ...news, id: observed.id });
+          // props. `dataset` is replacement-only (handled in diff). If the
+          // field disappeared between observe and update, recreate.
+          return yield* update({ ...desired, id: observed.id }).pipe(
+            Effect.catchTag("NotFound", () => create(desired)),
+          );
         }),
         delete: Effect.fn(function* ({ output }) {
           yield* del({ id: output.id }).pipe(
             Effect.catchTag("NotFound", () => Effect.void),
           );
         }),
-        read: Effect.fn(function* ({ output }) {
+        read: Effect.fn(function* ({ id, output }) {
           if (!output?.id) return undefined;
-          return yield* get({ id: output.id }).pipe(
+          const stack = yield* Stack;
+          const stage = yield* Stage;
+          const existing = yield* get({ id: output.id }).pipe(
             Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
           );
+          if (!existing) return undefined;
+          const ownership = parseMarker(existing.description);
+          const isOurs =
+            ownership !== undefined &&
+            ownership.stack === stack.name &&
+            ownership.stage === stage &&
+            ownership.id === id;
+          return isOurs ? existing : Unowned(existing);
         }),
       };
     }),

--- a/packages/alchemy/test/Axiom/Annotation.test.ts
+++ b/packages/alchemy/test/Axiom/Annotation.test.ts
@@ -1,0 +1,225 @@
+import * as Axiom from "@/Axiom";
+import * as Test from "@/Test/Vitest";
+import * as AxiomSdk from "@distilled.cloud/axiom";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+
+const { test } = Test.make({ providers: Axiom.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const randomSuffix = () => Math.random().toString(36).slice(2, 8);
+
+const getAnnotation = (id: string) =>
+  AxiomSdk.getAnnotation({ id }).pipe(
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
+  );
+
+test.provider(
+  "redeploy with same props is a no-op (idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const ds = `alchemy-test-ann-${suffix}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.Annotation("A", {
+            type: "deploy",
+            title: "v1",
+            description: "stable",
+            datasets: [ds],
+            time: "2026-01-01T00:00:00Z",
+          });
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.Annotation("A", {
+            type: "deploy",
+            title: "v1",
+            description: "stable",
+            datasets: [ds],
+            time: "2026-01-01T00:00:00Z",
+          });
+        }),
+      );
+      expect(second.id).toEqual(initial.id);
+
+      yield* stack.destroy();
+      const after = yield* getAnnotation(initial.id!);
+      expect(after).toBeUndefined();
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile resets title mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const ds = `alchemy-test-ann-drift-${suffix}`;
+
+      const ann = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.Annotation("A", {
+            type: "deploy",
+            title: "managed",
+            description: "managed",
+            datasets: [ds],
+            time: "2026-01-01T00:00:00Z",
+          });
+        }),
+      );
+
+      yield* AxiomSdk.updateAnnotation({
+        id: ann.id!,
+        title: "drifted",
+        description: "drifted",
+        type: "deploy",
+        datasets: [ds],
+        time: "2026-01-01T00:00:00Z",
+      });
+
+      const drifted = yield* getAnnotation(ann.id!);
+      expect(drifted?.title).toEqual("drifted");
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.Annotation("A", {
+            type: "deploy",
+            title: "managed",
+            description: "managed",
+            datasets: [ds],
+            time: "2026-01-01T00:00:00Z",
+          });
+        }),
+      );
+
+      const reconverged = yield* getAnnotation(ann.id!);
+      expect(reconverged?.title).toEqual("managed");
+      expect(reconverged?.description).toContain("[alchemy:");
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile re-creates an annotation deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const ds = `alchemy-test-ann-recreate-${suffix}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.Annotation("A", {
+            type: "deploy",
+            title: "first",
+            datasets: [ds],
+            time: "2026-01-01T00:00:00Z",
+          });
+        }),
+      );
+
+      yield* AxiomSdk.deleteAnnotation({ id: initial.id! });
+      const gone = yield* getAnnotation(initial.id!);
+      expect(gone).toBeUndefined();
+
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.Annotation("A", {
+            type: "deploy",
+            title: "first",
+            datasets: [ds],
+            time: "2026-01-01T00:00:00Z",
+          });
+        }),
+      );
+      const live = yield* getAnnotation(recreated.id!);
+      expect(live?.title).toEqual("first");
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "changing title updates in place (not a replace)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const ds = `alchemy-test-ann-rename-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.Annotation("A", {
+            type: "deploy",
+            title: "title-a",
+            datasets: [ds],
+            time: "2026-01-01T00:00:00Z",
+          });
+        }),
+      );
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.Annotation("A", {
+            type: "deploy",
+            title: "title-b",
+            datasets: [ds],
+            time: "2026-01-01T00:00:00Z",
+          });
+        }),
+      );
+      expect(b.id).toEqual(a.id);
+      expect(b.title).toEqual("title-b");
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "destroying an already-deleted annotation is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const ds = `alchemy-test-ann-doubledel-${suffix}`;
+
+      const ann = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.Annotation("A", {
+            type: "deploy",
+            datasets: [ds],
+            time: "2026-01-01T00:00:00Z",
+          });
+        }),
+      );
+
+      yield* AxiomSdk.deleteAnnotation({ id: ann.id! });
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);

--- a/packages/alchemy/test/Axiom/ApiToken.test.ts
+++ b/packages/alchemy/test/Axiom/ApiToken.test.ts
@@ -1,0 +1,128 @@
+import * as Axiom from "@/Axiom";
+import * as Test from "@/Test/Vitest";
+import * as AxiomSdk from "@distilled.cloud/axiom";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+
+const { test } = Test.make({ providers: Axiom.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const randomSuffix = () => Math.random().toString(36).slice(2, 8);
+
+const getToken = (id: string) =>
+  AxiomSdk.getAPIToken({ id }).pipe(
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
+  );
+
+test.provider(
+  "redeploy with same props is a no-op (no rotation)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const ds = `alchemy-test-token-${suffix}`;
+      const tokenName = `alchemy-test-token-${suffix}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.ApiToken("T", {
+            name: tokenName,
+            description: "stable",
+            datasetCapabilities: { [ds]: { ingest: ["create"] } },
+          });
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.ApiToken("T", {
+            name: tokenName,
+            description: "stable",
+            datasetCapabilities: { [ds]: { ingest: ["create"] } },
+          });
+        }),
+      );
+      expect(second.id).toEqual(initial.id);
+
+      yield* stack.destroy();
+      const after = yield* getToken(initial.id);
+      expect(after).toBeUndefined();
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "changing description triggers replace (token rotation)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const ds = `alchemy-test-token-rep-${suffix}`;
+      const tokenName = `alchemy-test-token-rep-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.ApiToken("T", {
+            name: tokenName,
+            description: "original",
+            datasetCapabilities: { [ds]: { ingest: ["create"] } },
+          });
+        }),
+      );
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.ApiToken("T", {
+            name: tokenName,
+            description: "rotated",
+            datasetCapabilities: { [ds]: { ingest: ["create"] } },
+          });
+        }),
+      );
+      expect(b.id).not.toEqual(a.id);
+
+      // Old token is gone.
+      const oldGone = yield* getToken(a.id);
+      expect(oldGone).toBeUndefined();
+      const newLive = yield* getToken(b.id);
+      expect(newLive?.id).toEqual(b.id);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "destroying an already-deleted token is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const ds = `alchemy-test-token-dd-${suffix}`;
+      const tokenName = `alchemy-test-token-dd-${suffix}`;
+
+      const tok = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.ApiToken("T", {
+            name: tokenName,
+            datasetCapabilities: { [ds]: { ingest: ["create"] } },
+          });
+        }),
+      );
+
+      yield* AxiomSdk.deleteAPIToken({ id: tok.id });
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);

--- a/packages/alchemy/test/Axiom/Dashboard.test.ts
+++ b/packages/alchemy/test/Axiom/Dashboard.test.ts
@@ -1,0 +1,250 @@
+import { adopt } from "@/AdoptPolicy";
+import * as Axiom from "@/Axiom";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import * as AxiomSdk from "@distilled.cloud/axiom";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+
+const { test } = Test.make({ providers: Axiom.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const randomSuffix = () => Math.random().toString(36).slice(2, 8);
+
+const getDashboard = (uid: string) =>
+  AxiomSdk.getDashboard({ uid }).pipe(
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
+  );
+
+const baseDoc = (name: string, description: string) => ({
+  name,
+  owner: "",
+  description,
+  charts: [],
+  layout: [],
+  refreshTime: 60 as const,
+  schemaVersion: 2 as const,
+  timeWindowStart: "qr-now-1h",
+  timeWindowEnd: "qr-now",
+});
+
+test.provider(
+  "redeploy with same props is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const dashName = `alchemy-test-dash-idem-${randomSuffix()}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dashboard("D", {
+            dashboard: baseDoc(dashName, "stable"),
+          });
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dashboard("D", {
+            dashboard: baseDoc(dashName, "stable"),
+          });
+        }),
+      );
+      expect(second.uid).toEqual(initial.uid);
+      expect(second.id).toEqual(initial.id);
+
+      yield* stack.destroy();
+      const after = yield* getDashboard(initial.uid);
+      expect(after).toBeUndefined();
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile resets description mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const dashName = `alchemy-test-dash-drift-${randomSuffix()}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dashboard("D", {
+            dashboard: baseDoc(dashName, "managed"),
+          });
+        }),
+      );
+
+      yield* AxiomSdk.updateDashboard({
+        uid: initial.uid,
+        dashboard: baseDoc(dashName, "drifted"),
+        overwrite: true,
+      });
+
+      const drifted = yield* getDashboard(initial.uid);
+      expect(drifted?.dashboard.description).toEqual("drifted");
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dashboard("D", {
+            dashboard: baseDoc(dashName, "managed"),
+          });
+        }),
+      );
+
+      const reconverged = yield* getDashboard(initial.uid);
+      expect(reconverged?.dashboard.description).toContain("managed");
+      expect(reconverged?.dashboard.description).toContain("[alchemy:");
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile re-creates a dashboard deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const dashName = `alchemy-test-dash-recreate-${randomSuffix()}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dashboard("D", {
+            dashboard: baseDoc(dashName, "first"),
+          });
+        }),
+      );
+
+      yield* AxiomSdk.deleteDashboard({ uid: initial.uid });
+      const gone = yield* getDashboard(initial.uid);
+      expect(gone).toBeUndefined();
+
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dashboard("D", {
+            dashboard: baseDoc(dashName, "first"),
+          });
+        }),
+      );
+      // New uid since dashboards are server-id'd.
+      const live = yield* getDashboard(recreated.uid);
+      expect(live?.dashboard.name).toEqual(dashName);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "changing dashboard name updates in place (not a replace)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const nameA = `alchemy-test-dash-rename-a-${suffix}`;
+      const nameB = `alchemy-test-dash-rename-b-${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dashboard("D", {
+            dashboard: baseDoc(nameA, "rename"),
+          });
+        }),
+      );
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dashboard("D", {
+            dashboard: baseDoc(nameB, "rename"),
+          });
+        }),
+      );
+      expect(b.uid).toEqual(a.uid);
+      const live = yield* getDashboard(b.uid);
+      expect(live?.dashboard.name).toEqual(nameB);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "destroying an already-deleted dashboard is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const dashName = `alchemy-test-dash-doubledel-${randomSuffix()}`;
+      const dash = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dashboard("D", {
+            dashboard: baseDoc(dashName, "to-be-deleted"),
+          });
+        }),
+      );
+
+      yield* AxiomSdk.deleteDashboard({ uid: dash.uid });
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "adopt(true) re-claims a foreign-marked dashboard",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const dashName = `alchemy-test-dash-adopt-${randomSuffix()}`;
+
+      const original = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Axiom.Dashboard("Original", {
+            dashboard: baseDoc(dashName, "original"),
+          });
+        }),
+      );
+
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "Original",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      // Without state, a fresh logical id under the same uid would
+      // create a *new* dashboard (uid is server-assigned). The adoption
+      // story for Dashboard is "if state was lost but you remember the
+      // uid, read can recognize it as foreign." Here we exercise read's
+      // Unowned path indirectly: we'd need to pass the uid through.
+      // Since alchemy can't recover the uid without state, this path
+      // mainly exercises that creating a new dashboard with the same
+      // *name* succeeds (uids differ).
+      const takenOver = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            return yield* Axiom.Dashboard("Taken", {
+              dashboard: baseDoc(dashName, "taken-over"),
+            });
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(takenOver.uid).not.toEqual(original.uid);
+
+      // Cleanup the orphan.
+      yield* AxiomSdk.deleteDashboard({ uid: original.uid }).pipe(
+        Effect.catchTag("NotFound", () => Effect.void),
+      );
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);

--- a/packages/alchemy/test/Axiom/View.test.ts
+++ b/packages/alchemy/test/Axiom/View.test.ts
@@ -1,0 +1,297 @@
+import { adopt } from "@/AdoptPolicy";
+import * as Axiom from "@/Axiom";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import * as AxiomSdk from "@distilled.cloud/axiom";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+
+const { test } = Test.make({ providers: Axiom.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const randomSuffix = () => Math.random().toString(36).slice(2, 8);
+
+const getView = (id: string) =>
+  AxiomSdk.getView({ id }).pipe(
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
+  );
+
+const assertViewDeleted = Effect.fn(function* (id: string) {
+  const found = yield* getView(id);
+  expect(found).toBeUndefined();
+});
+
+const datasetName = (suffix: string) => `alchemy-test-view-${suffix}`;
+
+test.provider(
+  "redeploy with same props is a no-op (reconcile is idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const name = `alchemy-test-view-idem-${suffix}`;
+      const ds = datasetName(suffix);
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.View("V", {
+            name,
+            description: "stable",
+            datasets: [ds],
+            aplQuery: `['${ds}']`,
+          });
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.View("V", {
+            name,
+            description: "stable",
+            datasets: [ds],
+            aplQuery: `['${ds}']`,
+          });
+        }),
+      );
+      expect(second.id).toEqual(initial.id);
+
+      yield* stack.destroy();
+      yield* assertViewDeleted(name);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile resets description / aplQuery mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const name = `alchemy-test-view-drift-${suffix}`;
+      const ds = datasetName(suffix);
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.View("V", {
+            name,
+            description: "managed",
+            datasets: [ds],
+            aplQuery: `['${ds}']`,
+          });
+        }),
+      );
+
+      yield* AxiomSdk.updateView({
+        id: name,
+        name,
+        description: "drifted",
+        datasets: [ds],
+        aplQuery: `['${ds}'] | take 1`,
+      });
+
+      const drifted = yield* getView(name);
+      expect(drifted?.description).toEqual("drifted");
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.View("V", {
+            name,
+            description: "managed",
+            datasets: [ds],
+            aplQuery: `['${ds}']`,
+          });
+        }),
+      );
+
+      const reconverged = yield* getView(name);
+      expect(reconverged?.aplQuery).toEqual(`['${ds}']`);
+      expect(reconverged?.description).toContain("managed");
+      expect(reconverged?.description).toContain("[alchemy:");
+
+      yield* stack.destroy();
+      yield* assertViewDeleted(name);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile re-creates a view that was deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const name = `alchemy-test-view-recreate-${suffix}`;
+      const ds = datasetName(suffix);
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.View("V", {
+            name,
+            description: "first",
+            datasets: [ds],
+            aplQuery: `['${ds}']`,
+          });
+        }),
+      );
+
+      yield* AxiomSdk.deleteView({ id: name });
+      yield* assertViewDeleted(name);
+
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.View("V", {
+            name,
+            description: "first",
+            datasets: [ds],
+            aplQuery: `['${ds}']`,
+          });
+        }),
+      );
+      expect(recreated.name).toEqual(name);
+
+      const live = yield* getView(name);
+      expect(live?.name).toEqual(name);
+
+      yield* stack.destroy();
+      yield* assertViewDeleted(name);
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "changing name triggers replace; old view is gone",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const nameA = `alchemy-test-view-rename-a-${suffix}`;
+      const nameB = `alchemy-test-view-rename-b-${suffix}`;
+      const ds = datasetName(suffix);
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.View("V", {
+            name: nameA,
+            datasets: [ds],
+            aplQuery: `['${ds}']`,
+          });
+        }),
+      );
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.View("V", {
+            name: nameB,
+            datasets: [ds],
+            aplQuery: `['${ds}']`,
+          });
+        }),
+      );
+
+      yield* assertViewDeleted(nameA);
+      const live = yield* getView(nameB);
+      expect(live?.name).toEqual(nameB);
+
+      yield* stack.destroy();
+      yield* assertViewDeleted(nameB);
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "destroying an already-deleted view is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const name = `alchemy-test-view-doubledel-${suffix}`;
+      const ds = datasetName(suffix);
+
+      const view = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.View("V", {
+            name,
+            datasets: [ds],
+            aplQuery: `['${ds}']`,
+          });
+        }),
+      );
+
+      yield* AxiomSdk.deleteView({ id: view.id });
+      yield* assertViewDeleted(name);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "adopt(true) re-claims a foreign view by name",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const name = `alchemy-test-view-adopt-${suffix}`;
+      const ds = datasetName(suffix);
+
+      const original = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.View("Original", {
+            name,
+            description: "original",
+            datasets: [ds],
+            aplQuery: `['${ds}']`,
+          });
+        }),
+      );
+
+      yield* Effect.gen(function* () {
+        const state = yield* State;
+        yield* state.delete({
+          stack: stack.name,
+          stage: "test",
+          fqn: "Original",
+        });
+      }).pipe(Effect.provide(stack.state));
+
+      const takenOver = yield* stack
+        .deploy(
+          Effect.gen(function* () {
+            yield* Axiom.Dataset("DS", { name: ds });
+            return yield* Axiom.View("Taken", {
+              name,
+              description: "taken-over",
+              datasets: [ds],
+              aplQuery: `['${ds}']`,
+            });
+          }),
+        )
+        .pipe(adopt(true));
+
+      expect(takenOver.name).toEqual(original.name);
+
+      const live = yield* getView(name);
+      expect(live?.description).toContain("id=Taken");
+
+      yield* stack.destroy();
+      yield* assertViewDeleted(name);
+    }).pipe(logLevel),
+);

--- a/packages/alchemy/test/Axiom/VirtualField.test.ts
+++ b/packages/alchemy/test/Axiom/VirtualField.test.ts
@@ -1,0 +1,233 @@
+import * as Axiom from "@/Axiom";
+import * as Test from "@/Test/Vitest";
+import * as AxiomSdk from "@distilled.cloud/axiom";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+
+const { test } = Test.make({ providers: Axiom.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const randomSuffix = () => Math.random().toString(36).slice(2, 8);
+
+const getVF = (id: string) =>
+  AxiomSdk.getVirtualField({ id }).pipe(
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
+  );
+
+test.provider(
+  "redeploy with same props is a no-op (idempotent)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const ds = `alchemy-test-vf-${suffix}`;
+      const vfName = `vf_${suffix}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.VirtualField("VF", {
+            dataset: ds,
+            name: vfName,
+            description: "stable",
+            expression: "1 + 1",
+            type: "number",
+          });
+        }),
+      );
+
+      const second = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.VirtualField("VF", {
+            dataset: ds,
+            name: vfName,
+            description: "stable",
+            expression: "1 + 1",
+            type: "number",
+          });
+        }),
+      );
+      expect(second.id).toEqual(initial.id);
+
+      yield* stack.destroy();
+      const after = yield* getVF(initial.id);
+      expect(after).toBeUndefined();
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile resets expression mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const ds = `alchemy-test-vf-drift-${suffix}`;
+      const vfName = `vf_drift_${suffix}`;
+
+      const vf = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.VirtualField("VF", {
+            dataset: ds,
+            name: vfName,
+            description: "managed",
+            expression: "status",
+            type: "number",
+          });
+        }),
+      );
+
+      yield* AxiomSdk.updateVirtualField({
+        id: vf.id,
+        dataset: ds,
+        name: vfName,
+        description: "drifted",
+        expression: "999",
+        type: "number",
+      });
+
+      const drifted = yield* getVF(vf.id);
+      expect(drifted?.expression).toEqual("999");
+
+      yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.VirtualField("VF", {
+            dataset: ds,
+            name: vfName,
+            description: "managed",
+            expression: "status",
+            type: "number",
+          });
+        }),
+      );
+
+      const reconverged = yield* getVF(vf.id);
+      expect(reconverged?.expression).toEqual("status");
+      expect(reconverged?.description).toContain("managed");
+      expect(reconverged?.description).toContain("[alchemy:");
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile re-creates a virtual field deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const ds = `alchemy-test-vf-recreate-${suffix}`;
+      const vfName = `vf_recreate_${suffix}`;
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.VirtualField("VF", {
+            dataset: ds,
+            name: vfName,
+            expression: "1",
+            type: "number",
+          });
+        }),
+      );
+
+      yield* AxiomSdk.deleteVirtualField({ id: initial.id });
+      const gone = yield* getVF(initial.id);
+      expect(gone).toBeUndefined();
+
+      const recreated = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.VirtualField("VF", {
+            dataset: ds,
+            name: vfName,
+            expression: "1",
+            type: "number",
+          });
+        }),
+      );
+      const live = yield* getVF(recreated.id);
+      expect(live?.name).toEqual(vfName);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test.provider(
+  "changing name updates in place (not a replace)",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const ds = `alchemy-test-vf-rename-${suffix}`;
+      const nameA = `vf_a_${suffix}`;
+      const nameB = `vf_b_${suffix}`;
+
+      const a = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.VirtualField("VF", {
+            dataset: ds,
+            name: nameA,
+            expression: "1",
+            type: "number",
+          });
+        }),
+      );
+
+      const b = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.VirtualField("VF", {
+            dataset: ds,
+            name: nameB,
+            expression: "1",
+            type: "number",
+          });
+        }),
+      );
+      expect(b.id).toEqual(a.id);
+      expect(b.name).toEqual(nameB);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "destroying an already-deleted virtual field is a no-op",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const suffix = randomSuffix();
+      const ds = `alchemy-test-vf-doubledel-${suffix}`;
+      const vfName = `vf_dd_${suffix}`;
+
+      const vf = yield* stack.deploy(
+        Effect.gen(function* () {
+          yield* Axiom.Dataset("DS", { name: ds });
+          return yield* Axiom.VirtualField("VF", {
+            dataset: ds,
+            name: vfName,
+            expression: "1",
+            type: "number",
+          });
+        }),
+      );
+
+      yield* AxiomSdk.deleteVirtualField({ id: vf.id });
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);


### PR DESCRIPTION
Stacked on top of [#197](https://github.com/alchemy-run/alchemy-effect/pull/197). Hardens the remaining Axiom REST resources (Dashboard, View, VirtualField, Annotation, ApiToken) the same way #197 did for Dataset.

### Reconciler changes

- **View** — name is the path identifier and `createView` declares only `UnprocessableEntity`, but 409s fall through `HTTP_STATUS_MAP` to `Conflict` / `UnknownAxiomError`. Replace the previous unsafe collision recovery with the observe-then-update pattern: re-`get` on conflict, fail loudly if ownership has flipped, otherwise PUT.

```diff
- if (observed === undefined) {
-   const result = yield* create(news);
-   return { ...result, id: news.name };
- }
+ if (observed === undefined) {
+   const result = yield* create(desired).pipe(
+     Effect.catch((e: { readonly _tag?: string }) => {
+       const tag = e._tag;
+       if (tag === "UnprocessableEntity" || tag === "Conflict" || tag === "UnknownAxiomError") {
+         return Effect.gen(function* () {
+           const existing = yield* get({ id: news.name }).pipe(
+             Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
+           );
+           if (existing === undefined) return yield* Effect.fail(e);
+           const ownership = parseMarker(existing.description);
+           const isOurs = ownership === undefined ||
+             (ownership.stack === stack.name && ownership.stage === stage && ownership.id === id);
+           if (!isOurs) return yield* Effect.fail(e);
+           return yield* update({ ...desired, id: news.name });
+         });
+       }
+       return Effect.fail(e);
+     }),
+   );
+   return { ...result, id: news.name };
+ }
```

- **Dashboard / View / VirtualField / Annotation** — sync-path `update` now catches `NotFound` and recreates if the resource was deleted out-of-band mid-reconcile. `updateDashboard` doesn't declare `NotFound` in its typed errors, but the SDK's `HTTP_STATUS_MAP` still maps 404 → `NotFound`, so we narrow on `_tag` instead of `Effect.catchTag`.

```diff
- return toAttrsFromCreate(
-   yield* update({ ...news, uid: observed.uid, overwrite: true }),
- );
+ return toAttrsFromCreate(
+   yield* update({ ...desired, uid: observed.uid, overwrite: true }).pipe(
+     Effect.catch((e: { readonly _tag?: string }) => {
+       if (e._tag === "NotFound") return create(desired);
+       return Effect.fail(e);
+     }),
+   ),
+ );
```

- **Dashboard / View / VirtualField / Annotation** — added the same description-marker ownership scheme Dataset uses, so `read` can return `Unowned(attrs)` when it finds a foreign-tagged resource. `reconcile` augments `description` with a deterministic `[alchemy:stack=…;stage=…;id=…]` marker on every write so subsequent reads can tell ours apart from someone else's.

- **ApiToken** — replaced `Effect.die` with `Effect.fail` on the (unreachable) "create returned no token" branch, so a misbehaving Axiom response surfaces as a typed error instead of crashing the engine.

### New lifecycle tests

One file per resource at `packages/alchemy/test/Axiom/{Dashboard,View,VirtualField,Annotation,ApiToken}.test.ts`. Each runs `destroy -> deploy -> ... -> destroy` on a `ScratchStack` and asserts convergence at every step.

- redeploy with same props is a no-op (id stable, no rotation for ApiToken)
- reconcile resets fields mutated out-of-band via the raw Axiom API
- reconcile re-creates a resource deleted out-of-band
- changing name (or `description` for ApiToken) — replace vs in-place update, depending on the resource
- destroying an already-deleted resource is a no-op
- (View) `adopt(true)` re-claims a foreign-marked view by name

### Distilled patch

No patch needed. Same reasoning as #197: Axiom's `client/api.ts` already routes HTTP status to typed errors via `HTTP_STATUS_MAP` (with `UnknownAxiomError` as the fallback) and the `Retry` Context.Service drives backoff. The reconciler change is purely about catching the right shapes alchemy-side.
