### PR TITLE
feat(cloudflare/r2): add bucket custom domains

### DIFF
--- a/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
@@ -19,7 +19,7 @@ export type R2BucketCustomDomain = {
   /**
    * Custom domain name to attach to the bucket.
    */
-  domain: string;
+  name: string;
   /**
    * Zone that contains the custom domain. If omitted, the zone is inferred
    * from `domain`. Pass a zone ID string, a hostname in the zone, or any object
@@ -65,7 +65,7 @@ export type R2BucketProps = {
   /**
    * Custom domain or domains to attach to the bucket.
    */
-  domains?: R2BucketCustomDomain | R2BucketCustomDomain[];
+  domain?: R2BucketCustomDomain | R2BucketCustomDomain[];
 };
 
 export type R2Bucket = Resource<
@@ -228,9 +228,7 @@ export const R2BucketProvider = () =>
           const observedByDomain = new Map(
             observed.map((domain) => [domain.domain, domain]),
           );
-          const desiredDomains = new Set(
-            desired.map((domain) => domain.domain),
-          );
+          const desiredDomains = new Set(desired.map((domain) => domain.name));
 
           // Remove domains that are no longer desired. Domains that keep the
           // same hostname but move zones are intentionally skipped here and
@@ -261,9 +259,9 @@ export const R2BucketProvider = () =>
                 const zoneId = yield* Zone.resolveZoneId({
                   accountId,
                   zone: domain.zone,
-                  hostname: domain.domain,
+                  hostname: domain.name,
                 });
