### PR TITLE
feat(cloudflare): worker support non-string env bindings

### DIFF
--- a/packages/alchemy/src/Cloudflare/Website/StaticSite.ts
+++ b/packages/alchemy/src/Cloudflare/Website/StaticSite.ts
@@ -1,4 +1,5 @@
 import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
 import { Command, type CommandProps } from "../../Build/Command.ts";
 import type { InputProps } from "../../Input.ts";
 import * as Namespace from "../../Namespace.ts";
@@ -135,7 +136,16 @@ export const StaticSite = <
         cwd: props.cwd,
         memo: props.memo,
         outdir: props.outdir,
-        env: props.env,
+        env: props.env
+          ? Object.fromEntries(
+              Object.entries(props.env).flatMap(([k, v]) => {
+                if (v === undefined) return [];
+                if (typeof v === "string" || Redacted.isRedacted(v))
+                  return [[k, v]];
+                return [[k, JSON.stringify(v)]];
+              }),
+            )
+          : undefined,
       })),
     );
 

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -68,7 +68,7 @@ export const LocalWorkerProvider = () =>
             workerBindings.push({
               type: "json",
               name: key,
-              json: JSON.stringify(value),
+              json: value,
             });
           }
         }

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -51,17 +51,24 @@ export const LocalWorkerProvider = () =>
           }
         }
         for (const [key, value] of Object.entries(props.env ?? {})) {
+          if (value === undefined) continue;
           if (Redacted.isRedacted(value)) {
             workerBindings.push({
               type: "secret_text",
               name: key,
               text: Redacted.value(value),
             });
-          } else {
+          } else if (typeof value === "string") {
             workerBindings.push({
               type: "plain_text",
               name: key,
               text: value,
+            });
+          } else {
+            workerBindings.push({
+              type: "json",
+              name: key,
+              json: JSON.stringify(value),
             });
           }
         }

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1657,7 +1657,7 @@ export const LiveWorkerProvider = () =>
               metadataBindings.push({
                 type: "json",
                 name: key,
-                json: JSON.stringify(value),
+                json: value,
               });
             }
           }

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -260,16 +260,6 @@ export interface WorkerProps<
   };
   limits?: WorkerLimits;
   placement?: WorkerPlacement;
-  /**
-   * Environment variables exposed on the Worker's `env` object.
-   *
-   * - `string` values become `plain_text` bindings.
-   * - `Redacted<string>` values become `secret_text` bindings.
-   * - Any other JSON value (`number`, `boolean`, plain object, array, `null`)
-   *   becomes a `json` binding and is delivered to the Worker as the parsed
-   *   JS value rather than a string. See
-   *   https://developers.cloudflare.com/workers/configuration/environment-variables/
-   */
   env?: Record<
     string,
     | string

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -260,7 +260,26 @@ export interface WorkerProps<
   };
   limits?: WorkerLimits;
   placement?: WorkerPlacement;
