### PR TITLE
fix(core): persist resolved bindings on terminal commits

### DIFF
--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -550,7 +550,11 @@ const executeNode = (
           resourceType: node.resource.Type,
           props: news,
           attr,
-          bindings: excludeDeletedBindings(node.bindings),
+          // Persist the *resolved* bindings (same payload the provider just
+          // applied), not the raw `node.bindings` Output expressions.
+          // Otherwise the next plan's binding diff sees `id: <Output>` ↦
+          // `id: <resolved>` and fires a spurious update.
+          bindings: bindingOutputs,
           providerVersion: node.provider.version ?? 0,
           downstream: node.downstream,
           removalPolicy: node.resource.RemovalPolicy,
@@ -677,7 +681,7 @@ const executeNode = (
             resourceType: node.resource.Type,
             props: news,
             attr,
-            bindings: excludeDeletedBindings(node.bindings),
+            bindings: bindingOutputs,
             providerVersion: node.provider.version ?? 0,
             downstream: node.downstream,
             removalPolicy: node.resource.RemovalPolicy,
@@ -841,7 +845,7 @@ const executeNode = (
           props: news,
           attr,
           providerVersion: node.provider.version ?? 0,
-          bindings: excludeDeletedBindings(node.bindings),
+          bindings: bindingOutputs,
           downstream: node.downstream,
           // Preserve the remaining backlog exactly as-is. GC is responsible for
           // popping one generation at a time until the chain is exhausted.

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -408,6 +408,52 @@ describe("linear update propagation", () => {
   );
 });
 
+describe("binding persistence", () => {
+  // Regression: when a resource is created with bindings whose data
+  // references another resource's Output (e.g. a Hyperdrive id used in a
+  // Worker binding), the persisted binding state must be the *resolved*
+  // payload, not the raw Output expression. Otherwise the next plan's
+  // binding diff sees `id: undefined` (stored) ↦ `id: <resolved>` (fresh)
+  // and forces a spurious update.
+  test.provider(
+    "second deploy noops when bindings reference a peer resource's output",
+    (stack) =>
+      Effect.gen(function* () {
+        const program = () =>
+          Effect.gen(function* () {
+            const A = yield* BindingTarget("A", {
+              name: "a",
+              string: "a-value",
+            });
+            const B = yield* BindingTarget("B", {
+              name: "b",
+              string: "b-value",
+            });
+            yield* B.bind("FromA", {
+              env: { PEER: A.string },
+            });
+            return { A, B };
+          });
+
+        yield* stack.deploy(program());
+        const stateAfterFirst = yield* getState("B");
+        expect(stateAfterFirst?.status).toEqual("created");
+        // Persisted binding payload must already have A.string resolved,
+        // not stored as an unresolved Output expression.
+        expect(stateAfterFirst?.bindings?.[0]?.data).toEqual({
+          env: { PEER: "a-value" },
+        });
+
+        yield* stack.deploy(program());
+        // Second deploy with no prop changes must noop both — before the
+        // fix, B was forced to update because its persisted binding lost
+        // the resolved peer value during JSON serialization.
+        expect((yield* getState("A"))?.status).toEqual("created");
+        expect((yield* getState("B"))?.status).toEqual("created");
+      }),
+  );
+});
+
 describe("circularity via bindings", () => {
   const selfBoundStack = (props: {
     string: string;


### PR DESCRIPTION
After `reconcile` runs we know each binding's fully-resolved data payload (`bindingOutputs`) — the same payload the provider just shipped. The terminal `created` / `updated` / `replaced` commits were instead persisting raw `node.bindings`, which still hold unresolved `Output` expressions for any cross-resource reference (e.g. a Hyperdrive binding carrying `id: hyperdrive.hyperdriveId`).

JSON-serializing an `Output` silently drops the value, so the state file stores `{ name, /* id missing */ }`. On the next plan the binding diff fires (`id: undefined` ↦ `id: <resolved>`) and forces a spurious update.

Reproduces in `examples/cloudflare-neon-drizzle`:

```sh
bun alchemy destroy --yes
bun alchemy deploy --yes  # 5 created
bun alchemy deploy --yes  # before: Api updated; after: 5 noop
```

```diff lang="ts"
  yield* commit<CreatedResourceState>({
    status: "created",
    ...
-   bindings: excludeDeletedBindings(node.bindings),
+   bindings: bindingOutputs,
  });
```

Same change in the `updated` and `replaced` terminal commits. Intermediate `creating` / `updating` / `replacing` commits keep raw `node.bindings` since they may run before upstreams have published their attrs.

Regression test in `packages/alchemy/test/apply.test.ts` deploys a stack twice where one resource's binding references another's output, and asserts the second deploy noops both — and that the persisted binding payload has the peer value resolved.
