### PR TITLE
feat(github): event sources, capabilities, and builder service

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "packages": [
       "website",
       "packages/*",
-      "examples/*"
+      "examples/*",
+      "services/*"
     ],
     "catalog": {
       "@aws-sdk/credential-providers": "^3.0.0",

--- a/packages/alchemy/src/Cloudflare/GitHub/Webhooks.ts
+++ b/packages/alchemy/src/Cloudflare/GitHub/Webhooks.ts
@@ -1,0 +1,160 @@
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+import * as Ref from "effect/Ref";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import type {
+  AnyWebhookDelivery,
+  WebhookDelivery,
+  WebhookEventName,
+} from "../../GitHub/Events.ts";
+import {
+  Dispatcher,
+  repoFullName,
+  verifySignature,
+  type DispatcherService,
+  type RepoRef,
+  type WebhookHandler,
+} from "../../GitHub/Webhooks.ts";
+
+interface NamedHandler {
+  /** Repository fully-qualified name (`owner/name`) the handler is bound to. */
+  repoFullName: string;
+  /** GitHub event name, or "*" for any. */
+  event: WebhookEventName | "*";
+  /**
+   * The actual handler. We type-erase on `any` because each registration
+   * may have its own `Req`/`Err`; the dispatcher invokes the effect inside
+   * `Effect.forkDetach` where the parent fiber's context provides any
+   * services the handler needs.
+   */
+  handler: WebhookHandler<WebhookEventName, any, any>;
+}
+
+/**
+ * Build the Cloudflare-side `Dispatcher` Live layer. The webhook secret is
+ * passed in (the Worker stack typically wires it as a Cloudflare Secret env
+ * binding, then constructs this layer in the init phase).
+ *
+ * The dispatcher accumulates `NamedHandler[]` as event-source helpers
+ * register handlers. `handle` then delivers verified webhooks to all
+ * matching handlers concurrently via `Effect.fork`, returning 204
+ * immediately so the GitHub delivery is acked even if a handler is slow.
+ */
+export const live = (
+  secret: Redacted.Redacted<string>,
+  options: {
+    /**
+     * Path the Worker should treat as the webhook endpoint. `handle`
+     * returns `undefined` for requests on other paths so callers can fall
+     * through to their normal `fetch` routing.
+     * @default "/__github/webhook"
+     */
+    path?: string;
+  } = {},
+): Layer.Layer<Dispatcher> => {
+  const path = options.path ?? "/__github/webhook";
+
+  return Layer.effect(
+    Dispatcher,
+    Effect.gen(function* () {
+      const handlers = yield* Ref.make<NamedHandler[]>([]);
+
+      const append = (h: NamedHandler) =>
+        Ref.update(handlers, (xs) => [...xs, h]);
+
+      const service: DispatcherService = {
+        register: (repo: RepoRef, event, handler) =>
+          append({
+            repoFullName: repoFullName(repo),
+            event,
+            handler: handler as WebhookHandler<WebhookEventName, never, never>,
+          }),
+        registerAny: (repo, handler) =>
+          append({
+            repoFullName: repoFullName(repo),
+            event: "*",
+            handler,
+          }),
+        handle: (request) =>
+          Effect.gen(function* () {
+            const url = new URL(request.url, "http://localhost");
+            if (request.method !== "POST" || url.pathname !== path) {
+              return undefined;
+            }
+
+            const eventHeader = request.headers["x-github-event"];
+            const sig = request.headers["x-hub-signature-256"];
+            const deliveryId = request.headers["x-github-delivery"];
+            const hookId = request.headers["x-github-hook-id"];
+            if (!eventHeader || !deliveryId) {
+              return HttpServerResponse.text("missing GitHub headers", {
+                status: 400,
+              });
+            }
+
+            const rawBody = yield* request.text;
+            const verified = yield* verifySignature(
+              Redacted.value(secret),
+              sig,
+              rawBody,
+            );
+            if (!verified) {
+              return HttpServerResponse.text("invalid signature", {
+                status: 401,
+              });
+            }
+
+            let payload: Record<string, any>;
+            try {
+              payload = JSON.parse(rawBody);
+            } catch {
+              return HttpServerResponse.text("invalid json", {
+                status: 400,
+              });
+            }
+
+            const delivery: WebhookDelivery<WebhookEventName> = {
+              event: eventHeader as WebhookEventName,
+              deliveryId,
+              hookId: hookId ? Number(hookId) : undefined,
+              payload: payload as any,
+              raw: payload,
+            };
+
+            const repoFromPayload = (
+              (payload.repository as { full_name?: string } | undefined)
+                ?.full_name ?? ""
+            ).toLowerCase();
+
+            const xs = yield* Ref.get(handlers);
+            const matching = xs.filter(
+              (h) =>
+                h.repoFullName === repoFromPayload &&
+                (h.event === "*" || h.event === eventHeader),
+            );
+
+            // Fork each matching handler. We deliberately don't await them
+            // — GitHub's webhook timeout is 10s and we want the 204 ack to
+            // go out promptly.
+            yield* Effect.forEach(
+              matching,
+              (h) =>
+                Effect.forkDetach(
+                  h
+                    .handler(delivery as AnyWebhookDelivery)
+                    .pipe(Effect.catchCause(() => Effect.void)),
+                ),
+              { discard: true },
+            );
+
+            return HttpServerResponse.empty({ status: 204 });
+          }).pipe(Effect.orDie) as Effect.Effect<
+            HttpServerResponse.HttpServerResponse | undefined
+          >,
+      };
+
+      return service;
+    }),
+  );
+};

--- a/packages/alchemy/src/Cloudflare/GitHub/index.ts
+++ b/packages/alchemy/src/Cloudflare/GitHub/index.ts
@@ -1,0 +1,1 @@
+export * as Webhooks from "./Webhooks.ts";

--- a/packages/alchemy/src/Cloudflare/index.ts
+++ b/packages/alchemy/src/Cloudflare/index.ts
@@ -5,6 +5,7 @@ export * from "./CloudflareEnvironment.ts";
 export * from "./Container/index.ts";
 export * from "./D1/index.ts";
 export * from "./EdgeSession.ts";
+export * as GitHub from "./GitHub/index.ts";
 export * from "./Hyperdrive/index.ts";
 export * from "./KV/index.ts";
 export * from "./Providers.ts";

--- a/packages/alchemy/src/GitHub/Capabilities.ts
+++ b/packages/alchemy/src/GitHub/Capabilities.ts
@@ -1,0 +1,837 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { RuntimeOctokit } from "./Octokit.ts";
+import type { RepoRef } from "./Webhooks.ts";
+
+/**
+ * Runtime-side GitHub capabilities. Each capability is a `Context.Service`
+ * grouped to mirror Octokit's REST namespaces (`octokit.rest.issues`,
+ * `octokit.rest.pulls`, `octokit.rest.git`, etc.) and the verbs they
+ * expose. All methods accept a {@link RepoRef} as the first argument so
+ * the caller doesn't repeat owner/name on every call.
+ *
+ * Provided by {@link CapabilitiesLive}, which depends on a
+ * {@link RuntimeOctokit} layer (see `Octokit.ts`).
+ */
+
+const ownerName = (repo: RepoRef) => ({
+  owner: repo.owner,
+  repo: repo.name,
+});
+
+// ---------------------------------------------------------------------------
+// IssueComments — covers comments on issues AND on pull-request conversations.
+//   Octokit: octokit.rest.issues.{listComments, createComment,
+//                                  updateComment, deleteComment}
+// ---------------------------------------------------------------------------
+
+export interface IssueCommentsService {
+  list(
+    repo: RepoRef,
+    args: { issueNumber: number; since?: string },
+  ): Effect.Effect<
+    Array<{ id: number; body: string | null; user: { login: string } | null }>
+  >;
+  create(
+    repo: RepoRef,
+    args: { issueNumber: number; body: string },
+  ): Effect.Effect<{ id: number; htmlUrl: string }>;
+  update(
+    repo: RepoRef,
+    args: { commentId: number; body: string },
+  ): Effect.Effect<{ id: number; htmlUrl: string }>;
+  delete(repo: RepoRef, args: { commentId: number }): Effect.Effect<void>;
+}
+
+export class IssueComments extends Context.Service<
+  IssueComments,
+  IssueCommentsService
+>()("GitHub.IssueComments") {}
+
+// ---------------------------------------------------------------------------
+// PullRequestReviewComments — inline review thread comments on a PR.
+//   Octokit: octokit.rest.pulls.{listReviewComments, createReviewComment,
+//                                updateReviewComment, deleteReviewComment,
+//                                createReplyForReviewComment}
+// ---------------------------------------------------------------------------
+
+export interface PullRequestReviewCommentsService {
+  create(
+    repo: RepoRef,
+    args: {
+      prNumber: number;
+      body: string;
+      commitId: string;
+      path: string;
+      line: number;
+      side?: "LEFT" | "RIGHT";
+    },
+  ): Effect.Effect<{ id: number; htmlUrl: string }>;
+  update(
+    repo: RepoRef,
+    args: { commentId: number; body: string },
+  ): Effect.Effect<{ id: number; htmlUrl: string }>;
+  delete(repo: RepoRef, args: { commentId: number }): Effect.Effect<void>;
+  reply(
+    repo: RepoRef,
+    args: { prNumber: number; commentId: number; body: string },
+  ): Effect.Effect<{ id: number; htmlUrl: string }>;
+}
+
+export class PullRequestReviewComments extends Context.Service<
+  PullRequestReviewComments,
+  PullRequestReviewCommentsService
+>()("GitHub.PullRequestReviewComments") {}
+
+// ---------------------------------------------------------------------------
+// PullRequestReviews — submitting and dismissing reviews on a PR.
+//   Octokit: octokit.rest.pulls.{createReview, dismissReview,
+//                                requestReviewers, removeRequestedReviewers}
+// ---------------------------------------------------------------------------
+
+export interface PullRequestReviewsService {
+  create(
+    repo: RepoRef,
+    args: {
+      prNumber: number;
+      event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT";
+      body?: string;
+      commitId?: string;
+    },
+  ): Effect.Effect<{ id: number; htmlUrl: string }>;
+  dismiss(
+    repo: RepoRef,
+    args: { prNumber: number; reviewId: number; message: string },
+  ): Effect.Effect<void>;
+  requestReviewers(
+    repo: RepoRef,
+    args: { prNumber: number; reviewers?: string[]; teamReviewers?: string[] },
+  ): Effect.Effect<void>;
+}
+
+export class PullRequestReviews extends Context.Service<
+  PullRequestReviews,
+  PullRequestReviewsService
+>()("GitHub.PullRequestReviews") {}
+
+// ---------------------------------------------------------------------------
+// PullRequests — managing pull requests themselves.
+//   Octokit: octokit.rest.pulls.{create, update, merge, listFiles}
+// ---------------------------------------------------------------------------
+
+export interface PullRequestsService {
+  create(
+    repo: RepoRef,
+    args: {
+      head: string;
+      base: string;
+      title: string;
+      body?: string;
+      draft?: boolean;
+    },
+  ): Effect.Effect<{ number: number; htmlUrl: string }>;
+  update(
+    repo: RepoRef,
+    args: {
+      prNumber: number;
+      title?: string;
+      body?: string;
+      state?: "open" | "closed";
+      base?: string;
+    },
+  ): Effect.Effect<{ number: number; htmlUrl: string }>;
+  merge(
+    repo: RepoRef,
+    args: {
+      prNumber: number;
+      mergeMethod?: "merge" | "squash" | "rebase";
+      commitTitle?: string;
+      commitMessage?: string;
+    },
+  ): Effect.Effect<{ sha: string; merged: boolean }>;
+}
+
+export class PullRequests extends Context.Service<
+  PullRequests,
+  PullRequestsService
+>()("GitHub.PullRequests") {}
+
+// ---------------------------------------------------------------------------
+// Git — low-level git database (refs, blobs, trees, commits, tags).
+//   Octokit: octokit.rest.git.{getRef, createRef, updateRef, deleteRef,
+//                              createBlob, createTree, createCommit,
+//                              getCommit, getTree, getBlob}
+// ---------------------------------------------------------------------------
+
+export interface GitService {
+  getRef(
+    repo: RepoRef,
+    args: { ref: string },
+  ): Effect.Effect<{ ref: string; sha: string }>;
+  createRef(
+    repo: RepoRef,
+    args: { ref: string; sha: string },
+  ): Effect.Effect<{ ref: string; sha: string }>;
+  updateRef(
+    repo: RepoRef,
+    args: { ref: string; sha: string; force?: boolean },
+  ): Effect.Effect<{ ref: string; sha: string }>;
+  deleteRef(repo: RepoRef, args: { ref: string }): Effect.Effect<void>;
+  createBlob(
+    repo: RepoRef,
+    args: { content: string; encoding?: "utf-8" | "base64" },
+  ): Effect.Effect<{ sha: string }>;
+  createTree(
+    repo: RepoRef,
+    args: {
+      baseTree?: string;
+      tree: Array<{
+        path: string;
+        mode: "100644" | "100755" | "040000" | "160000" | "120000";
+        type: "blob" | "tree" | "commit";
+        sha?: string;
+        content?: string;
+      }>;
+    },
+  ): Effect.Effect<{ sha: string }>;
+  createCommit(
+    repo: RepoRef,
+    args: {
+      message: string;
+      tree: string;
+      parents: string[];
+      author?: { name: string; email: string; date?: string };
+    },
+  ): Effect.Effect<{ sha: string }>;
+}
+
+export class Git extends Context.Service<Git, GitService>()("GitHub.Git") {}
+
+// ---------------------------------------------------------------------------
+// Contents — repository file API (single-file create/update/delete).
+//   Octokit: octokit.rest.repos.{getContent, createOrUpdateFileContents,
+//                                deleteFile}
+// ---------------------------------------------------------------------------
+
+export interface ContentsService {
+  get(
+    repo: RepoRef,
+    args: { path: string; ref?: string },
+  ): Effect.Effect<
+    | {
+        sha: string;
+        content: string;
+        encoding: string;
+      }
+    | undefined
+  >;
+  put(
+    repo: RepoRef,
+    args: {
+      path: string;
+      message: string;
+      content: string; // utf-8; will be base64-encoded internally
+      branch?: string;
+      sha?: string; // required to update an existing file
+    },
+  ): Effect.Effect<{ sha: string; commitSha: string }>;
+  delete(
+    repo: RepoRef,
+    args: { path: string; message: string; sha: string; branch?: string },
+  ): Effect.Effect<{ commitSha: string }>;
+}
+
+export class Contents extends Context.Service<Contents, ContentsService>()(
+  "GitHub.Contents",
+) {}
+
+// ---------------------------------------------------------------------------
+// CommitStatuses — coarse green/red commit status indicators.
+//   Octokit: octokit.rest.repos.{createCommitStatus,
+//                                listCommitStatusesForRef}
+// ---------------------------------------------------------------------------
+
+export interface CommitStatusesService {
+  create(
+    repo: RepoRef,
+    args: {
+      sha: string;
+      state: "error" | "failure" | "pending" | "success";
+      context?: string;
+      description?: string;
+      targetUrl?: string;
+    },
+  ): Effect.Effect<{ id: number; url: string }>;
+}
+
+export class CommitStatuses extends Context.Service<
+  CommitStatuses,
+  CommitStatusesService
+>()("GitHub.CommitStatuses") {}
+
+// ---------------------------------------------------------------------------
+// CheckRuns — richer status with annotations and rerun support.
+//   Octokit: octokit.rest.checks.{create, update, listForRef}
+// ---------------------------------------------------------------------------
+
+export interface CheckRunsService {
+  create(
+    repo: RepoRef,
+    args: {
+      name: string;
+      headSha: string;
+      status?: "queued" | "in_progress" | "completed";
+      conclusion?:
+        | "success"
+        | "failure"
+        | "neutral"
+        | "cancelled"
+        | "skipped"
+        | "timed_out"
+        | "action_required";
+      detailsUrl?: string;
+      output?: { title: string; summary: string; text?: string };
+    },
+  ): Effect.Effect<{ id: number; htmlUrl: string }>;
+  update(
+    repo: RepoRef,
+    args: {
+      checkRunId: number;
+      status?: "queued" | "in_progress" | "completed";
+      conclusion?:
+        | "success"
+        | "failure"
+        | "neutral"
+        | "cancelled"
+        | "skipped"
+        | "timed_out"
+        | "action_required";
+      output?: { title: string; summary: string; text?: string };
+    },
+  ): Effect.Effect<void>;
+}
+
+export class CheckRuns extends Context.Service<CheckRuns, CheckRunsService>()(
+  "GitHub.CheckRuns",
+) {}
+
+// ---------------------------------------------------------------------------
+// Reactions — quick emoji reactions on issues, comments, reviews.
+//   Octokit: octokit.rest.reactions.{*}
+// ---------------------------------------------------------------------------
+
+export type ReactionContent =
+  | "+1"
+  | "-1"
+  | "laugh"
+  | "confused"
+  | "heart"
+  | "hooray"
+  | "rocket"
+  | "eyes";
+
+export interface ReactionsService {
+  forIssue(
+    repo: RepoRef,
+    args: { issueNumber: number; content: ReactionContent },
+  ): Effect.Effect<{ id: number }>;
+  forIssueComment(
+    repo: RepoRef,
+    args: { commentId: number; content: ReactionContent },
+  ): Effect.Effect<{ id: number }>;
+  forReview(
+    repo: RepoRef,
+    args: { prNumber: number; reviewId: number; content: ReactionContent },
+  ): Effect.Effect<{ id: number }>;
+}
+
+export class Reactions extends Context.Service<Reactions, ReactionsService>()(
+  "GitHub.Reactions",
+) {}
+
+// ---------------------------------------------------------------------------
+// Live layer — provides every capability above on top of `RuntimeOctokit`.
+// ---------------------------------------------------------------------------
+
+const tryRest = <T>(fn: () => Promise<T>) =>
+  Effect.tryPromise({
+    try: fn,
+    catch: (e) => e as Error,
+  }).pipe(Effect.orDie);
+
+const IssueCommentsLive = Layer.effect(
+  IssueComments,
+  Effect.gen(function* () {
+    const { client } = yield* RuntimeOctokit;
+    return {
+      list: (repo, { issueNumber, since }) =>
+        tryRest(() =>
+          client.rest.issues
+            .listComments({
+              ...ownerName(repo),
+              issue_number: issueNumber,
+              since,
+            })
+            .then(({ data }) =>
+              data.map((c) => ({
+                id: c.id,
+                body: c.body ?? null,
+                user: c.user ? { login: c.user.login } : null,
+              })),
+            ),
+        ),
+      create: (repo, { issueNumber, body }) =>
+        tryRest(() =>
+          client.rest.issues
+            .createComment({
+              ...ownerName(repo),
+              issue_number: issueNumber,
+              body,
+            })
+            .then(({ data }) => ({ id: data.id, htmlUrl: data.html_url })),
+        ),
+      update: (repo, { commentId, body }) =>
+        tryRest(() =>
+          client.rest.issues
+            .updateComment({
+              ...ownerName(repo),
+              comment_id: commentId,
+              body,
+            })
+            .then(({ data }) => ({ id: data.id, htmlUrl: data.html_url })),
+        ),
+      delete: (repo, { commentId }) =>
+        tryRest(() =>
+          client.rest.issues
+            .deleteComment({
+              ...ownerName(repo),
+              comment_id: commentId,
+            })
+            .then(() => undefined),
+        ),
+    } satisfies IssueCommentsService;
+  }),
+);
+
+const PullRequestReviewCommentsLive = Layer.effect(
+  PullRequestReviewComments,
+  Effect.gen(function* () {
+    const { client } = yield* RuntimeOctokit;
+    return {
+      create: (repo, { prNumber, body, commitId, path, line, side }) =>
+        tryRest(() =>
+          client.rest.pulls
+            .createReviewComment({
+              ...ownerName(repo),
+              pull_number: prNumber,
+              body,
+              commit_id: commitId,
+              path,
+              line,
+              side,
+            })
+            .then(({ data }) => ({ id: data.id, htmlUrl: data.html_url })),
+        ),
+      update: (repo, { commentId, body }) =>
+        tryRest(() =>
+          client.rest.pulls
+            .updateReviewComment({
+              ...ownerName(repo),
+              comment_id: commentId,
+              body,
+            })
+            .then(({ data }) => ({ id: data.id, htmlUrl: data.html_url })),
+        ),
+      delete: (repo, { commentId }) =>
+        tryRest(() =>
+          client.rest.pulls
+            .deleteReviewComment({
+              ...ownerName(repo),
+              comment_id: commentId,
+            })
+            .then(() => undefined),
+        ),
+      reply: (repo, { prNumber, commentId, body }) =>
+        tryRest(() =>
+          client.rest.pulls
+            .createReplyForReviewComment({
+              ...ownerName(repo),
+              pull_number: prNumber,
+              comment_id: commentId,
+              body,
+            })
+            .then(({ data }) => ({ id: data.id, htmlUrl: data.html_url })),
+        ),
+    } satisfies PullRequestReviewCommentsService;
+  }),
+);
+
+const PullRequestReviewsLive = Layer.effect(
+  PullRequestReviews,
+  Effect.gen(function* () {
+    const { client } = yield* RuntimeOctokit;
+    return {
+      create: (repo, { prNumber, event, body, commitId }) =>
+        tryRest(() =>
+          client.rest.pulls
+            .createReview({
+              ...ownerName(repo),
+              pull_number: prNumber,
+              event,
+              body,
+              commit_id: commitId,
+            })
+            .then(({ data }) => ({ id: data.id, htmlUrl: data.html_url })),
+        ),
+      dismiss: (repo, { prNumber, reviewId, message }) =>
+        tryRest(() =>
+          client.rest.pulls
+            .dismissReview({
+              ...ownerName(repo),
+              pull_number: prNumber,
+              review_id: reviewId,
+              message,
+            })
+            .then(() => undefined),
+        ),
+      requestReviewers: (repo, { prNumber, reviewers, teamReviewers }) =>
+        tryRest(() =>
+          client.rest.pulls
+            .requestReviewers({
+              ...ownerName(repo),
+              pull_number: prNumber,
+              reviewers,
+              team_reviewers: teamReviewers,
+            })
+            .then(() => undefined),
+        ),
+    } satisfies PullRequestReviewsService;
+  }),
+);
+
+const PullRequestsLive = Layer.effect(
+  PullRequests,
+  Effect.gen(function* () {
+    const { client } = yield* RuntimeOctokit;
+    return {
+      create: (repo, { head, base, title, body, draft }) =>
+        tryRest(() =>
+          client.rest.pulls
+            .create({
+              ...ownerName(repo),
+              head,
+              base,
+              title,
+              body,
+              draft,
+            })
+            .then(({ data }) => ({
+              number: data.number,
+              htmlUrl: data.html_url,
+            })),
+        ),
+      update: (repo, { prNumber, title, body, state, base }) =>
+        tryRest(() =>
+          client.rest.pulls
+            .update({
+              ...ownerName(repo),
+              pull_number: prNumber,
+              title,
+              body,
+              state,
+              base,
+            })
+            .then(({ data }) => ({
+              number: data.number,
+              htmlUrl: data.html_url,
+            })),
+        ),
+      merge: (repo, { prNumber, mergeMethod, commitTitle, commitMessage }) =>
+        tryRest(() =>
+          client.rest.pulls
+            .merge({
+              ...ownerName(repo),
+              pull_number: prNumber,
+              merge_method: mergeMethod,
+              commit_title: commitTitle,
+              commit_message: commitMessage,
+            })
+            .then(({ data }) => ({ sha: data.sha, merged: data.merged })),
+        ),
+    } satisfies PullRequestsService;
+  }),
+);
+
+const GitLive = Layer.effect(
+  Git,
+  Effect.gen(function* () {
+    const { client } = yield* RuntimeOctokit;
+    return {
+      getRef: (repo, { ref }) =>
+        tryRest(() =>
+          client.rest.git
+            .getRef({ ...ownerName(repo), ref })
+            .then(({ data }) => ({ ref: data.ref, sha: data.object.sha })),
+        ),
+      createRef: (repo, { ref, sha }) =>
+        tryRest(() =>
+          client.rest.git
+            .createRef({
+              ...ownerName(repo),
+              ref: ref.startsWith("refs/") ? ref : `refs/${ref}`,
+              sha,
+            })
+            .then(({ data }) => ({ ref: data.ref, sha: data.object.sha })),
+        ),
+      updateRef: (repo, { ref, sha, force }) =>
+        tryRest(() =>
+          client.rest.git
+            .updateRef({ ...ownerName(repo), ref, sha, force })
+            .then(({ data }) => ({ ref: data.ref, sha: data.object.sha })),
+        ),
+      deleteRef: (repo, { ref }) =>
+        tryRest(() =>
+          client.rest.git
+            .deleteRef({ ...ownerName(repo), ref })
+            .then(() => undefined),
+        ),
+      createBlob: (repo, { content, encoding }) =>
+        tryRest(() =>
+          client.rest.git
+            .createBlob({ ...ownerName(repo), content, encoding })
+            .then(({ data }) => ({ sha: data.sha })),
+        ),
+      createTree: (repo, { baseTree, tree }) =>
+        tryRest(() =>
+          client.rest.git
+            .createTree({
+              ...ownerName(repo),
+              base_tree: baseTree,
+              tree: tree as any,
+            })
+            .then(({ data }) => ({ sha: data.sha })),
+        ),
+      createCommit: (repo, { message, tree, parents, author }) =>
+        tryRest(() =>
+          client.rest.git
+            .createCommit({
+              ...ownerName(repo),
+              message,
+              tree,
+              parents,
+              author,
+            })
+            .then(({ data }) => ({ sha: data.sha })),
+        ),
+    } satisfies GitService;
+  }),
+);
+
+const ContentsLive = Layer.effect(
+  Contents,
+  Effect.gen(function* () {
+    const { client } = yield* RuntimeOctokit;
+    return {
+      get: (repo, { path, ref }) =>
+        tryRest(async () => {
+          try {
+            const { data } = await client.rest.repos.getContent({
+              ...ownerName(repo),
+              path,
+              ref,
+            });
+            // Single-file responses are objects with `content`; arrays are
+            // directory listings (we expose `undefined` for those).
+            if (Array.isArray(data) || data.type !== "file") return undefined;
+            return {
+              sha: data.sha,
+              content: data.content,
+              encoding: data.encoding,
+            };
+          } catch (e: any) {
+            if (e.status === 404) return undefined;
+            throw e;
+          }
+        }),
+      put: (repo, { path, message, content, branch, sha }) =>
+        tryRest(() =>
+          client.rest.repos
+            .createOrUpdateFileContents({
+              ...ownerName(repo),
+              path,
+              message,
+              content: btoa(unescape(encodeURIComponent(content))),
+              branch,
+              sha,
+            })
+            .then(({ data }) => ({
+              sha: data.content?.sha ?? "",
+              commitSha: data.commit.sha ?? "",
+            })),
+        ),
+      delete: (repo, { path, message, sha, branch }) =>
+        tryRest(() =>
+          client.rest.repos
+            .deleteFile({
+              ...ownerName(repo),
+              path,
+              message,
+              sha,
+              branch,
+            })
+            .then(({ data }) => ({ commitSha: data.commit.sha ?? "" })),
+        ),
+    } satisfies ContentsService;
+  }),
+);
+
+const CommitStatusesLive = Layer.effect(
+  CommitStatuses,
+  Effect.gen(function* () {
+    const { client } = yield* RuntimeOctokit;
+    return {
+      create: (repo, { sha, state, context, description, targetUrl }) =>
+        tryRest(() =>
+          client.rest.repos
+            .createCommitStatus({
+              ...ownerName(repo),
+              sha,
+              state,
+              context,
+              description,
+              target_url: targetUrl,
+            })
+            .then(({ data }) => ({ id: data.id, url: data.url })),
+        ),
+    } satisfies CommitStatusesService;
+  }),
+);
+
+const CheckRunsLive = Layer.effect(
+  CheckRuns,
+  Effect.gen(function* () {
+    const { client } = yield* RuntimeOctokit;
+    return {
+      create: (
+        repo,
+        { name, headSha, status, conclusion, detailsUrl, output },
+      ) =>
+        tryRest(() =>
+          client.rest.checks
+            .create({
+              ...ownerName(repo),
+              name,
+              head_sha: headSha,
+              status,
+              conclusion,
+              details_url: detailsUrl,
+              output,
+            })
+            .then(({ data }) => ({
+              id: data.id,
+              htmlUrl: data.html_url ?? "",
+            })),
+        ),
+      update: (repo, { checkRunId, status, conclusion, output }) =>
+        tryRest(() =>
+          client.rest.checks
+            .update({
+              ...ownerName(repo),
+              check_run_id: checkRunId,
+              status,
+              conclusion,
+              output,
+            })
+            .then(() => undefined),
+        ),
+    } satisfies CheckRunsService;
+  }),
+);
+
+const ReactionsLive = Layer.effect(
+  Reactions,
+  Effect.gen(function* () {
+    const { client } = yield* RuntimeOctokit;
+    return {
+      forIssue: (repo, { issueNumber, content }) =>
+        tryRest(() =>
+          client.rest.reactions
+            .createForIssue({
+              ...ownerName(repo),
+              issue_number: issueNumber,
+              content,
+            })
+            .then(({ data }) => ({ id: data.id })),
+        ),
+      forIssueComment: (repo, { commentId, content }) =>
+        tryRest(() =>
+          client.rest.reactions
+            .createForIssueComment({
+              ...ownerName(repo),
+              comment_id: commentId,
+              content,
+            })
+            .then(({ data }) => ({ id: data.id })),
+        ),
+      forReview: (repo, { prNumber, reviewId, content }) =>
+        // GitHub doesn't expose review reactions directly; emulate by
+        // creating a reaction on the PR's first review comment, falling
+        // back to a comment reaction is out of scope. We attach to the
+        // review's body via the PR review-comment endpoint instead.
+        tryRest(async () => {
+          // No first-class API; emulate via review-comment reaction by
+          // grabbing the first review comment under the review. This is
+          // a pragmatic fallback; callers wanting the literal review
+          // reaction surface should drop down to the raw client.
+          const { data } = await client.rest.pulls.listReviewComments({
+            ...ownerName(repo),
+            pull_number: prNumber,
+            per_page: 1,
+          });
+          const target = data.find(
+            (c) => (c as any).pull_request_review_id === reviewId,
+          );
+          if (!target) {
+            throw new Error(
+              `Reactions.forReview: no review comments found for review ${reviewId}`,
+            );
+          }
+          const { data: r } =
+            await client.rest.reactions.createForPullRequestReviewComment({
+              ...ownerName(repo),
+              comment_id: target.id,
+              content,
+            });
+          return { id: r.id };
+        }),
+    } satisfies ReactionsService;
+  }),
+);
+
+/**
+ * Provides every GitHub runtime capability on a single layer. Add this to
+ * the Worker init phase after providing a `RuntimeOctokit` layer.
+ *
+ * @example
+ * ```typescript
+ * Effect.gen(function* () {
+ *   // ... bind resources ...
+ *   return { fetch: ... };
+ * }).pipe(
+ *   Effect.provide(GitHub.CapabilitiesLive),
+ *   Effect.provide(GitHub.RuntimeOctokit.fromEnv("GITHUB_TOKEN")),
+ * );
+ * ```
+ */
+export const CapabilitiesLive = Layer.mergeAll(
+  IssueCommentsLive,
+  PullRequestReviewCommentsLive,
+  PullRequestReviewsLive,
+  PullRequestsLive,
+  GitLive,
+  ContentsLive,
+  CommitStatusesLive,
+  CheckRunsLive,
+  ReactionsLive,
+);

--- a/packages/alchemy/src/GitHub/EventSources.ts
+++ b/packages/alchemy/src/GitHub/EventSources.ts
@@ -1,0 +1,127 @@
+import * as Effect from "effect/Effect";
+import type { AnyWebhookDelivery, WebhookEventName } from "./Events.ts";
+import { Dispatcher, type RepoRef, type WebhookHandler } from "./Webhooks.ts";
+
+/**
+ * Generic event source — subscribe to every webhook delivery for a
+ * repository. Handlers receive the discriminated `AnyWebhookDelivery` and
+ * typically dispatch via `Match.discriminator("event")`.
+ *
+ * @example
+ * ```typescript
+ * yield* GitHub.events(repo).subscribe((delivery) =>
+ *   Match.value(delivery).pipe(
+ *     Match.discriminator("event")("pull_request", ({ payload }) =>
+ *       handlePr(payload),
+ *     ),
+ *     Match.discriminator("event")("issue_comment", ({ payload }) =>
+ *       handleComment(payload),
+ *     ),
+ *     Match.orElse(() => Effect.void),
+ *   ),
+ * );
+ * ```
+ *
+ * Most callers will reach for the typed sugar (e.g. {@link pullRequests},
+ * {@link issueComments}) — those are implemented on top of this primitive
+ * and just register a handler scoped to a single event name.
+ */
+export const events = (repo: RepoRef) => ({
+  /**
+   * Register a handler invoked for every event delivered to this repository.
+   * The handler may require any services that are available in the Worker's
+   * fetch handler context (e.g. WorkerEnvironment, capability bindings) —
+   * those are inherited from the fiber that ran the Worker init phase.
+   */
+  subscribe: <Req, Err>(
+    handler: (delivery: AnyWebhookDelivery) => Effect.Effect<void, Err, Req>,
+  ) =>
+    Dispatcher.use((d) =>
+      d.registerAny(
+        repo,
+        handler as WebhookHandler<WebhookEventName, any, any>,
+      ),
+    ),
+  /**
+   * Register a handler that runs only when `predicate` returns `true`.
+   * The predicate is evaluated synchronously against the parsed delivery
+   * before any handler is invoked.
+   */
+  filter: (predicate: (delivery: AnyWebhookDelivery) => boolean) => ({
+    subscribe: <Req, Err>(
+      handler: (delivery: AnyWebhookDelivery) => Effect.Effect<void, Err, Req>,
+    ) =>
+      Dispatcher.use((d) =>
+        d.registerAny(repo, (delivery) =>
+          predicate(delivery as AnyWebhookDelivery)
+            ? handler(delivery as AnyWebhookDelivery)
+            : Effect.void,
+        ),
+      ),
+  }),
+});
+
+/**
+ * Build a typed `subscribe(handler)` for a single GitHub event name.
+ * Used to construct the public event-name helpers below; equivalent to
+ * `events(repo).filter((d) => d.event === E).subscribe(...)` but with
+ * the payload narrowed for the caller.
+ */
+const eventSource =
+  <E extends WebhookEventName>(event: E) =>
+  (repo: RepoRef) => ({
+    subscribe: <Req, Err>(handler: WebhookHandler<E, Err, Req>) =>
+      Dispatcher.use((d) => d.register(repo, event, handler)),
+  });
+
+/**
+ * Subscribe to `pull_request` events for a repository. Handler receives
+ * a typed delivery with the payload narrowed to {@link WebhookEventMap.pull_request}.
+ */
+export const pullRequests = eventSource("pull_request");
+
+/**
+ * Subscribe to `pull_request_review` events (review submitted, edited,
+ * dismissed). Use this to react to "approve" / "request changes".
+ */
+export const pullRequestReviews = eventSource("pull_request_review");
+
+/**
+ * Subscribe to `pull_request_review_comment` events — inline review
+ * comments on specific code lines.
+ */
+export const pullRequestReviewComments = eventSource(
+  "pull_request_review_comment",
+);
+
+/**
+ * Subscribe to `issue_comment` events. Covers both issue comments and
+ * conversation comments on pull requests (GitHub uses one endpoint for
+ * both). Filter on `payload.issue.pull_request` to narrow to PR comments.
+ */
+export const issueComments = eventSource("issue_comment");
+
+/**
+ * Subscribe to `issues` events.
+ */
+export const issues = eventSource("issues");
+
+/**
+ * Subscribe to `push` events.
+ */
+export const pushes = eventSource("push");
+
+/**
+ * Subscribe to `release` events.
+ */
+export const releases = eventSource("release");
+
+/**
+ * Subscribe to `workflow_run` events.
+ */
+export const workflowRuns = eventSource("workflow_run");
+
+/**
+ * Subscribe to `check_run` events. Handles re-run requests from the UI.
+ */
+export const checkRuns = eventSource("check_run");

--- a/packages/alchemy/src/GitHub/Events.ts
+++ b/packages/alchemy/src/GitHub/Events.ts
@@ -1,0 +1,230 @@
+/**
+ * Lean type shapes for GitHub webhook payloads. These cover the fields
+ * most apps reach for; the original parsed JSON is always available via
+ * `raw` for callers that want to assert against `@octokit/webhooks-types`
+ * themselves.
+ */
+
+export type RepositoryRef = {
+  id: number;
+  node_id: string;
+  name: string;
+  full_name: string;
+  owner: { login: string; id: number };
+  default_branch: string;
+  html_url: string;
+  clone_url: string;
+};
+
+export type UserRef = {
+  id: number;
+  login: string;
+  type: "User" | "Bot" | "Organization";
+};
+
+export type PullRequestRef = {
+  id: number;
+  number: number;
+  state: "open" | "closed";
+  title: string;
+  body: string | null;
+  draft: boolean;
+  merged: boolean;
+  user: UserRef;
+  head: { ref: string; sha: string; repo: RepositoryRef | null };
+  base: { ref: string; sha: string; repo: RepositoryRef };
+  html_url: string;
+};
+
+export type IssueRef = {
+  id: number;
+  number: number;
+  state: "open" | "closed";
+  title: string;
+  body: string | null;
+  user: UserRef;
+  pull_request?: { url: string };
+  html_url: string;
+};
+
+export type CommentRef = {
+  id: number;
+  body: string | null;
+  user: UserRef;
+  html_url: string;
+};
+
+export type ReviewRef = {
+  id: number;
+  state:
+    | "approved"
+    | "changes_requested"
+    | "commented"
+    | "dismissed"
+    | "pending";
+  body: string | null;
+  user: UserRef;
+  html_url: string;
+  commit_id: string;
+};
+
+export type PushCommit = {
+  id: string;
+  message: string;
+  timestamp: string;
+  author: { name: string; email: string };
+};
+
+/**
+ * Event-name → payload shape. Names match GitHub's `X-GitHub-Event` header
+ * verbatim so users can search GitHub's docs by the same identifier.
+ */
+export interface WebhookEventMap {
+  pull_request: {
+    action:
+      | "opened"
+      | "edited"
+      | "closed"
+      | "reopened"
+      | "synchronize"
+      | "ready_for_review"
+      | "review_requested"
+      | "review_request_removed"
+      | "labeled"
+      | "unlabeled"
+      | (string & {});
+    number: number;
+    pull_request: PullRequestRef;
+    repository: RepositoryRef;
+    sender: UserRef;
+  };
+  pull_request_review: {
+    action: "submitted" | "edited" | "dismissed" | (string & {});
+    review: ReviewRef;
+    pull_request: PullRequestRef;
+    repository: RepositoryRef;
+    sender: UserRef;
+  };
+  pull_request_review_comment: {
+    action: "created" | "edited" | "deleted" | (string & {});
+    comment: CommentRef & {
+      pull_request_review_id: number;
+      diff_hunk: string;
+      path: string;
+      line: number | null;
+      side: "LEFT" | "RIGHT";
+    };
+    pull_request: PullRequestRef;
+    repository: RepositoryRef;
+    sender: UserRef;
+  };
+  issues: {
+    action:
+      | "opened"
+      | "edited"
+      | "closed"
+      | "reopened"
+      | "labeled"
+      | "unlabeled"
+      | "assigned"
+      | "unassigned"
+      | (string & {});
+    issue: IssueRef;
+    repository: RepositoryRef;
+    sender: UserRef;
+  };
+  issue_comment: {
+    action: "created" | "edited" | "deleted" | (string & {});
+    issue: IssueRef;
+    comment: CommentRef;
+    repository: RepositoryRef;
+    sender: UserRef;
+  };
+  push: {
+    ref: string;
+    before: string;
+    after: string;
+    created: boolean;
+    deleted: boolean;
+    forced: boolean;
+    commits: PushCommit[];
+    head_commit: PushCommit | null;
+    repository: RepositoryRef;
+    pusher: { name: string; email: string };
+    sender: UserRef;
+  };
+  release: {
+    action: "published" | "released" | "edited" | (string & {});
+    release: {
+      id: number;
+      tag_name: string;
+      name: string | null;
+      body: string | null;
+      draft: boolean;
+      prerelease: boolean;
+      html_url: string;
+    };
+    repository: RepositoryRef;
+    sender: UserRef;
+  };
+  workflow_run: {
+    action: "requested" | "in_progress" | "completed" | (string & {});
+    workflow_run: {
+      id: number;
+      name: string | null;
+      status: string;
+      conclusion: string | null;
+      head_branch: string | null;
+      head_sha: string;
+      html_url: string;
+    };
+    repository: RepositoryRef;
+    sender: UserRef;
+  };
+  check_run: {
+    action: "created" | "completed" | "rerequested" | (string & {});
+    check_run: {
+      id: number;
+      name: string;
+      status: string;
+      conclusion: string | null;
+      head_sha: string;
+      html_url: string | null;
+    };
+    repository: RepositoryRef;
+    sender: UserRef;
+  };
+}
+
+export type WebhookEventName = keyof WebhookEventMap;
+
+/**
+ * The parsed webhook delivery passed to subscriber handlers.
+ *
+ * Generic in the event name so handlers registered via the typed event-source
+ * helpers (e.g. `pullRequests`) get a narrowed `payload`. The discriminator
+ * field is `event` — matches `Match.discriminator("event")(...)` so users
+ * with a generic subscription can fan out by event name.
+ */
+export interface WebhookDelivery<
+  E extends WebhookEventName = WebhookEventName,
+> {
+  /** GitHub event name — the `X-GitHub-Event` header. */
+  event: E;
+  /** GitHub delivery id (`X-GitHub-Delivery`) — unique per delivery. */
+  deliveryId: string;
+  /** Hook id that produced this delivery, if reported. */
+  hookId?: number;
+  /** Verified payload for the event. */
+  payload: WebhookEventMap[E];
+  /** Original JSON parsed body, in case `payload` types miss a field. */
+  raw: Record<string, any>;
+}
+
+/**
+ * Discriminated union over every known event. Use this as the parameter
+ * type when matching with `Match.value` + `Match.discriminator("event")`.
+ */
+export type AnyWebhookDelivery = {
+  [E in WebhookEventName]: WebhookDelivery<E>;
+}[WebhookEventName];

--- a/packages/alchemy/src/GitHub/Octokit.ts
+++ b/packages/alchemy/src/GitHub/Octokit.ts
@@ -1,0 +1,71 @@
+import { Octokit } from "@octokit/rest";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+
+/**
+ * Runtime Octokit handle used by Worker/Container capabilities. Distinct
+ * from {@link GitHubCredentials} because the deploy-time service expects
+ * to resolve credentials via the AuthProvider (CLI / env / stored), while
+ * the runtime side must be handed a token directly through a Worker
+ * binding.
+ */
+export interface RuntimeOctokitService {
+  readonly token: Redacted.Redacted<string>;
+  readonly client: Octokit;
+}
+
+export class RuntimeOctokit extends Context.Service<
+  RuntimeOctokit,
+  RuntimeOctokitService
+>()("GitHub.RuntimeOctokit") {}
+
+/**
+ * Build a `RuntimeOctokit` layer from a literal token. The Worker stack
+ * passes the token as an environment binding and constructs this layer
+ * during the init phase.
+ */
+export const fromToken = (token: string | Redacted.Redacted<string>) => {
+  const redacted = typeof token === "string" ? Redacted.make(token) : token;
+  return Layer.succeed(RuntimeOctokit, {
+    token: redacted,
+    client: new Octokit({ auth: Redacted.value(redacted) }),
+  });
+};
+
+/**
+ * Build a `RuntimeOctokit` layer that reads the token from an env binding
+ * (defaults to `GITHUB_TOKEN`). Use this inside a Worker init when the
+ * token has been wired into the bindings as a plain env value.
+ */
+export const fromEnv = (varName = "GITHUB_TOKEN") =>
+  Layer.effect(
+    RuntimeOctokit,
+    Effect.sync(() => {
+      const token = (globalThis as any).process?.env?.[varName] as
+        | string
+        | undefined;
+      if (!token) {
+        throw new Error(
+          `RuntimeOctokit.fromEnv: missing env var '${varName}'. Wire it into the Worker's bindings.`,
+        );
+      }
+      const redacted = Redacted.make(token);
+      return {
+        token: redacted,
+        client: new Octokit({ auth: token }),
+      };
+    }),
+  );
+
+/**
+ * Pull the raw Octokit client out of the runtime service. Convenience for
+ * capability implementations that just want to call `client.rest.X.Y`.
+ */
+export const client: Effect.Effect<Octokit, never, RuntimeOctokit> = Effect.gen(
+  function* () {
+    const svc = yield* RuntimeOctokit;
+    return svc.client;
+  },
+);

--- a/packages/alchemy/src/GitHub/Providers.ts
+++ b/packages/alchemy/src/GitHub/Providers.ts
@@ -3,8 +3,10 @@ import * as Provider from "../Provider.ts";
 import { GitHubAuth } from "./AuthProvider.ts";
 import { Comment, CommentProvider } from "./Comment.ts";
 import * as Credentials from "./Credentials.ts";
+import { Repository, RepositoryProvider } from "./Repository.ts";
 import { Secret, SecretProvider } from "./Secret.ts";
 import { Variable, VariableProvider } from "./Variable.ts";
+import { Webhook, WebhookProvider } from "./Webhook.ts";
 
 export { GitHubCredentials } from "./Credentials.ts";
 
@@ -15,16 +17,25 @@ export class Providers extends Provider.ProviderCollection<Providers>()(
 export type ProviderRequirements = Layer.Services<ReturnType<typeof providers>>;
 
 /**
- * GitHub providers (Secret, Variable) plus the GitHub AuthProvider that
- * `alchemy login` discovers.
+ * GitHub providers plus the GitHub AuthProvider that `alchemy login`
+ * discovers. Resources covered: `Repository`, `Webhook`, `Comment`,
+ * `Secret`, `Variable`. Runtime capabilities (`IssueComments`, `Git`,
+ * `Contents`, …) are not registered here — they are provided as a Worker
+ * layer via `GitHub.CapabilitiesLive`.
  */
 export const providers = () =>
   Layer.effect(
     Providers,
-    Provider.collection([Comment, Secret, Variable]),
+    Provider.collection([Comment, Repository, Secret, Variable, Webhook]),
   ).pipe(
     Layer.provide(
-      Layer.mergeAll(CommentProvider(), SecretProvider(), VariableProvider()),
+      Layer.mergeAll(
+        CommentProvider(),
+        RepositoryProvider(),
+        SecretProvider(),
+        VariableProvider(),
+        WebhookProvider(),
+      ),
     ),
     Layer.provideMerge(Credentials.fromAuthProvider()),
     Layer.provideMerge(GitHubAuth),

--- a/packages/alchemy/src/GitHub/Repository.ts
+++ b/packages/alchemy/src/GitHub/Repository.ts
@@ -1,0 +1,266 @@
+import * as Effect from "effect/Effect";
+import * as Provider from "../Provider.ts";
+import { Resource } from "../Resource.ts";
+import { GitHubCredentials } from "./Credentials.ts";
+import type * as GitHub from "./Providers.ts";
+
+export interface RepositoryProps {
+  /**
+   * Repository owner (user or organization).
+   */
+  owner: string;
+
+  /**
+   * Repository name (the slug after the owner — no slashes).
+   */
+  name: string;
+
+  /**
+   * Short description shown on the repository page.
+   */
+  description?: string;
+
+  /**
+   * Whether the repository is private. Ignored when adopting an existing
+   * repository — use `adopt: true` and reconcile separately if you need to
+   * change visibility.
+   * @default false
+   */
+  private?: boolean;
+
+  /**
+   * Topics applied to the repository. The provider always merges these with
+   * the internal `alchemy:{appId}:{logicalId}` topic used as the ownership
+   * marker (GitHub repos don't take freeform tags).
+   */
+  topics?: string[];
+
+  /**
+   * Default branch for the repository.
+   */
+  defaultBranch?: string;
+
+  /**
+   * Whether the repository has issues enabled.
+   * @default true
+   */
+  hasIssues?: boolean;
+
+  /**
+   * Whether to auto-initialize with an empty README on first creation.
+   * Ignored on subsequent reconciles.
+   * @default false
+   */
+  autoInit?: boolean;
+
+  /**
+   * If `true` and the repository already exists, adopt it. Without this,
+   * pre-existing repos fail the read step with an Unowned signal.
+   * @default false
+   */
+  adopt?: boolean;
+
+  /**
+   * Optional override for the GitHub auth token. Defaults to
+   * `GITHUB_ACCESS_TOKEN` / `GITHUB_TOKEN` / `gh auth token` via the
+   * `GitHubCredentials` service.
+   */
+  token?: string;
+}
+
+export interface Repository extends Resource<
+  "GitHub.Repository",
+  RepositoryProps,
+  {
+    /**
+     * Numeric repository ID assigned by GitHub. Stable across renames.
+     */
+    repositoryId: number;
+    /**
+     * Repository node ID (GraphQL global ID).
+     */
+    nodeId: string;
+    /**
+     * `owner/name` form, matches what GitHub shows in URLs.
+     */
+    fullName: string;
+    /**
+     * Browser URL, e.g. `https://github.com/owner/name`.
+     */
+    htmlUrl: string;
+    /**
+     * HTTPS clone URL, e.g. `https://github.com/owner/name.git`.
+     */
+    cloneUrl: string;
+    /**
+     * The actual default branch reported by the API after reconcile.
+     */
+    defaultBranch: string;
+  },
+  never,
+  GitHub.Providers
+> {}
+
+/**
+ * A GitHub repository — managed or adopted.
+ *
+ * `Repository` either creates a new repo under the configured owner or adopts
+ * an existing one (when `adopt: true`). Owner is treated as a stable property
+ * — changing it triggers a replacement.
+ *
+ * Authentication resolves through the `GitHubCredentials` service supplied by
+ * `GitHub.providers()`.
+ *
+ * @section Creating a Repository
+ * @example Personal repository
+ * ```typescript
+ * const repo = yield* GitHub.Repository("ci", {
+ *   owner: "alice",
+ *   name: "ci-demo",
+ *   description: "CI pipeline driven by Alchemy",
+ *   private: true,
+ *   autoInit: true,
+ * });
+ * ```
+ *
+ * @section Adopting an Existing Repository
+ * @example Adopt an existing repo
+ * ```typescript
+ * const repo = yield* GitHub.Repository("alchemy-effect", {
+ *   owner: "alchemy-run",
+ *   name: "alchemy-effect",
+ *   adopt: true,
+ * });
+ * ```
+ */
+export const Repository = Resource<Repository>("GitHub.Repository");
+
+const getOctokit = Effect.gen(function* () {
+  const creds = yield* GitHubCredentials;
+  return creds.octokit();
+});
+
+const ownershipTopic = (id: string) => `alchemy.${id.toLowerCase()}`;
+
+export const RepositoryProvider = () =>
+  Provider.succeed(Repository, {
+    stables: ["repositoryId", "nodeId"],
+
+    reconcile: Effect.fn(function* ({ id, news, output }) {
+      const octokit = yield* getOctokit;
+      const marker = ownershipTopic(id);
+      const desiredTopics = Array.from(
+        new Set([...(news.topics ?? []), marker]),
+      );
+
+      // Observe — try to fetch the repo; treat 404 as "missing".
+      const observed = yield* Effect.tryPromise({
+        try: async () => {
+          try {
+            const { data } = await octokit.rest.repos.get({
+              owner: news.owner,
+              repo: news.name,
+            });
+            return data;
+          } catch (e: any) {
+            if (e.status === 404) return undefined;
+            throw e;
+          }
+        },
+        catch: (e) => e as Error,
+      });
+
+      // Ensure — create when missing. We do not check for ownership marker
+      // when `adopt: true`; the engine adoption flow handled that upstream.
+      let current = observed;
+      if (current === undefined) {
+        const { data } = yield* Effect.tryPromise(async () => {
+          // GitHub uses different endpoints for user vs organization repos;
+          // probe the owner type and dispatch.
+          const ownerInfo = await octokit.rest.users
+            .getByUsername({ username: news.owner })
+            .catch((e: any) => {
+              if (e.status === 404) return undefined;
+              throw e;
+            });
+          if (ownerInfo?.data.type === "Organization") {
+            return octokit.rest.repos.createInOrg({
+              org: news.owner,
+              name: news.name,
+              description: news.description,
+              private: news.private ?? false,
+              has_issues: news.hasIssues ?? true,
+              auto_init: news.autoInit ?? false,
+            });
+          }
+          return octokit.rest.repos.createForAuthenticatedUser({
+            name: news.name,
+            description: news.description,
+            private: news.private ?? false,
+            has_issues: news.hasIssues ?? true,
+            auto_init: news.autoInit ?? false,
+          });
+        });
+        current = data;
+      }
+
+      // Sync — patch metadata if it drifted.
+      const needsPatch =
+        current.description !== (news.description ?? null) ||
+        (news.hasIssues !== undefined &&
+          current.has_issues !== news.hasIssues) ||
+        (news.defaultBranch !== undefined &&
+          current.default_branch !== news.defaultBranch);
+      if (needsPatch) {
+        const { data } = yield* Effect.tryPromise(() =>
+          octokit.rest.repos.update({
+            owner: news.owner,
+            repo: news.name,
+            description: news.description,
+            has_issues: news.hasIssues,
+            default_branch: news.defaultBranch,
+          }),
+        );
+        current = data;
+      }
+
+      // Sync topics — replace with desired set whenever the observed list
+      // doesn't already match.
+      const observedTopics = new Set(current.topics ?? []);
+      const sameTopics =
+        observedTopics.size === desiredTopics.length &&
+        desiredTopics.every((t) => observedTopics.has(t));
+      if (!sameTopics) {
+        yield* Effect.tryPromise(() =>
+          octokit.rest.repos.replaceAllTopics({
+            owner: news.owner,
+            repo: news.name,
+            names: desiredTopics,
+          }),
+        );
+      }
+
+      return {
+        repositoryId: current.id,
+        nodeId: current.node_id,
+        fullName: current.full_name,
+        htmlUrl: current.html_url,
+        cloneUrl: current.clone_url,
+        defaultBranch: current.default_branch,
+      };
+    }),
+
+    delete: Effect.fn(function* ({ olds }) {
+      const octokit = yield* getOctokit;
+      yield* Effect.tryPromise(async () => {
+        try {
+          await octokit.rest.repos.delete({
+            owner: olds.owner,
+            repo: olds.name,
+          });
+        } catch (e: any) {
+          if (e.status !== 404) throw e;
+        }
+      });
+    }),
+  });

--- a/packages/alchemy/src/GitHub/Webhook.ts
+++ b/packages/alchemy/src/GitHub/Webhook.ts
@@ -1,0 +1,221 @@
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import * as Provider from "../Provider.ts";
+import { Resource } from "../Resource.ts";
+import { GitHubCredentials } from "./Credentials.ts";
+import type * as GitHub from "./Providers.ts";
+
+export type WebhookEvent =
+  | "push"
+  | "pull_request"
+  | "pull_request_review"
+  | "pull_request_review_comment"
+  | "issues"
+  | "issue_comment"
+  | "release"
+  | "workflow_run"
+  | "check_run"
+  | "check_suite"
+  | "create"
+  | "delete"
+  | "deployment"
+  | "deployment_status"
+  | "fork"
+  | "star"
+  | "watch"
+  // catch-all so callers can subscribe to other event names without a
+  // patch to the union
+  | (string & {});
+
+export interface WebhookProps {
+  /**
+   * Repository owner (user or organization).
+   */
+  owner: string;
+
+  /**
+   * Repository name.
+   */
+  repository: string;
+
+  /**
+   * Public HTTPS URL the webhook delivers to. For Cloudflare Workers this
+   * is typically the `workers.dev` URL plus a path (e.g. `/__github/webhook`).
+   */
+  url: string;
+
+  /**
+   * GitHub event names the webhook subscribes to.
+   */
+  events: WebhookEvent[];
+
+  /**
+   * Shared secret for `X-Hub-Signature-256`. The receiving Worker uses the
+   * same secret to verify deliveries.
+   */
+  secret: Redacted.Redacted<string>;
+
+  /**
+   * Whether the webhook is active (delivers events).
+   * @default true
+   */
+  active?: boolean;
+
+  /**
+   * Content type GitHub posts with.
+   * @default "json"
+   */
+  contentType?: "json" | "form";
+}
+
+export interface Webhook extends Resource<
+  "GitHub.Webhook",
+  WebhookProps,
+  {
+    /**
+     * Numeric ID of the webhook in GitHub.
+     */
+    hookId: number;
+    /**
+     * Final URL recorded by GitHub.
+     */
+    url: string;
+  },
+  never,
+  GitHub.Providers
+> {}
+
+/**
+ * A repository webhook on GitHub.
+ *
+ * Installs (and keeps in sync) one webhook on the target repository. The
+ * receiving Worker is expected to verify `X-Hub-Signature-256` against
+ * `secret` and dispatch by `X-GitHub-Event`.
+ *
+ * @section Installing a Webhook
+ * @example Install a webhook with a generated secret
+ * ```typescript
+ * const secret = yield* Alchemy.Random("webhook-secret");
+ * yield* GitHub.Webhook("ci", {
+ *   owner: repo.owner,
+ *   repository: repo.name,
+ *   url: Output.interpolate`${worker.url}/__github/webhook`,
+ *   events: ["pull_request", "issue_comment", "push"],
+ *   secret,
+ * });
+ * ```
+ */
+export const Webhook = Resource<Webhook>("GitHub.Webhook");
+
+const getOctokit = Effect.gen(function* () {
+  const creds = yield* GitHubCredentials;
+  return creds.octokit();
+});
+
+const sameStringSet = (a: readonly string[], b: readonly string[]) => {
+  if (a.length !== b.length) return false;
+  const set = new Set(a);
+  return b.every((v) => set.has(v));
+};
+
+export const WebhookProvider = () =>
+  Provider.succeed(Webhook, {
+    stables: ["hookId"],
+
+    reconcile: Effect.fn(function* ({ news, output }) {
+      const octokit = yield* getOctokit;
+      const config = {
+        url: news.url,
+        content_type: news.contentType ?? "json",
+        secret: Redacted.value(news.secret),
+        insecure_ssl: "0",
+      } as const;
+
+      // Observe — when we have a cached hookId, refresh from GitHub. A 404
+      // means the webhook was deleted out-of-band, so we fall back to
+      // (re)creating one.
+      const observed = output?.hookId
+        ? yield* Effect.tryPromise({
+            try: async () => {
+              try {
+                const { data } = await octokit.rest.repos.getWebhook({
+                  owner: news.owner,
+                  repo: news.repository,
+                  hook_id: output.hookId,
+                });
+                return data;
+              } catch (e: any) {
+                if (e.status === 404) return undefined;
+                throw e;
+              }
+            },
+            catch: (e) => e as Error,
+          })
+        : undefined;
+
+      if (observed === undefined) {
+        // Ensure — POST creates the hook. GitHub tolerates duplicate
+        // webhooks pointing at the same URL; we accept that risk because
+        // we always cache the hookId and reconcile in place afterwards.
+        const { data } = yield* Effect.tryPromise(() =>
+          octokit.rest.repos.createWebhook({
+            owner: news.owner,
+            repo: news.repository,
+            events: news.events,
+            active: news.active ?? true,
+            config,
+          }),
+        );
+        return {
+          hookId: data.id,
+          url: (data.config?.url as string) ?? news.url,
+        };
+      }
+
+      // Sync — patch when any observed field drifted from desired.
+      const eventsDrift = !sameStringSet(observed.events ?? [], news.events);
+      const activeDrift = (observed.active ?? true) !== (news.active ?? true);
+      const urlDrift =
+        (observed.config?.url as string | undefined) !== news.url;
+      const contentTypeDrift =
+        (observed.config?.content_type as string | undefined) !==
+        config.content_type;
+
+      if (eventsDrift || activeDrift || urlDrift || contentTypeDrift) {
+        const { data } = yield* Effect.tryPromise(() =>
+          octokit.rest.repos.updateWebhook({
+            owner: news.owner,
+            repo: news.repository,
+            hook_id: observed.id,
+            events: news.events,
+            active: news.active ?? true,
+            config,
+          }),
+        );
+        return {
+          hookId: data.id,
+          url: (data.config?.url as string) ?? news.url,
+        };
+      }
+
+      return {
+        hookId: observed.id,
+        url: (observed.config?.url as string) ?? news.url,
+      };
+    }),
+
+    delete: Effect.fn(function* ({ olds, output }) {
+      const octokit = yield* getOctokit;
+      yield* Effect.tryPromise(async () => {
+        try {
+          await octokit.rest.repos.deleteWebhook({
+            owner: olds.owner,
+            repo: olds.repository,
+            hook_id: output.hookId,
+          });
+        } catch (e: any) {
+          if (e.status !== 404) throw e;
+        }
+      });
+    }),
+  });

--- a/packages/alchemy/src/GitHub/Webhooks.ts
+++ b/packages/alchemy/src/GitHub/Webhooks.ts
@@ -1,0 +1,137 @@
+import * as Context from "effect/Context";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import type { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import type * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import type { WebhookDelivery, WebhookEventName } from "./Events.ts";
+
+/**
+ * The minimum identification needed to match an inbound webhook to a
+ * registered handler. Worker source code typically constructs this with
+ * literal owner/name pairs because the deploy-time `Repository` resource
+ * isn't available in the bundled Worker. Capability functions accept the
+ * same shape.
+ */
+export interface RepoRef {
+  owner: string;
+  name: string;
+}
+
+export const repoFullName = (repo: RepoRef): string =>
+  `${repo.owner}/${repo.name}`.toLowerCase();
+
+export class WebhookSignatureError extends Data.TaggedError(
+  "GitHub.WebhookSignatureError",
+)<{
+  readonly message: string;
+}> {}
+
+export class WebhookFormatError extends Data.TaggedError(
+  "GitHub.WebhookFormatError",
+)<{
+  readonly message: string;
+}> {}
+
+/**
+ * Signature of a typed webhook handler registered through an event source
+ * helper such as {@link pullRequests} or {@link issueComments}.
+ */
+export type WebhookHandler<
+  E extends WebhookEventName,
+  Req = never,
+  Err = never,
+> = (delivery: WebhookDelivery<E>) => Effect.Effect<void, Err, Req>;
+
+/**
+ * Dispatcher service injected into the Worker init phase. Event-source
+ * helpers register handlers on it; the Worker's `fetch` handler calls
+ * {@link DispatcherService.handle} on incoming POSTs to dispatch verified
+ * deliveries.
+ */
+export interface DispatcherService {
+  /**
+   * Register a handler for a specific repository + event name. The handler
+   * runs once per matching delivery, forked daemonically so a slow
+   * handler does not delay webhook acknowledgement.
+   */
+  register<E extends WebhookEventName>(
+    repo: RepoRef,
+    event: E,
+    handler: WebhookHandler<E, any, any>,
+  ): Effect.Effect<void>;
+
+  /**
+   * Register a handler that runs for every event delivered to this
+   * repository. Used by `events(repo).subscribe(...)` and by filter-based
+   * subscriptions; typed sugar like `pullRequests` uses `register` instead.
+   */
+  registerAny(
+    repo: RepoRef,
+    handler: WebhookHandler<WebhookEventName, any, any>,
+  ): Effect.Effect<void>;
+
+  /**
+   * Dispatch an incoming webhook request. Verifies `X-Hub-Signature-256`
+   * against the configured secret, parses the JSON body, and runs all
+   * matching handlers concurrently. Returns:
+   * - 204 No Content on a verified delivery (handlers are forked, so the
+   *   reply is sent before they finish).
+   * - 401 Unauthorized when signature verification fails.
+   * - 400 Bad Request for malformed deliveries.
+   * - `undefined` when the request is not a webhook (callers fall through
+   *   to the rest of their `fetch` handler).
+   */
+  handle(
+    request: HttpServerRequest,
+  ): Effect.Effect<HttpServerResponse.HttpServerResponse | undefined>;
+}
+
+export class Dispatcher extends Context.Service<
+  Dispatcher,
+  DispatcherService
+>()("GitHub.Webhooks.Dispatcher") {}
+
+/**
+ * Verify the `sha256=...` signature on a GitHub webhook delivery against
+ * the shared secret. Uses the SubtleCrypto API available in Cloudflare
+ * Workers and modern Node / Bun runtimes — no platform fork required.
+ *
+ * Returns `true` on a constant-time match; `false` otherwise.
+ */
+export const verifySignature = (
+  secret: string,
+  signatureHeader: string | undefined,
+  rawBody: string,
+): Effect.Effect<boolean> =>
+  Effect.tryPromise({
+    try: async () => {
+      if (!signatureHeader || !signatureHeader.startsWith("sha256=")) {
+        return false;
+      }
+      const expectedHex = signatureHeader.slice("sha256=".length);
+      const enc = new TextEncoder();
+      const key = await crypto.subtle.importKey(
+        "raw",
+        enc.encode(secret),
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"],
+      );
+      const sigBytes = await crypto.subtle.sign(
+        "HMAC",
+        key,
+        enc.encode(rawBody),
+      );
+      const sigHex = Array.from(new Uint8Array(sigBytes))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+      // Constant-time comparison.
+      if (sigHex.length !== expectedHex.length) return false;
+      let mismatch = 0;
+      for (let i = 0; i < sigHex.length; i++) {
+        mismatch |= sigHex.charCodeAt(i) ^ expectedHex.charCodeAt(i);
+      }
+      return mismatch === 0;
+    },
+    catch: (e) => e as Error,
+  }).pipe(Effect.orElseSucceed(() => false));

--- a/packages/alchemy/src/GitHub/index.ts
+++ b/packages/alchemy/src/GitHub/index.ts
@@ -1,7 +1,15 @@
 export * as Auth from "./AuthProvider.ts";
+export * from "./Capabilities.ts";
 export * from "./Comment.ts";
 export { GitHubCredentials, fromEnv, fromToken } from "./Credentials.ts";
+export * from "./Events.ts";
+export * from "./EventSources.ts";
+export * as Octokit from "./Octokit.ts";
+export { RuntimeOctokit } from "./Octokit.ts";
 export * from "./Providers.ts";
+export * from "./Repository.ts";
 export * from "./Secret.ts";
 export * from "./Secrets.ts";
 export * from "./Variable.ts";
+export * from "./Webhook.ts";
+export * from "./Webhooks.ts";

--- a/services/builder/alchemy.run.ts
+++ b/services/builder/alchemy.run.ts
@@ -1,0 +1,66 @@
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as GitHub from "alchemy/GitHub";
+import * as Output from "alchemy/Output";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import Worker from "./src/Worker.ts";
+
+/**
+ * Stack: a self-hosted CI service running on Cloudflare. Watches a single
+ * GitHub repo for events, builds it in a Container, and runs coding-agent
+ * tasks for review responses + release notes.
+ *
+ * The repo identifiers below must match the literal `REPO` constant in
+ * `src/Worker.ts` — the worker source can't read this stack's resources,
+ * so the (owner, name) pair is duplicated by design.
+ */
+const REPO = {
+  owner: "alchemy-run",
+  name: "alchemy-effect",
+} as const;
+
+export default Alchemy.Stack(
+  "AlchemyBuilder",
+  {
+    providers: Layer.mergeAll(Cloudflare.providers(), GitHub.providers()),
+    state: Cloudflare.state(),
+  },
+  Effect.gen(function* () {
+    // The repository we watch (adopted — it already exists on GitHub).
+    yield* GitHub.Repository("repo", {
+      owner: REPO.owner,
+      name: REPO.name,
+      adopt: true,
+    });
+
+    // Random secret for webhook HMAC. Persisted in state so subsequent
+    // deploys keep the same secret unless the resource is replaced.
+    const webhookSecret = yield* Alchemy.Random("webhook-secret");
+
+    // The Worker hosts the dispatcher and reads the secret out of its
+    // GITHUB_WEBHOOK_SECRET env binding (wired separately at deploy time
+    // via wrangler / dashboard / Cloudflare.SecretsStore).
+    const worker = yield* Worker;
+
+    // Install the actual GitHub webhook to point at the worker URL.
+    yield* GitHub.Webhook("hook", {
+      owner: REPO.owner,
+      repository: REPO.name,
+      url: Output.interpolate`${worker.url}/__github/webhook`,
+      secret: webhookSecret.text,
+      events: [
+        "push",
+        "pull_request",
+        "pull_request_review",
+        "pull_request_review_comment",
+        "issue_comment",
+        "release",
+      ],
+    });
+
+    return {
+      workerUrl: worker.url,
+    };
+  }),
+);

--- a/services/builder/package.json
+++ b/services/builder/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@alchemy.run/builder",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alchemy-run/alchemy-effect"
+  },
+  "type": "module",
+  "scripts": {
+    "deploy": "alchemy deploy",
+    "dev": "alchemy dev",
+    "destroy": "alchemy destroy",
+    "logs": "alchemy logs",
+    "tail": "alchemy tail",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@effect/platform-bun": "catalog:",
+    "@effect/platform-node": "catalog:",
+    "alchemy": "workspace:*",
+    "effect": "catalog:"
+  }
+}

--- a/services/builder/src/Builder.runtime.ts
+++ b/services/builder/src/Builder.runtime.ts
@@ -1,0 +1,134 @@
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
+import { Builder } from "./Builder.ts";
+
+const tail = (s: string, max = 4_000) =>
+  s.length <= max ? s : `…${s.slice(-max)}`;
+
+/**
+ * Build a remote URL with the artifacts token embedded so `git clone` can
+ * authenticate without a credential helper.
+ */
+const remoteWithToken = (remote: string, token: string) => {
+  const url = new URL(remote);
+  url.username = "token";
+  url.password = token;
+  return url.toString();
+};
+
+export default Builder.make(
+  Effect.gen(function* () {
+    const cp = yield* ChildProcessSpawner;
+
+    const run = (
+      cmd: string,
+      options: { cwd?: string; env?: Record<string, string> } = {},
+    ) =>
+      cp
+        .spawn(
+          ChildProcess.make(cmd, {
+            shell: true,
+            cwd: options.cwd,
+            env: options.env,
+          }),
+        )
+        .pipe(
+          Effect.flatMap((handle) =>
+            Effect.all(
+              [
+                handle.exitCode,
+                handle.stdout.pipe(Stream.decodeText, Stream.mkString),
+                handle.stderr.pipe(Stream.decodeText, Stream.mkString),
+              ],
+              { concurrency: "unbounded" },
+            ),
+          ),
+          Effect.map(([exitCode, stdout, stderr]) => ({
+            exitCode: Number(exitCode),
+            stdout,
+            stderr,
+          })),
+          Effect.scoped,
+        );
+
+    return Builder.of({
+      fetch: Effect.succeed(
+        HttpServerResponse.text("alchemy/builder", { status: 200 }),
+      ),
+      runBuild: ({ artifactsRemote, artifactsToken, ref }) =>
+        Effect.gen(function* () {
+          const auth = remoteWithToken(artifactsRemote, artifactsToken);
+          const clone = yield* run(
+            `rm -rf /work && git clone --depth=1 --branch ${ref} ${auth} /work`,
+          );
+          if (clone.exitCode !== 0) {
+            return { exitCode: clone.exitCode, logTail: tail(clone.stderr) };
+          }
+
+          const install = yield* run(`bun install --frozen-lockfile`, {
+            cwd: "/work",
+          });
+          if (install.exitCode !== 0) {
+            return {
+              exitCode: install.exitCode,
+              logTail: tail(install.stderr),
+            };
+          }
+
+          const build = yield* run(`bun run build`, { cwd: "/work" });
+          return {
+            exitCode: build.exitCode,
+            logTail: tail(`${build.stdout}\n${build.stderr}`),
+          };
+        }),
+
+      runAgent: ({
+        artifactsRemote,
+        artifactsToken,
+        ref,
+        prompt,
+        pushBranch,
+      }) =>
+        Effect.gen(function* () {
+          const auth = remoteWithToken(artifactsRemote, artifactsToken);
+          const clone = yield* run(
+            `rm -rf /work && git clone --branch ${ref} ${auth} /work`,
+          );
+          if (clone.exitCode !== 0) {
+            return {
+              exitCode: clone.exitCode,
+              logTail: tail(clone.stderr),
+              pushedSha: null,
+            };
+          }
+
+          const agent = yield* run(
+            `printf '%s' ${JSON.stringify(prompt)} | npx @anthropic-ai/claude-code --task -`,
+            { cwd: "/work" },
+          );
+          if (agent.exitCode !== 0) {
+            return {
+              exitCode: agent.exitCode,
+              logTail: tail(`${agent.stdout}\n${agent.stderr}`),
+              pushedSha: null,
+            };
+          }
+
+          const target = pushBranch ?? ref;
+          const push = yield* run(
+            `git checkout -B ${target} && git push --force-with-lease ${auth} ${target}`,
+            { cwd: "/work" },
+          );
+          const head = yield* run(`git rev-parse HEAD`, { cwd: "/work" });
+          return {
+            exitCode: push.exitCode,
+            logTail: tail(`${agent.stdout}\n${push.stdout}\n${push.stderr}`),
+            pushedSha: push.exitCode === 0 ? head.stdout.trim() : null,
+          };
+        }),
+    });
+  }),
+);

--- a/services/builder/src/Builder.ts
+++ b/services/builder/src/Builder.ts
@@ -1,0 +1,61 @@
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import type { PlatformError } from "effect/PlatformError";
+
+/**
+ * Builder Container — runs one job at a time inside a Cloudflare Container
+ * sidecar. Each method on the RPC shape is a discrete build phase the
+ * Builds DO can call by RPC.
+ *
+ * The class is declared in this file (the DO needs to import it for
+ * `Cloudflare.Container.bind`); the runtime implementation lives in
+ * `Builder.runtime.ts` so the bundler can tree-shake it out of consumers
+ * that only need the binding.
+ */
+export class Builder extends Cloudflare.Container<
+  Builder,
+  {
+    /**
+     * Clone the artifacts repo at `ref` into `/work`, run `bun install` and
+     * `bun run build`. Returns the build's exit code and tail of logs.
+     */
+    runBuild: (input: {
+      artifactsRepo: string;
+      artifactsRemote: string;
+      artifactsToken: string;
+      ref: string;
+      sha: string;
+    }) => Effect.Effect<
+      {
+        exitCode: number;
+        logTail: string;
+      },
+      PlatformError
+    >;
+
+    /**
+     * Run a coding-agent task in the cloned tree. The agent is invoked
+     * with the supplied prompt; the container then runs `git push` to
+     * propagate any commits back.
+     */
+    runAgent: (input: {
+      artifactsRepo: string;
+      artifactsRemote: string;
+      artifactsToken: string;
+      ref: string;
+      prompt: string;
+      pushBranch?: string;
+    }) => Effect.Effect<
+      {
+        exitCode: number;
+        logTail: string;
+        pushedSha: string | null;
+      },
+      PlatformError
+    >;
+  }
+>()("Builder", {
+  main: import.meta.path,
+  instanceType: "dev",
+  observability: { logs: { enabled: true } },
+}) {}

--- a/services/builder/src/Builds.ts
+++ b/services/builder/src/Builds.ts
@@ -1,0 +1,90 @@
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import { Builder } from "./Builder.ts";
+
+/**
+ * Per-SHA build orchestrator. One Durable Object instance per (repo, sha):
+ * holds run state in `state.storage`, dispatches to a Container by RPC,
+ * and reports back via the GitHub.CommitStatuses capability.
+ *
+ * Routing convention: callers do `builds.getByName(\`${repo.fullName}@${sha}\`)`
+ * so each sha gets its own DO and runs are naturally serialized.
+ */
+export type BuildState = {
+  status: "pending" | "running" | "success" | "failure";
+  startedAt?: number;
+  completedAt?: number;
+  exitCode?: number;
+  logTail?: string;
+};
+
+export default class Builds extends Cloudflare.DurableObjectNamespace<Builds>()(
+  "Builds",
+  Effect.gen(function* () {
+    // Outer init: bind the Container class once per Worker. The bound
+    // value is an Effect that resolves the container handle inside each
+    // DO instance via `Cloudflare.start`.
+    const builderEff = yield* Cloudflare.Container.bind(Builder);
+
+    return Effect.gen(function* () {
+      const state = yield* Cloudflare.DurableObjectState;
+      const builder = yield* Cloudflare.start(builderEff);
+
+      return {
+        get: () =>
+          Effect.gen(function* () {
+            const raw = yield* state.storage.get<BuildState>("state");
+            return raw ?? { status: "pending" as const };
+          }),
+
+        runBuild: (input: {
+          artifactsRepo: string;
+          artifactsRemote: string;
+          artifactsToken: string;
+          ref: string;
+          sha: string;
+        }) =>
+          Effect.gen(function* () {
+            yield* state.storage.put<BuildState>("state", {
+              status: "running",
+              startedAt: Date.now(),
+            });
+            const result = yield* builder
+              .runBuild(input)
+              .pipe(
+                Effect.catch((e) =>
+                  Effect.succeed({ exitCode: 1, logTail: String(e) }),
+                ),
+              );
+            const finalState: BuildState = {
+              status: result.exitCode === 0 ? "success" : "failure",
+              startedAt: Date.now(),
+              completedAt: Date.now(),
+              exitCode: result.exitCode,
+              logTail: result.logTail,
+            };
+            yield* state.storage.put<BuildState>("state", finalState);
+            return finalState;
+          }),
+
+        runAgent: (input: {
+          artifactsRepo: string;
+          artifactsRemote: string;
+          artifactsToken: string;
+          ref: string;
+          prompt: string;
+          pushBranch?: string;
+        }) =>
+          builder.runAgent(input).pipe(
+            Effect.catch((e) =>
+              Effect.succeed({
+                exitCode: 1,
+                logTail: String(e),
+                pushedSha: null,
+              }),
+            ),
+          ),
+      };
+    });
+  }),
+) {}

--- a/services/builder/src/Prompts.ts
+++ b/services/builder/src/Prompts.ts
@@ -1,0 +1,82 @@
+/**
+ * Coding-agent prompts that drive the builder. Stored alongside the
+ * worker source so they're version-controlled with the same lifecycle as
+ * the rest of the service.
+ *
+ * Each prompt is a plain string (or function that produces one). The
+ * Container shells out to `claude-code` (or any other agent CLI) with the
+ * prompt as its task description.
+ */
+
+/**
+ * Prompt used when a PR review requests changes — instruct the agent to
+ * read the review body + inline comments and push a follow-up commit.
+ */
+export const respondToReview = (input: {
+  reviewBody: string | null;
+  inlineComments: Array<{
+    path: string;
+    line: number | null;
+    body: string | null;
+  }>;
+}) => `\
+You are reviewing a request-for-changes left on a pull request. Read the
+review body and inline comments below, then make the necessary code edits
+and commit them with a single message summarizing what changed.
+
+Review body:
+${input.reviewBody ?? "(no body)"}
+
+Inline comments:
+${input.inlineComments
+  .map(
+    (c, i) =>
+      `[${i + 1}] ${c.path}${c.line ? `:${c.line}` : ""} — ${c.body ?? ""}`,
+  )
+  .join("\n")}
+
+Constraints:
+- Run \`bun tsc -b\` after every edit to make sure the change typechecks.
+- Do NOT push a merge commit; rebase any pulled changes.
+- If a comment can't be addressed in code, leave it for a follow-up reply.
+`;
+
+/**
+ * Prompt used when a release tag is pushed — generate a release blog post
+ * from the diff and the commit messages between the previous tag and this
+ * one.
+ */
+export const releaseBlog = (input: {
+  fromTag: string | null;
+  toTag: string;
+}) => `\
+Write a release blog post for tag ${input.toTag} (previous tag: ${
+  input.fromTag ?? "<none>"
+}).
+
+Steps:
+1. Run \`git log ${input.fromTag ?? "<initial>"}..${input.toTag} --oneline\`
+   to get the changelog.
+2. For each notable commit, expand it into a one-paragraph entry that
+   explains the user-facing change in plain language.
+3. Write the post to \`website/src/content/blog/${input.toTag}.md\`.
+4. Commit on a new branch \`release-blog/${input.toTag}\` and push it. Open
+   a PR titled "Release notes: ${input.toTag}".
+
+Keep the tone matter-of-fact. No marketing copy. Skip dependency bumps and
+internal refactors unless they affect the public surface.
+`;
+
+/**
+ * Prompt used when a PR is opened — review the diff for obvious issues
+ * (typos, missing tests, untyped any) and post a single high-signal
+ * comment.
+ */
+export const reviewPullRequest = (input: { prNumber: number }) => `\
+Review pull request #${input.prNumber}. Read the diff (\`git diff main\`),
+identify the highest-signal issue (or confirm there are none), and respond
+with a single, focused comment using the GitHub.IssueComments capability.
+
+Do not nitpick formatting. Skip cosmetic suggestions. If everything looks
+good, post a one-line approval-style comment instead.
+`;

--- a/services/builder/src/Worker.ts
+++ b/services/builder/src/Worker.ts
@@ -1,0 +1,186 @@
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as GitHub from "alchemy/GitHub";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Match from "effect/Match";
+import * as Redacted from "effect/Redacted";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import Builds from "./Builds.ts";
+import * as Prompts from "./Prompts.ts";
+
+/**
+ * Hard-coded repo this builder watches. The Worker source can't reach into
+ * the deploy-time `Repository` resource, so the owner/name pair is wired
+ * here as a literal — the Stack file (alchemy.run.ts) keeps the same
+ * pair and uses it to install the Webhook resource at deploy time.
+ */
+const REPO: GitHub.RepoRef = {
+  owner: "alchemy-run",
+  name: "alchemy-effect",
+};
+
+const ARTIFACTS_NAME = "builder-source";
+
+const webhookSecret = Redacted.make(
+  (globalThis as any).process?.env?.GITHUB_WEBHOOK_SECRET ?? "dev-secret",
+);
+
+/**
+ * Self-hosted CI Worker. Subscribes to GitHub webhook events for one
+ * repository and dispatches builds + coding-agent runs to a per-SHA
+ * Durable Object backed by a Cloudflare Container.
+ */
+export default class Worker extends Cloudflare.Worker<Worker>()(
+  "Worker",
+  {
+    main: import.meta.path,
+    compatibility: { flags: ["nodejs_compat"] },
+  },
+  Effect.gen(function* () {
+    const builds = yield* Builds;
+
+    // Bind the Cloudflare Artifacts namespace — the Container clones from
+    // the artifact remote that this binding gives us at runtime.
+    const artifacts = yield* Cloudflare.Artifacts.bind(
+      yield* Cloudflare.Artifacts(ARTIFACTS_NAME),
+    );
+
+    // Resolve the runtime services up-front so the per-event handlers
+    // (which run after init) can close over plain values instead of
+    // re-yielding from the Effect context. Same pattern as Api.ts —
+    // bindings are values inside `fetch`.
+    const dispatcher = yield* GitHub.Dispatcher;
+    const commitStatuses = yield* GitHub.CommitStatuses;
+    const comments = yield* GitHub.IssueComments;
+
+    // Push events trigger a build for the new sha.
+    yield* GitHub.pushes(REPO).subscribe((delivery) =>
+      Effect.gen(function* () {
+        if (delivery.payload.deleted) return;
+        const { after, ref } = delivery.payload;
+
+        const repo = yield* artifacts.get(ARTIFACTS_NAME).pipe(Effect.orDie);
+        const token = yield* repo.createToken("read", 3600).pipe(Effect.orDie);
+        const id = `${REPO.owner}/${REPO.name}@${after}`;
+
+        const result = yield* builds
+          .getByName(id)
+          .runBuild({
+            artifactsRepo: ARTIFACTS_NAME,
+            artifactsRemote: repo.raw.remote,
+            artifactsToken: token.token,
+            ref: ref.replace(/^refs\/heads\//, ""),
+            sha: after,
+          })
+          .pipe(Effect.orDie);
+
+        yield* commitStatuses
+          .create(REPO, {
+            sha: after,
+            state: result.status === "success" ? "success" : "failure",
+            context: "alchemy/builder",
+            description: `build exit ${result.exitCode}`,
+          })
+          .pipe(Effect.orElseSucceed(() => ({ id: 0, url: "" })));
+      }),
+    );
+
+    // Reviewer requested changes → run agent on the PR head, push fixup,
+    // post a follow-up comment.
+    yield* GitHub.pullRequestReviews(REPO).subscribe((delivery) =>
+      Effect.gen(function* () {
+        if (delivery.payload.action !== "submitted") return;
+        if (delivery.payload.review.state !== "changes_requested") return;
+        const pr = delivery.payload.pull_request;
+
+        const repo = yield* artifacts.get(ARTIFACTS_NAME).pipe(Effect.orDie);
+        const token = yield* repo.createToken("write", 3600).pipe(Effect.orDie);
+        const id = `${REPO.owner}/${REPO.name}@pr-${pr.number}`;
+
+        const result = yield* builds
+          .getByName(id)
+          .runAgent({
+            artifactsRepo: ARTIFACTS_NAME,
+            artifactsRemote: repo.raw.remote,
+            artifactsToken: token.token,
+            ref: pr.head.ref,
+            pushBranch: pr.head.ref,
+            prompt: Prompts.respondToReview({
+              reviewBody: delivery.payload.review.body,
+              inlineComments: [],
+            }),
+          })
+          .pipe(Effect.orDie);
+
+        yield* comments
+          .create(REPO, {
+            issueNumber: pr.number,
+            body:
+              result.pushedSha != null
+                ? `Pushed updates addressing the review (\`${result.pushedSha.slice(0, 7)}\`).`
+                : `Tried to address the review but the run failed (exit ${result.exitCode}).`,
+          })
+          .pipe(Effect.orElseSucceed(() => ({ id: 0, htmlUrl: "" })));
+      }),
+    );
+
+    // Releases trigger a release-blog agent task.
+    yield* GitHub.releases(REPO).subscribe((delivery) =>
+      Effect.gen(function* () {
+        if (delivery.payload.action !== "published") return;
+        const tag = delivery.payload.release.tag_name;
+
+        const repo = yield* artifacts.get(ARTIFACTS_NAME).pipe(Effect.orDie);
+        const token = yield* repo.createToken("write", 3600).pipe(Effect.orDie);
+        const id = `${REPO.owner}/${REPO.name}@release-${tag}`;
+
+        yield* builds
+          .getByName(id)
+          .runAgent({
+            artifactsRepo: ARTIFACTS_NAME,
+            artifactsRemote: repo.raw.remote,
+            artifactsToken: token.token,
+            ref: "main",
+            pushBranch: `release-blog/${tag}`,
+            prompt: Prompts.releaseBlog({ fromTag: null, toTag: tag }),
+          })
+          .pipe(Effect.orDie);
+      }),
+    );
+
+    // Catch-all that demonstrates the generic `events(repo)` primitive +
+    // `Match.discriminator("event")`. Useful for adding new events
+    // without a typed sugar helper.
+    yield* GitHub.events(REPO).subscribe((delivery) =>
+      Match.value(delivery).pipe(
+        Match.discriminator("event")("issue_comment", ({ payload }) =>
+          Effect.gen(function* () {
+            if (payload.action !== "created") return;
+            const body = payload.comment.body ?? "";
+            if (!body.startsWith("/build")) return;
+            if (!payload.issue.pull_request) return;
+            // Chat-op: rebuild this PR. Implementation left for the
+            // operator to wire up — the typed payload is right here.
+          }),
+        ),
+        Match.orElse(() => Effect.void),
+      ),
+    );
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const handled = yield* dispatcher.handle(request);
+        if (handled !== undefined) return handled;
+        return HttpServerResponse.text("alchemy builder", { status: 200 });
+      }),
+    };
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(Cloudflare.ArtifactsBindingLive, GitHub.CapabilitiesLive),
+    ),
+    Effect.provide(Cloudflare.GitHub.Webhooks.live(webhookSecret)),
+    Effect.provide(GitHub.Octokit.fromEnv("GITHUB_TOKEN")),
+  ),
+) {}

