### PR TITLE
feat(Neon/Project): add enableLogicalReplication option

### DIFF
--- a/packages/alchemy/src/Neon/Project.ts
+++ b/packages/alchemy/src/Neon/Project.ts
@@ -75,6 +75,14 @@ export type ProjectProps = {
    */
   orgId?: string;
   /**
+   * Enable Postgres logical replication on the project. Once enabled,
+   * Neon does not support disabling it again.
+   *
+   * @default false
+   * @see https://neon.tech/docs/guides/logical-replication-neon
+   */
+  enableLogicalReplication?: boolean;
+  /**
    * Directory containing `.sql` migration files. Files are sorted by their
    * numeric prefix (e.g. `0001_init.sql`) and applied in order against the
    * default branch's primary database.
@@ -118,6 +126,7 @@ export type Project = Resource<
      */
     origin: PostgresOrigin;
     historyRetentionSeconds: number;
+    enableLogicalReplication: boolean;
     migrationsDir: string | undefined;
     migrationsTable: string | undefined;
     migrationsHashes: Record<string, string>;
@@ -145,6 +154,13 @@ export type Project = Resource<
  * const project = yield* Neon.Project("my-project", {
  *   region: "aws-eu-central-1",
  *   pgVersion: 17,
+ * });
+ * ```
+ *
+ * @example Project with logical replication enabled
+ * ```typescript
+ * const project = yield* Neon.Project("my-project", {
+ *   enableLogicalReplication: true,
  * });
  * ```
  *
@@ -242,6 +258,12 @@ export const ProjectProvider = () =>
           ) {
             return { action: "update" } as const;
           }
+          if (
+            (news.enableLogicalReplication ?? false) !==
+            (output?.enableLogicalReplication ?? false)
+          ) {
+            return { action: "update" } as const;
+          }
           if (news.migrationsDir) {
             const newHashes = yield* hashMigrations(news.migrationsDir);
             if (!recordsEqual(newHashes, output?.migrationsHashes ?? {})) {
@@ -269,6 +291,8 @@ export const ProjectProvider = () =>
                 ...output,
                 projectName: project.name,
                 historyRetentionSeconds: project.history_retention_seconds,
+                enableLogicalReplication:
+                  project.settings?.enable_logical_replication === true,
               })),
               Effect.catchTag("ProjectNotFound", () =>
                 Effect.succeed(undefined),
@@ -310,6 +334,8 @@ export const ProjectProvider = () =>
             pooledConnectionUri: conn.pooled,
             origin: parsePostgresOrigin(conn.uri),
             historyRetentionSeconds: match.history_retention_seconds,
+            enableLogicalReplication:
+              match.settings?.enable_logical_replication === true,
             migrationsDir: olds?.migrationsDir,
             migrationsTable: olds?.migrationsTable,
             migrationsHashes: {},
@@ -325,6 +351,14 @@ export const ProjectProvider = () =>
                 .updateProject(output.projectId, {
                   name: news.name,
                   history_retention_seconds: news.historyRetentionSeconds,
+                  settings:
+                    (news.enableLogicalReplication ?? false) !==
+                    (output.enableLogicalReplication ?? false)
+                      ? {
+                          enable_logical_replication:
+                            news.enableLogicalReplication ?? false,
+                        }
+                      : undefined,
                 })
                 .pipe(
                   Effect.map((r) => ({
@@ -342,6 +376,8 @@ export const ProjectProvider = () =>
                     historyRetentionSeconds:
                       r.project.history_retention_seconds ??
                       output.historyRetentionSeconds,
+                    enableLogicalReplication:
+                      r.project.settings?.enable_logical_replication === true,
                   })),
                 )
             : yield* Effect.gen(function* () {
@@ -357,6 +393,9 @@ export const ProjectProvider = () =>
                   },
                   history_retention_seconds: news.historyRetentionSeconds,
                   org_id: news.orgId,
+                  settings: news.enableLogicalReplication
+                    ? { enable_logical_replication: true }
+                    : undefined,
                 });
                 yield* api.waitForOperations(created.operations);
 
@@ -383,6 +422,9 @@ export const ProjectProvider = () =>
                   origin: parsePostgresOrigin(conn.uri),
                   historyRetentionSeconds:
                     created.project.history_retention_seconds ?? 86400,
+                  enableLogicalReplication:
+                    created.project.settings?.enable_logical_replication ===
+                    true,
                 };
               });
 

--- a/packages/alchemy/src/Neon/api.ts
+++ b/packages/alchemy/src/Neon/api.ts
@@ -146,6 +146,7 @@ export interface CreateProjectInput {
   };
   history_retention_seconds?: number;
   org_id?: string;
+  settings?: Record<string, unknown>;
 }
 
 export interface CreateProjectOutput {
@@ -288,6 +289,7 @@ export const createProject = (input: CreateProjectInput) =>
           : undefined),
       history_retention_seconds: input.history_retention_seconds,
       org_id: input.org_id,
+      settings: input.settings,
     },
   });
 

--- a/packages/alchemy/test/Neon/Project.test.ts
+++ b/packages/alchemy/test/Neon/Project.test.ts
@@ -37,6 +37,43 @@ test.provider("create and delete project with default props", (stack) =>
 );
 
 test.provider(
+  "enable logical replication on update",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Neon.Project("LogicalReplicationProject", {
+            name: "alchemy-test-logical-replication",
+            region: "aws-us-east-1",
+          });
+        }),
+      );
+      expect(initial.enableLogicalReplication).toEqual(false);
+
+      const enabled = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Neon.Project("LogicalReplicationProject", {
+            name: "alchemy-test-logical-replication",
+            region: "aws-us-east-1",
+            enableLogicalReplication: true,
+          });
+        }),
+      );
+      expect(enabled.projectId).toEqual(initial.projectId);
+      expect(enabled.enableLogicalReplication).toEqual(true);
+
+      const fetched = yield* api.getProject(enabled.projectId);
+      expect(fetched.project.settings).toMatchObject({
+        enable_logical_replication: true,
+      });
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+);
+
+test.provider(
   "create project, apply migrations and seed data, then create a branch",
   (stack) =>
     Effect.gen(function* () {


### PR DESCRIPTION
Add `enableLogicalReplication` to `Neon.Project`. Sets `settings.enable_logical_replication` on the Neon project (required for logical decoding / CDC sinks).

```ts
const project = yield* Neon.Project("my-project", {
  enableLogicalReplication: true,
});
```

Sent on create when truthy, sent on update only when the value changes vs. observed cloud state, read back from `project.settings`. Once enabled, Neon does not allow disabling — the JSDoc calls this out.

### Test

`enable logical replication on update` deploys without the flag (asserts `false`), redeploys with `true` (asserts `update` plan + stable `projectId`), and cross-checks via `api.getProject()` that Neon persisted `settings.enable_logical_replication: true`.