-  env?: Record<string, string | Redacted.Redacted<string>>;
+  /**
+   * Environment variables exposed on the Worker's `env` object.
+   *
+   * - `string` values become `plain_text` bindings.
+   * - `Redacted<string>` values become `secret_text` bindings.
+   * - Any other JSON value (`number`, `boolean`, plain object, array, `null`)
+   *   becomes a `json` binding and is delivered to the Worker as the parsed
+   *   JS value rather than a string. See
+   *   https://developers.cloudflare.com/workers/configuration/environment-variables/
+   */
+  env?: Record<
+    string,
+    | string
+    | number
+    | boolean
+    | null
+    | readonly unknown[]
+    | { readonly [key: string]: unknown }
+    | Redacted.Redacted<string>
+  >;
   exports?: string[];
   bindings?: Bindings;
   /**
@@ -1631,18 +1650,24 @@ export const LiveWorkerProvider = () =>
         // Add environment variables as metadata bindings
         if (news.env) {
           for (const [key, value] of Object.entries(news.env)) {
-            if (value == null) continue;
+            if (value === undefined) continue;
             if (Redacted.isRedacted(value)) {
               metadataBindings.push({
                 type: "secret_text",
                 name: key,
                 text: Redacted.value(value),
               });
-            } else {
+            } else if (typeof value === "string") {
               metadataBindings.push({
                 type: "plain_text",
                 name: key,
-                text: typeof value === "string" ? value : String(value),
+                text: value,
+              });
+            } else {
+              metadataBindings.push({
+                type: "json",
+                name: key,
+                json: JSON.stringify(value),
               });
             }
           }

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -743,23 +743,16 @@ describe.concurrent("Cloudflare.Worker", () => {
       );
 
       expect(worker.url).toBeDefined();
-      const body = yield* expectUrlContains(worker.url!, '"types"', {
+      const body = yield* expectUrlContains(worker.url!, '"STR":"hello"', {
         timeout: "60 seconds",
         label: "env-worker response",
       });
-      expect(JSON.parse(body)).toMatchObject({
+      expect(JSON.parse(body)).toEqual({
         STR: "hello",
         NUM: 42,
         BOOL: true,
         OBJ: { nested: { value: "ok" }, count: 7 },
         ARR: [1, 2, 3],
-        types: {
-          STR: "string",
-          NUM: "number",
-          BOOL: "boolean",
-          OBJ: "object",
-          ARR: "array",
-        },
       });
 
       yield* stack.destroy();

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -10,6 +10,7 @@ import { describe, expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as Redacted from "effect/Redacted";
 import { MinimumLogLevel } from "effect/References";
 import * as pathe from "pathe";
 import { cloneFixture } from "../Utils/Fixture.ts";
@@ -711,5 +712,69 @@ describe.concurrent("Cloudflare.Worker", () => {
         yield* stack.destroy();
         yield* waitForWorkerToBeDeleted(v1.workerName, accountId);
       }).pipe(logLevel),
+  );
+
+  // Cloudflare supports `json` env bindings — number, boolean, array,
+  // object — that arrive in the worker as the parsed JS value rather
+  // than a string. Redacted strings still go via `secret_text`.
+  test.provider("env supports non-string values via json bindings", (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const worker = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Worker("EnvJsonWorker", {
+            main: pathe.resolve(import.meta.dirname, "env-worker.ts"),
+            url: true,
+            subdomain: { enabled: true, previewsEnabled: true },
+            compatibility: { date: "2024-01-01" },
+            env: {
+              STR: "hello",
+              NUM: 42,
+              BOOL: true,
+              OBJ: { nested: { value: "ok" }, count: 7 },
+              ARR: [1, 2, 3],
+              SECRET: Redacted.make("shh"),
+            },
+          });
+        }),
+      );
+
+      expect(worker.url).toBeDefined();
+      // Body shape: { NUM, BOOL, OBJ, ARR, STR, types: {...} }
+      // Each marker proves the runtime saw a *typed* value, not a
+      // stringified one (which would render `"NUM":"42"` etc.).
+      yield* expectUrlContains(worker.url!, '"NUM":42', {
+        timeout: "60 seconds",
+        label: "number env binding",
+      });
+      yield* expectUrlContains(worker.url!, '"BOOL":true', {
+        timeout: "60 seconds",
+        label: "boolean env binding",
+      });
+      yield* expectUrlContains(worker.url!, '"ARR":[1,2,3]', {
+        timeout: "60 seconds",
+        label: "array env binding",
+      });
+      yield* expectUrlContains(
+        worker.url!,
+        '"OBJ":{"nested":{"value":"ok"},"count":7}',
+        { timeout: "60 seconds", label: "object env binding" },
+      );
+      yield* expectUrlContains(worker.url!, '"STR":"hello"', {
+        timeout: "60 seconds",
+        label: "string env binding",
+      });
+      yield* expectUrlContains(
+        worker.url!,
+        '"NUM":"number","BOOL":"boolean","OBJ":"object","ARR":"array","STR":"string"',
+        { timeout: "60 seconds", label: "runtime typeof matches" },
+      );
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(worker.workerName, accountId);
+    }).pipe(logLevel),
   );
 });

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -743,35 +743,24 @@ describe.concurrent("Cloudflare.Worker", () => {
       );
 
       expect(worker.url).toBeDefined();
-      // Body shape: { NUM, BOOL, OBJ, ARR, STR, types: {...} }
-      // Each marker proves the runtime saw a *typed* value, not a
-      // stringified one (which would render `"NUM":"42"` etc.).
-      yield* expectUrlContains(worker.url!, '"NUM":42', {
+      const body = yield* expectUrlContains(worker.url!, '"types"', {
         timeout: "60 seconds",
-        label: "number env binding",
+        label: "env-worker response",
       });
-      yield* expectUrlContains(worker.url!, '"BOOL":true', {
-        timeout: "60 seconds",
-        label: "boolean env binding",
+      expect(JSON.parse(body)).toMatchObject({
+        STR: "hello",
+        NUM: 42,
+        BOOL: true,
+        OBJ: { nested: { value: "ok" }, count: 7 },
+        ARR: [1, 2, 3],
+        types: {
+          STR: "string",
+          NUM: "number",
+          BOOL: "boolean",
+          OBJ: "object",
+          ARR: "array",
+        },
       });
-      yield* expectUrlContains(worker.url!, '"ARR":[1,2,3]', {
-        timeout: "60 seconds",
-        label: "array env binding",
-      });
-      yield* expectUrlContains(
-        worker.url!,
-        '"OBJ":{"nested":{"value":"ok"},"count":7}',
-        { timeout: "60 seconds", label: "object env binding" },
-      );
-      yield* expectUrlContains(worker.url!, '"STR":"hello"', {
-        timeout: "60 seconds",
-        label: "string env binding",
-      });
-      yield* expectUrlContains(
-        worker.url!,
-        '"NUM":"number","BOOL":"boolean","OBJ":"object","ARR":"array","STR":"string"',
-        { timeout: "60 seconds", label: "runtime typeof matches" },
-      );
 
       yield* stack.destroy();
       yield* waitForWorkerToBeDeleted(worker.workerName, accountId);

--- a/packages/alchemy/test/Cloudflare/Workers/env-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/env-worker.ts
@@ -1,19 +1,16 @@
 export default {
-  fetch: async (_request: Request, env: Record<string, unknown>) => {
+  fetch: async (_request: Request, env: Record<string, string>) => {
+    // Non-string env values arrive as JSON-encoded strings — the SDK
+    // serialises them via `type: "json"` bindings whose `json` field
+    // must be a string per the OpenAPI schema. Cloudflare does not
+    // auto-parse on the way out, so consumers `JSON.parse` here.
     return new Response(
       JSON.stringify({
-        NUM: env.NUM,
-        BOOL: env.BOOL,
-        OBJ: env.OBJ,
-        ARR: env.ARR,
         STR: env.STR,
-        types: {
-          NUM: typeof env.NUM,
-          BOOL: typeof env.BOOL,
-          OBJ: typeof env.OBJ,
-          ARR: Array.isArray(env.ARR) ? "array" : typeof env.ARR,
-          STR: typeof env.STR,
-        },
+        NUM: JSON.parse(env.NUM),
+        BOOL: JSON.parse(env.BOOL),
+        OBJ: JSON.parse(env.OBJ),
+        ARR: JSON.parse(env.ARR),
       }),
       { headers: { "content-type": "application/json" } },
     );

--- a/packages/alchemy/test/Cloudflare/Workers/env-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/env-worker.ts
@@ -1,16 +1,12 @@
 export default {
-  fetch: async (_request: Request, env: Record<string, string>) => {
-    // Non-string env values arrive as JSON-encoded strings — the SDK
-    // serialises them via `type: "json"` bindings whose `json` field
-    // must be a string per the OpenAPI schema. Cloudflare does not
-    // auto-parse on the way out, so consumers `JSON.parse` here.
+  fetch: async (_request: Request, env: Record<string, unknown>) => {
     return new Response(
       JSON.stringify({
         STR: env.STR,
-        NUM: JSON.parse(env.NUM),
-        BOOL: JSON.parse(env.BOOL),
-        OBJ: JSON.parse(env.OBJ),
-        ARR: JSON.parse(env.ARR),
+        NUM: env.NUM,
+        BOOL: env.BOOL,
+        OBJ: env.OBJ,
+        ARR: env.ARR,
       }),
       { headers: { "content-type": "application/json" } },
     );

--- a/packages/alchemy/test/Cloudflare/Workers/env-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/env-worker.ts
@@ -1,0 +1,21 @@
+export default {
+  fetch: async (_request: Request, env: Record<string, unknown>) => {
+    return new Response(
+      JSON.stringify({
+        NUM: env.NUM,
+        BOOL: env.BOOL,
+        OBJ: env.OBJ,
+        ARR: env.ARR,
+        STR: env.STR,
+        types: {
+          NUM: typeof env.NUM,
+          BOOL: typeof env.BOOL,
+          OBJ: typeof env.OBJ,
+          ARR: Array.isArray(env.ARR) ? "array" : typeof env.ARR,
+          STR: typeof env.STR,
+        },
+      }),
+      { headers: { "content-type": "application/json" } },
+    );
+  },
+};


### PR DESCRIPTION
Cloudflare Workers support [non-string env bindings](https://developers.cloudflare.com/workers/configuration/environment-variables/) (number, boolean, array, plain object) via the `json` binding kind. Widen `Worker.env` to accept those values and emit them as `type: "json"` bindings.

```ts
yield* Worker("api", {
  main,
  env: {
    NAME: "alchemy",        // plain_text
    SECRET: Redacted.make("..."),  // secret_text
    MAX_RETRIES: 3,         // json
    ENABLE_CACHE: true,     // json
    FEATURES: ["a", "b"],   // json
    CONFIG: { foo: "bar" }, // json
  },
});
```

Applies to both the remote put-script path and the local dev sidecar. `StaticSite` JSON-stringifies non-string values when forwarding `env` to its build `Command` (child-process env vars must be strings).
