### PR TITLE
fix(cloudflare/workflow): harden Workflow reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Workflow.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Workflow.ts
@@ -475,6 +475,7 @@ export const WorkflowProvider = () =>
     WorkflowResource,
     Effect.gen(function* () {
       const { accountId } = yield* CloudflareEnvironment;
+      const getWorkflow = yield* workflows.getWorkflow;
       const putWorkflow = yield* workflows.putWorkflow;
       const deleteWorkflow = yield* workflows.deleteWorkflow;
 
@@ -485,10 +486,48 @@ export const WorkflowProvider = () =>
           yield* Effect.logInfo(
             `Cloudflare Workflow reconcile: ${news.workflowName}`,
           );
-          // Cloudflare's `putWorkflow` is a true PUT-as-upsert: identical
-          // payloads converge to the same state and a missing workflow is
-          // created on the spot. There is no separate observe step needed
-          // — the API is naturally reconciler-shaped.
+
+          // Observe live cloud state. `output` is at most a hint —
+          // someone may have deleted the workflow out-of-band, or
+          // adoption may have just handed us a workflow we've never
+          // seen. We only swallow `WorkflowNotFound` (resource really
+          // is missing); auth, throttling, and 5xx errors must surface
+          // so the engine can retry or report cleanly. Treating any
+          // failure as "no workflow live" would silently re-PUT on top
+          // of a transient API blip.
+          const observed = yield* getWorkflow({
+            accountId: acct,
+            workflowName: news.workflowName,
+          }).pipe(
+            Effect.map(
+              (r) => r as workflows.GetWorkflowResponse | undefined,
+            ),
+            Effect.catchTag("WorkflowNotFound", () =>
+              Effect.succeed(undefined),
+            ),
+          );
+
+          // Skip the put when desired state already matches what's
+          // live — saves an API call on idempotent redeploys. A real
+          // change in `className` or `scriptName` falls through to
+          // putWorkflow below.
+          if (
+            observed !== undefined &&
+            observed.className === news.className &&
+            observed.scriptName === news.scriptName
+          ) {
+            return {
+              workflowId: observed.id,
+              workflowName: observed.name,
+              className: observed.className,
+              scriptName: observed.scriptName,
+              accountId: acct,
+            };
+          }
+
+          // `putWorkflow` is a true PUT-as-upsert: identical payloads
+          // converge to the same state and a missing workflow is
+          // created on the spot.
           const result = yield* putWorkflow({
             accountId: acct,
             workflowName: news.workflowName,

--- a/packages/alchemy/test/Cloudflare/Workers/Workflow.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Workflow.test.ts
@@ -1,3 +1,5 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import {
   isWorkflowExport,
   task,
@@ -9,8 +11,25 @@ import {
   type WorkflowBody,
 } from "@/Cloudflare/Workers/Workflow";
 import { makeWorkflowBridge } from "@/Cloudflare/Workers/Rpc";
+import * as Test from "@/Test/Vitest";
+import * as workflows from "@distilled.cloud/cloudflare/workflows";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as pathe from "pathe";
+import { waitForWorkerToBeDeleted } from "../Utils/Worker.ts";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const workflowMain = pathe.resolve(
+  import.meta.dirname,
+  "workflow-worker.ts",
+);
 
 // ---------------------------------------------------------------------------
 // isWorkflowExport
@@ -231,3 +250,219 @@ describe("makeWorkflowBridge", () => {
     }),
   );
 });
+
+// ─────────────────────────────────────────────────────────────────────
+// Lifecycle convergence
+//
+// Reconcile must converge from any starting state — pristine, drifted,
+// or out-of-band-deleted — without leaning on `olds` as a source of
+// truth. Each test runs `destroy → deploy → … → destroy` against a
+// real Cloudflare account.
+// ─────────────────────────────────────────────────────────────────────
+
+test.provider(
+  "redeploy with same props is a no-op (workflow identity preserved)",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const v1 = yield* stack.deploy(
+        Effect.gen(function* () {
+          const worker = yield* Cloudflare.Worker("WorkflowIdempotent", {
+            main: workflowMain,
+            url: false,
+            compatibility: { date: "2024-01-01" },
+          });
+          return worker;
+        }),
+      );
+
+      const observed1 = yield* workflows.getWorkflow({
+        accountId,
+        workflowName: "EchoWorkflow",
+      });
+      expect(observed1.scriptName).toEqual(v1.workerName);
+      expect(observed1.className).toEqual("EchoWorkflow");
+
+      const v2 = yield* stack.deploy(
+        Effect.gen(function* () {
+          const worker = yield* Cloudflare.Worker("WorkflowIdempotent", {
+            main: workflowMain,
+            url: false,
+            compatibility: { date: "2024-01-01" },
+          });
+          return worker;
+        }),
+      );
+      expect(v2.workerName).toEqual(v1.workerName);
+
+      const observed2 = yield* workflows.getWorkflow({
+        accountId,
+        workflowName: "EchoWorkflow",
+      });
+      // Workflow id is stable across no-op redeploys.
+      expect(observed2.id).toEqual(observed1.id);
+      expect(observed2.scriptName).toEqual(observed1.scriptName);
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(v1.workerName, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile resets workflow scriptName mutated out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const v1 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Worker("WorkflowDrift", {
+            main: workflowMain,
+            url: false,
+            compatibility: { date: "2024-01-01" },
+          });
+        }),
+      );
+
+      // Out-of-band: stand up a *different* worker that also defines
+      // EchoWorkflow, then re-`putWorkflow` to point at that script.
+      // This simulates a dashboard edit that re-targets the workflow.
+      const driftedWorker = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Worker("WorkflowDriftAlt", {
+            main: workflowMain,
+            url: false,
+            compatibility: { date: "2024-01-01" },
+          });
+        }),
+      );
+
+      yield* workflows.putWorkflow({
+        accountId,
+        workflowName: "EchoWorkflow",
+        className: "EchoWorkflow",
+        scriptName: driftedWorker.workerName,
+      });
+
+      const drifted = yield* workflows.getWorkflow({
+        accountId,
+        workflowName: "EchoWorkflow",
+      });
+      expect(drifted.scriptName).toEqual(driftedWorker.workerName);
+
+      // Reconcile of the original logical resource must observe the
+      // drifted scriptName and putWorkflow back to the original
+      // worker's script.
+      const v2 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Worker("WorkflowDrift", {
+            main: workflowMain,
+            url: false,
+            compatibility: { date: "2024-01-01" },
+          });
+        }),
+      );
+      expect(v2.workerName).toEqual(v1.workerName);
+
+      const reconverged = yield* workflows.getWorkflow({
+        accountId,
+        workflowName: "EchoWorkflow",
+      });
+      expect(reconverged.scriptName).toEqual(v1.workerName);
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(v1.workerName, accountId);
+      yield* waitForWorkerToBeDeleted(driftedWorker.workerName, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider(
+  "reconcile re-creates a workflow deleted out-of-band",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const v1 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Worker("WorkflowRecreate", {
+            main: workflowMain,
+            url: false,
+            compatibility: { date: "2024-01-01" },
+          });
+        }),
+      );
+
+      // Delete the workflow out-of-band. Local state still claims it
+      // exists; Cloudflare disagrees. Reconcile must observe the
+      // missing workflow (WorkflowNotFound caught), fall through to
+      // putWorkflow, and converge.
+      yield* workflows.deleteWorkflow({
+        accountId,
+        workflowName: "EchoWorkflow",
+      });
+
+      const v2 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Worker("WorkflowRecreate", {
+            main: workflowMain,
+            url: false,
+            compatibility: { date: "2024-01-01" },
+          });
+        }),
+      );
+      expect(v2.workerName).toEqual(v1.workerName);
+
+      const recreated = yield* workflows.getWorkflow({
+        accountId,
+        workflowName: "EchoWorkflow",
+      });
+      expect(recreated.scriptName).toEqual(v1.workerName);
+      expect(recreated.className).toEqual("EchoWorkflow");
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(v1.workerName, accountId);
+    }).pipe(logLevel),
+);
+
+test.provider("destroying an already-deleted workflow is a no-op", (stack) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* CloudflareEnvironment;
+
+    yield* stack.destroy();
+
+    const worker = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.Worker("WorkflowDoubleDestroy", {
+          main: workflowMain,
+          url: false,
+          compatibility: { date: "2024-01-01" },
+        });
+      }),
+    );
+
+    // Delete the workflow out-of-band so the next destroy hits the
+    // `WorkflowNotFound` path inside provider.delete. It must succeed.
+    yield* workflows.deleteWorkflow({
+      accountId,
+      workflowName: "EchoWorkflow",
+    });
+
+    // First destroy: the engine still has state for this resource;
+    // delete should idempotently succeed because the underlying
+    // `deleteWorkflow` call catches `WorkflowNotFound`.
+    yield* stack.destroy();
+
+    // Second destroy: state is gone; this is a true no-op. Repeated
+    // destroys must never throw.
+    yield* stack.destroy();
+
+    yield* waitForWorkerToBeDeleted(worker.workerName, accountId);
+  }).pipe(logLevel),
+);

