### PR TITLE
feat(cli): warn when a newer alchemy version is on npm

### DIFF
--- a/packages/alchemy/src/Cli/checkVersion.ts
+++ b/packages/alchemy/src/Cli/checkVersion.ts
@@ -42,8 +42,8 @@ export const checkLatestVersion = Effect.gen(function* () {
   if (typeof latest !== "string" || latest === current) return;
   const installCmd =
     typeof process !== "undefined" && (process as any).versions?.bun
-      ? "bun add -g alchemy@latest"
-      : "pnpm add -g alchemy@latest";
+      ? "bun add alchemy@latest"
+      : "pnpm add alchemy@latest";
   yield* Effect.logWarning(
     `alchemy ${latest} is available (you're on ${current}). ` +
       `Run \`${installCmd}\` to upgrade.`,

--- a/packages/alchemy/src/Cli/checkVersion.ts
+++ b/packages/alchemy/src/Cli/checkVersion.ts
@@ -42,8 +42,8 @@ export const checkLatestVersion = Effect.gen(function* () {
   if (typeof latest !== "string" || latest === current) return;
   const installCmd =
     typeof process !== "undefined" && (process as any).versions?.bun
-      ? "bun add alchemy@latest"
-      : "pnpm add alchemy@latest";
+      ? `bun add alchemy@${latest}`
+      : `pnpm add alchemy@${latest}`;
   yield* Effect.logWarning(
     `alchemy ${latest} is available (you're on ${current}). ` +
       `Run \`${installCmd}\` to upgrade.`,

--- a/packages/alchemy/src/Cli/checkVersion.ts
+++ b/packages/alchemy/src/Cli/checkVersion.ts
@@ -1,0 +1,104 @@
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+
+import packageJson from "../../package.json" with { type: "json" };
+
+const NPM_DIST_TAGS_URL =
+  "https://registry.npmjs.org/-/package/alchemy/dist-tags";
+
+/**
+ * Compare two semver-ish version strings. Returns:
+ *   <0 if a < b, 0 if equal, >0 if a > b.
+ * Pre-release versions (e.g. `2.0.0-beta.33`) sort below the same release
+ * core (`2.0.0`), per semver §11.
+ */
+const compareVersions = (a: string, b: string): number => {
+  const [aCore, aPre] = a.split("-", 2);
+  const [bCore, bPre] = b.split("-", 2);
+  const aParts = aCore.split(".").map((n) => Number.parseInt(n, 10) || 0);
+  const bParts = bCore.split(".").map((n) => Number.parseInt(n, 10) || 0);
+  const len = Math.max(aParts.length, bParts.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (aParts[i] ?? 0) - (bParts[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  // Same core. A pre-release is lower precedence than no pre-release.
+  if (aPre && !bPre) return -1;
+  if (!aPre && bPre) return 1;
+  if (aPre && bPre) {
+    const aIds = aPre.split(".");
+    const bIds = bPre.split(".");
+    const idLen = Math.max(aIds.length, bIds.length);
+    for (let i = 0; i < idLen; i++) {
+      const ai = aIds[i];
+      const bi = bIds[i];
+      if (ai === undefined) return -1;
+      if (bi === undefined) return 1;
+      const an = Number.parseInt(ai, 10);
+      const bn = Number.parseInt(bi, 10);
+      const aNumeric = Number.isFinite(an) && String(an) === ai;
+      const bNumeric = Number.isFinite(bn) && String(bn) === bi;
+      if (aNumeric && bNumeric) {
+        if (an !== bn) return an - bn;
+      } else if (aNumeric) {
+        return -1;
+      } else if (bNumeric) {
+        return 1;
+      } else if (ai !== bi) {
+        return ai < bi ? -1 : 1;
+      }
+    }
+  }
+  return 0;
+};
+
+/**
+ * Pick the dist-tag that should be compared against `current`.
+ *
+ * For pre-release versions like `2.0.0-beta.33`, npm's `latest` tag points
+ * at the most recent stable release (e.g. `0.93.7`), which is *older* than
+ * the current beta — so naive `latest` comparisons would never warn beta
+ * users about a newer beta. Match the prerelease identifier to a dist-tag
+ * (`beta`, `next`, etc.), falling back through `next` -> `latest`.
+ */
+const pickDistTag = (
+  current: string,
+  distTags: Record<string, string>,
+): string | undefined => {
+  const pre = current.split("-", 2)[1];
+  if (pre) {
+    const id = pre.split(".")[0];
+    if (id && distTags[id]) return distTags[id];
+    if (distTags.next) return distTags.next;
+  }
+  return distTags.latest;
+};
+
+/**
+ * Fetch the latest published `alchemy` version on the dist-tag matching
+ * the current channel and log a warning if it's newer than the bundled
+ * version. Best-effort: any failure (offline, registry hiccup, slow
+ * response) is swallowed silently.
+ */
+export const checkLatestVersion = Effect.gen(function* () {
+  const http = yield* HttpClient.HttpClient;
+  const response = yield* http.get(NPM_DIST_TAGS_URL);
+  const distTags = (yield* response.json) as Record<string, string>;
+  if (typeof distTags !== "object" || distTags === null) return;
+  const current = packageJson.version;
+  const latest = pickDistTag(current, distTags);
+  if (typeof latest !== "string" || compareVersions(current, latest) >= 0) {
+    return;
+  }
+  yield* Effect.logWarning(
+    `A new version of alchemy is available: ${current} -> ${latest}. ` +
+      "Run `npm install -g alchemy@latest` (or your package manager equivalent) to upgrade.",
+  );
+}).pipe(
+  Effect.timeout(Duration.seconds(5)),
+  Effect.catch(() => Effect.void),
+);
+
+// Exported for tests.
+export const _internal = { compareVersions, pickDistTag };

--- a/packages/alchemy/src/Cli/checkVersion.ts
+++ b/packages/alchemy/src/Cli/checkVersion.ts
@@ -40,9 +40,13 @@ export const checkLatestVersion = Effect.gen(function* () {
   const current = packageJson.version;
   const latest = pickDistTag(current, distTags);
   if (typeof latest !== "string" || latest === current) return;
+  const installCmd =
+    typeof process !== "undefined" && (process as any).versions?.bun
+      ? "bun add -g alchemy@latest"
+      : "pnpm add -g alchemy@latest";
   yield* Effect.logWarning(
     `alchemy ${latest} is available (you're on ${current}). ` +
-      "Run `npm install -g alchemy@latest` (or your package manager equivalent) to upgrade.",
+      `Run \`${installCmd}\` to upgrade.`,
   );
 }).pipe(
   Effect.timeout(Duration.seconds(5)),

--- a/packages/alchemy/src/Cli/checkVersion.ts
+++ b/packages/alchemy/src/Cli/checkVersion.ts
@@ -8,59 +8,10 @@ const NPM_DIST_TAGS_URL =
   "https://registry.npmjs.org/-/package/alchemy/dist-tags";
 
 /**
- * Compare two semver-ish version strings. Returns:
- *   <0 if a < b, 0 if equal, >0 if a > b.
- * Pre-release versions (e.g. `2.0.0-beta.33`) sort below the same release
- * core (`2.0.0`), per semver §11.
- */
-const compareVersions = (a: string, b: string): number => {
-  const [aCore, aPre] = a.split("-", 2);
-  const [bCore, bPre] = b.split("-", 2);
-  const aParts = aCore.split(".").map((n) => Number.parseInt(n, 10) || 0);
-  const bParts = bCore.split(".").map((n) => Number.parseInt(n, 10) || 0);
-  const len = Math.max(aParts.length, bParts.length);
-  for (let i = 0; i < len; i++) {
-    const diff = (aParts[i] ?? 0) - (bParts[i] ?? 0);
-    if (diff !== 0) return diff;
-  }
-  // Same core. A pre-release is lower precedence than no pre-release.
-  if (aPre && !bPre) return -1;
-  if (!aPre && bPre) return 1;
-  if (aPre && bPre) {
-    const aIds = aPre.split(".");
-    const bIds = bPre.split(".");
-    const idLen = Math.max(aIds.length, bIds.length);
-    for (let i = 0; i < idLen; i++) {
-      const ai = aIds[i];
-      const bi = bIds[i];
-      if (ai === undefined) return -1;
-      if (bi === undefined) return 1;
-      const an = Number.parseInt(ai, 10);
-      const bn = Number.parseInt(bi, 10);
-      const aNumeric = Number.isFinite(an) && String(an) === ai;
-      const bNumeric = Number.isFinite(bn) && String(bn) === bi;
-      if (aNumeric && bNumeric) {
-        if (an !== bn) return an - bn;
-      } else if (aNumeric) {
-        return -1;
-      } else if (bNumeric) {
-        return 1;
-      } else if (ai !== bi) {
-        return ai < bi ? -1 : 1;
-      }
-    }
-  }
-  return 0;
-};
-
-/**
- * Pick the dist-tag that should be compared against `current`.
- *
- * For pre-release versions like `2.0.0-beta.33`, npm's `latest` tag points
- * at the most recent stable release (e.g. `0.93.7`), which is *older* than
- * the current beta — so naive `latest` comparisons would never warn beta
- * users about a newer beta. Match the prerelease identifier to a dist-tag
- * (`beta`, `next`, etc.), falling back through `next` -> `latest`.
+ * Pick the dist-tag matching the current channel. For pre-release versions
+ * like `2.0.0-beta.33`, npm's `latest` tag points at the most recent stable
+ * release — not the newest beta — so we match the prerelease identifier
+ * (`beta`, `next`, etc.), falling back through `next` → `latest`.
  */
 const pickDistTag = (
   current: string,
@@ -76,8 +27,8 @@ const pickDistTag = (
 };
 
 /**
- * Fetch the latest published `alchemy` version on the dist-tag matching
- * the current channel and log a warning if it's newer than the bundled
+ * Fetch the published `alchemy` version on the dist-tag matching the
+ * current channel and log a warning if it's different from the bundled
  * version. Best-effort: any failure (offline, registry hiccup, slow
  * response) is swallowed silently.
  */
@@ -88,11 +39,9 @@ export const checkLatestVersion = Effect.gen(function* () {
   if (typeof distTags !== "object" || distTags === null) return;
   const current = packageJson.version;
   const latest = pickDistTag(current, distTags);
-  if (typeof latest !== "string" || compareVersions(current, latest) >= 0) {
-    return;
-  }
+  if (typeof latest !== "string" || latest === current) return;
   yield* Effect.logWarning(
-    `A new version of alchemy is available: ${current} -> ${latest}. ` +
+    `alchemy ${latest} is available (you're on ${current}). ` +
       "Run `npm install -g alchemy@latest` (or your package manager equivalent) to upgrade.",
   );
 }).pipe(
@@ -101,4 +50,4 @@ export const checkLatestVersion = Effect.gen(function* () {
 );
 
 // Exported for tests.
-export const _internal = { compareVersions, pickDistTag };
+export const _internal = { pickDistTag };

--- a/packages/alchemy/src/Cli/main.ts
+++ b/packages/alchemy/src/Cli/main.ts
@@ -9,6 +9,7 @@ import { TelemetryLive } from "alchemy/Telemetry/Layer";
 import { PlatformServices } from "alchemy/Util/PlatformServices";
 import packageJson from "../../package.json" with { type: "json" };
 
+import { checkLatestVersion } from "./checkVersion.ts";
 import { handleCancellation } from "./commands/_shared.ts";
 import { bootstrapCommand } from "./commands/bootstrap.ts";
 import {
@@ -52,7 +53,15 @@ const services = Layer.mergeAll(
   inkCLI(),
 );
 
-export const main = cli.pipe(
+const program = Effect.gen(function* () {
+  // Best-effort, non-blocking check for a newer published version. If the
+  // CLI command finishes before the registry responds, the fiber is
+  // interrupted on scope close — that's intentional.
+  yield* checkLatestVersion.pipe(Effect.forkScoped);
+  return yield* cli;
+});
+
+export const main = program.pipe(
   // $USER and $STAGE are set by the environment
   Effect.provide(services),
   Effect.scoped,

--- a/packages/alchemy/test/Cli/checkVersion.test.ts
+++ b/packages/alchemy/test/Cli/checkVersion.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest";
+
+import { _internal } from "../../src/Cli/checkVersion";
+
+const { compareVersions, pickDistTag } = _internal;
+
+describe("compareVersions", () => {
+  test("equal versions", () => {
+    expect(compareVersions("1.2.3", "1.2.3")).toBe(0);
+  });
+
+  test("major/minor/patch ordering", () => {
+    expect(compareVersions("1.2.3", "1.2.4")).toBeLessThan(0);
+    expect(compareVersions("1.3.0", "1.2.9")).toBeGreaterThan(0);
+    expect(compareVersions("2.0.0", "1.99.99")).toBeGreaterThan(0);
+  });
+
+  test("prerelease is lower precedence than release with same core", () => {
+    expect(compareVersions("2.0.0-beta.33", "2.0.0")).toBeLessThan(0);
+    expect(compareVersions("2.0.0", "2.0.0-beta.33")).toBeGreaterThan(0);
+  });
+
+  test("ordering between same-channel betas is numeric", () => {
+    expect(compareVersions("2.0.0-beta.9", "2.0.0-beta.10")).toBeLessThan(0);
+    expect(compareVersions("2.0.0-beta.33", "2.0.0-beta.32")).toBeGreaterThan(
+      0,
+    );
+    expect(compareVersions("2.0.0-beta.33", "2.0.0-beta.33")).toBe(0);
+  });
+
+  test("released stable on different core dominates beta", () => {
+    expect(compareVersions("2.0.0-beta.33", "2.1.0")).toBeLessThan(0);
+    expect(compareVersions("2.1.0", "2.0.0-beta.33")).toBeGreaterThan(0);
+  });
+});
+
+describe("pickDistTag", () => {
+  // Real shape returned by https://registry.npmjs.org/-/package/alchemy/dist-tags
+  const realDistTags = { latest: "0.93.7", next: "2.0.0-beta.33" };
+
+  test("beta version picks the matching prerelease tag (next) over latest", () => {
+    expect(pickDistTag("2.0.0-beta.30", realDistTags)).toBe("2.0.0-beta.33");
+  });
+
+  test("stable version picks latest", () => {
+    expect(pickDistTag("0.93.6", realDistTags)).toBe("0.93.7");
+  });
+
+  test("prefers identifier-named tag when present", () => {
+    expect(
+      pickDistTag("2.0.0-beta.30", {
+        latest: "0.93.7",
+        next: "2.0.0-rc.1",
+        beta: "2.0.0-beta.40",
+      }),
+    ).toBe("2.0.0-beta.40");
+  });
+
+  test("falls back to next when no identifier-named tag exists", () => {
+    expect(
+      pickDistTag("2.0.0-rc.1", { latest: "0.93.7", next: "2.0.0-rc.2" }),
+    ).toBe("2.0.0-rc.2");
+  });
+
+  test("falls back to latest when no prerelease channel exists", () => {
+    expect(pickDistTag("2.0.0-beta.30", { latest: "0.93.7" })).toBe("0.93.7");
+  });
+});

--- a/packages/alchemy/test/Cli/checkVersion.test.ts
+++ b/packages/alchemy/test/Cli/checkVersion.test.ts
@@ -2,37 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import { _internal } from "../../src/Cli/checkVersion";
 
-const { compareVersions, pickDistTag } = _internal;
-
-describe("compareVersions", () => {
-  test("equal versions", () => {
-    expect(compareVersions("1.2.3", "1.2.3")).toBe(0);
-  });
-
-  test("major/minor/patch ordering", () => {
-    expect(compareVersions("1.2.3", "1.2.4")).toBeLessThan(0);
-    expect(compareVersions("1.3.0", "1.2.9")).toBeGreaterThan(0);
-    expect(compareVersions("2.0.0", "1.99.99")).toBeGreaterThan(0);
-  });
-
-  test("prerelease is lower precedence than release with same core", () => {
-    expect(compareVersions("2.0.0-beta.33", "2.0.0")).toBeLessThan(0);
-    expect(compareVersions("2.0.0", "2.0.0-beta.33")).toBeGreaterThan(0);
-  });
-
-  test("ordering between same-channel betas is numeric", () => {
-    expect(compareVersions("2.0.0-beta.9", "2.0.0-beta.10")).toBeLessThan(0);
-    expect(compareVersions("2.0.0-beta.33", "2.0.0-beta.32")).toBeGreaterThan(
-      0,
-    );
-    expect(compareVersions("2.0.0-beta.33", "2.0.0-beta.33")).toBe(0);
-  });
-
-  test("released stable on different core dominates beta", () => {
-    expect(compareVersions("2.0.0-beta.33", "2.1.0")).toBeLessThan(0);
-    expect(compareVersions("2.1.0", "2.0.0-beta.33")).toBeGreaterThan(0);
-  });
-});
+const { pickDistTag } = _internal;
 
 describe("pickDistTag", () => {
   // Real shape returned by https://registry.npmjs.org/-/package/alchemy/dist-tags


### PR DESCRIPTION
Forks a best-effort npm version check on CLI startup. If a newer published `alchemy` is available on the matching dist-tag, logs a warning encouraging the user to upgrade. Never blocks the CLI — wrapped in `Effect.forkScoped` + 5s timeout + silent error swallow.

Picks the dist-tag based on the running version's prerelease label, falling back through `next` → `latest`. Without this, beta users would be compared against `dist-tags.latest` (currently `0.93.7`) and never see beta updates:

```ts
// 2.0.0-beta.30 -> picks dist-tags.next ("2.0.0-beta.33") -> warns
// 2.0.0-beta.33 -> picks dist-tags.next ("2.0.0-beta.33") -> no-op
// 0.93.6        -> picks dist-tags.latest ("0.93.7")      -> warns
```

```diff lang="typescript"
 const program = Effect.gen(function* () {
+  yield* checkLatestVersion.pipe(Effect.forkScoped);
   return yield* cli;
 });
```
