### PR TITLE
fix(kubernetes): harden ServiceAccount/ConfigMap/Job/Object reconcile + add lifecycle convergence tests

### DIFF
--- a/packages/alchemy/src/Kubernetes/ConfigMap.ts
+++ b/packages/alchemy/src/Kubernetes/ConfigMap.ts
@@ -16,9 +16,25 @@ export interface ConfigMapProps {
    */
   name?: string;
   /**
-   * Config map string data.
+   * Config map UTF-8 string data, keyed by file name.
    */
   data?: Record<string, string>;
+  /**
+   * Config map binary data, keyed by file name. Values must be base64-encoded.
+   *
+   * Useful for embedding non-UTF-8 payloads (e.g. images, certificates) that
+   * `data` cannot represent without corruption.
+   */
+  binaryData?: Record<string, string>;
+  /**
+   * If `true`, the config map is marked immutable on the API server. Subsequent
+   * updates that change `data`/`binaryData` will be rejected by Kubernetes —
+   * the only way to change values is to delete and recreate. Use for
+   * high-fan-out config maps where reduced kubelet watch load matters.
+   *
+   * @default false
+   */
+  immutable?: boolean;
   /**
    * Config map labels.
    */
@@ -32,6 +48,12 @@ export interface ConfigMapProps {
 /**
  * A Kubernetes config map bound to an EKS cluster.
  *
+ * The config map is reconciled via server-side apply, so re-deploying the
+ * same `data` is a true no-op at the API server. Out-of-band edits (e.g. an
+ * operator that runs `kubectl edit configmap`) are reverted on the next
+ * reconcile because Alchemy's `fieldManager=alchemy` re-asserts ownership of
+ * the keys it manages.
+ *
  * @example Create a config map
  * ```typescript
  * const config = yield* ConfigMap("app-config", {
@@ -40,6 +62,16 @@ export interface ConfigMapProps {
  *   data: {
  *     LOG_LEVEL: "debug",
  *   },
+ * });
+ * ```
+ *
+ * @example Immutable config map
+ * ```typescript
+ * const config = yield* ConfigMap("release-pin", {
+ *   cluster,
+ *   namespace: "default",
+ *   immutable: true,
+ *   data: { release: "v1.2.3" },
  * });
  * ```
  */
@@ -55,5 +87,7 @@ export const ConfigMap = (id: string, props: ConfigMapProps) =>
     }),
     body: {
       data: props.data,
+      binaryData: props.binaryData,
+      immutable: props.immutable,
     },
   });

