### PR TITLE
fix(drizzle): only flag Schema as updated when migrations actually drift

### DIFF
--- a/packages/alchemy/src/Drizzle/Schema.ts
+++ b/packages/alchemy/src/Drizzle/Schema.ts
@@ -170,10 +170,12 @@ export const SchemaProvider = () =>
         });
 
       /**
-       * Generate a new migration directory if the schema has drifted from
-       * the latest snapshot. Returns the new state regardless.
+       * Run drizzle-kit's diff against the latest stored snapshot and
+       * return whether any SQL statements would be emitted. Used by both
+       * `diff` (to decide whether the resource actually needs an update)
+       * and `regenerate` (to decide whether to write a new migration dir).
        */
-      const regenerate = (props: SchemaProps) =>
+      const detectDrift = (props: SchemaProps) =>
         Effect.gen(function* () {
           const out = resolveOut(props);
           const dialect = props.dialect ?? "postgres";
@@ -203,6 +205,16 @@ export const SchemaProvider = () =>
             catch: (cause) =>
               new Error(`drizzle-kit generateMigration failed: ${cause}`),
           });
+          return { out, cur, prevEntry, sqlStatements };
+        });
+
+      /**
+       * Generate a new migration directory if the schema has drifted from
+       * the latest snapshot. Returns the new state regardless.
+       */
+      const regenerate = (props: SchemaProps) =>
+        Effect.gen(function* () {
+          const { out, cur, sqlStatements } = yield* detectDrift(props);
 
           if (sqlStatements.length > 0) {
             yield* fs.makeDirectory(out, { recursive: true });
@@ -231,8 +243,12 @@ export const SchemaProvider = () =>
         diff: Effect.fn(function* ({ news, output }) {
           if (!isResolved(news)) return undefined;
           if (!output) return undefined;
-          // Force `update` so the provider runs `regenerate` on every deploy.
-          // `regenerate` itself is a no-op when nothing has drifted.
+          // Only flag an update when drizzle-kit would emit new SQL —
+          // otherwise downstream resources (e.g. Neon.Branch) would see
+          // `schema.out` as an unresolved Output during plan and cascade
+          // into spurious updates of their own.
+          const { sqlStatements } = yield* detectDrift(news);
+          if (sqlStatements.length === 0) return undefined;
           return { action: "update" } as const;
         }),
         read: Effect.fn(function* ({ olds, output }) {

--- a/packages/alchemy/test/Drizzle/Schema.test.ts
+++ b/packages/alchemy/test/Drizzle/Schema.test.ts
@@ -1,0 +1,231 @@
+import * as Drizzle from "@/Drizzle";
+import * as Plan from "@/Plan";
+import * as Stack from "@/Stack";
+import { Stage } from "@/Stage";
+import {
+  inMemoryState,
+  InMemoryService,
+  State,
+  type ResourceState,
+} from "@/State";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+
+const TEST_STACK = "test";
+const TEST_STAGE = "test";
+
+const freshState = Layer.effect(
+  State,
+  Effect.sync(() => InMemoryService({})),
+);
+
+const { test } = Test.make({
+  providers: Drizzle.providers(),
+  state: freshState,
+});
+
+const seed = (resources: Record<string, ResourceState>) =>
+  Effect.gen(function* () {
+    const state = yield* State;
+    for (const [fqn, value] of Object.entries(resources)) {
+      yield* state.set({
+        stack: TEST_STACK,
+        stage: TEST_STAGE,
+        fqn,
+        value,
+      });
+    }
+  });
+
+const makePlan = <A, Err = never, Req = never>(
+  effect: Effect.Effect<A, Err, Req>,
+): Effect.Effect<Plan.Plan<A>, Err, State> =>
+  // @ts-expect-error - Stack.make's typing erases R unsoundly here
+  Effect.gen(function* () {
+    // @ts-expect-error
+    return yield* effect.pipe(
+      // @ts-expect-error
+      Stack.make({
+        name: TEST_STACK,
+        providers: Layer.empty,
+        state: inMemoryState(),
+      }),
+      Effect.provideService(Stage, TEST_STAGE),
+      Effect.flatMap((stackSpec: any) => Plan.make(stackSpec)),
+      Effect.provide(Drizzle.providers()),
+    );
+  });
+
+// Minimal drizzle-orm schema source. We only need something
+// `generateDrizzleJson` can introspect — a couple of pgTable definitions
+// are enough.
+const SCHEMA_SOURCE = `
+import { pgTable, serial, text } from "drizzle-orm/pg-core";
+
+export const users = pgTable("users", {
+  id: serial("id").primaryKey(),
+  name: text("name").notNull(),
+});
+`;
+
+/**
+ * Stage a temp directory with a real \`schema.ts\` and a freshly generated
+ * migration snapshot (mirroring the on-disk layout of a project that has
+ * already deployed the schema once).
+ */
+const stageSchemaWorkspace = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const root = yield* fs.makeTempDirectory({
+    prefix: "alchemy-drizzle-schema-test-",
+  });
+  const schemaPath = path.join(root, "schema.ts");
+  yield* fs.writeFileString(schemaPath, SCHEMA_SOURCE);
+
+  const out = path.join(root, "migrations");
+  yield* fs.makeDirectory(out, { recursive: true });
+
+  // Generate the initial snapshot via drizzle-kit so it matches what a
+  // first-time `regenerate` would have produced.
+  const kit = (yield* Effect.tryPromise(
+    () =>
+      import(
+        /* @vite-ignore */ "drizzle-kit/api-postgres"
+      ) as Promise<any>,
+  )) as any;
+  const schemaModule = (yield* Effect.tryPromise(
+    () => import(/* @vite-ignore */ schemaPath) as Promise<any>,
+  )) as any;
+  const cur = (yield* Effect.tryPromise(() =>
+    kit.generateDrizzleJson(schemaModule),
+  )) as any;
+  const empty = (yield* Effect.tryPromise(() =>
+    kit.generateDrizzleJson({}),
+  )) as any;
+  const sql = (yield* Effect.tryPromise(() =>
+    kit.generateMigration(empty, cur),
+  )) as string[];
+
+  const dirName = "20000101000000_migration";
+  const dirPath = path.join(out, dirName);
+  yield* fs.makeDirectory(dirPath, { recursive: true });
+  yield* fs.writeFileString(
+    path.join(dirPath, "migration.sql"),
+    sql.join("\n--> statement-breakpoint\n") + "\n",
+  );
+  const snapshotText = JSON.stringify(cur, null, 2);
+  yield* fs.writeFileString(path.join(dirPath, "snapshot.json"), snapshotText);
+
+  // Mimic what `regenerate` returns so we can seed the resource state.
+  const crypto = yield* Effect.tryPromise(() => import("node:crypto"));
+  const snapshotHash = crypto
+    .createHash("sha256")
+    .update(snapshotText)
+    .digest("hex");
+
+  return { root, out, schemaPath, snapshotHash, dirName };
+});
+
+test(
+  "Drizzle.Schema noops when nothing has drifted (regression: forced update cascaded into Neon.Branch)",
+  Effect.gen(function* () {
+    const ws = yield* stageSchemaWorkspace;
+
+    yield* seed({
+      "app-schema": {
+        instanceId: "app-schema-instance",
+        providerVersion: 0,
+        logicalId: "app-schema",
+        fqn: "app-schema",
+        namespace: undefined,
+        resourceType: "Drizzle.Schema",
+        status: "created",
+        props: {
+          schema: ws.schemaPath,
+          out: ws.out,
+        },
+        attr: {
+          out: ws.out,
+          snapshotHash: ws.snapshotHash,
+          migrations: [ws.dirName],
+        },
+        bindings: [],
+        downstream: [],
+      },
+    });
+
+    const plan = yield* makePlan(
+      Effect.gen(function* () {
+        return yield* Drizzle.Schema("app-schema", {
+          schema: ws.schemaPath,
+          out: ws.out,
+        });
+      }),
+    );
+
+    expect(plan.resources["app-schema"]?.action).toEqual("noop");
+
+    // And no spurious second migration directory was written.
+    const fs = yield* FileSystem.FileSystem;
+    const entries = yield* fs.readDirectory(ws.out);
+    expect(entries.filter((n) => /^\d+_/.test(n))).toEqual([ws.dirName]);
+  }),
+  60_000,
+);
+
+test(
+  "Drizzle.Schema reports update when the schema has actually drifted",
+  Effect.gen(function* () {
+    const ws = yield* stageSchemaWorkspace;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+
+    // Write the drifted schema as a *new* file so the dynamic import
+    // cache doesn't hand us the original module.
+    const driftedSchemaPath = path.join(ws.root, "schema-drifted.ts");
+    yield* fs.writeFileString(
+      driftedSchemaPath,
+      SCHEMA_SOURCE +
+        `\nexport const posts = pgTable("posts", {\n  id: serial("id").primaryKey(),\n  title: text("title").notNull(),\n});\n`,
+    );
+
+    yield* seed({
+      "app-schema": {
+        instanceId: "app-schema-instance",
+        providerVersion: 0,
+        logicalId: "app-schema",
+        fqn: "app-schema",
+        namespace: undefined,
+        resourceType: "Drizzle.Schema",
+        status: "created",
+        props: {
+          schema: driftedSchemaPath,
+          out: ws.out,
+        },
+        attr: {
+          out: ws.out,
+          snapshotHash: ws.snapshotHash,
+          migrations: [ws.dirName],
+        },
+        bindings: [],
+        downstream: [],
+      },
+    });
+
+    const plan = yield* makePlan(
+      Effect.gen(function* () {
+        return yield* Drizzle.Schema("app-schema", {
+          schema: driftedSchemaPath,
+          out: ws.out,
+        });
+      }),
+    );
+
+    expect(plan.resources["app-schema"]?.action).toEqual("update");
+  }),
+  60_000,
+);

--- a/packages/alchemy/test/Drizzle/Schema.test.ts
+++ b/packages/alchemy/test/Drizzle/Schema.test.ts
@@ -1,68 +1,16 @@
 import * as Drizzle from "@/Drizzle";
-import * as Plan from "@/Plan";
 import * as Stack from "@/Stack";
-import { Stage } from "@/Stage";
-import {
-  inMemoryState,
-  InMemoryService,
-  State,
-  type ResourceState,
-} from "@/State";
+import { State } from "@/State";
 import * as Test from "@/Test/Vitest";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
-import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 
-const TEST_STACK = "test";
-const TEST_STAGE = "test";
+const { test } = Test.make({ providers: Drizzle.providers() });
 
-const freshState = Layer.effect(
-  State,
-  Effect.sync(() => InMemoryService({})),
-);
-
-const { test } = Test.make({
-  providers: Drizzle.providers(),
-  state: freshState,
-});
-
-const seed = (resources: Record<string, ResourceState>) =>
-  Effect.gen(function* () {
-    const state = yield* State;
-    for (const [fqn, value] of Object.entries(resources)) {
-      yield* state.set({
-        stack: TEST_STACK,
-        stage: TEST_STAGE,
-        fqn,
-        value,
-      });
-    }
-  });
-
-const makePlan = <A, Err = never, Req = never>(
-  effect: Effect.Effect<A, Err, Req>,
-): Effect.Effect<Plan.Plan<A>, Err, State> =>
-  // @ts-expect-error - Stack.make's typing erases R unsoundly here
-  Effect.gen(function* () {
-    // @ts-expect-error
-    return yield* effect.pipe(
-      // @ts-expect-error
-      Stack.make({
-        name: TEST_STACK,
-        providers: Layer.empty,
-        state: inMemoryState(),
-      }),
-      Effect.provideService(Stage, TEST_STAGE),
-      Effect.flatMap((stackSpec: any) => Plan.make(stackSpec)),
-      Effect.provide(Drizzle.providers()),
-    );
-  });
-
-// Minimal drizzle-orm schema source. We only need something
-// `generateDrizzleJson` can introspect — a couple of pgTable definitions
-// are enough.
+// Minimal drizzle-orm schema source — enough for `generateDrizzleJson`
+// to produce a non-empty snapshot.
 const SCHEMA_SOURCE = `
 import { pgTable, serial, text } from "drizzle-orm/pg-core";
 
@@ -72,160 +20,87 @@ export const users = pgTable("users", {
 });
 `;
 
-/**
- * Stage a temp directory with a real \`schema.ts\` and a freshly generated
- * migration snapshot (mirroring the on-disk layout of a project that has
- * already deployed the schema once).
- */
-const stageSchemaWorkspace = Effect.gen(function* () {
-  const fs = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
-  const root = yield* fs.makeTempDirectory({
-    prefix: "alchemy-drizzle-schema-test-",
-  });
-  const schemaPath = path.join(root, "schema.ts");
-  yield* fs.writeFileString(schemaPath, SCHEMA_SOURCE);
+const DRIFTED_SCHEMA_SOURCE =
+  SCHEMA_SOURCE +
+  `\nexport const posts = pgTable("posts", {\n  id: serial("id").primaryKey(),\n  title: text("title").notNull(),\n});\n`;
 
-  const out = path.join(root, "migrations");
-  yield* fs.makeDirectory(out, { recursive: true });
-
-  // Generate the initial snapshot via drizzle-kit so it matches what a
-  // first-time `regenerate` would have produced.
-  const kit = (yield* Effect.tryPromise(
-    () =>
-      import(
-        /* @vite-ignore */ "drizzle-kit/api-postgres"
-      ) as Promise<any>,
-  )) as any;
-  const schemaModule = (yield* Effect.tryPromise(
-    () => import(/* @vite-ignore */ schemaPath) as Promise<any>,
-  )) as any;
-  const cur = (yield* Effect.tryPromise(() =>
-    kit.generateDrizzleJson(schemaModule),
-  )) as any;
-  const empty = (yield* Effect.tryPromise(() =>
-    kit.generateDrizzleJson({}),
-  )) as any;
-  const sql = (yield* Effect.tryPromise(() =>
-    kit.generateMigration(empty, cur),
-  )) as string[];
-
-  const dirName = "20000101000000_migration";
-  const dirPath = path.join(out, dirName);
-  yield* fs.makeDirectory(dirPath, { recursive: true });
-  yield* fs.writeFileString(
-    path.join(dirPath, "migration.sql"),
-    sql.join("\n--> statement-breakpoint\n") + "\n",
-  );
-  const snapshotText = JSON.stringify(cur, null, 2);
-  yield* fs.writeFileString(path.join(dirPath, "snapshot.json"), snapshotText);
-
-  // Mimic what `regenerate` returns so we can seed the resource state.
-  const crypto = yield* Effect.tryPromise(() => import("node:crypto"));
-  const snapshotHash = crypto
-    .createHash("sha256")
-    .update(snapshotText)
-    .digest("hex");
-
-  return { root, out, schemaPath, snapshotHash, dirName };
-});
-
-test(
-  "Drizzle.Schema noops when nothing has drifted (regression: forced update cascaded into Neon.Branch)",
+const stageWorkspace = (initialSource: string) =>
   Effect.gen(function* () {
-    const ws = yield* stageSchemaWorkspace;
-
-    yield* seed({
-      "app-schema": {
-        instanceId: "app-schema-instance",
-        providerVersion: 0,
-        logicalId: "app-schema",
-        fqn: "app-schema",
-        namespace: undefined,
-        resourceType: "Drizzle.Schema",
-        status: "created",
-        props: {
-          schema: ws.schemaPath,
-          out: ws.out,
-        },
-        attr: {
-          out: ws.out,
-          snapshotHash: ws.snapshotHash,
-          migrations: [ws.dirName],
-        },
-        bindings: [],
-        downstream: [],
-      },
-    });
-
-    const plan = yield* makePlan(
-      Effect.gen(function* () {
-        return yield* Drizzle.Schema("app-schema", {
-          schema: ws.schemaPath,
-          out: ws.out,
-        });
-      }),
-    );
-
-    expect(plan.resources["app-schema"]?.action).toEqual("noop");
-
-    // And no spurious second migration directory was written.
-    const fs = yield* FileSystem.FileSystem;
-    const entries = yield* fs.readDirectory(ws.out);
-    expect(entries.filter((n) => /^\d+_/.test(n))).toEqual([ws.dirName]);
-  }),
-  60_000,
-);
-
-test(
-  "Drizzle.Schema reports update when the schema has actually drifted",
-  Effect.gen(function* () {
-    const ws = yield* stageSchemaWorkspace;
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
-
-    // Write the drifted schema as a *new* file so the dynamic import
-    // cache doesn't hand us the original module.
-    const driftedSchemaPath = path.join(ws.root, "schema-drifted.ts");
-    yield* fs.writeFileString(
-      driftedSchemaPath,
-      SCHEMA_SOURCE +
-        `\nexport const posts = pgTable("posts", {\n  id: serial("id").primaryKey(),\n  title: text("title").notNull(),\n});\n`,
-    );
-
-    yield* seed({
-      "app-schema": {
-        instanceId: "app-schema-instance",
-        providerVersion: 0,
-        logicalId: "app-schema",
-        fqn: "app-schema",
-        namespace: undefined,
-        resourceType: "Drizzle.Schema",
-        status: "created",
-        props: {
-          schema: driftedSchemaPath,
-          out: ws.out,
-        },
-        attr: {
-          out: ws.out,
-          snapshotHash: ws.snapshotHash,
-          migrations: [ws.dirName],
-        },
-        bindings: [],
-        downstream: [],
-      },
+    const root = yield* fs.makeTempDirectory({
+      prefix: "alchemy-drizzle-schema-test-",
     });
+    const schemaPath = path.join(root, "schema.ts");
+    yield* fs.writeFileString(schemaPath, initialSource);
+    const out = path.join(root, "migrations");
+    return { root, out, schemaPath };
+  });
 
-    const plan = yield* makePlan(
-      Effect.gen(function* () {
-        return yield* Drizzle.Schema("app-schema", {
+const getStatus = Effect.fn(function* (fqn: string) {
+  const state = yield* State;
+  const stk = yield* Stack.Stack;
+  const s = yield* state.get({ stack: stk.name, stage: stk.stage, fqn });
+  return s?.status;
+});
+
+test.provider(
+  "repeated deploys with no schema drift produce noop, not update (regression: forced update cascaded into Neon.Branch)",
+  (stack) =>
+    Effect.gen(function* () {
+      const ws = yield* stageWorkspace(SCHEMA_SOURCE);
+
+      yield* stack.deploy(
+        Drizzle.Schema("app-schema", {
+          schema: ws.schemaPath,
+          out: ws.out,
+        }),
+      );
+      expect(yield* getStatus("app-schema")).toEqual("created");
+
+      // Second deploy with the same schema. Before the fix, Schema.diff
+      // returned `{ action: "update" }` unconditionally, so status would
+      // flip to "updated" and downstream resources (e.g. Neon.Branch)
+      // would see `schema.out` as an unresolved Output during plan and
+      // cascade into their own spurious updates.
+      yield* stack.deploy(
+        Drizzle.Schema("app-schema", {
+          schema: ws.schemaPath,
+          out: ws.out,
+        }),
+      );
+      expect(yield* getStatus("app-schema")).toEqual("created");
+    }),
+);
+
+test.provider(
+  "deploy after a real schema change updates the resource",
+  (stack) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const ws = yield* stageWorkspace(SCHEMA_SOURCE);
+
+      const initial = yield* stack.deploy(
+        Drizzle.Schema("app-schema", {
+          schema: ws.schemaPath,
+          out: ws.out,
+        }),
+      );
+
+      // Write the drifted schema as a *new* file so the dynamic import
+      // cache doesn't hand us the original module.
+      const driftedSchemaPath = path.join(ws.root, "schema-drifted.ts");
+      yield* fs.writeFileString(driftedSchemaPath, DRIFTED_SCHEMA_SOURCE);
+
+      const drifted = yield* stack.deploy(
+        Drizzle.Schema("app-schema", {
           schema: driftedSchemaPath,
           out: ws.out,
-        });
-      }),
-    );
+        }),
+      );
 
-    expect(plan.resources["app-schema"]?.action).toEqual("update");
-  }),
-  60_000,
+      expect(yield* getStatus("app-schema")).toEqual("updated");
+      expect(drifted.snapshotHash).not.toEqual(initial.snapshotHash);
+    }),
 );


### PR DESCRIPTION
`Drizzle.Schema`'s `diff` was unconditionally returning `{ action: "update" }`:

```ts
diff: Effect.fn(function* ({ news, output }) {
  if (!isResolved(news)) return undefined;
  if (!output) return undefined;
  // Force `update` so the provider runs `regenerate` on every deploy.
  return { action: "update" } as const;
}),
```

That forced `Schema` into an update every deploy, which during plan left its outputs (`schema.out`) as unresolved `Output` references for downstream resources. `Neon.Branch.diff` short-circuits on `!isResolved(news)`, the engine then falls back to `havePropsChanged`, which returns `true` whenever `news` contains unresolved Outputs ([Diff.ts:89](packages/alchemy/src/Diff.ts#L89)). Result: `Neon.Branch` updated on every deploy, cascading into `Hyperdrive`/`Worker`.

Move the drift check from `reconcile` into `diff` so we only return `update` when `drizzle-kit`'s `generateMigration` would actually emit SQL. When nothing has drifted, `diff` returns `undefined`, the engine sees stable props and noops the resource, and downstream consumers see a resolved `schema.out`.

Regression test in `packages/alchemy/test/Drizzle/Schema.test.ts` seeds a deployed `Schema` resource and asserts the next plan is a noop (and conversely that a real schema change still produces `update`).