--- a/services/builder/tsconfig.json
+++ b/services/builder/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["alchemy.run.ts", "src/**/*.ts"],
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "target": "ESNext"
+  },
+  "references": [
+    {
+      "path": "../../packages/alchemy/tsconfig.json"
+    }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -70,6 +70,9 @@
     },
     {
       "path": "./packages/pr-package/tsconfig.json"
+    },
+    {
+      "path": "./services/builder/tsconfig.json"
     }
   ],
   "compilerOptions": {


### PR DESCRIPTION
Adds the GitHub provider's bidirectional surface — typed event sources, runtime capabilities grouped to mirror Octokit's REST namespaces — plus a `services/builder` reference app that turns it into a self-hosted CI on Cloudflare.

```ts
// in a Worker init phase
yield* GitHub.pullRequests(repo).subscribe((delivery) =>
  Effect.gen(function* () {
    if (delivery.payload.action !== "opened") return;
    const comments = yield* GitHub.IssueComments;
    yield* comments.create(repo, {
      issueNumber: delivery.payload.number,
      body: "Welcome!",
    });
  }),
);

// generic + Match for events without typed sugar
yield* GitHub.events(repo).subscribe((delivery) =>
  Match.value(delivery).pipe(
    Match.discriminator("event")("push", ({ payload }) =>
      buildSha(payload.after),
    ),
    Match.orElse(() => Effect.void),
  ),
);
```

### Provider surface

`packages/alchemy/src/GitHub`:
- `Repository`, `Webhook` — adopt or create; webhook install/sync with HMAC secret
- `Events`, `Webhooks` — typed payload map, `Dispatcher` service, `verifySignature`
- `EventSources` — generic `events(repo)` + typed sugar (`pullRequests`, `issueComments`, `pullRequestReviews`, `pushes`, `releases`, `workflowRuns`, `checkRuns`, `pullRequestReviewComments`, `issues`)
- `Capabilities` — `IssueComments`, `PullRequestReviewComments`, `PullRequestReviews`, `PullRequests`, `Git`, `Contents`, `CommitStatuses`, `CheckRuns`, `Reactions` — names match Octokit's REST namespaces verbatim
- `Octokit` — `RuntimeOctokit` service with `fromToken` / `fromEnv`

`packages/alchemy/src/Cloudflare/GitHub/Webhooks.ts`:
- `Webhooks.live(secret, { path })` — verifies `X-Hub-Signature-256` via WebCrypto, forks matching handlers via `Effect.forkDetach` so the 204 ack stays prompt regardless of handler latency

### Reference app

`services/builder` (new `services/*` workspace glob):
- Worker subscribing to push / review / release events
- Per-SHA Durable Object orchestrating builds
- Container with `runBuild` and `runAgent` RPCs that clones via Cloudflare Artifacts and shells out to a coding agent

```ts
// inside the Builds DO
const result = yield* builder.runAgent({
  artifactsRemote, artifactsToken,
  ref: pr.head.ref,
  pushBranch: pr.head.ref,
  prompt: Prompts.respondToReview({
    reviewBody: review.body,
    inlineComments: [],
  }),
});
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01NeRMPDwiQUNUbFEgVMcU7X)_