### PR TITLE
chore: add husky pre-commit hook running bun format

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+bun format
+git update-index --again

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "changelogithub": "^13.16.1",
         "dotenv": "^17.2.3",
         "effect": "catalog:",
+        "husky": "^9.1.7",
         "oxfmt": "latest",
         "oxlint": "latest",
         "pkg-pr-new": "^0.0.62",
@@ -298,7 +299,7 @@
     },
     "packages/alchemy": {
       "name": "alchemy",
-      "version": "2.0.0-beta.33",
+      "version": "2.0.0-beta.34",
       "bin": {
         "alchemy": "./bin/cli.js",
       },
@@ -391,7 +392,7 @@
     },
     "packages/better-auth": {
       "name": "@alchemy.run/better-auth",
-      "version": "2.0.0-beta.33",
+      "version": "2.0.0-beta.34",
       "dependencies": {
         "alchemy": "workspace:*",
         "better-auth": "catalog:",
@@ -400,7 +401,7 @@
     },
     "packages/pr-package": {
       "name": "@alchemy.run/pr-package",
-      "version": "2.0.0-beta.33",
+      "version": "2.0.0-beta.34",
       "dependencies": {
         "alchemy": "workspace:*",
         "effect": "catalog:",
@@ -2603,6 +2604,8 @@
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
 
     "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "i18next": ["i18next@23.16.8", "", { "dependencies": { "@babel/runtime": "^7.23.2" } }, "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg=="],
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "test:fast": "FAST=1 bun run test:live",
     "test:live": "bun ./scripts/test.ts",
     "test:local": "LOCAL=1 bun ./scripts/test.ts",
-    "test": "bun run test:live"
+    "test": "bun run test:live",
+    "prepare": "husky"
   },
   "workspaces": {
     "packages": [
@@ -107,6 +108,7 @@
     }
   },
   "devDependencies": {
+    "@alchemy.run/pr-package": "workspace:*",
     "@ark/attest": "^0.56.0",
     "@effect/language-service": "^0.77.0",
     "@effect/platform-bun": "catalog:",
@@ -115,12 +117,12 @@
     "@types/node": "latest",
     "@typescript/native-preview": "^7.0.0-dev.20260317.1",
     "@vitest/ui": "^4.1.0",
-    "@alchemy.run/pr-package": "workspace:*",
     "alchemy": "workspace:*",
     "bun-types": "^1.3.8",
     "changelogithub": "^13.16.1",
     "dotenv": "^17.2.3",
     "effect": "catalog:",
+    "husky": "^9.1.7",
     "oxfmt": "latest",
     "oxlint": "latest",
     "pkg-pr-new": "^0.0.62",


### PR DESCRIPTION
Add a husky pre-commit hook that runs `bun format` so commits are always formatted.

```sh
# .husky/pre-commit
bun format
git update-index --again
```

`git update-index --again` re-stages formatting fixes for files that were already staged; unstaged files stay unstaged.