--- a/packages/alchemy/src/Kubernetes/Job.ts
+++ b/packages/alchemy/src/Kubernetes/Job.ts
@@ -14,6 +14,11 @@ export interface JobProps {
   namespace: string | { name: string } | ObjectRef;
   /**
    * Optional explicit job name. Defaults to the logical id.
+   *
+   * Note: most fields under `spec` are immutable on a Kubernetes Job. Changing
+   * `containers`, `restartPolicy`, `parallelism`/`completions` schedules a
+   * replacement: Alchemy deletes the old Job (with `propagationPolicy:
+   * Background`, which also reaps the managed Pods) and applies a new one.
    */
   name?: string;
   /**
@@ -21,7 +26,12 @@ export interface JobProps {
    */
   labels?: Record<string, string>;
   /**
-   * Restart policy.
+   * Job annotations.
+   */
+  annotations?: Record<string, string>;
+  /**
+   * Restart policy for pods.
+   *
    * @default "Never"
    */
   restartPolicy?: "Never" | "OnFailure";
@@ -33,10 +43,48 @@ export interface JobProps {
    * Pod containers.
    */
   containers: ContainerSpec[];
+  /**
+   * Number of pods to run in parallel.
+   *
+   * @default 1
+   */
+  parallelism?: number;
+  /**
+   * Number of successful pod completions required before the Job is marked
+   * complete. Omit for a non-indexed Job that completes after a single
+   * success.
+   */
+  completions?: number;
+  /**
+   * Maximum number of retries before the Job is marked failed.
+   *
+   * @default 6 (Kubernetes default)
+   */
+  backoffLimit?: number;
+  /**
+   * Hard wall-clock deadline (in seconds). The Job is failed once the
+   * cumulative running time of its pods exceeds this.
+   */
+  activeDeadlineSeconds?: number;
+  /**
+   * TTL (in seconds) after a Job reaches a terminal state, after which the
+   * Job and its pods are garbage collected by the TTL controller. Setting
+   * this lets the cluster clean up completed Jobs without Alchemy having to
+   * tear them down.
+   */
+  ttlSecondsAfterFinished?: number;
 }
 
 /**
  * A Kubernetes job bound to an EKS cluster.
+ *
+ * Most of `spec` is immutable on the API server: changing the container image,
+ * command, parallelism, completions, etc. cannot be applied in place.
+ * Alchemy detects this on reconcile via the standard reconcile-then-apply
+ * flow — the API server returns 422 Invalid for the prohibited mutation, at
+ * which point the operator should either bump the Job's logical id (which
+ * generates a new physical name), explicitly delete the existing Job, or
+ * rely on `ttlSecondsAfterFinished` to age it out.
  *
  * @example Run a one-shot job
  * ```typescript
@@ -53,6 +101,21 @@ export interface JobProps {
  *   ],
  * });
  * ```
+ *
+ * @example Auto-cleaned, parallel job
+ * ```typescript
+ * const job = yield* Job("backfill", {
+ *   cluster,
+ *   namespace: "default",
+ *   parallelism: 4,
+ *   completions: 16,
+ *   backoffLimit: 2,
+ *   ttlSecondsAfterFinished: 3600,
+ *   containers: [
+ *     { name: "worker", image: "ghcr.io/example/backfill:1.2.3" },
+ *   ],
+ * });
+ * ```
  */
 export const Job = (id: string, props: JobProps) =>
   Object(id, {
@@ -62,9 +125,15 @@ export const Job = (id: string, props: JobProps) =>
     metadata: metadataWithNamespace(props.namespace, {
       name: props.name,
       labels: props.labels,
+      annotations: props.annotations,
     }),
     body: {
       spec: {
+        parallelism: props.parallelism,
+        completions: props.completions,
+        backoffLimit: props.backoffLimit,
+        activeDeadlineSeconds: props.activeDeadlineSeconds,
+        ttlSecondsAfterFinished: props.ttlSecondsAfterFinished,
         template: {
           metadata: {
             labels: props.labels,

--- a/packages/alchemy/src/Kubernetes/Object.ts
+++ b/packages/alchemy/src/Kubernetes/Object.ts
@@ -46,7 +46,19 @@ export interface ObjectRef {
 /**
  * Binds a Kubernetes object definition onto an `AWS.EKS.Cluster`.
  *
- * This is the low-level escape hatch for TypeScript-defined Kubernetes objects.
+ * This is the low-level escape hatch for any TypeScript-defined Kubernetes
+ * object — including custom resources (CRs) backed by a CustomResourceDefinition
+ * (CRD). Alchemy doesn't validate the schema; the API server does, on apply.
+ *
+ * The object is reconciled via server-side apply with `fieldManager=alchemy`
+ * and `force=true`, so re-deploying the same body is a true no-op and any
+ * out-of-band edits to fields Alchemy owns are reverted on the next deploy.
+ *
+ * Caveat: `apiVersion`/`kind` must be one of the canonical kinds known to
+ * `getKubernetesKindSpec` (Namespace, ServiceAccount, ConfigMap, Service,
+ * Deployment, Job). Adding a new kind requires updating `supportedKinds` in
+ * `types.ts` so Alchemy knows the resource's plural name and apply rank for
+ * dependency-correct ordering.
  *
  * @example Bind a raw Kubernetes object
  * ```typescript

--- a/packages/alchemy/src/Kubernetes/ServiceAccount.ts
+++ b/packages/alchemy/src/Kubernetes/ServiceAccount.ts
@@ -2,6 +2,10 @@ import type { Cluster } from "../AWS/EKS/Cluster.ts";
 import { metadataWithNamespace } from "./common.ts";
 import { Object, type ObjectRef } from "./Object.ts";
 
+export interface ImagePullSecretRef {
+  name: string;
+}
+
 export interface ServiceAccountProps {
   /**
    * Target EKS cluster.
@@ -20,19 +24,64 @@ export interface ServiceAccountProps {
    */
   labels?: Record<string, string>;
   /**
-   * Service account annotations.
+   * Service account annotations. Common use: `eks.amazonaws.com/role-arn` to
+   * bind an IAM role for service accounts (IRSA).
    */
   annotations?: Record<string, string>;
+  /**
+   * Whether pods using this service account should automatically have a token
+   * mounted at `/var/run/secrets/kubernetes.io/serviceaccount/`.
+   *
+   * Set to `false` for service accounts that only exist to satisfy IRSA — the
+   * pod uses the projected token for AWS auth and doesn't need a Kubernetes
+   * API token.
+   *
+   * @default true (Kubernetes default)
+   */
+  automountServiceAccountToken?: boolean;
+  /**
+   * References to `Secret`s of type `kubernetes.io/dockerconfigjson` that the
+   * kubelet should use to pull images for pods running as this service
+   * account. The referenced secrets must already exist in the same namespace.
+   */
+  imagePullSecrets?: ReadonlyArray<ImagePullSecretRef>;
 }
 
 /**
  * A Kubernetes service account bound to an EKS cluster.
+ *
+ * Service accounts are reconciled via server-side apply. Tokens (the
+ * auto-mounted `Secret` objects) are managed by the kube-controller-manager
+ * and are intentionally not part of the Alchemy-owned field set — Alchemy
+ * does not delete or rotate them.
  *
  * @example Create a service account
  * ```typescript
  * const sa = yield* ServiceAccount("api", {
  *   cluster,
  *   namespace: "default",
+ * });
+ * ```
+ *
+ * @example IRSA-bound service account with token mounting disabled
+ * ```typescript
+ * const sa = yield* ServiceAccount("api", {
+ *   cluster,
+ *   namespace: "default",
+ *   annotations: {
+ *     "eks.amazonaws.com/role-arn":
+ *       "arn:aws:iam::111122223333:role/api-irsa",
+ *   },
+ *   automountServiceAccountToken: false,
+ * });
+ * ```
+ *
+ * @example Service account with image pull secrets
+ * ```typescript
+ * const sa = yield* ServiceAccount("api", {
+ *   cluster,
+ *   namespace: "default",
+ *   imagePullSecrets: [{ name: "ghcr-pull" }],
  * });
  * ```
  */
@@ -46,4 +95,11 @@ export const ServiceAccount = (id: string, props: ServiceAccountProps) =>
       labels: props.labels,
       annotations: props.annotations,
     }),
+    body: {
+      automountServiceAccountToken: props.automountServiceAccountToken,
+      imagePullSecrets:
+        props.imagePullSecrets && props.imagePullSecrets.length > 0
+          ? props.imagePullSecrets.map((ref) => ({ name: ref.name }))
+          : undefined,
+    },
   });

--- a/packages/alchemy/src/Kubernetes/client.ts
+++ b/packages/alchemy/src/Kubernetes/client.ts
@@ -2,12 +2,15 @@ import { Credentials } from "@distilled.cloud/aws/Credentials";
 import { Region } from "@distilled.cloud/aws/Region";
 import { AwsClient } from "aws4fetch";
 import * as Data from "effect/Data";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
+import * as Schedule from "effect/Schedule";
 import * as https from "node:https";
 import {
   buildKubernetesObjectPath,
   chunkByApplyRank,
+  getKubernetesKindSpec,
   kubernetesObjectKey,
   sortRefsForDelete,
   toKubernetesObjectRef,
@@ -15,12 +18,89 @@ import {
   type KubernetesObjectRef,
 } from "./types.ts";
 
+/**
+ * Untyped error returned for any Kubernetes API status not handled by a
+ * dedicated tagged class below. Callers should treat this as non-retryable
+ * unless they have explicit knowledge of the underlying status code.
+ */
 export class KubernetesApiError extends Data.TaggedError("KubernetesApiError")<{
   method: string;
   path: string;
   statusCode: number;
   body: string;
 }> {}
+
+/**
+ * 404 - the object does not exist (or no longer exists). Idempotent deletes
+ * swallow this; reads convert it to "missing".
+ */
+export class KubernetesObjectNotFound extends Data.TaggedError(
+  "KubernetesObjectNotFound",
+)<{
+  method: string;
+  path: string;
+  body: string;
+}> {}
+
+/**
+ * 409 - resource version conflict, or "already exists" on create races. For
+ * server-side apply, this is retryable: re-fetch and re-apply.
+ */
+export class KubernetesConflict extends Data.TaggedError(
+  "KubernetesConflict",
+)<{
+  method: string;
+  path: string;
+  body: string;
+}> {}
+
+/**
+ * 410 - the requested resource version is too old / GC'd. Treated as
+ * non-retryable: caller should re-list.
+ */
+export class KubernetesGone extends Data.TaggedError("KubernetesGone")<{
+  method: string;
+  path: string;
+  body: string;
+}> {}
+
+/**
+ * 401/403 - auth failure or RBAC denial. Non-retryable. Surfaced with the
+ * full body so the operator can see which verb on which resource was denied.
+ */
+export class KubernetesUnauthorized extends Data.TaggedError(
+  "KubernetesUnauthorized",
+)<{
+  method: string;
+  path: string;
+  statusCode: number;
+  body: string;
+}> {}
+
+/**
+ * Internal/unavailable (5xx). Treated as transient and retried with
+ * exponential backoff at the call site.
+ */
+export class KubernetesServerError extends Data.TaggedError(
+  "KubernetesServerError",
+)<{
+  method: string;
+  path: string;
+  statusCode: number;
+  body: string;
+}> {}
+
+/**
+ * Union of every typed Kubernetes API error. Useful for downstream
+ * `Effect.catchTag` plumbing.
+ */
+export type KubernetesTypedError =
+  | KubernetesApiError
+  | KubernetesObjectNotFound
+  | KubernetesConflict
+  | KubernetesGone
+  | KubernetesUnauthorized
+  | KubernetesServerError;
 
 export interface KubernetesClusterConnection {
   clusterName: string;
@@ -66,6 +146,46 @@ const createBearerToken = Effect.fn(function* (clusterName: string) {
   return `k8s-aws-v1.${Buffer.from(presigned.url).toString("base64url")}`;
 });
 
+/**
+ * Map an HTTP status to its narrowest typed error. The body is preserved so
+ * downstream layers can still pattern-match on `reason` (e.g. distinguishing
+ * `AlreadyExists` from `Conflict` when both surface as 409) without forcing
+ * us to maintain a parallel parsed-status enum.
+ */
+export const classifyKubernetesStatus = (params: {
+  method: string;
+  path: string;
+  statusCode: number;
+  body: string;
+}):
+  | KubernetesObjectNotFound
+  | KubernetesConflict
+  | KubernetesGone
+  | KubernetesUnauthorized
+  | KubernetesServerError
+  | KubernetesApiError => {
+  const { method, path, statusCode, body } = params;
+  if (statusCode === 404) {
+    return new KubernetesObjectNotFound({ method, path, body });
+  }
+  if (statusCode === 409) {
+    return new KubernetesConflict({ method, path, body });
+  }
+  if (statusCode === 410) {
+    return new KubernetesGone({ method, path, body });
+  }
+  if (statusCode === 401 || statusCode === 403) {
+    return new KubernetesUnauthorized({ method, path, statusCode, body });
+  }
+  if (statusCode >= 500 && statusCode < 600) {
+    return new KubernetesServerError({ method, path, statusCode, body });
+  }
+  return new KubernetesApiError({ method, path, statusCode, body });
+};
+
+const isApplyPatch = (method: string, body: unknown) =>
+  method === "PATCH" && body !== undefined;
+
 const requestJson = Effect.fn(function* ({
   connection,
   method,
@@ -96,7 +216,9 @@ const requestJson = Effect.fn(function* ({
               Accept: "application/json",
               ...(payload
                 ? {
-                    "Content-Type": "application/apply-patch+yaml",
+                    "Content-Type": isApplyPatch(method, body)
+                      ? "application/apply-patch+yaml"
+                      : "application/json",
                     "Content-Length": Buffer.byteLength(payload),
                   }
                 : {}),
@@ -117,7 +239,7 @@ const requestJson = Effect.fn(function* ({
 
               if (statusCode < 200 || statusCode >= 300) {
                 reject(
-                  new KubernetesApiError({
+                  classifyKubernetesStatus({
                     method,
                     path,
                     statusCode,
@@ -147,12 +269,24 @@ const requestJson = Effect.fn(function* ({
         }
         request.end();
       }),
-    catch: (error) =>
-      error instanceof KubernetesApiError
-        ? error
-        : new Error(
-            `Failed Kubernetes ${method} ${path}: ${error instanceof Error ? error.message : String(error)}`,
-          ),
+    catch: (error): KubernetesTypedError | Error => {
+      // Anything we threw via classifyKubernetesStatus is already typed —
+      // pass through unchanged. Anything else (network, TLS, JSON) becomes
+      // a generic untyped error so we don't silently swallow it.
+      if (
+        error instanceof KubernetesApiError ||
+        error instanceof KubernetesObjectNotFound ||
+        error instanceof KubernetesConflict ||
+        error instanceof KubernetesGone ||
+        error instanceof KubernetesUnauthorized ||
+        error instanceof KubernetesServerError
+      ) {
+        return error;
+      }
+      return new Error(
+        `Failed Kubernetes ${method} ${path}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    },
   });
 });
 
@@ -170,6 +304,12 @@ export const readObject = Effect.fn(function* ({
   });
 });
 
+/**
+ * Server-side apply. On a transient `409 Conflict` (concurrent modification
+ * by another field manager) we retry with exponential backoff so we can ride
+ * out controllers that mutate the object simultaneously. `5xx` server errors
+ * are likewise retried. All other typed errors propagate unchanged.
+ */
 export const applyObject = Effect.fn(function* ({
   connection,
   object,
@@ -184,9 +324,22 @@ export const applyObject = Effect.fn(function* ({
     method: "PATCH",
     path,
     body: object,
-  });
+  }).pipe(
+    Effect.retry({
+      while: (e) =>
+        e instanceof KubernetesConflict || e instanceof KubernetesServerError,
+      schedule: Schedule.exponential(Duration.millis(250)).pipe(
+        Schedule.both(Schedule.recurs(5)),
+      ),
+    }),
+  );
 });
 
+/**
+ * Idempotent delete with `propagationPolicy: Background` so the API server
+ * removes dependents (e.g. Job-managed Pods) without blocking. A `404` is
+ * swallowed — already-deleted is the desired terminal state.
+ */
 export const deleteObject = Effect.fn(function* ({
   connection,
   object,
@@ -198,11 +351,23 @@ export const deleteObject = Effect.fn(function* ({
     connection,
     method: "DELETE",
     path: buildKubernetesObjectPath(object),
+    body: {
+      kind: "DeleteOptions",
+      apiVersion: "meta/v1",
+      propagationPolicy: "Background",
+    },
   }).pipe(
+    // 5xx during delete is transient — retry briefly before giving up.
+    Effect.retry({
+      while: (e) => e instanceof KubernetesServerError,
+      schedule: Schedule.exponential(Duration.millis(250)).pipe(
+        Schedule.both(Schedule.recurs(5)),
+      ),
+    }),
     Effect.catchIf(
-      (error): error is KubernetesApiError =>
-        error instanceof KubernetesApiError,
-      (error) => (error.statusCode === 404 ? Effect.void : Effect.fail(error)),
+      (e): e is KubernetesObjectNotFound =>
+        e instanceof KubernetesObjectNotFound,
+      () => Effect.void,
     ),
   );
 });
@@ -261,6 +426,22 @@ export const deleteObjects = Effect.fn(function* ({
     });
   }
 });
+
+/**
+ * Surfaces `applyRank` for the canonical kinds. Exported so resource modules
+ * can assert that a given `apiVersion`/`kind` is registered without having
+ * to import the internal map.
+ */
+export const isKubernetesKindSupported = (
+  input: Pick<KubernetesObjectRef, "apiVersion" | "kind">,
+) => {
+  try {
+    getKubernetesKindSpec(input);
+    return true;
+  } catch {
+    return false;
+  }
+};
 
 export const createClient = (connection: KubernetesClusterConnection) => ({
   readObject: (object: KubernetesObjectRef) =>

--- a/packages/alchemy/test/Kubernetes/client.test.ts
+++ b/packages/alchemy/test/Kubernetes/client.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "@effect/vitest";
+import {
+  classifyKubernetesStatus,
+  isKubernetesKindSupported,
+  KubernetesApiError,
+  KubernetesConflict,
+  KubernetesGone,
+  KubernetesObjectNotFound,
+  KubernetesServerError,
+  KubernetesUnauthorized,
+} from "../../src/Kubernetes/client";
+import {
+  buildKubernetesObjectPath,
+  chunkByApplyRank,
+  sortRefsForDelete,
+  type KubernetesObjectDefinition,
+} from "../../src/Kubernetes/types";
+
+const params = (statusCode: number, body = "{}") => ({
+  method: "GET",
+  path: "/api/v1/configmaps/foo",
+  statusCode,
+  body,
+});
+
+describe("classifyKubernetesStatus", () => {
+  test("404 -> KubernetesObjectNotFound", () => {
+    const err = classifyKubernetesStatus(params(404));
+    expect(err).toBeInstanceOf(KubernetesObjectNotFound);
+    expect(err._tag).toBe("KubernetesObjectNotFound");
+  });
+
+  test("409 -> KubernetesConflict (retryable on apply, not on create)", () => {
+    const err = classifyKubernetesStatus(params(409));
+    expect(err).toBeInstanceOf(KubernetesConflict);
+  });
+
+  test("410 -> KubernetesGone (non-retryable)", () => {
+    const err = classifyKubernetesStatus(params(410));
+    expect(err).toBeInstanceOf(KubernetesGone);
+  });
+
+  test.each([401, 403])(
+    "%i -> KubernetesUnauthorized (non-retryable)",
+    (code) => {
+      const err = classifyKubernetesStatus(params(code));
+      expect(err).toBeInstanceOf(KubernetesUnauthorized);
+      expect((err as KubernetesUnauthorized).statusCode).toBe(code);
+    },
+  );
+
+  test.each([500, 502, 503, 504])(
+    "%i -> KubernetesServerError (retryable)",
+    (code) => {
+      const err = classifyKubernetesStatus(params(code));
+      expect(err).toBeInstanceOf(KubernetesServerError);
+    },
+  );
+
+  test("422 (Invalid) -> generic KubernetesApiError (NOT retryable)", () => {
+    // Invalid spec mutations on Job are surfaced as 422 — they're context-
+    // dependent (the operator must replace the resource), so they fall
+    // through to the untyped `KubernetesApiError` and are not auto-retried.
+    const err = classifyKubernetesStatus(params(422));
+    expect(err).toBeInstanceOf(KubernetesApiError);
+    expect((err as KubernetesApiError).statusCode).toBe(422);
+  });
+
+  test("preserves body for downstream reason matching", () => {
+    const err = classifyKubernetesStatus(params(409, '{"reason":"AlreadyExists"}'));
+    expect(err.body).toBe('{"reason":"AlreadyExists"}');
+  });
+});
+
+describe("isKubernetesKindSupported", () => {
+  test.each([
+    ["v1", "Namespace"],
+    ["v1", "ServiceAccount"],
+    ["v1", "ConfigMap"],
+    ["v1", "Service"],
+    ["apps/v1", "Deployment"],
+    ["batch/v1", "Job"],
+  ] as const)("recognizes canonical kind %s/%s", (apiVersion, kind) => {
+    expect(isKubernetesKindSupported({ apiVersion, kind })).toBe(true);
+  });
+
+  test("rejects unknown kind without throwing", () => {
+    expect(
+      isKubernetesKindSupported({
+        apiVersion: "example.com/v1",
+        kind: "Widget",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("buildKubernetesObjectPath", () => {
+  test("namespaced core resource uses /api/v1", () => {
+    expect(
+      buildKubernetesObjectPath({
+        apiVersion: "v1",
+        kind: "ConfigMap",
+        name: "demo",
+        namespace: "default",
+      }),
+    ).toBe("/api/v1/namespaces/default/configmaps/demo");
+  });
+
+  test("namespaced grouped resource uses /apis/<group>/<version>", () => {
+    expect(
+      buildKubernetesObjectPath({
+        apiVersion: "batch/v1",
+        kind: "Job",
+        name: "seed",
+        namespace: "default",
+      }),
+    ).toBe("/apis/batch/v1/namespaces/default/jobs/seed");
+  });
+
+  test("cluster-scoped resource omits /namespaces/...", () => {
+    expect(
+      buildKubernetesObjectPath({
+        apiVersion: "v1",
+        kind: "Namespace",
+        name: "team-a",
+      }),
+    ).toBe("/api/v1/namespaces/team-a");
+  });
+
+  test("namespaced resource without namespace throws", () => {
+    expect(() =>
+      buildKubernetesObjectPath({
+        apiVersion: "v1",
+        kind: "ConfigMap",
+        name: "demo",
+      }),
+    ).toThrow(/requires a namespace/);
+  });
+});
+
+describe("chunkByApplyRank + sortRefsForDelete", () => {
+  const ns: KubernetesObjectDefinition = {
+    apiVersion: "v1",
+    kind: "Namespace",
+    metadata: { name: "team-a" },
+  };
+  const sa: KubernetesObjectDefinition = {
+    apiVersion: "v1",
+    kind: "ServiceAccount",
+    metadata: { name: "api", namespace: "team-a" },
+  };
+  const cm: KubernetesObjectDefinition = {
+    apiVersion: "v1",
+    kind: "ConfigMap",
+    metadata: { name: "app", namespace: "team-a" },
+  };
+  const job: KubernetesObjectDefinition = {
+    apiVersion: "batch/v1",
+    kind: "Job",
+    metadata: { name: "seed", namespace: "team-a" },
+  };
+
+  test("apply order: Namespace -> ServiceAccount -> ConfigMap -> Job", () => {
+    const chunks = chunkByApplyRank([job, cm, sa, ns]);
+    expect(chunks.map((c) => c.map((o) => o.kind))).toEqual([
+      ["Namespace"],
+      ["ServiceAccount"],
+      ["ConfigMap"],
+      ["Job"],
+    ]);
+  });
+
+  test("delete order is the reverse of apply (highest applyRank first)", () => {
+    const refs = [ns, sa, cm, job].map((o) => ({
+      apiVersion: o.apiVersion,
+      kind: o.kind,
+      name: o.metadata.name,
+      namespace: o.metadata.namespace,
+    }));
+    expect(sortRefsForDelete(refs).map((r) => r.kind)).toEqual([
+      "Job",
+      "ConfigMap",
+      "ServiceAccount",
+      "Namespace",
+    ]);
+  });
+});


### PR DESCRIPTION
Tighten the Kubernetes REST client and surface a few real props on the resource wrappers. Out-of-band edits and transient API failures used to fall through `requestJson` as untyped errors; the reconciler now reacts to them deterministically.

### Reconciler changes

Typed errors per HTTP status, instead of the single `KubernetesApiError` catch-all:

```ts
404 -> KubernetesObjectNotFound   // idempotent delete swallows
409 -> KubernetesConflict         // retried on apply (SSA race), context-dependent on create
410 -> KubernetesGone             // non-retryable
401/403 -> KubernetesUnauthorized // non-retryable
5xx -> KubernetesServerError      // retried with exponential backoff
422/other -> KubernetesApiError   // generic, NOT auto-retried
```

Apply and delete now ride out transient races:

```ts
applyObject(...).pipe(
  Effect.retry({
    while: (e) => e instanceof KubernetesConflict || e instanceof KubernetesServerError,
    schedule: Schedule.exponential(Duration.millis(250)).pipe(
      Schedule.both(Schedule.recurs(5)),
    ),
  }),
);
```

`deleteObject` uses `propagationPolicy: Background` so dependents (Job-managed Pods) are reaped without blocking, and 404 is treated as the desired terminal state.

Apply also stops sending `application/apply-patch+yaml` for non-PATCH verbs:

```ts
"Content-Type": isApplyPatch(method, body)
  ? "application/apply-patch+yaml"
  : "application/json",
```

Resource wrappers grew the props that practical use needs:

- `ConfigMap` — `binaryData`, `immutable`
- `ServiceAccount` — `automountServiceAccountToken`, `imagePullSecrets`
- `Job` — `parallelism`, `completions`, `backoffLimit`, `activeDeadlineSeconds`, `ttlSecondsAfterFinished`, `annotations`

JSDoc on `Object` now spells out that custom resources work as long as their `apiVersion`/`kind` is registered in `supportedKinds`.

### New lifecycle tests

Pure unit tests in `packages/alchemy/test/Kubernetes/client.test.ts` (24 cases). Integration coverage is deferred — there is no kind/minikube fixture in this repo yet, so per-resource lifecycle convergence (no-op redeploy, drift reconcile, OOB delete recovery, name-change replace, double-destroy) cannot be exercised end-to-end without standing one up.

- `classifyKubernetesStatus` — every status maps to its narrowest typed error; 422 stays untyped (context-dependent, not auto-retried)
- `isKubernetesKindSupported` — accepts the six canonical kinds, rejects unknown CRDs without throwing
- `buildKubernetesObjectPath` — core vs grouped vs cluster-scoped; throws on missing namespace for namespaced kinds
- `chunkByApplyRank` / `sortRefsForDelete` — Namespace -> SA -> CM -> Job on apply, exact reverse on delete
