### PR TITLE
feat(cli): cloudflare/aws namespaces + cloudflare state logs

### DIFF
--- a/packages/alchemy/src/Cli/commands/aws.ts
+++ b/packages/alchemy/src/Cli/commands/aws.ts
@@ -18,17 +18,10 @@ import {
 import * as AWSCredentials from "../../AWS/Credentials";
 import * as AWSEnvironment from "../../AWS/Environment";
 import * as AWSRegion from "../../AWS/Region";
-import { AuthProviders } from "../../Auth/AuthProvider";
-import { withProfileOverride } from "../../Auth/Profile";
-import * as CloudflareAccess from "../../Cloudflare/Access.ts";
-import { CloudflareAuth } from "../../Cloudflare/Auth/AuthProvider";
-import * as CloudflareEnvironment from "../../Cloudflare/CloudflareEnvironment";
-import * as CloudflareCredentials from "../../Cloudflare/Credentials";
-import { bootstrap as bootstrapCloudflare } from "../../Cloudflare/StateStore/State";
 import { loadConfigProvider } from "../../Util/ConfigProvider";
 import { fileLogger } from "../../Util/FileLogger";
 
-import { envFile, instrumentCommand, profile } from "./_shared.ts";
+import { envFile, instrumentCommand } from "./_shared.ts";
 
 const awsProfile = Flag.string("profile").pipe(
   Flag.withDescription("AWS profile to use for credentials"),
@@ -49,8 +42,8 @@ const bootstrapDestroy = Flag.boolean("destroy").pipe(
   Flag.withDefault(false),
 );
 
-const bootstrapAwsCommand = Command.make(
-  "aws",
+const bootstrapCommand = Command.make(
+  "bootstrap",
   {
     envFile,
     profile: awsProfile,
@@ -58,7 +51,7 @@ const bootstrapAwsCommand = Command.make(
     destroy: bootstrapDestroy,
   },
   instrumentCommand(
-    "bootstrap.aws",
+    "aws.bootstrap",
     (a: { profile: string; region: string | undefined; destroy: boolean }) => ({
       "alchemy.profile": a.profile,
       "alchemy.region": a.region ?? "",
@@ -78,11 +71,6 @@ const bootstrapAwsCommand = Command.make(
           );
         }
 
-        // Build a single AWSEnvironment, then derive Region/Credentials from
-        // it so resource providers downstream see a consistent view. The
-        // credentials Effect captures FileSystem/Path/HttpClient via the
-        // ambient context; AWSEnvironment expects R=never, so we provide it
-        // here.
         const ambient = yield* Effect.context<FileSystem | Path | HttpClient>();
         const environment = AWSEnvironment.makeEnvironment({
           accountId: ssoProfile.sso_account_id,
@@ -134,83 +122,6 @@ const bootstrapAwsCommand = Command.make(
   ),
 );
 
-const cloudflareForce = Flag.boolean("force").pipe(
-  Flag.withDescription(
-    "Force a full redeploy even if the state-store worker already exists. " +
-      "Without this flag, an existing worker is adopted and only its credentials are refreshed.",
-  ),
-  Flag.withDefault(false),
-);
-
-const cloudflareWorkerName = Flag.string("worker-name").pipe(
-  Flag.withDescription(
-    "Override the default state-store worker name (advanced; only needed for multiple state stores per account).",
-  ),
-  Flag.optional,
-  Flag.map(Option.getOrUndefined),
-);
-
-const bootstrapCloudflareCommand = Command.make(
-  "cloudflare",
-  {
-    envFile,
-    profile,
-    force: cloudflareForce,
-    workerName: cloudflareWorkerName,
-  },
-  instrumentCommand(
-    "bootstrap.cloudflare",
-    (a: {
-      profile: string;
-      force: boolean;
-      workerName: string | undefined;
-    }) => ({
-      "alchemy.profile": a.profile,
-      "alchemy.force": a.force,
-      "alchemy.worker_name": a.workerName ?? "",
-    }),
-  )(
-    Effect.fnUntraced(function* ({ envFile, profile, force, workerName }) {
-      const logger = Logger.layer([fileLogger("bootstrap.txt")], {
-        mergeWithExisting: true,
-      });
-
-      // Wire up the same Cloudflare auth chain that
-      // `Cloudflare.state(...)` uses internally. CloudflareAuth is an
-      // `effectDiscard` layer that registers itself into the
-      // `AuthProviders` registry at build time, and downstream layers
-      // (`fromProfile`, `fromAuthProvider`) plus the deploy stack all
-      // look the registry back up through `getAuthProvider`. We need
-      // the registry to remain visible all the way through, so the
-      // composition uses `provideMerge` (provides + re-exports) rather
-      // than `provide` (provides + hides).
-      const authProviders: AuthProviders["Service"] = {};
-      const authRegistry = Layer.succeed(AuthProviders, authProviders);
-      const authLayer = Layer.provideMerge(CloudflareAuth, authRegistry);
-      const cloudflareLayers = Layer.provideMerge(
-        Layer.mergeAll(
-          CloudflareCredentials.fromAuthProvider(),
-          CloudflareEnvironment.fromProfile(),
-          CloudflareAccess.AccessLive,
-        ),
-        authLayer,
-      );
-
-      const services = Layer.mergeAll(
-        cloudflareLayers,
-        ConfigProvider.layer(
-          withProfileOverride(yield* loadConfigProvider(envFile), profile),
-        ),
-        logger,
-      );
-
-      yield* bootstrapCloudflare({ workerName, force }).pipe(
-        Effect.provide(services),
-      );
-    }),
-  ),
-);
-
-export const bootstrapCommand = Command.make("bootstrap", {}).pipe(
-  Command.withSubcommands([bootstrapAwsCommand, bootstrapCloudflareCommand]),
+export const awsCommand = Command.make("aws", {}).pipe(
+  Command.withSubcommands([bootstrapCommand]),
 );

--- a/packages/alchemy/src/Cli/commands/cloudflare.ts
+++ b/packages/alchemy/src/Cli/commands/cloudflare.ts
@@ -1,0 +1,218 @@
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
+import * as Option from "effect/Option";
+import * as Stream from "effect/Stream";
+import { Command, Flag } from "effect/unstable/cli";
+
+import { AuthProviders } from "../../Auth/AuthProvider";
+import { withProfileOverride } from "../../Auth/Profile";
+import * as CloudflareAccess from "../../Cloudflare/Access.ts";
+import { CloudflareAuth } from "../../Cloudflare/Auth/AuthProvider";
+import * as CloudflareEnvironment from "../../Cloudflare/CloudflareEnvironment";
+import * as CloudflareCredentials from "../../Cloudflare/Credentials";
+import { CloudflareLogs } from "../../Cloudflare/Logs.ts";
+import { STATE_STORE_SCRIPT_NAME } from "../../Cloudflare/StateStore/Api.ts";
+import { bootstrap as bootstrapCloudflare } from "../../Cloudflare/StateStore/State";
+import { loadConfigProvider } from "../../Util/ConfigProvider";
+import { fileLogger } from "../../Util/FileLogger";
+
+import {
+  envFile,
+  formatLocalTimestamp,
+  instrumentCommand,
+  parseSince,
+  profile,
+} from "./_shared.ts";
+
+/**
+ * Build the Cloudflare auth + environment layer stack used by every
+ * `alchemy cloudflare ...` subcommand. Mirrors the wiring inside
+ * `Cloudflare.state(...)` so the command can talk to the user's
+ * account out-of-band.
+ */
+const cloudflareLayers = (envFileOpt: Option.Option<string>, profileName: string) =>
+  Effect.gen(function* () {
+    const authProviders: AuthProviders["Service"] = {};
+    const authRegistry = Layer.succeed(AuthProviders, authProviders);
+    const authLayer = Layer.provideMerge(CloudflareAuth, authRegistry);
+    const cf = Layer.provideMerge(
+      Layer.mergeAll(
+        CloudflareCredentials.fromAuthProvider(),
+        CloudflareEnvironment.fromProfile(),
+        CloudflareAccess.AccessLive,
+      ),
+      authLayer,
+    );
+
+    const logger = Logger.layer([fileLogger("cloudflare.txt")], {
+      mergeWithExisting: true,
+    });
+
+    return Layer.mergeAll(
+      cf,
+      ConfigProvider.layer(
+        withProfileOverride(yield* loadConfigProvider(envFileOpt), profileName),
+      ),
+      logger,
+    );
+  });
+
+const cloudflareForce = Flag.boolean("force").pipe(
+  Flag.withDescription(
+    "Force a full redeploy even if the state-store worker already exists. " +
+      "Without this flag, an existing worker is adopted and only its credentials are refreshed.",
+  ),
+  Flag.withDefault(false),
+);
+
+const cloudflareWorkerName = Flag.string("worker-name").pipe(
+  Flag.withDescription(
+    "Override the default state-store worker name (advanced; only needed for multiple state stores per account).",
+  ),
+  Flag.optional,
+  Flag.map(Option.getOrUndefined),
+);
+
+const bootstrapCommand = Command.make(
+  "bootstrap",
+  {
+    envFile,
+    profile,
+    force: cloudflareForce,
+    workerName: cloudflareWorkerName,
+  },
+  instrumentCommand(
+    "cloudflare.bootstrap",
+    (a: {
+      profile: string;
+      force: boolean;
+      workerName: string | undefined;
+    }) => ({
+      "alchemy.profile": a.profile,
+      "alchemy.force": a.force,
+      "alchemy.worker_name": a.workerName ?? "",
+    }),
+  )(
+    Effect.fnUntraced(function* ({ envFile, profile, force, workerName }) {
+      const services = yield* cloudflareLayers(envFile, profile);
+      yield* bootstrapCloudflare({ workerName, force }).pipe(
+        Effect.provide(services),
+      );
+    }),
+  ),
+);
+
+const tailFlag = Flag.boolean("tail").pipe(
+  Flag.withDescription(
+    "Stream logs in real time via the Cloudflare tail websocket instead of fetching past entries.",
+  ),
+  Flag.withDefault(false),
+);
+
+const limitFlag = Flag.integer("limit").pipe(
+  Flag.withDescription("Number of log entries to fetch (ignored with --tail)"),
+  Flag.withDefault(100),
+);
+
+const sinceFlag = Flag.string("since").pipe(
+  Flag.withDescription(
+    "Fetch logs since this time (e.g. '1h', '30m', '2024-01-01T00:00:00Z')",
+  ),
+  Flag.optional,
+  Flag.map(Option.getOrUndefined),
+);
+
+/**
+ * `alchemy cloudflare state logs` — get or tail logs from the
+ * `alchemy-state-store` Worker on the user's account. Lets us debug
+ * the state-store worker without standing up a stack file.
+ */
+const stateLogsCommand = Command.make(
+  "logs",
+  {
+    envFile,
+    profile,
+    workerName: cloudflareWorkerName,
+    tail: tailFlag,
+    limit: limitFlag,
+    since: sinceFlag,
+  },
+  instrumentCommand(
+    "cloudflare.state.logs",
+    (a: {
+      profile: string;
+      workerName: string | undefined;
+      tail: boolean;
+      limit: number;
+    }) => ({
+      "alchemy.profile": a.profile,
+      "alchemy.worker_name": a.workerName ?? STATE_STORE_SCRIPT_NAME,
+      "alchemy.tail": a.tail,
+      "alchemy.limit": a.limit,
+    }),
+  )(
+    Effect.fnUntraced(function* ({
+      envFile,
+      profile,
+      workerName,
+      tail,
+      limit,
+      since,
+    }) {
+      const services = yield* cloudflareLayers(envFile, profile);
+      const scriptName = workerName ?? STATE_STORE_SCRIPT_NAME;
+
+      yield* Effect.gen(function* () {
+        const { accountId } = yield* CloudflareEnvironment.CloudflareEnvironment;
+        const telemetry = yield* CloudflareLogs;
+
+        const formatLine = (line: { timestamp: Date; message: string }) =>
+          `${formatLocalTimestamp(line.timestamp)} [${scriptName}] ${line.message}`;
+
+        if (tail) {
+          yield* Console.log(`Tailing ${scriptName}...`);
+          yield* telemetry
+            .tailScript({ accountId, scriptName })
+            .pipe(Stream.runForEach((line) => Console.log(formatLine(line))));
+          return;
+        }
+
+        const sinceDate = since ? parseSince(since) : undefined;
+        const lines = yield* telemetry.queryLogs({
+          accountId,
+          filters: [
+            {
+              key: "$workers.scriptName",
+              operation: "eq",
+              type: "string",
+              value: scriptName,
+            },
+          ],
+          options: { limit, since: sinceDate },
+        });
+
+        if (lines.length === 0) {
+          yield* Console.log(`(no log entries for ${scriptName})`);
+          return;
+        }
+
+        for (const line of lines.sort(
+          (a, b) => a.timestamp.getTime() - b.timestamp.getTime(),
+        )) {
+          yield* Console.log(formatLine(line));
+        }
+      }).pipe(Effect.provide(services));
+    }),
+  ),
+);
+
+const stateCommand = Command.make("state", {}).pipe(
+  Command.withSubcommands([stateLogsCommand]),
+);
+
+export const cloudflareCommand = Command.make("cloudflare", {}).pipe(
+  Command.withSubcommands([bootstrapCommand, stateCommand]),
+);

--- a/packages/alchemy/src/Cli/main.ts
+++ b/packages/alchemy/src/Cli/main.ts
@@ -11,7 +11,8 @@ import packageJson from "../../package.json" with { type: "json" };
 
 import { checkLatestVersion } from "./checkVersion.ts";
 import { handleCancellation } from "./commands/_shared.ts";
-import { bootstrapCommand } from "./commands/bootstrap.ts";
+import { awsCommand } from "./commands/aws.ts";
+import { cloudflareCommand } from "./commands/cloudflare.ts";
 import {
   deployCommand,
   destroyCommand,
@@ -27,7 +28,8 @@ import { inkCLI } from "./tui/InkCLI.tsx";
 
 const root = Command.make("alchemy", {}).pipe(
   Command.withSubcommands([
-    bootstrapCommand,
+    awsCommand,
+    cloudflareCommand,
     deployCommand,
     devCommand,
     destroyCommand,

--- a/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
@@ -680,6 +680,8 @@ export const DEFAULT_SCOPES = [
   "user:read",
   "vectorize:write",
   "workers_kv:write",
+  "workers_observability:read",
+  "workers_observability_telemetry:write",
   "workers_routes:write",
   "workers_scripts:write",
   "workers_tail:read",

--- a/packages/alchemy/src/Cloudflare/Logs.ts
+++ b/packages/alchemy/src/Cloudflare/Logs.ts
@@ -1,6 +1,10 @@
 import * as workers from "@distilled.cloud/cloudflare/workers";
+import type * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
+import * as Queue from "effect/Queue";
+import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
+import * as Socket from "effect/unstable/socket/Socket";
 import type { LogLine, LogsInput } from "../Provider.ts";
 
 const DEFAULT_LOOKBACK_MS = 1 * 60 * 60 * 1000;
@@ -21,6 +25,33 @@ export interface TelemetryFilter {
     | "not_in";
   type: "string" | "number" | "boolean";
   value?: string | number | boolean;
+}
+
+interface TailEventMessage {
+  eventTimestamp?: number;
+  wallTime: number;
+  cpuTime: number;
+  truncated: boolean;
+  outcome: string;
+  scriptName: string;
+  exceptions: {
+    name: string;
+    message: string;
+    stack: string;
+    timestamp: string;
+  }[];
+  logs: {
+    message: string[];
+    level: string;
+    timestamp: string;
+  }[];
+  event:
+    | {
+        request: { method: string; url: string };
+        response?: { status: number };
+      }
+    | null
+    | undefined;
 }
 
 const parseEvents = (
@@ -44,6 +75,8 @@ const parseEvents = (
 
 export const CloudflareLogs = Effect.gen(function* () {
   const queryTelemetry = yield* workers.queryObservabilityTelemetry;
+  const createScriptTail = yield* workers.createScriptTail;
+  const deleteScriptTail = yield* workers.deleteScriptTail;
 
   const queryLogs = (opts: {
     accountId: string;
@@ -83,6 +116,87 @@ export const CloudflareLogs = Effect.gen(function* () {
       return parseEvents(response);
     });
 
+  /**
+   * Open a real-time Workers tail session against `scriptName` and
+   * surface its messages as a {@link LogLine} stream. The websocket is
+   * automatically reconnected (with `Stream.repeat`) when Cloudflare
+   * closes it after its idle window.
+   */
+  const tailScript = (opts: { accountId: string; scriptName: string }) => {
+    const runTailSession = Effect.gen(function* () {
+      const { id: tailId, url } = yield* createScriptTail({
+        scriptName: opts.scriptName,
+        accountId: opts.accountId,
+        body: { filters: [] },
+      });
+
+      const socket = yield* Socket.makeWebSocket(url, {
+        protocols: ["trace-v1"],
+      });
+
+      const queue = yield* Queue.make<LogLine, Cause.Done>();
+
+      yield* socket
+        .runRaw((raw) => {
+          const text =
+            typeof raw === "string" ? raw : new TextDecoder().decode(raw);
+          const data: TailEventMessage = JSON.parse(text);
+          const eventTs = new Date(data.eventTimestamp ?? Date.now());
+
+          if (data.event && "request" in data.event) {
+            const reqEvent = data.event;
+            const pathname = (() => {
+              try {
+                return new URL(reqEvent.request.url).pathname;
+              } catch {
+                return reqEvent.request.url;
+              }
+            })();
+            const status = reqEvent.response?.status ?? 500;
+            Queue.offerUnsafe(queue, {
+              timestamp: eventTs,
+              message: `${reqEvent.request.method} ${pathname} > ${status} (cpu: ${Math.round(data.cpuTime)}ms, wall: ${Math.round(data.wallTime)}ms)`,
+            });
+          }
+
+          for (const log of data.logs) {
+            const msg = log.message.join(" ");
+            Queue.offerUnsafe(queue, {
+              timestamp: new Date(log.timestamp),
+              message: log.level === "log" ? msg : `${log.level}: ${msg}`,
+            });
+          }
+
+          for (const exception of data.exceptions) {
+            Queue.offerUnsafe(queue, {
+              timestamp: new Date(exception.timestamp),
+              message: `${exception.name} ${exception.message}\n${exception.stack}`,
+            });
+          }
+        })
+        .pipe(
+          Effect.ensuring(
+            Effect.all([
+              deleteScriptTail({
+                scriptName: opts.scriptName,
+                id: tailId,
+                accountId: opts.accountId,
+              }).pipe(Effect.ignore),
+              Queue.end(queue),
+            ]),
+          ),
+          Effect.ignore,
+          Effect.forkChild(),
+        );
+
+      return Stream.fromQueue(queue);
+    });
+
+    return Stream.unwrap(runTailSession).pipe(
+      Stream.repeat(Schedule.spaced("1 second")),
+    );
+  };
+
   const tailStream = (opts: {
     accountId: string;
     filters: TelemetryFilter[];
@@ -118,5 +232,5 @@ export const CloudflareLogs = Effect.gen(function* () {
     return poll(Date.now());
   };
 
-  return { queryLogs, tailStream };
+  return { queryLogs, tailScript, tailStream };
 });

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -3,7 +3,6 @@ import cloudflareRolldown from "@distilled.cloud/cloudflare-rolldown-plugin";
 import cloudflareVite from "@distilled.cloud/cloudflare-vite-plugin";
 import * as workers from "@distilled.cloud/cloudflare/workers";
 import * as zones from "@distilled.cloud/cloudflare/zones";
-import type * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
@@ -12,12 +11,9 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
-import * as Queue from "effect/Queue";
 import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
 import * as Scope from "effect/Scope";
-import * as Stream from "effect/Stream";
-import * as Socket from "effect/unstable/socket/Socket";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -44,7 +40,6 @@ import {
   type PlatformProps,
   type Rpc,
 } from "../../Platform.ts";
-import type { LogLine } from "../../Provider.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource, type ResourceBinding } from "../../Resource.ts";
 import * as Serverless from "../../Serverless/index.ts";
@@ -1067,9 +1062,7 @@ export const LiveWorkerProvider = () =>
       const stack = yield* Stack;
 
       const createScriptSubdomain = yield* workers.createScriptSubdomain;
-      const createScriptTail = yield* workers.createScriptTail;
       const deleteScript = yield* workers.deleteScript;
-      const deleteScriptTail = yield* workers.deleteScriptTail;
       const getScriptSubdomain = yield* workers.getScriptSubdomain;
       const getScriptSettings = yield* workers.getScriptScriptAndVersionSetting;
       const getSubdomain = yield* workers.getSubdomain;
@@ -2328,80 +2321,11 @@ export const LiveWorkerProvider = () =>
             scriptName: output.workerName,
           }).pipe(Effect.catchTag("WorkerNotFound", () => Effect.void));
         }),
-        tail: ({ output }) => {
-          const runTailSession = Effect.gen(function* () {
-            const { id: tailId, url } = yield* createScriptTail({
-              scriptName: output.workerName,
-              accountId: output.accountId,
-              body: { filters: [] },
-            });
-
-            const socket = yield* Socket.makeWebSocket(url, {
-              protocols: ["trace-v1"],
-            });
-
-            const queue = yield* Queue.make<LogLine, Cause.Done>();
-
-            yield* socket
-              .runRaw((raw) => {
-                const text =
-                  typeof raw === "string" ? raw : new TextDecoder().decode(raw);
-                const data: TailEventMessage = JSON.parse(text);
-                const eventTs = new Date(data.eventTimestamp ?? Date.now());
-
-                if (data.event && "request" in data.event) {
-                  const reqEvent = data.event;
-                  const pathname = (() => {
-                    try {
-                      return new URL(reqEvent.request.url).pathname;
-                    } catch {
-                      return reqEvent.request.url;
-                    }
-                  })();
-                  const status = reqEvent.response?.status ?? 500;
-                  Queue.offerUnsafe(queue, {
-                    timestamp: eventTs,
-                    message: `${reqEvent.request.method} ${pathname} > ${status} (cpu: ${Math.round(data.cpuTime)}ms, wall: ${Math.round(data.wallTime)}ms)`,
-                  });
-                }
-
-                for (const log of data.logs) {
-                  const msg = log.message.join(" ");
-                  Queue.offerUnsafe(queue, {
-                    timestamp: new Date(log.timestamp),
-                    message: log.level === "log" ? msg : `${log.level}: ${msg}`,
-                  });
-                }
-
-                for (const exception of data.exceptions) {
-                  Queue.offerUnsafe(queue, {
-                    timestamp: new Date(exception.timestamp),
-                    message: `${exception.name} ${exception.message}\n${exception.stack}`,
-                  });
-                }
-              })
-              .pipe(
-                Effect.ensuring(
-                  Effect.all([
-                    deleteScriptTail({
-                      scriptName: output.workerName,
-                      id: tailId,
-                      accountId: output.accountId,
-                    }).pipe(Effect.ignore),
-                    Queue.end(queue),
-                  ]),
-                ),
-                Effect.ignore,
-                Effect.forkChild(),
-              );
-
-            return Stream.fromQueue(queue);
-          });
-
-          return Stream.unwrap(runTailSession).pipe(
-            Stream.repeat(Schedule.spaced("1 second")),
-          );
-        },
+        tail: ({ output }) =>
+          telemetry.tailScript({
+            accountId: output.accountId,
+            scriptName: output.workerName,
+          }),
         logs: ({ output, options }) =>
           telemetry.queryLogs({
             accountId: output.accountId,
@@ -2418,33 +2342,6 @@ export const LiveWorkerProvider = () =>
       });
     }),
   );
-
-interface TailEventMessage {
-  eventTimestamp?: number;
-  wallTime: number;
-  cpuTime: number;
-  truncated: boolean;
-  outcome: string;
-  scriptName: string;
-  exceptions: {
-    name: string;
-    message: string;
-    stack: string;
-    timestamp: string;
-  }[];
-  logs: {
-    message: string[];
-    level: string;
-    timestamp: string;
-  }[];
-  event:
-    | {
-        request: { method: string; url: string };
-        response?: { status: number };
-      }
-    | null
-    | undefined;
-}
 
 const contentTypeFromExtension = (extension: string) => {
   switch (extension) {


### PR DESCRIPTION
Reorganize CLI under per-cloud namespaces and add a state-store debug command.

### Command moves

- `alchemy bootstrap aws` → `alchemy aws bootstrap`
- `alchemy bootstrap cloudflare` → `alchemy cloudflare bootstrap`

### New: `alchemy cloudflare state logs`

Get or tail logs from the `alchemy-state-store` Worker on the user's account, without needing a stack file.

```sh
alchemy cloudflare state logs                  # last hour, up to 100 entries
alchemy cloudflare state logs --since 30m
alchemy cloudflare state logs --tail           # real-time websocket tail
alchemy cloudflare state logs --worker-name my-store --tail
```

Wires the same `CloudflareAuth` + `Credentials` + `Environment` + `Access` layers `bootstrap` uses, so it talks directly to the user's account.

### Refactor

The WebSocket tail loop previously inlined in `Worker.ts`'s `tail:` provider is now `CloudflareLogs.tailScript({ accountId, scriptName })`. Worker delegates to it; the new `cloudflare state logs --tail` reuses it.

```ts
// Cloudflare/Logs.ts
const { queryLogs, tailScript, tailStream } = yield* CloudflareLogs;
tailScript({ accountId, scriptName }); // Stream<LogLine>
```