--- a/packages/alchemy/test/Cloudflare/Workers/workflow-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/workflow-worker.ts
@@ -1,0 +1,38 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * Test fixture: a Worker that defines a single Workflow class.
+ *
+ * The Workflow body just echoes the event payload through a `task` so
+ * the bundle has real workflow metadata that exercises the
+ * `WorkflowResource` reconcile path.
+ */
+class EchoWorkflow extends Cloudflare.Workflow<EchoWorkflow>()(
+  "EchoWorkflow",
+  Effect.gen(function* () {
+    return Effect.gen(function* () {
+      const event = yield* Cloudflare.WorkflowEvent;
+      return yield* Cloudflare.task(
+        "echo",
+        Effect.succeed({ received: event.payload }),
+      );
+    });
+  }),
+) {}
+
+export default class WorkflowFixtureWorker extends Cloudflare.Worker<WorkflowFixtureWorker>()(
+  "WorkflowFixtureWorker",
+  {
+    main: import.meta.filename,
+  },
+  Effect.gen(function* () {
+    yield* EchoWorkflow;
+    return {
+      fetch: Effect.gen(function* () {
+        return HttpServerResponse.text("ok", { status: 200 });
+      }),
+    };
+  }),
+) {}


### PR DESCRIPTION
Hardens the Cloudflare Workflow reconciler. Previously every reconcile did a blind PUT regardless of live state, so every redeploy re-PUT and there was no signal when desired state already matched.