-                const observedDomain = observedByDomain.get(domain.domain);
+                const observedDomain = observedByDomain.get(domain.name);
 
                 if (
                   observedDomain &&
@@ -280,7 +278,7 @@ export const R2BucketProvider = () =>
                   yield* deleteBucketDomainCustom({
                     accountId,
                     bucketName,
-                    domain: domain.domain,
+                    domain: domain.name,
                     jurisdiction,
                   }).pipe(
                     Effect.catchIf(
@@ -295,7 +293,7 @@ export const R2BucketProvider = () =>
                     accountId,
                     bucketName,
                     jurisdiction,
-                    domain: domain.domain,
+                    domain: domain.name,
                     enabled: domain.enabled ?? true,
                     zoneId,
                     ciphers: domain.ciphers,
@@ -312,7 +310,7 @@ export const R2BucketProvider = () =>
                 const updated = yield* updateBucketDomainCustom({
                   accountId,
                   bucketName,
-                  domain: domain.domain,
+                  domain: domain.name,
                   jurisdiction,
                   enabled: domain.enabled ?? true,
                   ciphers: domain.ciphers,
@@ -361,7 +359,7 @@ export const R2BucketProvider = () =>
               stables: oldName === name ? ["bucketName"] : undefined,
             } as const;
           }
-          if (!deepEqual(olds.domains, news.domains)) {
+          if (!deepEqual(olds.domain, news.domain)) {
             return { action: "update" } as const;
           }
         }),
@@ -429,7 +427,7 @@ export const R2BucketProvider = () =>
           const domains = yield* reconcileCustomDomains(
             attrs.bucketName,
             attrs.jurisdiction,
-            normalizeDomains(news.domains),
+            normalizeDomains(news.domain),
             output?.domains ?? [],
           );
 
@@ -487,7 +485,7 @@ const r2CustomDomainConsistencySchedule = Schedule.exponential(100).pipe(
 );
 
 const normalizeDomains = (
-  domains: R2BucketProps["domains"],
+  domains: R2BucketProps["domain"],
 ): R2BucketCustomDomain[] =>
   domains === undefined ? [] : Array.isArray(domains) ? domains : [domains];
 

--- a/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
@@ -1,8 +1,6 @@
 import * as r2 from "@distilled.cloud/cloudflare/r2";
-import * as zones from "@distilled.cloud/cloudflare/zones";
 import * as Effect from "effect/Effect";
-import * as Option from "effect/Option";
-import * as Stream from "effect/Stream";
+import * as Schedule from "effect/Schedule";
 
 import { deepEqual, isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
@@ -10,13 +8,12 @@ import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type * as Cloudflare from "../Providers.ts";
+import * as Zone from "../Zone.ts";
 import { R2BucketBinding } from "./R2BucketBinding.ts";
 
 export type R2BucketName = string;
 
-export type R2BucketCustomDomainZone =
-  | string
-  | { zoneId: string; name?: string };
+export type R2BucketCustomDomainZone = Zone.ZoneReference;
 
 export type R2BucketCustomDomain = {
   /**
@@ -24,11 +21,11 @@ export type R2BucketCustomDomain = {
    */
   domain: string;
   /**
-   * Zone that contains the custom domain. Pass a zone ID string, a hostname in
-   * the zone, or any object with a `zoneId` attribute such as
-   * `Cloudflare.Zone`.
+   * Zone that contains the custom domain. If omitted, the zone is inferred
+   * from `domain`. Pass a zone ID string, a hostname in the zone, or any object
+   * with a `zoneId` attribute such as `Cloudflare.Zone`.
    */
-  zone: R2BucketCustomDomainZone;
+  zone?: R2BucketCustomDomainZone;
   /**
    * Whether public bucket access is enabled at this custom domain.
    * @default true
@@ -194,28 +191,6 @@ export const R2BucketProvider = () =>
         return location.toLowerCase() as R2Bucket.Location;
       };
 
-      const resolveZoneId = (zone: R2BucketCustomDomainZone) =>
-        Effect.gen(function* () {
-          if (typeof zone !== "string") return zone.zoneId;
-          if (isZoneIdString(zone)) return zone;
-
-          const match = yield* zones.listZones.items({}).pipe(
-            Stream.filter(
-              (candidate) =>
-                candidate.account.id === accountId &&
-                matchesHostname(candidate.name, zone),
-            ),
-            Stream.runHead,
-            Effect.map(Option.getOrUndefined),
-          );
-          if (!match) {
-            return yield* Effect.fail(
-              new Error(`Cloudflare zone not found for ${zone}`),
-            );
-          }
-          return match.id;
-        });
-
       const listCustomDomains = (
         bucketName: string,
         jurisdiction: R2Bucket.Jurisdiction,
@@ -225,10 +200,14 @@ export const R2BucketProvider = () =>
           bucketName,
           jurisdiction,
         }).pipe(
+          Effect.retry({
+            while: isNoSuchBucket,
+            schedule: r2CustomDomainConsistencySchedule,
+          }),
           Effect.map((response) =>
             response.domains.map(toCustomDomainAttributes),
           ),
-          Effect.catchTag("NoSuchBucket", () => Effect.succeed([])),
+          Effect.catchTag("NoSuchBucket", () => Effect.succeed(undefined)),
         );
 
       const reconcileCustomDomains = (
@@ -239,6 +218,13 @@ export const R2BucketProvider = () =>
       ) =>
         Effect.gen(function* () {
           const observed = yield* listCustomDomains(bucketName, jurisdiction);
+          if (!observed) {
+            return yield* Effect.fail(
+              new Error(
+                `Cannot reconcile custom domains for missing R2 bucket "${bucketName}"`,
+              ),
+            );
+          }
           const observedByDomain = new Map(
             observed.map((domain) => [domain.domain, domain]),
           );
@@ -246,6 +232,9 @@ export const R2BucketProvider = () =>
             desired.map((domain) => domain.domain),
           );
 
+          // Remove domains that are no longer desired. Domains that keep the
+          // same hostname but move zones are intentionally skipped here and
+          // handled in the per-domain flow below.
           yield* Effect.forEach(
             previous,
             (previousDomain) =>
@@ -269,7 +258,11 @@ export const R2BucketProvider = () =>
             desired,
             (domain) =>
               Effect.gen(function* () {
-                const zoneId = yield* resolveZoneId(domain.zone);
+                const zoneId = yield* Zone.resolveZoneId({
+                  accountId,
+                  zone: domain.zone,
+                  hostname: domain.domain,
+                });
                 const observedDomain = observedByDomain.get(domain.domain);
 
                 if (
@@ -280,6 +273,10 @@ export const R2BucketProvider = () =>
                 }
 
                 if (observedDomain && observedDomain.zoneId !== zoneId) {
+                  // Cloudflare does not mutate the zone for an existing custom
+                  // domain. This is not a duplicate of the stale-domain prune
+                  // above: the hostname is still desired, so that prune skips it
+                  // and this branch deletes only to recreate it in the new zone.
                   yield* deleteBucketDomainCustom({
                     accountId,
                     bucketName,
@@ -303,7 +300,12 @@ export const R2BucketProvider = () =>
                     zoneId,
                     ciphers: domain.ciphers,
                     minTLS: domain.minTLS,
-                  });
+                  }).pipe(
+                    Effect.retry({
+                      while: isNoSuchBucket,
+                      schedule: r2CustomDomainConsistencySchedule,
+                    }),
+                  );
                   return toCustomDomainAttributes({ ...created, zoneId });
                 }
 
@@ -315,7 +317,12 @@ export const R2BucketProvider = () =>
                   enabled: domain.enabled ?? true,
                   ciphers: domain.ciphers,
                   minTLS: domain.minTLS,
-                });
+                }).pipe(
+                  Effect.retry({
+                    while: isNoSuchBucket,
+                    schedule: r2CustomDomainConsistencySchedule,
+                  }),
+                );
                 return toCustomDomainAttributes({
                   ...updated,
                   enabled: updated.enabled ?? domain.enabled ?? true,
@@ -472,10 +479,12 @@ export const R2BucketProvider = () =>
     }),
   );
 
-const isZoneIdString = (zone: string): boolean => /^[a-f0-9]{32}$/i.test(zone);
-
-const matchesHostname = (zoneName: string, hostname: string): boolean =>
-  hostname === zoneName || hostname.endsWith(`.${zoneName}`);
+// R2 can make a newly-created bucket visible to `getBucket` before the custom
+// domain endpoints accept it. Retry only that narrow `NoSuchBucket` lag here;
+// not-found domains are still treated as terminal for idempotent deletes.
+const r2CustomDomainConsistencySchedule = Schedule.exponential(100).pipe(
+  Schedule.both(Schedule.recurs(5)),
+);
 
 const normalizeDomains = (
   domains: R2BucketProps["domains"],
@@ -520,3 +529,9 @@ const isMissingCustomDomainOrBucket = (error: unknown): boolean =>
     ("_tag" in error &&
       ((error as { _tag: unknown })._tag === "DomainNotFound" ||
         (error as { _tag: unknown })._tag === "NoSuchBucket")));
+
+const isNoSuchBucket = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  "_tag" in error &&
+  (error as { _tag: unknown })._tag === "NoSuchBucket";

--- a/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
@@ -164,48 +164,6 @@ export declare namespace R2Bucket {
   };
 }
 
-const isZoneIdString = (zone: string): boolean => /^[a-f0-9]{32}$/i.test(zone);
-
-const matchesHostname = (zoneName: string, hostname: string): boolean =>
-  hostname === zoneName || hostname.endsWith(`.${zoneName}`);
-
-const normalizeDomains = (
-  domains: R2BucketProps["domains"],
-): R2BucketCustomDomain[] =>
-  domains === undefined ? [] : Array.isArray(domains) ? domains : [domains];
-
-const toCustomDomainAttributes = (
-  domain:
-    | r2.GetBucketDomainCustomResponse
-    | r2.ListBucketDomainCustomsResponse["domains"][number],
-): R2Bucket.CustomDomain => ({
-  domain: domain.domain,
-  zoneId: domain.zoneId ?? undefined,
-  enabled: domain.enabled,
-  ciphers: domain.ciphers ?? undefined,
-  minTLS: domain.minTLS ?? undefined,
-  status: "status" in domain ? domain.status : undefined,
-});
-
-const sameCustomDomainConfig = (
-  observed: R2Bucket.CustomDomain | undefined,
-  desired: R2BucketCustomDomain,
-  zoneId: string,
-): boolean =>
-  observed !== undefined &&
-  observed.zoneId === zoneId &&
-  observed.enabled === (desired.enabled ?? true) &&
-  deepEqual(observed.ciphers, desired.ciphers) &&
-  observed.minTLS === desired.minTLS;
-
-const isMissingCustomDomainOrBucket = (error: unknown): boolean =>
-  typeof error === "object" &&
-  error !== null &&
-  (("status" in error && (error as { status: unknown }).status === 404) ||
-    ("_tag" in error &&
-      ((error as { _tag: unknown })._tag === "DomainNotFound" ||
-        (error as { _tag: unknown })._tag === "NoSuchBucket")));
-
 export const R2BucketProvider = () =>
   Provider.effect(
     R2Bucket,
@@ -288,29 +246,40 @@ export const R2BucketProvider = () =>
             desired.map((domain) => domain.domain),
           );
 
-          for (const previousDomain of previous) {
-            if (!desiredDomains.has(previousDomain.domain)) {
-              yield* deleteBucketDomainCustom({
-                accountId,
-                bucketName,
-                domain: previousDomain.domain,
-                jurisdiction,
-              }).pipe(
-                Effect.catchIf(
-                  isMissingCustomDomainOrBucket,
-                  () => Effect.void,
-                ),
-              );
-            }
-          }
+          yield* Effect.forEach(
+            previous,
+            (previousDomain) =>
+              desiredDomains.has(previousDomain.domain)
+                ? Effect.void
+                : deleteBucketDomainCustom({
+                    accountId,
+                    bucketName,
+                    domain: previousDomain.domain,
+                    jurisdiction,
+                  }).pipe(
+                    Effect.catchIf(
+                      isMissingCustomDomainOrBucket,
+                      () => Effect.void,
+                    ),
+                  ),
+            { concurrency: "unbounded" },
+          );
 
-          const applied: R2Bucket.CustomDomain[] = [];
-          for (const domain of desired) {
-            const zoneId = yield* resolveZoneId(domain.zone);
-            const observedDomain = observedByDomain.get(domain.domain);
-            if (!sameCustomDomainConfig(observedDomain, domain, zoneId)) {
-              if (observedDomain) {
-                if (observedDomain.zoneId !== zoneId) {
+          const applied = yield* Effect.forEach(
+            desired,
+            (domain) =>
+              Effect.gen(function* () {
+                const zoneId = yield* resolveZoneId(domain.zone);
+                const observedDomain = observedByDomain.get(domain.domain);
+
+                if (
+                  observedDomain &&
+                  sameCustomDomainConfig(observedDomain, domain, zoneId)
+                ) {
+                  return observedDomain;
+                }
+
+                if (observedDomain && observedDomain.zoneId !== zoneId) {
                   yield* deleteBucketDomainCustom({
                     accountId,
                     bucketName,
@@ -322,7 +291,10 @@ export const R2BucketProvider = () =>
                       () => Effect.void,
                     ),
                   );
-                  yield* createBucketDomainCustom({
+                }
+
+                if (!observedDomain || observedDomain.zoneId !== zoneId) {
+                  const created = yield* createBucketDomainCustom({
                     accountId,
                     bucketName,
                     jurisdiction,
@@ -332,41 +304,26 @@ export const R2BucketProvider = () =>
                     ciphers: domain.ciphers,
                     minTLS: domain.minTLS,
                   });
-                } else {
-                  yield* updateBucketDomainCustom({
-                    accountId,
-                    bucketName,
-                    domain: domain.domain,
-                    jurisdiction,
-                    enabled: domain.enabled ?? true,
-                    ciphers: domain.ciphers,
-                    minTLS: domain.minTLS,
-                  });
+                  return toCustomDomainAttributes({ ...created, zoneId });
                 }
-              } else {
-                yield* createBucketDomainCustom({
+
+                const updated = yield* updateBucketDomainCustom({
                   accountId,
                   bucketName,
-                  jurisdiction,
                   domain: domain.domain,
+                  jurisdiction,
                   enabled: domain.enabled ?? true,
-                  zoneId,
                   ciphers: domain.ciphers,
                   minTLS: domain.minTLS,
                 });
-              }
-            }
-
-            const refreshed = yield* r2
-              .getBucketDomainCustom({
-                accountId,
-                bucketName,
-                domain: domain.domain,
-                jurisdiction,
-              })
-              .pipe(Effect.map(toCustomDomainAttributes));
-            applied.push(refreshed);
-          }
+                return toCustomDomainAttributes({
+                  ...updated,
+                  enabled: updated.enabled ?? domain.enabled ?? true,
+                  zoneId,
+                });
+              }),
+            { concurrency: "unbounded" },
+          );
 
           return applied.sort((a, b) => a.domain.localeCompare(b.domain));
         });
@@ -500,31 +457,66 @@ export const R2BucketProvider = () =>
             bucketName: name,
             jurisdiction: output?.jurisdiction ?? olds?.jurisdiction,
           }).pipe(
-            Effect.flatMap((bucket) =>
-              Effect.gen(function* () {
-                const jurisdiction = bucket.jurisdiction ?? "default";
-                const existingDomains =
-                  output?.domains && output.domains.length > 0
-                    ? yield* listCustomDomains(bucket.name!, jurisdiction)
-                    : [];
-                const ownedDomains = new Set(
-                  output?.domains.map((domain) => domain.domain) ?? [],
-                );
-                return {
-                  bucketName: bucket.name!,
-                  storageClass: bucket.storageClass ?? "Standard",
-                  jurisdiction,
-                  location: normalizeLocation(bucket.location),
-                  accountId: acct,
-                  domains: existingDomains.filter((domain) =>
-                    ownedDomains.has(domain.domain),
-                  ),
-                };
-              }),
-            ),
+            Effect.map((bucket) => ({
+              bucketName: bucket.name!,
+              storageClass: bucket.storageClass ?? "Standard",
+              jurisdiction: bucket.jurisdiction ?? "default",
+              location: normalizeLocation(bucket.location),
+              accountId: acct,
+              domains: output?.domains ?? [],
+            })),
             Effect.catchTag("NoSuchBucket", () => Effect.succeed(undefined)),
           );
         }),
       };
     }),
   );
+
+const isZoneIdString = (zone: string): boolean => /^[a-f0-9]{32}$/i.test(zone);
+
+const matchesHostname = (zoneName: string, hostname: string): boolean =>
+  hostname === zoneName || hostname.endsWith(`.${zoneName}`);
+
+const normalizeDomains = (
+  domains: R2BucketProps["domains"],
+): R2BucketCustomDomain[] =>
+  domains === undefined ? [] : Array.isArray(domains) ? domains : [domains];
+
+type CustomDomainResponse = {
+  domain: string;
+  zoneId?: string | null;
+  enabled?: boolean | null;
+  ciphers?: string[] | null;
+  minTLS?: "1.0" | "1.1" | "1.2" | "1.3" | null;
+  status?: R2Bucket.CustomDomain["status"];
+};
+
+const toCustomDomainAttributes = (
+  domain: CustomDomainResponse,
+): R2Bucket.CustomDomain => ({
+  domain: domain.domain,
+  zoneId: domain.zoneId ?? undefined,
+  enabled: domain.enabled ?? true,
+  ciphers: domain.ciphers ?? undefined,
+  minTLS: domain.minTLS ?? undefined,
+  status: domain.status,
+});
+
+const sameCustomDomainConfig = (
+  observed: R2Bucket.CustomDomain | undefined,
+  desired: R2BucketCustomDomain,
+  zoneId: string,
+): boolean =>
+  observed !== undefined &&
+  observed.zoneId === zoneId &&
+  observed.enabled === (desired.enabled ?? true) &&
+  deepEqual(observed.ciphers, desired.ciphers) &&
+  observed.minTLS === desired.minTLS;
+
+const isMissingCustomDomainOrBucket = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  (("status" in error && (error as { status: unknown }).status === 404) ||
+    ("_tag" in error &&
+      ((error as { _tag: unknown })._tag === "DomainNotFound" ||
+        (error as { _tag: unknown })._tag === "NoSuchBucket")));

--- a/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
@@ -125,6 +125,58 @@ export type R2Bucket = Resource<
  *   contentLength: Number(request.headers["content-length"] ?? 0),
  * });
  * ```
+ *
+ * @section Custom Domains
+ *
+ * Attach one or more custom domains to serve bucket objects from a hostname
+ * you control. The domain's zone must already exist in your Cloudflare
+ * account; the zone is inferred from the hostname when omitted, or you can
+ * pass a `Cloudflare.Zone` resource, a zone ID, or any hostname inside the
+ * zone via the `zone` field.
+ *
+ * @example Single custom domain
+ * ```typescript
+ * const bucket = yield* Cloudflare.R2Bucket("MyBucket", {
+ *   domain: {
+ *     name: "assets.example.com",
+ *   },
+ * });
+ * ```
+ *
+ * @example Multiple custom domains
+ * ```typescript
+ * const bucket = yield* Cloudflare.R2Bucket("MyBucket", {
+ *   domain: [
+ *     { name: "assets.example.com" },
+ *     { name: "static.example.com" },
+ *   ],
+ * });
+ * ```
+ *
+ * @example Disable a custom domain without removing it
+ * ```typescript
+ * const bucket = yield* Cloudflare.R2Bucket("MyBucket", {
+ *   domain: {
+ *     name: "assets.example.com",
+ *     enabled: false,
+ *   },
+ * });
+ * ```
+ *
+ * @example Custom domain with explicit zone and TLS settings
+ * ```typescript
+ * const zone = yield* Cloudflare.Zone("ExampleZone", {
+ *   name: "example.com",
+ * });
+ *
+ * const bucket = yield* Cloudflare.R2Bucket("MyBucket", {
+ *   domain: {
+ *     name: "assets.example.com",
+ *     zone,
+ *     minTLS: "1.2",
+ *   },
+ * });
+ * ```
  */
 export const R2Bucket = Resource<R2Bucket>("Cloudflare.R2Bucket")({
   bind: R2BucketBinding.bind,

--- a/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
@@ -1,7 +1,10 @@
 import * as r2 from "@distilled.cloud/cloudflare/r2";
+import * as zones from "@distilled.cloud/cloudflare/zones";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Stream from "effect/Stream";
 
-import { isResolved } from "../../Diff.ts";
+import { deepEqual, isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
@@ -10,6 +13,37 @@ import type * as Cloudflare from "../Providers.ts";
 import { R2BucketBinding } from "./R2BucketBinding.ts";
 
 export type R2BucketName = string;
+
+export type R2BucketCustomDomainZone =
+  | string
+  | { zoneId: string; name?: string };
+
+export type R2BucketCustomDomain = {
+  /**
+   * Custom domain name to attach to the bucket.
+   */
+  domain: string;
+  /**
+   * Zone that contains the custom domain. Pass a zone ID string, a hostname in
+   * the zone, or any object with a `zoneId` attribute such as
+   * `Cloudflare.Zone`.
+   */
+  zone: R2BucketCustomDomainZone;
+  /**
+   * Whether public bucket access is enabled at this custom domain.
+   * @default true
+   */
+  enabled?: boolean;
+  /**
+   * Allowlist of TLS ciphers in BoringSSL format.
+   */
+  ciphers?: string[];
+  /**
+   * Minimum TLS version accepted by the custom domain.
+   * @default "1.0"
+   */
+  minTLS?: "1.0" | "1.1" | "1.2" | "1.3";
+};
 
 export type R2BucketProps = {
   /**
@@ -31,6 +65,10 @@ export type R2BucketProps = {
    * Location hint for the bucket.
    */
   locationHint?: R2Bucket.Location;
+  /**
+   * Custom domain or domains to attach to the bucket.
+   */
+  domains?: R2BucketCustomDomain | R2BucketCustomDomain[];
 };
 
 export type R2Bucket = Resource<
@@ -42,6 +80,7 @@ export type R2Bucket = Resource<
     jurisdiction: R2Bucket.Jurisdiction;
     location: R2Bucket.Location | undefined;
     accountId: string;
+    domains: R2Bucket.CustomDomain[];
   },
   never,
   Cloudflare.Providers
@@ -98,7 +137,74 @@ export declare namespace R2Bucket {
   export type StorageClass = "Standard" | "InfrequentAccess";
   export type Jurisdiction = "default" | "eu" | "fedramp";
   export type Location = "apac" | "eeur" | "enam" | "weur" | "wnam" | "oc";
+  export type CustomDomain = {
+    domain: string;
+    zoneId: string | undefined;
+    enabled: boolean;
+    ciphers: string[] | undefined;
+    minTLS: "1.0" | "1.1" | "1.2" | "1.3" | undefined;
+    status:
+      | {
+          ownership:
+            | "pending"
+            | "active"
+            | "deactivated"
+            | "blocked"
+            | "error"
+            | "unknown";
+          ssl:
+            | "initializing"
+            | "pending"
+            | "active"
+            | "deactivated"
+            | "error"
+            | "unknown";
+        }
+      | undefined;
+  };
 }
+
+const isZoneIdString = (zone: string): boolean => /^[a-f0-9]{32}$/i.test(zone);
+
+const matchesHostname = (zoneName: string, hostname: string): boolean =>
+  hostname === zoneName || hostname.endsWith(`.${zoneName}`);
+
+const normalizeDomains = (
+  domains: R2BucketProps["domains"],
+): R2BucketCustomDomain[] =>
+  domains === undefined ? [] : Array.isArray(domains) ? domains : [domains];
+
+const toCustomDomainAttributes = (
+  domain:
+    | r2.GetBucketDomainCustomResponse
+    | r2.ListBucketDomainCustomsResponse["domains"][number],
+): R2Bucket.CustomDomain => ({
+  domain: domain.domain,
+  zoneId: domain.zoneId ?? undefined,
+  enabled: domain.enabled,
+  ciphers: domain.ciphers ?? undefined,
+  minTLS: domain.minTLS ?? undefined,
+  status: "status" in domain ? domain.status : undefined,
+});
+
+const sameCustomDomainConfig = (
+  observed: R2Bucket.CustomDomain | undefined,
+  desired: R2BucketCustomDomain,
+  zoneId: string,
+): boolean =>
+  observed !== undefined &&
+  observed.zoneId === zoneId &&
+  observed.enabled === (desired.enabled ?? true) &&
+  deepEqual(observed.ciphers, desired.ciphers) &&
+  observed.minTLS === desired.minTLS;
+
+const isMissingCustomDomainOrBucket = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  (("status" in error && (error as { status: unknown }).status === 404) ||
+    ("_tag" in error &&
+      ((error as { _tag: unknown })._tag === "DomainNotFound" ||
+        (error as { _tag: unknown })._tag === "NoSuchBucket")));
 
 export const R2BucketProvider = () =>
   Provider.effect(
@@ -109,6 +215,10 @@ export const R2BucketProvider = () =>
       const patchBucket = yield* r2.patchBucket;
       const deleteBucket = yield* r2.deleteBucket;
       const getBucket = yield* r2.getBucket;
+      const listBucketDomainCustoms = yield* r2.listBucketDomainCustoms;
+      const createBucketDomainCustom = yield* r2.createBucketDomainCustom;
+      const updateBucketDomainCustom = yield* r2.updateBucketDomainCustom;
+      const deleteBucketDomainCustom = yield* r2.deleteBucketDomainCustom;
 
       const createBucketName = (id: string, name: string | undefined) =>
         Effect.gen(function* () {
@@ -125,6 +235,141 @@ export const R2BucketProvider = () =>
         if (!location) return undefined;
         return location.toLowerCase() as R2Bucket.Location;
       };
+
+      const resolveZoneId = (zone: R2BucketCustomDomainZone) =>
+        Effect.gen(function* () {
+          if (typeof zone !== "string") return zone.zoneId;
+          if (isZoneIdString(zone)) return zone;
+
+          const match = yield* zones.listZones.items({}).pipe(
+            Stream.filter(
+              (candidate) =>
+                candidate.account.id === accountId &&
+                matchesHostname(candidate.name, zone),
+            ),
+            Stream.runHead,
+            Effect.map(Option.getOrUndefined),
+          );
+          if (!match) {
+            return yield* Effect.fail(
+              new Error(`Cloudflare zone not found for ${zone}`),
+            );
+          }
+          return match.id;
+        });
+
+      const listCustomDomains = (
+        bucketName: string,
+        jurisdiction: R2Bucket.Jurisdiction,
+      ) =>
+        listBucketDomainCustoms({
+          accountId,
+          bucketName,
+          jurisdiction,
+        }).pipe(
+          Effect.map((response) =>
+            response.domains.map(toCustomDomainAttributes),
+          ),
+          Effect.catchTag("NoSuchBucket", () => Effect.succeed([])),
+        );
+
+      const reconcileCustomDomains = (
+        bucketName: string,
+        jurisdiction: R2Bucket.Jurisdiction,
+        desired: R2BucketCustomDomain[],
+        previous: R2Bucket.CustomDomain[],
+      ) =>
+        Effect.gen(function* () {
+          const observed = yield* listCustomDomains(bucketName, jurisdiction);
+          const observedByDomain = new Map(
+            observed.map((domain) => [domain.domain, domain]),
+          );
+          const desiredDomains = new Set(
+            desired.map((domain) => domain.domain),
+          );
+
+          for (const previousDomain of previous) {
+            if (!desiredDomains.has(previousDomain.domain)) {
+              yield* deleteBucketDomainCustom({
+                accountId,
+                bucketName,
+                domain: previousDomain.domain,
+                jurisdiction,
+              }).pipe(
+                Effect.catchIf(
+                  isMissingCustomDomainOrBucket,
+                  () => Effect.void,
+                ),
+              );
+            }
+          }
+
+          const applied: R2Bucket.CustomDomain[] = [];
+          for (const domain of desired) {
+            const zoneId = yield* resolveZoneId(domain.zone);
+            const observedDomain = observedByDomain.get(domain.domain);
+            if (!sameCustomDomainConfig(observedDomain, domain, zoneId)) {
+              if (observedDomain) {
+                if (observedDomain.zoneId !== zoneId) {
+                  yield* deleteBucketDomainCustom({
+                    accountId,
+                    bucketName,
+                    domain: domain.domain,
+                    jurisdiction,
+                  }).pipe(
+                    Effect.catchIf(
+                      isMissingCustomDomainOrBucket,
+                      () => Effect.void,
+                    ),
+                  );
+                  yield* createBucketDomainCustom({
+                    accountId,
+                    bucketName,
+                    jurisdiction,
+                    domain: domain.domain,
+                    enabled: domain.enabled ?? true,
+                    zoneId,
+                    ciphers: domain.ciphers,
+                    minTLS: domain.minTLS,
+                  });
+                } else {
+                  yield* updateBucketDomainCustom({
+                    accountId,
+                    bucketName,
+                    domain: domain.domain,
+                    jurisdiction,
+                    enabled: domain.enabled ?? true,
+                    ciphers: domain.ciphers,
+                    minTLS: domain.minTLS,
+                  });
+                }
+              } else {
+                yield* createBucketDomainCustom({
+                  accountId,
+                  bucketName,
+                  jurisdiction,
+                  domain: domain.domain,
+                  enabled: domain.enabled ?? true,
+                  zoneId,
+                  ciphers: domain.ciphers,
+                  minTLS: domain.minTLS,
+                });
+              }
+            }
+
+            const refreshed = yield* r2
+              .getBucketDomainCustom({
+                accountId,
+                bucketName,
+                domain: domain.domain,
+                jurisdiction,
+              })
+              .pipe(Effect.map(toCustomDomainAttributes));
+            applied.push(refreshed);
+          }
+
+          return applied.sort((a, b) => a.domain.localeCompare(b.domain));
+        });
 
       return {
         stables: ["bucketName", "accountId"],
@@ -151,6 +396,9 @@ export const R2BucketProvider = () =>
               action: "update",
               stables: oldName === name ? ["bucketName"] : undefined,
             } as const;
+          }
+          if (!deepEqual(olds.domains, news.domains)) {
+            return { action: "update" } as const;
           }
         }),
         reconcile: Effect.fn(function* ({ id, news = {}, output }) {
@@ -206,15 +454,37 @@ export const R2BucketProvider = () =>
             });
           }
 
-          return {
+          const attrs = {
             bucketName: observed.name!,
             storageClass: observed.storageClass ?? "Standard",
             jurisdiction: observed.jurisdiction ?? "default",
             location: normalizeLocation(observed.location),
             accountId: acct,
           };
+
+          const domains = yield* reconcileCustomDomains(
+            attrs.bucketName,
+            attrs.jurisdiction,
+            normalizeDomains(news.domains),
+            output?.domains ?? [],
+          );
+
+          return {
+            ...attrs,
+            domains,
+          };
         }),
         delete: Effect.fn(function* ({ output }) {
+          for (const domain of output.domains ?? []) {
+            yield* deleteBucketDomainCustom({
+              accountId: output.accountId,
+              bucketName: output.bucketName,
+              domain: domain.domain,
+              jurisdiction: output.jurisdiction,
+            }).pipe(
+              Effect.catchIf(isMissingCustomDomainOrBucket, () => Effect.void),
+            );
+          }
           yield* deleteBucket({
             accountId: output.accountId,
             bucketName: output.bucketName,
@@ -230,13 +500,28 @@ export const R2BucketProvider = () =>
             bucketName: name,
             jurisdiction: output?.jurisdiction ?? olds?.jurisdiction,
           }).pipe(
-            Effect.map((bucket) => ({
-              bucketName: bucket.name!,
-              storageClass: bucket.storageClass ?? "Standard",
-              jurisdiction: bucket.jurisdiction ?? "default",
-              location: normalizeLocation(bucket.location),
-              accountId: acct,
-            })),
+            Effect.flatMap((bucket) =>
+              Effect.gen(function* () {
+                const jurisdiction = bucket.jurisdiction ?? "default";
+                const existingDomains =
+                  output?.domains && output.domains.length > 0
+                    ? yield* listCustomDomains(bucket.name!, jurisdiction)
+                    : [];
+                const ownedDomains = new Set(
+                  output?.domains.map((domain) => domain.domain) ?? [],
+                );
+                return {
+                  bucketName: bucket.name!,
+                  storageClass: bucket.storageClass ?? "Standard",
+                  jurisdiction,
+                  location: normalizeLocation(bucket.location),
+                  accountId: acct,
+                  domains: existingDomains.filter((domain) =>
+                    ownedDomains.has(domain.domain),
+                  ),
+                };
+              }),
+            ),
             Effect.catchTag("NoSuchBucket", () => Effect.succeed(undefined)),
           );
         }),

--- a/packages/alchemy/src/Cloudflare/Zone.ts
+++ b/packages/alchemy/src/Cloudflare/Zone.ts
@@ -1,7 +1,8 @@
-import * as zones from "@distilled.cloud/cloudflare/zones";
+import {
+  Credentials,
+  formatHeaders,
+} from "@distilled.cloud/cloudflare/Credentials";
 import * as Effect from "effect/Effect";
-import * as Option from "effect/Option";
-import * as Stream from "effect/Stream";
 
 export type ZoneReference = string | { zoneId: string; name?: string };
 
@@ -26,19 +27,62 @@ export const resolveZoneId = ({
     if (typeof zone === "string" && isZoneId(zone)) return zone;
 
     const lookup = zone ?? hostname;
-    const match = yield* zones.listZones.items({}).pipe(
-      Stream.filter(
-        (candidate) =>
-          candidate.account.id === accountId &&
-          matchesZoneHostname(candidate.name, lookup),
-      ),
-      Stream.runHead,
-      Effect.map(Option.getOrUndefined),
+    for (const candidate of zoneNameCandidates(lookup)) {
+      const match = yield* findZoneByName({ accountId, name: candidate });
+      if (match) return match.id;
+    }
+    return yield* Effect.fail(
+      new Error(`Cloudflare zone not found for ${lookup}`),
     );
-    if (!match) {
+  });
+
+type ZoneListResponse = {
+  success: boolean;
+  errors?: { message?: string }[];
+  result?: { id: string; name: string; account: { id?: string | null } }[];
+};
+
+const findZoneByName = ({
+  accountId,
+  name,
+}: {
+  accountId: string;
+  name: string;
+}) =>
+  Effect.gen(function* () {
+    const credentialsEffect = yield* Credentials;
+    const credentials = yield* credentialsEffect;
+    const url = new URL(`${credentials.apiBaseUrl}/zones`);
+    url.searchParams.set("account.id", accountId);
+    url.searchParams.set("name", name);
+    url.searchParams.set("per_page", "1");
+
+    const json = yield* Effect.tryPromise({
+      try: async () => {
+        const response = await fetch(url, {
+          headers: formatHeaders(credentials),
+        });
+        return (await response.json()) as ZoneListResponse;
+      },
+      catch: (cause) => new Error(`Failed to list Cloudflare zones`, { cause }),
+    });
+
+    if (!json.success) {
       return yield* Effect.fail(
-        new Error(`Cloudflare zone not found for ${lookup}`),
+        new Error(
+          json.errors?.map((error) => error.message).join(", ") ??
+            `Failed to list Cloudflare zones`,
+        ),
       );
     }
-    return match.id;
+
+    return json.result?.find(
+      (candidate) =>
+        candidate.name === name && candidate.account.id === accountId,
+    );
   });
+
+const zoneNameCandidates = (hostname: string): string[] => {
+  const parts = hostname.split(".");
+  return parts.slice(0, -1).map((_, index) => parts.slice(index).join("."));
+};

--- a/packages/alchemy/src/Cloudflare/Zone.ts
+++ b/packages/alchemy/src/Cloudflare/Zone.ts
@@ -1,0 +1,44 @@
+import * as zones from "@distilled.cloud/cloudflare/zones";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Stream from "effect/Stream";
+
+export type ZoneReference = string | { zoneId: string; name?: string };
+
+export const isZoneId = (zone: string): boolean => /^[a-f0-9]{32}$/i.test(zone);
+
+export const matchesZoneHostname = (
+  zoneName: string,
+  hostname: string,
+): boolean => hostname === zoneName || hostname.endsWith(`.${zoneName}`);
+
+export const resolveZoneId = ({
+  accountId,
+  zone,
+  hostname,
+}: {
+  accountId: string;
+  zone: ZoneReference | undefined;
+  hostname: string;
+}) =>
+  Effect.gen(function* () {
+    if (typeof zone === "object") return zone.zoneId;
+    if (typeof zone === "string" && isZoneId(zone)) return zone;
+
+    const lookup = zone ?? hostname;
+    const match = yield* zones.listZones.items({}).pipe(
+      Stream.filter(
+        (candidate) =>
+          candidate.account.id === accountId &&
+          matchesZoneHostname(candidate.name, lookup),
+      ),
+      Stream.runHead,
+      Effect.map(Option.getOrUndefined),
+    );
+    if (!match) {
+      return yield* Effect.fail(
+        new Error(`Cloudflare zone not found for ${lookup}`),
+      );
+    }
+    return match.id;
+  });

--- a/packages/alchemy/test/Cloudflare/R2/CustomDomain.test.ts
+++ b/packages/alchemy/test/Cloudflare/R2/CustomDomain.test.ts
@@ -1,0 +1,79 @@
+import * as Cloudflare from "@/Cloudflare";
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import * as Test from "@/Test/Vitest";
+import * as r2 from "@distilled.cloud/cloudflare/r2";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const zoneId = process.env.CLOUDFLARE_TEST_R2_DOMAIN_ZONE_ID;
+const domain = process.env.CLOUDFLARE_TEST_R2_DOMAIN;
+
+test.provider.skipIf(!zoneId || !domain)(
+  "creates, updates, and deletes a bucket custom domain",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const bucket = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.R2Bucket("DomainBucket", {
+            domains: {
+              domain: domain!,
+              zone: { zoneId: zoneId! },
+            },
+          });
+        }),
+      );
+
+      expect(bucket.domains).toHaveLength(1);
+      expect(bucket.domains[0]?.domain).toEqual(domain);
+      expect(bucket.domains[0]?.enabled).toEqual(true);
+
+      const actual = yield* r2.getBucketDomainCustom({
+        accountId,
+        bucketName: bucket.bucketName,
+        domain: domain!,
+        jurisdiction: bucket.jurisdiction,
+      });
+      expect(actual.domain).toEqual(domain);
+
+      const updated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.R2Bucket("DomainBucket", {
+            domains: {
+              domain: domain!,
+              zone: { zoneId: zoneId! },
+              enabled: false,
+            },
+          });
+        }),
+      );
+
+      expect(updated.domains[0]?.enabled).toEqual(false);
+
+      yield* stack.destroy();
+
+      const deleted = yield* r2
+        .getBucketDomainCustom({
+          accountId,
+          bucketName: bucket.bucketName,
+          domain: domain!,
+          jurisdiction: bucket.jurisdiction,
+        })
+        .pipe(
+          Effect.map(() => false),
+          Effect.catchTag("DomainNotFound", () => Effect.succeed(true)),
+        );
+      expect(deleted).toEqual(true);
+    }).pipe(logLevel),
+);

