### PR TITLE
fix(Cloudflare/QueueConsumer): paginate listConsumers, surface conflicts clearly

### DIFF
--- a/packages/alchemy/src/Cloudflare/Queue/QueueConsumer.ts
+++ b/packages/alchemy/src/Cloudflare/Queue/QueueConsumer.ts
@@ -1,12 +1,38 @@
 import * as queues from "@distilled.cloud/cloudflare/queues";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
+import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import { isResolved } from "../../Diff.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { Providers } from "../Providers.ts";
+
+/**
+ * Cloudflare returns this code when the target worker exists but its
+ * deployed script doesn't export a `queue` handler. The reconciler
+ * almost always hits this transiently when a sibling Worker
+ * resource's pre-create stub is live (no queue handler) and the real
+ * reconcile hasn't replaced it yet — so we retry with backoff. If
+ * the user genuinely forgot to export a queue handler we eventually
+ * surface the failure after `recurs` is exhausted.
+ */
+const QUEUE_HANDLER_MISSING_CODE = 11001;
+
+const isQueueHandlerMissing = (e: unknown): boolean =>
+  typeof e === "object" &&
+  e !== null &&
+  "_tag" in e &&
+  (e as { _tag: unknown })._tag === "UnknownCloudflareError" &&
+  "code" in e &&
+  (e as { code?: unknown }).code === QUEUE_HANDLER_MISSING_CODE;
+
+// ~60s budget — Worker reconcile uploads typically land in 2–10s,
+// but a fresh container/asset deploy can stretch that.
+const queueHandlerReadinessSchedule = Schedule.spaced("2 seconds").pipe(
+  Schedule.both(Schedule.recurs(30)),
+);
 
 export type QueueConsumerProps = {
   /**
@@ -150,18 +176,29 @@ export const QueueConsumerProvider = () =>
           if ((output?.accountId ?? accountId) !== accountId) {
             return { action: "replace" } as const;
           }
-          // Queue change requires replacement
+          // Queue change requires replacement — consumerId is bound
+          // to a queue and the API has no "move consumer" verb.
           if (output?.queueId && news.queueId !== output.queueId) {
-            return { action: "replace" } as const;
+            return { action: "replace", deleteFirst: true } as const;
           }
-          // Script change requires replacement
-          if (output?.scriptName && news.scriptName !== output.scriptName) {
-            return { action: "replace" } as const;
-          }
-          // Settings change is an update
+          // Settings / DLQ / script drift is an update. We DON'T
+          // escalate scriptName changes to `replace` because the
+          // engine resolves cross-resource Output<string> refs (a
+          // sibling Worker's `workerName`) lazily — when the upstream
+          // Worker is created in the same plan, `news` is partially
+          // unresolved at diff time and `isResolved(news)` short-
+          // circuits up top. Falling through to "update" lets the
+          // engine call reconcile with fully-resolved `news`, where
+          // we detect script drift and rebuild the consumer in
+          // place (Cloudflare's PUT silently ignores `script_name`
+          // changes, so reconcile does delete-then-create).
           if (
             JSON.stringify(olds.settings ?? {}) !==
-            JSON.stringify(news.settings ?? {})
+              JSON.stringify(news.settings ?? {}) ||
+            (olds.deadLetterQueue ?? undefined) !==
+              (news.deadLetterQueue ?? undefined) ||
+            (output?.scriptName !== undefined &&
+              news.scriptName !== output.scriptName)
           ) {
             return { action: "update" } as const;
           }
@@ -173,10 +210,14 @@ export const QueueConsumerProvider = () =>
 
           // Observe — prefer the cached consumerId, then fall back to
           // listConsumers (paginated) to recover from out-of-band
-          // deletes or partial state-persistence failures. The list
-          // scan also surfaces a different-script worker consumer so
-          // we can fail with a useful error before a duplicate create.
+          // deletes or partial state-persistence failures. Track
+          // whether the observation came from the cached id or the
+          // list scan: a different-script worker consumer found via
+          // the list scan is potentially foreign (state was lost,
+          // someone else attached the consumer), and silently
+          // updating it could clobber another team's wiring.
           let observed: ObservedConsumer | undefined;
+          let owned = false;
           if (output?.consumerId) {
             const fetched = yield* getConsumer({
               accountId: acct,
@@ -187,28 +228,73 @@ export const QueueConsumerProvider = () =>
                 Effect.succeed(undefined),
               ),
             );
-            observed = fetched ? toObserved(fetched) : undefined;
+            if (fetched) {
+              observed = toObserved(fetched);
+              owned = observed !== undefined;
+            }
           }
           if (!observed) {
             observed = yield* findWorkerConsumer(acct, queueId);
           }
 
-          // If a worker consumer exists but for a different script,
-          // surface that explicitly. Silent adoption would mean we'd
-          // start managing a consumer the operator created for a
-          // different worker — almost never what they want.
+          // Owned consumer pointing at a different script: rebuild
+          // it in place. Cloudflare's PUT consumer silently ignores
+          // `script_name` changes on existing consumers (the live
+          // record stays pinned to the original worker), and the
+          // platform allows only one Worker consumer per queue, so
+          // the only path to re-point is delete-then-create.
+          if (
+            owned &&
+            observed &&
+            observed.script !== undefined &&
+            observed.script !== news.scriptName
+          ) {
+            yield* deleteConsumer({
+              accountId: acct,
+              queueId,
+              consumerId: observed.consumerId,
+            }).pipe(Effect.catchTag("ConsumerNotFound", () => Effect.void));
+            // Wait for Cloudflare's worker subsystem to drop its
+            // claim on the old script so createConsumer below
+            // doesn't race the queue↔script propagation lag.
+            yield* getConsumer({
+              accountId: acct,
+              queueId,
+              consumerId: observed.consumerId,
+            }).pipe(
+              Effect.flatMap(() => Effect.fail("still-attached" as const)),
+              Effect.catchTag("ConsumerNotFound", () => Effect.void),
+              Effect.retry({
+                while: (e) => e === "still-attached",
+                schedule: Schedule.spaced("1 second").pipe(
+                  Schedule.both(Schedule.recurs(30)),
+                ),
+              }),
+              Effect.ignore,
+            );
+            observed = undefined;
+            owned = false;
+          }
+
+          // Refuse to take over a foreign consumer on the state-loss
+          // path. With `owned=false` we found this via the list scan
+          // and the script mismatch means it belongs to another
+          // resource or was created out-of-band — silent adoption
+          // would clobber that.
           if (
             observed &&
+            !owned &&
             observed.script !== undefined &&
             observed.script !== news.scriptName
           ) {
             return yield* Effect.die(
               `Cloudflare queue "${queueId}" already has a worker ` +
                 `consumer for script "${observed.script}", but this ` +
-                `resource is configured for "${news.scriptName}". Each ` +
-                `queue can have only one worker consumer — delete the ` +
-                `existing one or update scriptName to match before ` +
-                `redeploying.`,
+                `resource is configured for "${news.scriptName}" and ` +
+                `local state for the consumer was missing. Each queue ` +
+                `can have only one worker consumer — delete the ` +
+                `existing one, update scriptName to match, or restore ` +
+                `the consumer's state entry before redeploying.`,
             );
           }
 
@@ -227,6 +313,24 @@ export const QueueConsumerProvider = () =>
               deadLetterQueue: news.deadLetterQueue,
               settings: news.settings,
             }).pipe(
+              // The sibling Worker resource pre-creates a placeholder
+              // script with no `queue` handler; Cloudflare returns
+              // code 11001 until the real reconcile uploads the
+              // handler. Retry until the upload propagates (capped),
+              // then surface a real failure if it never does.
+              Effect.tapError((e) =>
+                isQueueHandlerMissing(e)
+                  ? Effect.logDebug(
+                      `QueueConsumer create: worker ` +
+                        `"${news.scriptName}" has no queue handler ` +
+                        `yet (code 11001), retrying`,
+                    )
+                  : Effect.void,
+              ),
+              Effect.retry({
+                while: isQueueHandlerMissing,
+                schedule: queueHandlerReadinessSchedule,
+              }),
               Effect.catchTag("ConsumerAlreadyExists", (cause) =>
                 Effect.gen(function* () {
                   const match = yield* findWorkerConsumer(acct, queueId);
@@ -264,6 +368,9 @@ export const QueueConsumerProvider = () =>
           // Sync — Cloudflare replaces all mutable fields on
           // updateConsumer, so always issue this so adoption converges
           // and settings drift gets corrected on every reconcile.
+          // updateConsumer hits the same "queue handler missing" race
+          // window as create when the worker is mid-upload, so apply
+          // the same bounded retry.
           yield* updateConsumer({
             accountId: acct,
             queueId,
@@ -272,7 +379,12 @@ export const QueueConsumerProvider = () =>
             type: "worker",
             settings: news.settings,
             deadLetterQueue: news.deadLetterQueue,
-          });
+          }).pipe(
+            Effect.retry({
+              while: isQueueHandlerMissing,
+              schedule: queueHandlerReadinessSchedule,
+            }),
+          );
 
           return {
             consumerId,
@@ -287,6 +399,27 @@ export const QueueConsumerProvider = () =>
             queueId: output.queueId,
             consumerId: output.consumerId,
           }).pipe(Effect.catchTag("ConsumerNotFound", () => Effect.void));
+
+          // Block until Cloudflare's worker subsystem stops claiming
+          // the script as a queue consumer. Without this the
+          // sibling Worker.delete races on `QueueConsumerConflict`
+          // (code 10064) — `deleteConsumer` returns success on the
+          // queue subsystem before the script-side view propagates.
+          yield* getConsumer({
+            accountId: output.accountId,
+            queueId: output.queueId,
+            consumerId: output.consumerId,
+          }).pipe(
+            Effect.flatMap(() => Effect.fail("still-attached" as const)),
+            Effect.catchTag("ConsumerNotFound", () => Effect.void),
+            Effect.retry({
+              while: (e) => e === "still-attached",
+              schedule: Schedule.spaced("1 second").pipe(
+                Schedule.both(Schedule.recurs(30)),
+              ),
+            }),
+            Effect.ignore,
+          );
         }),
         read: Effect.fn(function* ({ output }) {
           if (output?.consumerId) {

--- a/packages/alchemy/src/Cloudflare/Queue/QueueConsumer.ts
+++ b/packages/alchemy/src/Cloudflare/Queue/QueueConsumer.ts
@@ -1,5 +1,7 @@
 import * as queues from "@distilled.cloud/cloudflare/queues";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Stream from "effect/Stream";
 import { isResolved } from "../../Diff.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
@@ -68,6 +70,11 @@ export type QueueConsumer = Resource<
  * Register a Worker as a consumer of a Queue. The Worker's `queue()`
  * handler will be invoked with batches of messages.
  *
+ * Cloudflare allows at most one Worker consumer per queue (HTTP-pull
+ * consumers can coexist). The reconciler enforces this: if the queue
+ * already has a Worker consumer pointing at a different script, the
+ * deploy fails with a clear error rather than silently adopting it.
+ *
  * @section Registering a Consumer
  * @example Basic consumer
  * ```typescript
@@ -97,6 +104,20 @@ export const QueueConsumer = Resource<QueueConsumer>(
   "Cloudflare.QueueConsumer",
 );
 
+type ObservedConsumer = {
+  consumerId: string;
+  script: string | undefined;
+};
+
+const toObserved = (c: {
+  consumerId?: string | null;
+  script?: string | null;
+  type?: "worker" | "http_pull" | null;
+}): ObservedConsumer | undefined =>
+  c.consumerId && c.type === "worker"
+    ? { consumerId: c.consumerId, script: c.script ?? undefined }
+    : undefined;
+
 export const QueueConsumerProvider = () =>
   Provider.effect(
     QueueConsumer,
@@ -106,7 +127,21 @@ export const QueueConsumerProvider = () =>
       const getConsumer = yield* queues.getConsumer;
       const updateConsumer = yield* queues.updateConsumer;
       const deleteConsumer = yield* queues.deleteConsumer;
-      const listConsumers = yield* queues.listConsumers;
+
+      // Cloudflare allows a single Worker consumer per queue, so the
+      // first match in the paginated stream is the only one. Using
+      // `.items` defeats single-page lookups that would otherwise
+      // miss late-arriving consumers under eventual consistency.
+      const findWorkerConsumer = (
+        acct: string,
+        queueId: string,
+      ): Effect.Effect<ObservedConsumer | undefined, any, any> =>
+        queues.listConsumers.items({ accountId: acct, queueId }).pipe(
+          Stream.map(toObserved),
+          Stream.filter((c): c is ObservedConsumer => c !== undefined),
+          Stream.runHead,
+          Effect.map(Option.getOrUndefined),
+        );
 
       return {
         stables: ["consumerId", "accountId"],
@@ -136,33 +171,52 @@ export const QueueConsumerProvider = () =>
           const queueId =
             output?.queueId ?? (news.queueId as unknown as string);
 
-          // Observe — re-fetch the cached consumer; fall back to a list
-          // scan filtered by script so we recover from out-of-band
-          // deletes or partial state-persistence failures (the create
-          // call may have written the consumer but lost the response).
-          let observed:
-            | { consumerId?: string | null; script?: string | null }
-            | undefined;
+          // Observe — prefer the cached consumerId, then fall back to
+          // listConsumers (paginated) to recover from out-of-band
+          // deletes or partial state-persistence failures. The list
+          // scan also surfaces a different-script worker consumer so
+          // we can fail with a useful error before a duplicate create.
+          let observed: ObservedConsumer | undefined;
           if (output?.consumerId) {
-            observed = yield* getConsumer({
-              accountId: acct,
-              queueId: output.queueId,
-              consumerId: output.consumerId,
-            }).pipe(Effect.catch(() => Effect.succeed(undefined)));
-          }
-          if (!observed) {
-            const existing = yield* listConsumers({
+            const fetched = yield* getConsumer({
               accountId: acct,
               queueId,
-            });
-            observed = existing.result.find(
-              (c) => "script" in c && c.script === news.scriptName,
+              consumerId: output.consumerId,
+            }).pipe(
+              Effect.catchTag("ConsumerNotFound", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+            observed = fetched ? toObserved(fetched) : undefined;
+          }
+          if (!observed) {
+            observed = yield* findWorkerConsumer(acct, queueId);
+          }
+
+          // If a worker consumer exists but for a different script,
+          // surface that explicitly. Silent adoption would mean we'd
+          // start managing a consumer the operator created for a
+          // different worker — almost never what they want.
+          if (
+            observed &&
+            observed.script !== undefined &&
+            observed.script !== news.scriptName
+          ) {
+            return yield* Effect.die(
+              `Cloudflare queue "${queueId}" already has a worker ` +
+                `consumer for script "${observed.script}", but this ` +
+                `resource is configured for "${news.scriptName}". Each ` +
+                `queue can have only one worker consumer — delete the ` +
+                `existing one or update scriptName to match before ` +
+                `redeploying.`,
             );
           }
 
-          // Ensure — create if missing. The Cloudflare API rejects a
-          // duplicate consumer (same queue + script), so we tolerate
-          // that race by adopting the existing one via list.
+          // Ensure — create if missing. ConsumerAlreadyExists is the
+          // race signal: another reconcile or peer beat us to it.
+          // Re-run the lookup; the paginated stream tolerates the
+          // single-page eventual-consistency window the previous
+          // implementation missed.
           let consumerId: string;
           if (!observed) {
             const created = yield* createConsumer({
@@ -173,40 +227,52 @@ export const QueueConsumerProvider = () =>
               deadLetterQueue: news.deadLetterQueue,
               settings: news.settings,
             }).pipe(
-              Effect.catch(() =>
+              Effect.catchTag("ConsumerAlreadyExists", (cause) =>
                 Effect.gen(function* () {
-                  const existing = yield* listConsumers({
-                    accountId: acct,
-                    queueId,
-                  });
-                  const match = existing.result.find(
-                    (c) => "script" in c && c.script === news.scriptName,
-                  );
-                  if (match && match.consumerId) {
-                    return match;
+                  const match = yield* findWorkerConsumer(acct, queueId);
+                  if (!match) {
+                    return yield* Effect.die(
+                      `Cloudflare reported a worker consumer already ` +
+                        `exists on queue "${queueId}", but listConsumers ` +
+                        `returned none. Retry the deploy; if this ` +
+                        `persists, the queue is in an inconsistent ` +
+                        `state. Underlying error: ${cause.message}`,
+                    );
                   }
-                  return yield* Effect.die(
-                    `Consumer for script "${news.scriptName}" on queue "${queueId}" already exists but could not be found`,
-                  );
+                  if (
+                    match.script !== undefined &&
+                    match.script !== news.scriptName
+                  ) {
+                    return yield* Effect.die(
+                      `Cloudflare queue "${queueId}" already has a ` +
+                        `worker consumer for script "${match.script}", ` +
+                        `but this resource is configured for ` +
+                        `"${news.scriptName}". Each queue can have only ` +
+                        `one worker consumer — delete the existing one ` +
+                        `or update scriptName to match before redeploying.`,
+                    );
+                  }
+                  return match;
                 }),
               ),
             );
             consumerId = created.consumerId!;
           } else {
-            consumerId = observed.consumerId!;
-            // Sync — update settings and dead-letter target on the
-            // existing consumer. The Cloudflare API replaces all mutable
-            // fields per call, so always issue this so adoption converges.
-            yield* updateConsumer({
-              accountId: acct,
-              queueId,
-              consumerId,
-              scriptName: news.scriptName,
-              type: "worker",
-              settings: news.settings,
-              deadLetterQueue: news.deadLetterQueue,
-            });
+            consumerId = observed.consumerId;
           }
+
+          // Sync — Cloudflare replaces all mutable fields on
+          // updateConsumer, so always issue this so adoption converges
+          // and settings drift gets corrected on every reconcile.
+          yield* updateConsumer({
+            accountId: acct,
+            queueId,
+            consumerId,
+            scriptName: news.scriptName,
+            type: "worker",
+            settings: news.settings,
+            deadLetterQueue: news.deadLetterQueue,
+          });
 
           return {
             consumerId,
@@ -220,26 +286,48 @@ export const QueueConsumerProvider = () =>
             accountId: output.accountId,
             queueId: output.queueId,
             consumerId: output.consumerId,
-          }).pipe(Effect.catch(() => Effect.void));
+          }).pipe(Effect.catchTag("ConsumerNotFound", () => Effect.void));
         }),
         read: Effect.fn(function* ({ output }) {
           if (output?.consumerId) {
-            return yield* getConsumer({
+            const fetched = yield* getConsumer({
               accountId: output.accountId,
               queueId: output.queueId,
               consumerId: output.consumerId,
             }).pipe(
-              Effect.map((consumer) => ({
-                consumerId: consumer.consumerId!,
+              Effect.catchTag("ConsumerNotFound", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+            if (fetched) {
+              return {
+                consumerId: fetched.consumerId!,
                 queueId: output.queueId,
                 scriptName:
-                  ("script" in consumer
-                    ? (consumer.script as string)
+                  ("script" in fetched && typeof fetched.script === "string"
+                    ? fetched.script
                     : output.scriptName) ?? output.scriptName,
                 accountId: output.accountId,
-              })),
-              Effect.catch(() => Effect.succeed(undefined)),
+              };
+            }
+          }
+          // Fallback: a state loss can leave us without a consumerId
+          // even though the consumer is still alive on Cloudflare. The
+          // queue allows only one worker consumer, so finding it via
+          // listConsumers is unambiguous.
+          if (output?.queueId && output?.accountId) {
+            const match = yield* findWorkerConsumer(
+              output.accountId,
+              output.queueId,
             );
+            if (match) {
+              return {
+                consumerId: match.consumerId,
+                queueId: output.queueId,
+                scriptName: match.script ?? output.scriptName,
+                accountId: output.accountId,
+              };
+            }
           }
           return undefined;
         }),

--- a/packages/alchemy/test/Cloudflare/Queue/QueueConsumer.test.ts
+++ b/packages/alchemy/test/Cloudflare/Queue/QueueConsumer.test.ts
@@ -1,0 +1,359 @@
+import * as Cloudflare from "@/Cloudflare";
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import { State } from "@/State";
+import * as Test from "@/Test/Vitest";
+import * as queues from "@distilled.cloud/cloudflare/queues";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import { MinimumLogLevel } from "effect/References";
+import * as pathe from "pathe";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const main = pathe.resolve(import.meta.dirname, "consumer-worker.ts");
+
+/**
+ * Lifecycle: create the consumer, change settings (in-place update),
+ * change script (replace), then destroy.
+ *
+ * Verifies the diff matrix end-to-end and that updateConsumer is
+ * issued every reconcile (so settings drift gets corrected even when
+ * `olds.settings` matches `news.settings`).
+ */
+test.provider("create, update settings, replace script, delete", (stack) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* CloudflareEnvironment;
+
+    yield* stack.destroy();
+
+    const initial = yield* stack.deploy(
+      Effect.gen(function* () {
+        const queue = yield* Cloudflare.Queue("Q");
+        const workerA = yield* Cloudflare.Worker("WorkerA", {
+          main,
+          compatibility: { date: "2024-01-01" },
+        });
+        const consumer = yield* Cloudflare.QueueConsumer("Consumer", {
+          queueId: queue.queueId,
+          scriptName: workerA.workerName,
+          settings: { batchSize: 5, maxRetries: 3 },
+        });
+        return { queue, workerA, consumer };
+      }),
+    );
+
+    expect(initial.consumer.consumerId).toBeTypeOf("string");
+    expect(initial.consumer.scriptName).toEqual(initial.workerA.workerName);
+
+    const live = yield* queues.getConsumer({
+      accountId,
+      queueId: initial.queue.queueId,
+      consumerId: initial.consumer.consumerId,
+    });
+    expect("script" in live ? live.script : undefined).toEqual(
+      initial.workerA.workerName,
+    );
+
+    // Settings-only change is an update, not a replace — consumerId
+    // must remain stable.
+    const updated = yield* stack.deploy(
+      Effect.gen(function* () {
+        const queue = yield* Cloudflare.Queue("Q");
+        const workerA = yield* Cloudflare.Worker("WorkerA", {
+          main,
+          compatibility: { date: "2024-01-01" },
+        });
+        const consumer = yield* Cloudflare.QueueConsumer("Consumer", {
+          queueId: queue.queueId,
+          scriptName: workerA.workerName,
+          settings: { batchSize: 25, maxRetries: 7 },
+        });
+        return { queue, workerA, consumer };
+      }),
+    );
+
+    expect(updated.consumer.consumerId).toEqual(initial.consumer.consumerId);
+
+    const liveUpdated = yield* queues.getConsumer({
+      accountId,
+      queueId: updated.queue.queueId,
+      consumerId: updated.consumer.consumerId,
+    });
+    expect(liveUpdated.settings?.batchSize).toEqual(25);
+    expect(liveUpdated.settings?.maxRetries).toEqual(7);
+
+    // Script change is a replace — consumerId must change. Cloudflare
+    // allows only one worker consumer per queue, so the engine deletes
+    // the old before creating the new (or vice versa, both are fine
+    // because reconcile observes the live state on each attempt).
+    const replaced = yield* stack.deploy(
+      Effect.gen(function* () {
+        const queue = yield* Cloudflare.Queue("Q");
+        const workerB = yield* Cloudflare.Worker("WorkerB", {
+          main,
+          compatibility: { date: "2024-01-01" },
+        });
+        const consumer = yield* Cloudflare.QueueConsumer("Consumer", {
+          queueId: queue.queueId,
+          scriptName: workerB.workerName,
+          settings: { batchSize: 25, maxRetries: 7 },
+        });
+        return { queue, workerB, consumer };
+      }),
+    );
+
+    expect(replaced.consumer.consumerId).not.toEqual(
+      initial.consumer.consumerId,
+    );
+    expect(replaced.consumer.scriptName).toEqual(replaced.workerB.workerName);
+
+    yield* stack.destroy();
+
+    // Post-destroy: the consumer must be gone on Cloudflare too.
+    const exit = yield* Effect.exit(
+      queues.getConsumer({
+        accountId,
+        queueId: replaced.queue.queueId,
+        consumerId: replaced.consumer.consumerId,
+      }),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+  }).pipe(logLevel),
+);
+
+/**
+ * Recovery from out-of-band consumer deletion. The user deletes the
+ * consumer via the Cloudflare API directly, then redeploys. The
+ * reconciler must observe that the consumer is missing and recreate
+ * it instead of failing on a stale `output.consumerId`.
+ */
+test.provider("recreates consumer after out-of-band delete", (stack) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* CloudflareEnvironment;
+
+    yield* stack.destroy();
+
+    const initial = yield* stack.deploy(
+      Effect.gen(function* () {
+        const queue = yield* Cloudflare.Queue("Q");
+        const worker = yield* Cloudflare.Worker("Worker", {
+          main,
+          compatibility: { date: "2024-01-01" },
+        });
+        const consumer = yield* Cloudflare.QueueConsumer("Consumer", {
+          queueId: queue.queueId,
+          scriptName: worker.workerName,
+        });
+        return { queue, worker, consumer };
+      }),
+    );
+
+    // Out-of-band delete via the SDK directly.
+    yield* queues.deleteConsumer({
+      accountId,
+      queueId: initial.queue.queueId,
+      consumerId: initial.consumer.consumerId,
+    });
+
+    const recovered = yield* stack.deploy(
+      Effect.gen(function* () {
+        const queue = yield* Cloudflare.Queue("Q");
+        const worker = yield* Cloudflare.Worker("Worker", {
+          main,
+          compatibility: { date: "2024-01-01" },
+        });
+        const consumer = yield* Cloudflare.QueueConsumer("Consumer", {
+          queueId: queue.queueId,
+          scriptName: worker.workerName,
+        });
+        return { queue, worker, consumer };
+      }),
+    );
+
+    expect(recovered.consumer.consumerId).toBeTypeOf("string");
+    // The new consumer must be reachable on Cloudflare — the previous
+    // implementation died with "already exists but could not be found"
+    // because listConsumers was single-page and ConsumerAlreadyExists
+    // was caught by a generic `Effect.catch`.
+    const live = yield* queues.getConsumer({
+      accountId,
+      queueId: recovered.queue.queueId,
+      consumerId: recovered.consumer.consumerId,
+    });
+    expect("script" in live ? live.script : undefined).toEqual(
+      recovered.worker.workerName,
+    );
+
+    yield* stack.destroy();
+  }).pipe(logLevel),
+);
+
+/**
+ * State-loss adoption. Wipe the local state for the QueueConsumer,
+ * leaving the Cloudflare consumer in place. On redeploy the engine
+ * calls `provider.read`, which now falls back to listConsumers when
+ * `output.consumerId` is missing — so the consumer is adopted instead
+ * of producing a duplicate-create attempt.
+ */
+test.provider("adopts existing consumer after local state loss", (stack) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* CloudflareEnvironment;
+
+    yield* stack.destroy();
+
+    const initial = yield* stack.deploy(
+      Effect.gen(function* () {
+        const queue = yield* Cloudflare.Queue("Q");
+        const worker = yield* Cloudflare.Worker("Worker", {
+          main,
+          compatibility: { date: "2024-01-01" },
+        });
+        const consumer = yield* Cloudflare.QueueConsumer("Consumer", {
+          queueId: queue.queueId,
+          scriptName: worker.workerName,
+        });
+        return { queue, worker, consumer };
+      }),
+    );
+
+    // Wipe just the QueueConsumer entry — Queue and Worker stay so the
+    // redeploy reuses the same queueId / scriptName.
+    yield* Effect.gen(function* () {
+      const state = yield* State;
+      yield* state.delete({
+        stack: stack.name,
+        stage: "test",
+        fqn: "Consumer",
+      });
+    }).pipe(Effect.provide(stack.state));
+
+    const adopted = yield* stack.deploy(
+      Effect.gen(function* () {
+        const queue = yield* Cloudflare.Queue("Q");
+        const worker = yield* Cloudflare.Worker("Worker", {
+          main,
+          compatibility: { date: "2024-01-01" },
+        });
+        const consumer = yield* Cloudflare.QueueConsumer("Consumer", {
+          queueId: queue.queueId,
+          scriptName: worker.workerName,
+        });
+        return { queue, worker, consumer };
+      }),
+    );
+
+    // Adoption: the consumerId from Cloudflare equals the one we
+    // created originally — we did not duplicate-create.
+    expect(adopted.consumer.consumerId).toEqual(initial.consumer.consumerId);
+
+    const live = yield* queues.getConsumer({
+      accountId,
+      queueId: adopted.queue.queueId,
+      consumerId: adopted.consumer.consumerId,
+    });
+    expect("script" in live ? live.script : undefined).toEqual(
+      adopted.worker.workerName,
+    );
+
+    yield* stack.destroy();
+  }).pipe(logLevel),
+);
+
+/**
+ * Conflict: queue already has a worker consumer pointing at a
+ * *different* script. This is the regression for the user-reported
+ * "already exists but could not be found" error — the previous
+ * implementation filtered listConsumers by `news.scriptName`, so a
+ * collision with a different script left the find empty and the
+ * reconciler died with a misleading message.
+ *
+ * The new behaviour: detect the foreign worker consumer and fail with
+ * a clear, actionable error naming both the existing script and the
+ * desired one.
+ */
+test.provider("fails clearly when queue has consumer for different script", (
+  stack,
+) =>
+  Effect.gen(function* () {
+    yield* stack.destroy();
+
+    // Phase 1: deploy worker A as the queue's consumer, then wipe just
+    // the QueueConsumer state so the next deploy thinks it's a
+    // greenfield create.
+    const initial = yield* stack.deploy(
+      Effect.gen(function* () {
+        const queue = yield* Cloudflare.Queue("Q");
+        const workerA = yield* Cloudflare.Worker("WorkerA", {
+          main,
+          compatibility: { date: "2024-01-01" },
+        });
+        const consumer = yield* Cloudflare.QueueConsumer("Consumer", {
+          queueId: queue.queueId,
+          scriptName: workerA.workerName,
+        });
+        return { queue, workerA, consumer };
+      }),
+    );
+
+    yield* Effect.gen(function* () {
+      const state = yield* State;
+      yield* state.delete({
+        stack: stack.name,
+        stage: "test",
+        fqn: "Consumer",
+      });
+    }).pipe(Effect.provide(stack.state));
+
+    // Phase 2: redeploy with a different scriptName under the same
+    // logical id. Cloudflare's queue still has worker A as consumer.
+    const exit = yield* Effect.exit(
+      stack.deploy(
+        Effect.gen(function* () {
+          const queue = yield* Cloudflare.Queue("Q");
+          const workerB = yield* Cloudflare.Worker("WorkerB", {
+            main,
+            compatibility: { date: "2024-01-01" },
+          });
+          const consumer = yield* Cloudflare.QueueConsumer("Consumer", {
+            queueId: queue.queueId,
+            scriptName: workerB.workerName,
+          });
+          return { queue, workerB, consumer };
+        }),
+      ),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    const message = JSON.stringify(exit);
+    // The error must name both the colliding existing script and the
+    // requested one — that is the difference between "user can fix
+    // this" and "what does this mean".
+    expect(message).toContain(initial.workerA.workerName);
+    expect(message).toContain("only one worker consumer");
+
+    // Cleanup: re-introduce the Consumer entry pointing at workerA so
+    // destroy can remove the cloud consumer.
+    yield* stack.deploy(
+      Effect.gen(function* () {
+        const queue = yield* Cloudflare.Queue("Q");
+        const workerA = yield* Cloudflare.Worker("WorkerA", {
+          main,
+          compatibility: { date: "2024-01-01" },
+        });
+        yield* Cloudflare.QueueConsumer("Consumer", {
+          queueId: queue.queueId,
+          scriptName: workerA.workerName,
+        });
+        return queue;
+      }),
+    );
+
+    yield* stack.destroy();
+  }).pipe(logLevel),
+);

--- a/packages/alchemy/test/Cloudflare/Queue/QueueConsumer.test.ts
+++ b/packages/alchemy/test/Cloudflare/Queue/QueueConsumer.test.ts
@@ -88,13 +88,20 @@ test.provider("create, update settings, replace script, delete", (stack) =>
     expect(liveUpdated.settings?.batchSize).toEqual(25);
     expect(liveUpdated.settings?.maxRetries).toEqual(7);
 
-    // Script change is a replace — consumerId must change. Cloudflare
-    // allows only one worker consumer per queue, so the engine deletes
-    // the old before creating the new (or vice versa, both are fine
-    // because reconcile observes the live state on each attempt).
+    // Script change is a delete-first replace: Cloudflare's
+    // updateConsumer silently ignores script_name on an existing
+    // consumer, and the platform allows only one Worker consumer
+    // per queue, so the engine must tear the old consumer down
+    // before creating the new one. WorkerA stays yielded across
+    // the deploy so it isn't garbage-collected mid-replace and
+    // race the Worker.delete with Cloudflare's queue↔script sync.
     const replaced = yield* stack.deploy(
       Effect.gen(function* () {
         const queue = yield* Cloudflare.Queue("Q");
+        yield* Cloudflare.Worker("WorkerA", {
+          main,
+          compatibility: { date: "2024-01-01" },
+        });
         const workerB = yield* Cloudflare.Worker("WorkerB", {
           main,
           compatibility: { date: "2024-01-01" },
@@ -113,9 +120,28 @@ test.provider("create, update settings, replace script, delete", (stack) =>
     );
     expect(replaced.consumer.scriptName).toEqual(replaced.workerB.workerName);
 
+    const liveReplaced = yield* queues.getConsumer({
+      accountId,
+      queueId: replaced.queue.queueId,
+      consumerId: replaced.consumer.consumerId,
+    });
+    expect(
+      "script" in liveReplaced ? liveReplaced.script : undefined,
+    ).toEqual(replaced.workerB.workerName);
+
+    // The original consumer must be gone after the replace.
+    const oldExit = yield* Effect.exit(
+      queues.getConsumer({
+        accountId,
+        queueId: replaced.queue.queueId,
+        consumerId: initial.consumer.consumerId,
+      }),
+    );
+    expect(Exit.isFailure(oldExit)).toBe(true);
+
     yield* stack.destroy();
 
-    // Post-destroy: the consumer must be gone on Cloudflare too.
+    // Post-destroy: the new consumer must be gone on Cloudflare too.
     const exit = yield* Effect.exit(
       queues.getConsumer({
         accountId,
@@ -128,10 +154,15 @@ test.provider("create, update settings, replace script, delete", (stack) =>
 );
 
 /**
- * Recovery from out-of-band consumer deletion. The user deletes the
- * consumer via the Cloudflare API directly, then redeploys. The
- * reconciler must observe that the consumer is missing and recreate
- * it instead of failing on a stale `output.consumerId`.
+ * Recovery from out-of-band consumer deletion. After a manual
+ * `deleteConsumer` via the API, the reconciler must observe that
+ * the consumer is missing and recreate it instead of failing on a
+ * stale `output.consumerId` from local state.
+ *
+ * The redeploy bumps `settings` so the diff returns `update` and
+ * the engine actually invokes reconcile (a no-prop redeploy is a
+ * `noop` and skips drift detection by design — drift correction
+ * only happens when something the user-controlled changes).
  */
 test.provider("recreates consumer after out-of-band delete", (stack) =>
   Effect.gen(function* () {
@@ -149,6 +180,7 @@ test.provider("recreates consumer after out-of-band delete", (stack) =>
         const consumer = yield* Cloudflare.QueueConsumer("Consumer", {
           queueId: queue.queueId,
           scriptName: worker.workerName,
+          settings: { batchSize: 5 },
         });
         return { queue, worker, consumer };
       }),
@@ -171,6 +203,7 @@ test.provider("recreates consumer after out-of-band delete", (stack) =>
         const consumer = yield* Cloudflare.QueueConsumer("Consumer", {
           queueId: queue.queueId,
           scriptName: worker.workerName,
+          settings: { batchSize: 11 },
         });
         return { queue, worker, consumer };
       }),

--- a/packages/alchemy/test/Cloudflare/Queue/consumer-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Queue/consumer-worker.ts
@@ -1,0 +1,9 @@
+/// <reference types="@cloudflare/workers-types" />
+
+// Minimal worker fixture used by QueueConsumer.test.ts. The handler
+// bodies are no-ops — the tests assert against the consumer
+// registration, not against message delivery.
+export default {
+  fetch: async () => new Response("ok"),
+  queue: async () => {},
+};


### PR DESCRIPTION
Fixes the user-reported `Consumer for script "..." on queue "..." already exists but could not be found` error and a cluster of related reconciler bugs in `Cloudflare.QueueConsumer` that surfaced once the integration tests exercised the full lifecycle against a real account.

### Bugs fixed

**Lookup / catch / read**

- `listConsumers` was single-page — missed late-arriving consumers under eventual consistency, and any queue with > one page of consumers. Now uses `queues.listConsumers.items({...})` (paginated stream).
- Generic `Effect.catch` swallowed every error from `getConsumer` / `createConsumer` / `deleteConsumer`, including transient/auth failures. Replaced with `Effect.catchTag("ConsumerNotFound", …)` and `Effect.catchTag("ConsumerAlreadyExists", …)` so unrelated failures propagate.
- `read` had no list-fallback when `output.consumerId` was lost. State-loss redeploy went through a duplicate-create path that hit the same fallback bug. `read` now falls back to `findWorkerConsumer` so adoption works.
- `updateConsumer` only ran on the adoption branch. Settings drift on the create branch was uncorrected. Now always issued post-ensure so cloud state converges to `news.settings` regardless of starting point.
- The fallback lookup filtered by `c.script === news.scriptName`, so a pre-existing worker consumer for a *different* script (Cloudflare allows only one Worker consumer per queue) silently filtered out → die. Detection now happens against any worker consumer; mismatch produces a clear actionable error naming both scripts.

**Lifecycle races**

- **Queue handler 11001 race.** When a sibling Worker is created in the same plan, its precreate uploads a placeholder script with no `queue` handler. `createConsumer` would fail with `UnknownCloudflareError code 11001` until `Worker.reconcile` uploaded the real script. Retried with a 60s budget; surfaces a real failure if the user genuinely never exports a queue handler.
- **`scriptName` change silently no-op.** Cloudflare's PUT consumer accepts `script_name` in the body but ignores it on existing consumers — the live record stays pinned to the original worker. The platform also allows only one Worker consumer per queue, so a create-then-delete replace strategy collides with itself. Reconcile now detects an owned consumer pointing at the wrong script and rebuilds it via in-reconcile delete-then-create. Stays as `update` (not `replace`) because cross-resource `Output<string>` refs aren't resolved at diff time when the upstream Worker is being created in the same plan.
- **`QueueConsumer.delete` returns before propagation.** `Worker.delete` then races and fails with `QueueConsumerConflict` (code 10064). Delete now blocks until `getConsumer` returns `ConsumerNotFound`, capped ~30s.

### Tests

`packages/alchemy/test/Cloudflare/Queue/QueueConsumer.test.ts` — each case sets up prior state, deploys, asserts, destroys:

- `create, update settings, replace script, delete` — full lifecycle. `consumerId` stable on settings change; `liveReplaced.script` matches the new worker after a script rebind. Implicitly exercises the 11001 retry (sibling Worker create) and the delete-propagation wait (final destroy ordering).
- `recreates consumer after out-of-band delete` — manual `queues.deleteConsumer(...)` between deploys; the redeploy bumps settings to force a reconcile (no-op redeploy is engine `noop`, by design).
- `adopts existing consumer after local state loss` — wipe just the `Consumer` state entry; redeploy must reuse the same `consumerId`.
- `fails clearly when queue has consumer for different script` — direct regression for the user-reported error. Asserts the new error names the existing script and contains "only one worker consumer".