### Reconciler changes

```diff
+ const observed = yield* getWorkflow({
+   accountId: acct,
+   workflowName: news.workflowName,
+ }).pipe(
+   Effect.map((r) => r as workflows.GetWorkflowResponse | undefined),
+   Effect.catchTag("WorkflowNotFound", () => Effect.succeed(undefined)),
+ );
+
+ if (
+   observed !== undefined &&
+   observed.className === news.className &&
+   observed.scriptName === news.scriptName
+ ) {
+   return {
+     workflowId: observed.id,
+     workflowName: observed.name,
+     className: observed.className,
+     scriptName: observed.scriptName,
+     accountId: acct,
+   };
+ }

  const result = yield* putWorkflow({ ... });
```

Observe live state first via `getWorkflow`. Only `WorkflowNotFound` is swallowed — auth, throttling, and 5xx errors must surface so the engine can retry or report cleanly. Skip the PUT when observed state already matches desired (no API churn on no-op redeploys).

### New lifecycle tests

Each test runs `destroy → deploy → … → destroy` against a real Cloudflare account.

- redeploy with same props is a no-op; workflow id is stable
- reconcile resets `scriptName` re-targeted out-of-band via raw `putWorkflow`
- reconcile re-creates a workflow deleted out-of-band (rides `WorkflowNotFound` in observe)
- destroying an already-deleted workflow is a no-op (`deleteWorkflow` catches `WorkflowNotFound`)

Workflow has no `read` lifecycle so `adopt(true)` and "owned without `--adopt`" cases don't apply here. Physical-name (`workflowName`) replace is also outside scope: `workflowName` derives from the user-facing class name in `Cloudflare.Workflow("X", ...)` and the engine's Resource diff handles class-rename as a logical-id change.

The pre-existing `output?.stableId` TS error from #167/#179 in `test.resources.ts` is fixed the same way the prior hardening PRs did.

### Distilled patch

No patch needed. Cloudflare's `client/api.ts` already maps HTTP status to categorized errors (`TooManyRequests` → throttling+retryable, 5xx → server+retryable), and `WorkflowNotFound` covers the only NotFound-like code the reconciler routes on.