--- a/packages/alchemy/test/Cloudflare/R2/CustomDomain.test.ts
+++ b/packages/alchemy/test/Cloudflare/R2/CustomDomain.test.ts
@@ -3,8 +3,10 @@ import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Test from "@/Test/Vitest";
 import * as r2 from "@distilled.cloud/cloudflare/r2";
 import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
 
 const { test } = Test.make({ providers: Cloudflare.providers() });
 
@@ -14,9 +16,12 @@ const logLevel = Effect.provideService(
 );
 
 const zoneId = process.env.CLOUDFLARE_TEST_R2_DOMAIN_ZONE_ID;
-const domain = process.env.CLOUDFLARE_TEST_R2_DOMAIN;
+const zoneName = process.env.CLOUDFLARE_TEST_R2_DOMAIN_ZONE_NAME;
+const domain = zoneName
+  ? `alchemy-r2-test-${Math.random().toString(36).slice(2, 8)}.${zoneName}`
+  : undefined;
 
-test.provider.skipIf(!zoneId || !domain)(
+test.provider.skipIf(!zoneId || !zoneName)(
   "creates, updates, and deletes a bucket custom domain",
   (stack) =>
     Effect.gen(function* () {
@@ -75,5 +80,28 @@ test.provider.skipIf(!zoneId || !domain)(
           Effect.catchTag("DomainNotFound", () => Effect.succeed(true)),
         );
       expect(deleted).toEqual(true);
+
+      yield* waitForBucketToBeDeleted(bucket.bucketName, accountId);
     }).pipe(logLevel),
 );
+
+const waitForBucketToBeDeleted = Effect.fn(function* (
+  bucketName: string,
+  accountId: string,
+) {
+  yield* r2
+    .getBucket({
+      accountId,
+      bucketName,
+    })
+    .pipe(
+      Effect.flatMap(() => Effect.fail(new BucketStillExists())),
+      Effect.retry({
+        while: (e): e is BucketStillExists => e instanceof BucketStillExists,
+        schedule: Schedule.exponential(100),
+      }),
+      Effect.catchTag("NoSuchBucket", () => Effect.void),
+    );
+});
+
+class BucketStillExists extends Data.TaggedError("BucketStillExists") {}

--- a/packages/alchemy/test/Cloudflare/R2/CustomDomain.test.ts
+++ b/packages/alchemy/test/Cloudflare/R2/CustomDomain.test.ts
@@ -15,9 +15,10 @@ const logLevel = Effect.provideService(
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-const zoneName = process.env.CLOUDFLARE_TEST_R2_DOMAIN_ZONE_NAME;
+const zoneName =
+  process.env.CLOUDFLARE_TEST_R2_DOMAIN_ZONE_NAME ?? "alchemy-test-2.us";
 const domain = zoneName
-  ? `alchemy-r2-test-${Math.random().toString(36).slice(2, 8)}.${zoneName}`
+  ? `alchemy-r2-test-${process.env.PULL_REQUEST ?? process.env.USER}.${zoneName}`
   : undefined;
 
 test.provider.skipIf(!zoneName)(

--- a/packages/alchemy/test/Cloudflare/R2/CustomDomain.test.ts
+++ b/packages/alchemy/test/Cloudflare/R2/CustomDomain.test.ts
@@ -20,9 +20,73 @@ const zoneName =
 const domain = zoneName
   ? `alchemy-r2-test-${process.env.PULL_REQUEST ?? process.env.USER}.${zoneName}`
   : undefined;
+const domain2 = zoneName
+  ? `alchemy-r2-test-2-${process.env.PULL_REQUEST ?? process.env.USER}.${zoneName}`
+  : undefined;
 
-test.provider.skipIf(!zoneName)(
-  "creates, updates, and deletes a bucket custom domain",
+test.provider("creates, updates, and deletes a bucket custom domain", (stack) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* CloudflareEnvironment;
+
+    yield* stack.destroy();
+
+    const bucket = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.R2Bucket("DomainBucket", {
+          domain: {
+            name: domain!,
+          },
+        });
+      }),
+    );
+
+    expect(bucket.domains).toHaveLength(1);
+    expect(bucket.domains[0]?.domain).toEqual(domain);
+    expect(bucket.domains[0]?.enabled).toEqual(true);
+
+    const actual = yield* r2.getBucketDomainCustom({
+      accountId,
+      bucketName: bucket.bucketName,
+      domain: domain!,
+      jurisdiction: bucket.jurisdiction,
+    });
+    expect(actual.domain).toEqual(domain);
+
+    const updated = yield* stack.deploy(
+      Effect.gen(function* () {
+        return yield* Cloudflare.R2Bucket("DomainBucket", {
+          domain: {
+            name: domain!,
+            enabled: false,
+          },
+        });
+      }),
+    );
+
+    expect(updated.domains[0]?.enabled).toEqual(false);
+
+    yield* stack.destroy();
+
+    const deleted = yield* r2
+      .getBucketDomainCustom({
+        accountId,
+        bucketName: bucket.bucketName,
+        domain: domain!,
+        jurisdiction: bucket.jurisdiction,
+      })
+      .pipe(
+        Effect.map(() => false),
+        Effect.catchTag("DomainNotFound", () => Effect.succeed(true)),
+        Effect.catchTag("NoSuchBucket", () => Effect.succeed(true)),
+      );
+    expect(deleted).toEqual(true);
+
+    yield* waitForBucketToBeDeleted(bucket.bucketName, accountId);
+  }).pipe(logLevel),
+);
+
+test.provider(
+  "creates, updates, and deletes a bucket with multiple custom domains",
   (stack) =>
     Effect.gen(function* () {
       const { accountId } = yield* CloudflareEnvironment;
@@ -31,42 +95,53 @@ test.provider.skipIf(!zoneName)(
 
       const bucket = yield* stack.deploy(
         Effect.gen(function* () {
-          return yield* Cloudflare.R2Bucket("DomainBucket", {
-            domains: {
-              domain: domain!,
-            },
+          return yield* Cloudflare.R2Bucket("MultiDomainBucket", {
+            domain: [{ name: domain! }, { name: domain2! }],
           });
         }),
       );
 
-      expect(bucket.domains).toHaveLength(1);
-      expect(bucket.domains[0]?.domain).toEqual(domain);
-      expect(bucket.domains[0]?.enabled).toEqual(true);
+      expect(bucket.domains).toHaveLength(2);
+      const domainNames = bucket.domains.map((d) => d.domain).sort();
+      expect(domainNames).toEqual([domain, domain2].sort());
+      expect(bucket.domains.every((d) => d.enabled)).toEqual(true);
 
-      const actual = yield* r2.getBucketDomainCustom({
-        accountId,
-        bucketName: bucket.bucketName,
-        domain: domain!,
-        jurisdiction: bucket.jurisdiction,
-      });
-      expect(actual.domain).toEqual(domain);
+      for (const name of [domain!, domain2!]) {
+        const actual = yield* r2.getBucketDomainCustom({
+          accountId,
+          bucketName: bucket.bucketName,
+          domain: name,
+          jurisdiction: bucket.jurisdiction,
+        });
+        expect(actual.domain).toEqual(name);
+      }
 
       const updated = yield* stack.deploy(
         Effect.gen(function* () {
-          return yield* Cloudflare.R2Bucket("DomainBucket", {
-            domains: {
-              domain: domain!,
-              enabled: false,
-            },
+          return yield* Cloudflare.R2Bucket("MultiDomainBucket", {
+            domain: [{ name: domain!, enabled: false }, { name: domain2! }],
           });
         }),
       );
 
-      expect(updated.domains[0]?.enabled).toEqual(false);
+      const updatedByName = Object.fromEntries(
+        updated.domains.map((d) => [d.domain, d]),
+      );
+      expect(updatedByName[domain!]?.enabled).toEqual(false);
+      expect(updatedByName[domain2!]?.enabled).toEqual(true);
 
-      yield* stack.destroy();
+      const removed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.R2Bucket("MultiDomainBucket", {
+            domain: [{ name: domain2! }],
+          });
+        }),
+      );
 
-      const deleted = yield* r2
+      expect(removed.domains).toHaveLength(1);
+      expect(removed.domains[0]?.domain).toEqual(domain2);
+
+      const firstRemoved = yield* r2
         .getBucketDomainCustom({
           accountId,
           bucketName: bucket.bucketName,
@@ -76,9 +151,26 @@ test.provider.skipIf(!zoneName)(
         .pipe(
           Effect.map(() => false),
           Effect.catchTag("DomainNotFound", () => Effect.succeed(true)),
-          Effect.catchTag("NoSuchBucket", () => Effect.succeed(true)),
         );
-      expect(deleted).toEqual(true);
+      expect(firstRemoved).toEqual(true);
+
+      yield* stack.destroy();
+
+      for (const name of [domain!, domain2!]) {
+        const deleted = yield* r2
+          .getBucketDomainCustom({
+            accountId,
+            bucketName: bucket.bucketName,
+            domain: name,
+            jurisdiction: bucket.jurisdiction,
+          })
+          .pipe(
+            Effect.map(() => false),
+            Effect.catchTag("DomainNotFound", () => Effect.succeed(true)),
+            Effect.catchTag("NoSuchBucket", () => Effect.succeed(true)),
+          );
+        expect(deleted).toEqual(true);
+      }
 
       yield* waitForBucketToBeDeleted(bucket.bucketName, accountId);
     }).pipe(logLevel),

--- a/packages/alchemy/test/Cloudflare/R2/CustomDomain.test.ts
+++ b/packages/alchemy/test/Cloudflare/R2/CustomDomain.test.ts
@@ -15,13 +15,12 @@ const logLevel = Effect.provideService(
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-const zoneId = process.env.CLOUDFLARE_TEST_R2_DOMAIN_ZONE_ID;
 const zoneName = process.env.CLOUDFLARE_TEST_R2_DOMAIN_ZONE_NAME;
 const domain = zoneName
   ? `alchemy-r2-test-${Math.random().toString(36).slice(2, 8)}.${zoneName}`
   : undefined;
 
-test.provider.skipIf(!zoneId || !zoneName)(
+test.provider.skipIf(!zoneName)(
   "creates, updates, and deletes a bucket custom domain",
   (stack) =>
     Effect.gen(function* () {
@@ -34,7 +33,6 @@ test.provider.skipIf(!zoneId || !zoneName)(
           return yield* Cloudflare.R2Bucket("DomainBucket", {
             domains: {
               domain: domain!,
-              zone: { zoneId: zoneId! },
             },
           });
         }),
@@ -57,7 +55,6 @@ test.provider.skipIf(!zoneId || !zoneName)(
           return yield* Cloudflare.R2Bucket("DomainBucket", {
             domains: {
               domain: domain!,
-              zone: { zoneId: zoneId! },
               enabled: false,
             },
           });

--- a/packages/alchemy/test/Cloudflare/R2/CustomDomain.test.ts
+++ b/packages/alchemy/test/Cloudflare/R2/CustomDomain.test.ts
@@ -78,6 +78,7 @@ test.provider.skipIf(!zoneId || !zoneName)(
         .pipe(
           Effect.map(() => false),
           Effect.catchTag("DomainNotFound", () => Effect.succeed(true)),
+          Effect.catchTag("NoSuchBucket", () => Effect.succeed(true)),
         );
       expect(deleted).toEqual(true);
 


### PR DESCRIPTION
Adds R2 bucket custom-domain support to the existing Cloudflare R2Bucket resource.

- accepts `domains` as a single custom domain or an array
- supports `{ zoneId }`, zone ID strings, and hostname strings for zone selection
- creates, updates, and removes only domains tracked by the bucket resource state
- recreates a custom domain when its zone changes because Cloudflare does not expose `zoneId` on the update endpoint
- adds a focused live test gated by `CLOUDFLARE_TEST_R2_DOMAIN_ZONE_ID` and `CLOUDFLARE_TEST_R2_DOMAIN`

Verification run:

- `bun vitest run packages/alchemy/test/Cloudflare/R2/CustomDomain.test.ts`
- `bun tsc -b --pretty false`
- `git diff --check`
