### PR TITLE
fix(cloudflare): cloudflare vite dev bindings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -298,7 +298,7 @@
     },
     "packages/alchemy": {
       "name": "alchemy",
-      "version": "2.0.0-beta.33",
+      "version": "2.0.0-beta.34",
       "bin": {
         "alchemy": "./bin/cli.js",
       },
@@ -344,8 +344,10 @@
         "react": "^19.2.0",
         "rolldown": "catalog:",
         "sonda": "catalog:",
+        "tsx": "^4.20.6",
         "web-tree-sitter": "catalog:",
         "workerd": "catalog:",
+        "ws": "^8.18.0",
         "yaml": "catalog:",
       },
       "devDependencies": {
@@ -362,6 +364,7 @@
         "@types/picomatch": "^4.0.0",
         "@types/proper-lockfile": "^4.1.4",
         "@types/react": "^19.2.2",
+        "@types/ws": "^8.5.13",
         "better-auth": "catalog:",
         "effect": "catalog:",
         "react-devtools-core": "^7.0.1",
@@ -391,7 +394,7 @@
     },
     "packages/better-auth": {
       "name": "@alchemy.run/better-auth",
-      "version": "2.0.0-beta.33",
+      "version": "2.0.0-beta.34",
       "dependencies": {
         "alchemy": "workspace:*",
         "better-auth": "catalog:",
@@ -400,7 +403,7 @@
     },
     "packages/pr-package": {
       "name": "@alchemy.run/pr-package",
-      "version": "2.0.0-beta.33",
+      "version": "2.0.0-beta.34",
       "dependencies": {
         "alchemy": "workspace:*",
         "effect": "catalog:",
@@ -3941,6 +3944,8 @@
     "@vue/language-core/@vue/compiler-dom": ["@vue/compiler-dom@3.5.33", "", { "dependencies": { "@vue/compiler-core": "3.5.33", "@vue/shared": "3.5.33" } }, "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA=="],
 
     "@vue/language-core/@vue/shared": ["@vue/shared@3.5.33", "", {}, "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ=="],
+
+    "alchemy/@types/node": ["@types/node@25.6.1", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-coJCN8O1q4AGyyqCAUSP06P+SrMTu18BkEj3NVAK07q6QUneD2wzj3CLv9+yP+BMeZQlMvneXqqvDe3w+xcq7g=="],
 
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 

--- a/packages/alchemy/bin/cli.js
+++ b/packages/alchemy/bin/cli.js
@@ -27,7 +27,13 @@ import { foregroundChild } from "foreground-child";
 
 const execpath = (process.env.npm_execpath ?? "").toLowerCase();
 const userAgent = (process.env.npm_config_user_agent ?? "").toLowerCase();
-const invokedByBun = execpath.includes("bun") || userAgent.startsWith("bun/");
+const lifecycleScript = (process.env.npm_lifecycle_script ?? "").toLowerCase();
+const runningUnderBun = typeof globalThis.Bun === "object";
+const invokedByBun =
+  runningUnderBun ||
+  execpath.includes("bun") ||
+  userAgent.startsWith("bun/") ||
+  /\bbun(?:\s+--bun)?\s+alchemy\b/.test(lifecycleScript);
 
 // Derive the bin dir from this launcher's own location rather than
 // require.resolve("alchemy/bin/alchemy.js"). The bundled alchemy.js is a

--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -311,8 +311,10 @@
     "react": "^19.2.0",
     "rolldown": "catalog:",
     "sonda": "catalog:",
+    "tsx": "^4.20.6",
     "web-tree-sitter": "catalog:",
     "workerd": "catalog:",
+    "ws": "^8.18.0",
     "yaml": "catalog:"
   },
   "devDependencies": {
@@ -329,6 +331,7 @@
     "@types/picomatch": "^4.0.0",
     "@types/proper-lockfile": "^4.1.4",
     "@types/react": "^19.2.2",
+    "@types/ws": "^8.5.13",
     "better-auth": "catalog:",
     "effect": "catalog:",
     "react-devtools-core": "^7.0.1",

--- a/packages/alchemy/src/Cli/commands/dev.ts
+++ b/packages/alchemy/src/Cli/commands/dev.ts
@@ -49,6 +49,7 @@ export const devCommand = Command.make(
         stdin: "inherit",
         stdout: "inherit",
         stderr: "inherit",
+        detached: false,
         env: {
           ALCHEMY_EXEC_OPTIONS: JSON.stringify(options),
         },

--- a/packages/alchemy/src/Cloudflare/Local/Sidecar.ts
+++ b/packages/alchemy/src/Cloudflare/Local/Sidecar.ts
@@ -28,6 +28,7 @@ export interface ServeViteOptions {
   rootDir: string;
   wranglerConfigPath: string;
   configHash: string;
+  remoteBindings: boolean;
 }
 
 export const SidecarSchema = defineSchema<Sidecar["Service"]>({

--- a/packages/alchemy/src/Cloudflare/Local/Sidecar.ts
+++ b/packages/alchemy/src/Cloudflare/Local/Sidecar.ts
@@ -22,8 +22,23 @@ export interface ServeOptions extends WorkerBundleOptions {
   durableObjectNamespaces: Worker.DurableObjectNamespace[];
 }
 
+export interface ServeViteOptions {
+  id: string;
+  name: string;
+  rootDir: string;
+  wranglerConfigPath: string;
+  configHash: string;
+}
+
 export const SidecarSchema = defineSchema<Sidecar["Service"]>({
   serve: {
+    success: Schema.Struct({
+      name: Schema.String,
+      address: Schema.String,
+    }),
+    error: Schema.Union([ServeError, BundleError]),
+  },
+  serveVite: {
     success: Schema.Struct({
       name: Schema.String,
       address: Schema.String,
@@ -38,6 +53,9 @@ export class Sidecar extends RpcClient.RpcClientService<
   {
     readonly serve: (
       options: ServeOptions,
+    ) => Effect.Effect<ServeResult, ServeError | BundleError>;
+    readonly serveVite: (
+      options: ServeViteOptions,
     ) => Effect.Effect<ServeResult, ServeError | BundleError>;
     readonly stop: (name: string) => Effect.Effect<void>;
   }

--- a/packages/alchemy/src/Cloudflare/Local/SidecarHandlers.ts
+++ b/packages/alchemy/src/Cloudflare/Local/SidecarHandlers.ts
@@ -9,6 +9,7 @@ import * as Hash from "effect/Hash";
 import * as Layer from "effect/Layer";
 import * as Result from "effect/Result";
 import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -38,6 +39,7 @@ export const SidecarHandlers = Layer.effect(
         server: vite.ViteDevServer;
       }
     >();
+    const viteConfigPathSemaphore = yield* Semaphore.make(1);
 
     const serveScoped = Effect.fnUntraced(function* (
       worker: ServeOptions,
@@ -91,40 +93,42 @@ export const SidecarHandlers = Layer.effect(
 
       yield* closeViteServer(worker.name);
 
-      const server = yield* Effect.tryPromise({
-        try: async () => {
-          const vite = await loadVite(worker.rootDir);
-          const previousConfigPath =
-            process.env.CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH;
-          process.env.CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH =
-            worker.wranglerConfigPath;
-          try {
-            const server = await vite.createServer({
-              root: worker.rootDir,
-              clearScreen: false,
-              server: {
-                host: "127.0.0.1",
-                port: 0,
-              },
-            });
-            await server.listen();
-            server.printUrls();
-            return server;
-          } finally {
-            if (previousConfigPath === undefined) {
-              delete process.env.CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH;
-            } else {
-              process.env.CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH =
-                previousConfigPath;
+      const server = yield* viteConfigPathSemaphore.withPermit(
+        Effect.tryPromise({
+          try: async () => {
+            const vite = await loadVite(worker.rootDir);
+            const previousConfigPath =
+              process.env.CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH;
+            process.env.CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH =
+              worker.wranglerConfigPath;
+            try {
+              const server = await vite.createServer({
+                root: worker.rootDir,
+                clearScreen: false,
+                server: {
+                  host: "127.0.0.1",
+                  port: 0,
+                },
+              });
+              await server.listen();
+              server.printUrls();
+              return server;
+            } finally {
+              if (previousConfigPath === undefined) {
+                delete process.env.CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH;
+              } else {
+                process.env.CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH =
+                  previousConfigPath;
+              }
             }
-          }
-        },
-        catch: (cause) =>
-          new Bundle.BundleError({
-            message: `Failed to start Vite dev server for ${worker.name}`,
-            cause,
-          }),
-      });
+          },
+          catch: (cause) =>
+            new Bundle.BundleError({
+              message: `Failed to start Vite dev server for ${worker.name}`,
+              cause,
+            }),
+        }),
+      );
       const address =
         server.resolvedUrls?.local?.[0]?.replace(/\/$/, "") ??
         `http://127.0.0.1:${server.config.server.port}`;

--- a/packages/alchemy/src/Cloudflare/Local/SidecarHandlers.ts
+++ b/packages/alchemy/src/Cloudflare/Local/SidecarHandlers.ts
@@ -319,7 +319,7 @@ async function getCloudflareVitePlugins(
 
   return plugin.cloudflare({
     configPath: worker.wranglerConfigPath,
-    remoteBindings: false,
+    remoteBindings: worker.remoteBindings,
     viteEnvironment: { name: "ssr" },
   });
 }

--- a/packages/alchemy/src/Cloudflare/Local/SidecarHandlers.ts
+++ b/packages/alchemy/src/Cloudflare/Local/SidecarHandlers.ts
@@ -102,9 +102,11 @@ export const SidecarHandlers = Layer.effect(
             process.env.CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH =
               worker.wranglerConfigPath;
             try {
+              const plugins = await getCloudflareVitePlugins(vite, worker);
               const server = await vite.createServer({
                 root: worker.rootDir,
                 clearScreen: false,
+                plugins,
                 server: {
                   host: "127.0.0.1",
                   port: 0,
@@ -280,9 +282,54 @@ function bundleOutputToWorkerModules(
 
 type ViteModule = typeof import("vite");
 
+async function getCloudflareVitePlugins(
+  vite: ViteModule,
+  worker: ServeViteOptions,
+): Promise<vite.PluginOption[]> {
+  const resolved = await vite.resolveConfig(
+    { root: worker.rootDir },
+    "serve",
+  );
+  if (
+    resolved.plugins.some((plugin) => plugin.name === "vite-plugin-cloudflare")
+  ) {
+    return [];
+  }
+
+  let plugin: {
+    cloudflare?: (options: {
+      configPath: string;
+      remoteBindings: boolean;
+      viteEnvironment: { name: string };
+    }) => vite.PluginOption[];
+  };
+  try {
+    const packageName = "@cloudflare/vite-plugin";
+    plugin = (await import(packageName)) as typeof plugin;
+  } catch (cause) {
+    throw new Bundle.BundleError({
+      message:
+        "Cloudflare.Vite dev requires @cloudflare/vite-plugin when the project Vite config does not include it.",
+      cause,
+    });
+  }
+
+  if (typeof plugin.cloudflare !== "function") {
+    throw new Bundle.BundleError({
+      message: "Invalid @cloudflare/vite-plugin export: missing cloudflare()",
+    });
+  }
+
+  return plugin.cloudflare({
+    configPath: worker.wranglerConfigPath,
+    remoteBindings: false,
+    viteEnvironment: { name: "ssr" },
+  });
+}
+
 async function loadVite(projectRoot: string): Promise<ViteModule> {
   try {
-    const require = createRequire(path.join(projectRoot, "package.json"));
+    const require = createRequire(path.resolve(projectRoot, "package.json"));
     const vitePath = require.resolve("vite");
     const viteUrl = pathToFileURL(vitePath);
     return await import(/* @vite-ignore */ viteUrl.href);

--- a/packages/alchemy/src/Cloudflare/Local/SidecarHandlers.ts
+++ b/packages/alchemy/src/Cloudflare/Local/SidecarHandlers.ts
@@ -10,9 +10,17 @@ import * as Layer from "effect/Layer";
 import * as Result from "effect/Result";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import type * as vite from "vite";
 import * as Bundle from "../../Bundle/Bundle.ts";
 import { WorkerBundle } from "../Workers/WorkerBundle.ts";
-import { Sidecar, type ServeOptions } from "./Sidecar.ts";
+import {
+  Sidecar,
+  type ServeOptions,
+  type ServeViteOptions,
+} from "./Sidecar.ts";
 
 export const SidecarHandlers = Layer.effect(
   Sidecar,
@@ -22,6 +30,14 @@ export const SidecarHandlers = Layer.effect(
 
     const rootScope = yield* Effect.scope;
     const serverScopes = new Map<string, Scope.Closeable>();
+    const viteServers = new Map<
+      string,
+      {
+        hash: string;
+        address: string;
+        server: vite.ViteDevServer;
+      }
+    >();
 
     const serveScoped = Effect.fnUntraced(function* (
       worker: ServeOptions,
@@ -49,6 +65,76 @@ export const SidecarHandlers = Layer.effect(
       }
       serverScopes.set(worker.name, scope);
       return result;
+    });
+
+    const closeViteServer = (name: string) =>
+      Effect.gen(function* () {
+        const existing = viteServers.get(name);
+        if (!existing) return;
+        viteServers.delete(name);
+        yield* Effect.tryPromise({
+          try: () => existing.server.close(),
+          catch: (cause) =>
+            new Bundle.BundleError({
+              message: `Failed to stop Vite dev server for ${name}`,
+              cause,
+            }),
+        });
+      });
+
+    const serveVite = Effect.fnUntraced(function* (worker: ServeViteOptions) {
+      const existing = viteServers.get(worker.name);
+      if (existing?.hash === worker.configHash) {
+        yield* Effect.log(`[${worker.id}] No Vite config changes`);
+        return { name: worker.name, address: existing.address };
+      }
+
+      yield* closeViteServer(worker.name);
+
+      const server = yield* Effect.tryPromise({
+        try: async () => {
+          const vite = await loadVite(worker.rootDir);
+          const previousConfigPath =
+            process.env.CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH;
+          process.env.CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH =
+            worker.wranglerConfigPath;
+          try {
+            const server = await vite.createServer({
+              root: worker.rootDir,
+              clearScreen: false,
+              server: {
+                host: "127.0.0.1",
+                port: 0,
+              },
+            });
+            await server.listen();
+            server.printUrls();
+            return server;
+          } finally {
+            if (previousConfigPath === undefined) {
+              delete process.env.CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH;
+            } else {
+              process.env.CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH =
+                previousConfigPath;
+            }
+          }
+        },
+        catch: (cause) =>
+          new Bundle.BundleError({
+            message: `Failed to start Vite dev server for ${worker.name}`,
+            cause,
+          }),
+      });
+      const address =
+        server.resolvedUrls?.local?.[0]?.replace(/\/$/, "") ??
+        `http://127.0.0.1:${server.config.server.port}`;
+      viteServers.set(worker.name, {
+        hash: worker.configHash,
+        address,
+        server,
+      });
+      yield* Effect.log(`[${worker.id}] Vite dev server started at ${address}`);
+      return { name: worker.name, address };
     });
 
     const watchers = new Map<
@@ -157,7 +243,9 @@ export const SidecarHandlers = Layer.effect(
           ),
         );
       }),
+      serveVite,
       stop: Effect.fn(function* (name: string) {
+        yield* closeViteServer(name).pipe(Effect.ignore);
         const watcher = watchers.get(name);
         if (watcher) {
           yield* Fiber.interrupt(watcher.fiber);
@@ -184,4 +272,17 @@ function bundleOutputToWorkerModules(
     });
   }
   return modules;
+}
+
+type ViteModule = typeof import("vite");
+
+async function loadVite(projectRoot: string): Promise<ViteModule> {
+  try {
+    const require = createRequire(path.join(projectRoot, "package.json"));
+    const vitePath = require.resolve("vite");
+    const viteUrl = pathToFileURL(vitePath);
+    return await import(/* @vite-ignore */ viteUrl.href);
+  } catch {
+    return await import("vite");
+  }
 }

--- a/packages/alchemy/src/Cloudflare/Local/SidecarHandlers.ts
+++ b/packages/alchemy/src/Cloudflare/Local/SidecarHandlers.ts
@@ -286,10 +286,7 @@ async function getCloudflareVitePlugins(
   vite: ViteModule,
   worker: ServeViteOptions,
 ): Promise<vite.PluginOption[]> {
-  const resolved = await vite.resolveConfig(
-    { root: worker.rootDir },
-    "serve",
-  );
+  const resolved = await vite.resolveConfig({ root: worker.rootDir }, "serve");
   if (
     resolved.plugins.some((plugin) => plugin.name === "vite-plugin-cloudflare")
   ) {

--- a/packages/alchemy/src/Cloudflare/Website/Vite.ts
+++ b/packages/alchemy/src/Cloudflare/Website/Vite.ts
@@ -22,6 +22,11 @@ export interface ViteProps<
    */
   rootDir?: string;
   /**
+   * Whether local Vite dev should proxy supported bindings to Cloudflare.
+   * Defaults to `true` so dev uses the same remote resources Alchemy manages.
+   */
+  remoteBindings?: boolean;
+  /**
    * Controls which files are hashed to decide whether a rebuild is needed.
    * By default every non-gitignored file in `cwd` is hashed, plus the nearest
    * lockfile. Provide explicit globs to narrow the scope.
@@ -137,6 +142,7 @@ export const Vite = <
         main: props?.main ?? undefined!,
         vite: {
           rootDir: props?.rootDir,
+          remoteBindings: props?.remoteBindings ?? true,
           memo: props?.memo,
         },
       }),

--- a/packages/alchemy/src/Cloudflare/Website/Vite.ts
+++ b/packages/alchemy/src/Cloudflare/Website/Vite.ts
@@ -1,6 +1,6 @@
 import * as Effect from "effect/Effect";
 import type { MemoOptions } from "../../Build/Memo.ts";
-import type { InputProps } from "../../Input.ts";
+import type { Input, InputProps } from "../../Input.ts";
 import {
   Worker,
   type WorkerAssetsConfig,
@@ -11,6 +11,11 @@ import {
 export interface ViteProps<
   Bindings extends WorkerBindingProps = {},
 > extends Omit<WorkerProps<Bindings>, "vite" | "main"> {
+  /**
+   * Worker entrypoint used by Vite integrations that require an explicit
+   * Wrangler `main` field during dev (for example TanStack Start).
+   */
+  main?: string;
   /**
    * Root directory passed to Vite's `root` option.
    * Defaults to the current working directory (`process.cwd()`).
@@ -25,6 +30,13 @@ export interface ViteProps<
    */
   memo?: MemoOptions;
 }
+
+type ViteInputProps<Bindings extends WorkerBindingProps = {}> = Omit<
+  InputProps<ViteProps<Bindings>>,
+  "main"
+> & {
+  main?: Input<string>;
+};
 
 /**
  * A Cloudflare Worker deployed from a Vite project.
@@ -113,8 +125,8 @@ export const Vite = <
 >(
   id: string,
   propsEff?:
-    | InputProps<ViteProps<Bindings>>
-    | Effect.Effect<InputProps<ViteProps<Bindings>>, never, Req>,
+    | ViteInputProps<Bindings>
+    | Effect.Effect<ViteInputProps<Bindings>, never, Req>,
 ) =>
   Worker<Bindings, WorkerAssetsConfig, Req>(
     id,
@@ -122,7 +134,7 @@ export const Vite = <
       Effect.isEffect(propsEff) ? propsEff : Effect.succeed(propsEff),
       (props) => ({
         ...props,
-        main: undefined!,
+        main: props?.main ?? undefined!,
         vite: {
           rootDir: props?.rootDir,
           memo: props?.memo,

--- a/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
@@ -15,18 +15,20 @@ export type InferEnv<W> = W extends
 
 type GetBindingType<T> = T extends Cloudflare.Assets
   ? Service
-  : T extends Cloudflare.D1Database
-    ? D1Database
-    : T extends Cloudflare.R2Bucket
-      ? R2Bucket
-      : T extends Cloudflare.KVNamespace
-        ? KVNamespace
-        : T extends Cloudflare.Queue
-          ? Queue<unknown>
-          : T extends Cloudflare.AiGateway
-            ? Ai
-            : T extends Cloudflare.Artifacts
-              ? Artifacts
-              : T extends Cloudflare.DurableObjectNamespaceLike
-                ? DurableObjectNamespace<Exclude<T["Shape"], undefined>>
-                : never;
+  : T extends Cloudflare.Worker
+    ? Fetcher
+    : T extends Cloudflare.D1Database
+      ? D1Database
+      : T extends Cloudflare.R2Bucket
+        ? R2Bucket
+        : T extends Cloudflare.KVNamespace
+          ? KVNamespace
+          : T extends Cloudflare.Queue
+            ? Queue<unknown>
+            : T extends Cloudflare.AiGateway
+              ? Ai
+              : T extends Cloudflare.Artifacts
+                ? Artifacts
+                : T extends Cloudflare.DurableObjectNamespaceLike
+                  ? DurableObjectNamespace<Exclude<T["Shape"], undefined>>
+                  : never;

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -15,6 +15,7 @@ import { createWorkerName } from "./WorkerName.ts";
 
 export const workerBindingsToWranglerConfig = (input: {
   name: string;
+  main?: string;
   compatibility: { date: string; flags: string[] };
   bindings: WorkerBinding[];
   hyperdrives?: Record<string, Required<HyperdriveOrigin>>;
@@ -24,6 +25,9 @@ export const workerBindingsToWranglerConfig = (input: {
     compatibility_date: input.compatibility.date,
     compatibility_flags: input.compatibility.flags,
   };
+  if (input.main) {
+    config.main = input.main;
+  }
 
   for (const binding of input.bindings) {
     switch (binding.type) {
@@ -188,6 +192,7 @@ export const LocalWorkerProvider = () =>
             props.vite.rootDir ?? (yield* Effect.sync(() => process.cwd()));
           const wranglerConfig = workerBindingsToWranglerConfig({
             name,
+            main: props.main,
             compatibility,
             bindings: workerBindings,
             hyperdrives,

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -17,6 +17,7 @@ export const workerBindingsToWranglerConfig = (input: {
   name: string;
   compatibility: { date: string; flags: string[] };
   bindings: WorkerBinding[];
+  hyperdrives?: Record<string, Required<HyperdriveOrigin>>;
 }) => {
   const config: any = {
     name: input.name,
@@ -82,6 +83,17 @@ export const workerBindingsToWranglerConfig = (input: {
         };
         break;
       }
+      case "hyperdrive": {
+        const origin = input.hyperdrives?.[binding.id];
+        (config.hyperdrive ??= []).push({
+          binding: binding.name,
+          id: binding.id,
+          localConnectionString: origin
+            ? hyperdriveOriginToConnectionString(origin)
+            : undefined,
+        });
+        break;
+      }
       case "durable_object_namespace": {
         config.durable_objects ??= {};
         (config.durable_objects.bindings ??= []).push({
@@ -95,6 +107,21 @@ export const workerBindingsToWranglerConfig = (input: {
   }
 
   return config;
+};
+
+const hyperdriveOriginToConnectionString = (
+  origin: Required<HyperdriveOrigin>,
+) => {
+  const url = new URL(`${origin.scheme}://localhost`);
+  url.username = origin.user;
+  url.password = origin.password;
+  url.hostname = origin.host;
+  url.port = String(origin.port);
+  url.pathname = `/${origin.database}`;
+  if (origin.sslmode) {
+    url.searchParams.set("sslmode", origin.sslmode);
+  }
+  return url.toString();
 };
 
 export const LocalWorkerProvider = () =>
@@ -163,6 +190,7 @@ export const LocalWorkerProvider = () =>
             name,
             compatibility,
             bindings: workerBindings,
+            hyperdrives,
           });
           const configHash = JSON.stringify({ rootDir, wranglerConfig });
           const configPath = path.join(

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -1,6 +1,7 @@
 import type { HyperdriveOrigin } from "@distilled.cloud/cloudflare-runtime/Worker";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
+import * as Hash from "effect/Hash";
 import * as Path from "effect/Path";
 import * as Redacted from "effect/Redacted";
 import nodePath from "node:path";
@@ -140,6 +141,26 @@ export const LocalWorkerProvider = () =>
       const path = yield* Path.Path;
       const { dotAlchemy } = yield* AlchemyContext;
 
+      const readViteConfigInputHash = Effect.fn(function* (rootDir: string) {
+        const files = yield* Effect.all(
+          viteConfigInputFiles.map((file) => {
+            const filePath = path.join(rootDir, file);
+            return fs.readFileString(filePath).pipe(
+              Effect.map((content) => [file, Hash.string(content)] as const),
+              Effect.catch(() => Effect.succeed(undefined)),
+            );
+          }),
+        );
+        const entries: Array<readonly [string, number]> = [];
+        for (const file of files) {
+          if (file !== undefined) {
+            entries.push(file);
+          }
+        }
+
+        return Object.fromEntries(entries);
+      });
+
       const run = Effect.fn(function* (
         id: string,
         props: WorkerProps,
@@ -199,7 +220,14 @@ export const LocalWorkerProvider = () =>
             bindings: workerBindings,
             hyperdrives,
           });
-          const configHash = JSON.stringify({ rootDir, wranglerConfig });
+          const remoteBindings = props.vite.remoteBindings ?? true;
+          const viteConfigInputHash = yield* readViteConfigInputHash(rootDir);
+          const configHash = JSON.stringify({
+            rootDir,
+            wranglerConfig,
+            remoteBindings,
+            viteConfigInputHash,
+          });
           const configPath = path.join(
             dotAlchemy,
             "local",
@@ -220,6 +248,7 @@ export const LocalWorkerProvider = () =>
             rootDir,
             wranglerConfigPath: configPath,
             configHash,
+            remoteBindings,
           });
           return {
             workerId: name,
@@ -279,3 +308,18 @@ export const LocalWorkerProvider = () =>
       };
     }),
   );
+
+const viteConfigInputFiles = [
+  "vite.config.ts",
+  "vite.config.mts",
+  "vite.config.cts",
+  "vite.config.js",
+  "vite.config.mjs",
+  "vite.config.cjs",
+  "package.json",
+  "bun.lock",
+  "bun.lockb",
+  "package-lock.json",
+  "pnpm-lock.yaml",
+  "yarn.lock",
+] as const;

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -1,6 +1,9 @@
 import type { HyperdriveOrigin } from "@distilled.cloud/cloudflare-runtime/Worker";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import * as Redacted from "effect/Redacted";
+import { AlchemyContext } from "../../AlchemyContext.ts";
 import * as Provider from "../../Provider.ts";
 import type { ResourceBinding } from "../../Resource.ts";
 import { Stack } from "../../Stack.ts";
@@ -10,6 +13,90 @@ import { getCompatibility } from "./Compatibility.ts";
 import { Worker, type WorkerBinding, type WorkerProps } from "./Worker.ts";
 import { createWorkerName } from "./WorkerName.ts";
 
+export const workerBindingsToWranglerConfig = (input: {
+  name: string;
+  compatibility: { date: string; flags: string[] };
+  bindings: WorkerBinding[];
+}) => {
+  const config: any = {
+    name: input.name,
+    compatibility_date: input.compatibility.date,
+    compatibility_flags: input.compatibility.flags,
+  };
+
+  for (const binding of input.bindings) {
+    switch (binding.type) {
+      case "plain_text":
+      case "secret_text": {
+        config.vars ??= {};
+        config.vars[binding.name] = binding.text;
+        break;
+      }
+      case "d1": {
+        (config.d1_databases ??= []).push({
+          binding: binding.name,
+          database_id: binding.id,
+          database_name: binding.name,
+          remote: true,
+        });
+        break;
+      }
+      case "kv_namespace": {
+        (config.kv_namespaces ??= []).push({
+          binding: binding.name,
+          id: binding.namespaceId,
+          remote: true,
+        });
+        break;
+      }
+      case "r2_bucket": {
+        (config.r2_buckets ??= []).push({
+          binding: binding.name,
+          bucket_name: binding.bucketName,
+          jurisdiction: binding.jurisdiction,
+          remote: true,
+        });
+        break;
+      }
+      case "queue": {
+        config.queues ??= {};
+        (config.queues.producers ??= []).push({
+          binding: binding.name,
+          queue: binding.queueName,
+          remote: true,
+        });
+        break;
+      }
+      case "service": {
+        (config.services ??= []).push({
+          binding: binding.name,
+          service: binding.service,
+          remote: true,
+        });
+        break;
+      }
+      case "ai": {
+        config.ai = {
+          binding: binding.name,
+          remote: true,
+        };
+        break;
+      }
+      case "durable_object_namespace": {
+        config.durable_objects ??= {};
+        (config.durable_objects.bindings ??= []).push({
+          name: binding.name,
+          class_name: binding.className,
+          script_name: "scriptName" in binding ? binding.scriptName : undefined,
+        });
+        break;
+      }
+    }
+  }
+
+  return config;
+};
+
 export const LocalWorkerProvider = () =>
   Provider.effect(
     Worker,
@@ -17,6 +104,9 @@ export const LocalWorkerProvider = () =>
       const { accountId } = yield* CloudflareEnvironment;
       const stack = yield* Stack;
       const sidecar = yield* Sidecar;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const { dotAlchemy } = yield* AlchemyContext;
 
       const run = Effect.fn(function* (
         id: string,
@@ -65,11 +155,53 @@ export const LocalWorkerProvider = () =>
             });
           }
         }
+        const compatibility = getCompatibility(props);
+        if (props.vite) {
+          const rootDir =
+            props.vite.rootDir ?? (yield* Effect.sync(() => process.cwd()));
+          const wranglerConfig = workerBindingsToWranglerConfig({
+            name,
+            compatibility,
+            bindings: workerBindings,
+          });
+          const configHash = JSON.stringify({ rootDir, wranglerConfig });
+          const configPath = path.join(
+            dotAlchemy,
+            "local",
+            "vite",
+            name,
+            "wrangler.json",
+          );
+          yield* fs.makeDirectory(path.dirname(configPath), {
+            recursive: true,
+          });
+          yield* fs.writeFileString(
+            configPath,
+            JSON.stringify(wranglerConfig, null, 2),
+          );
+          const result = yield* sidecar.serveVite({
+            id,
+            name,
+            rootDir,
+            wranglerConfigPath: configPath,
+            configHash,
+          });
+          return {
+            workerId: name,
+            workerName: name,
+            logpush: undefined,
+            url: result.address,
+            tags: [],
+            durableObjectNamespaces,
+            domains: [],
+            accountId,
+          } satisfies Worker["Attributes"];
+        }
         const result = yield* sidecar.serve({
           id,
           name,
           main: props.main,
-          compatibility: getCompatibility(props),
+          compatibility,
           entry: props.isExternal
             ? {
                 kind: "external",

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import * as Redacted from "effect/Redacted";
+import nodePath from "node:path";
 import { AlchemyContext } from "../../AlchemyContext.ts";
 import * as Provider from "../../Provider.ts";
 import type { ResourceBinding } from "../../Resource.ts";
@@ -188,8 +189,9 @@ export const LocalWorkerProvider = () =>
         }
         const compatibility = getCompatibility(props);
         if (props.vite) {
-          const rootDir =
-            props.vite.rootDir ?? (yield* Effect.sync(() => process.cwd()));
+          const rootDir = nodePath.resolve(
+            props.vite.rootDir ?? (yield* Effect.sync(() => process.cwd())),
+          );
           const wranglerConfig = workerBindingsToWranglerConfig({
             name,
             main: props.main,

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -76,10 +76,7 @@ import { workersHttpHandler } from "./HttpServer.ts";
 import { LocalWorkerProvider } from "./LocalWorkerProvider.ts";
 import { Request } from "./Request.ts";
 import { makeRpcStub } from "./Rpc.ts";
-import {
-  makeEffectVirtualEntry,
-  normalizeWorkerMain,
-} from "./WorkerBundle.ts";
+import { makeEffectVirtualEntry, normalizeWorkerMain } from "./WorkerBundle.ts";
 
 const WorkerTypeId = "Cloudflare.Worker";
 type WorkerTypeId = typeof WorkerTypeId;

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -307,6 +307,7 @@ export interface WorkerProps<
   /** @internal used by Cloudflare.Vite resource */
   vite?: {
     rootDir?: string;
+    remoteBindings?: boolean;
     memo?: MemoOptions;
   };
   logpush?: boolean;

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -180,6 +180,7 @@ export type WorkerShape = Main<WorkerServices | WorkerEnvironment>;
 
 export type WorkerBindingResource =
   | Assets
+  | Worker
   | R2Bucket
   | D1Database
   | KVNamespace
@@ -212,6 +213,69 @@ type NormalizedBindings<
 } & (undefined extends AssetsConfig ? {} : { ASSETS: Assets });
 
 export type WorkerAssetsConfig = string | AssetsProps | AssetsWithHash;
+
+export const toWorkerBinding = (
+  bindingName: string,
+  binding: WorkerBindingResource,
+): InputProps<WorkerBinding> | undefined =>
+  isAssets(binding)
+    ? {
+        type: "assets",
+        name: bindingName,
+      }
+    : isArtifactsBinding(binding)
+      ? ({
+          type: "artifacts",
+          name: bindingName,
+          namespace: binding.namespace,
+        } as any)
+      : isDurableObjectNamespaceLike(binding)
+        ? {
+            type: "durable_object_namespace",
+            name: bindingName,
+            className: binding.className ?? binding.name,
+          }
+        : isWorker(binding)
+          ? {
+              type: "service",
+              name: bindingName,
+              service: binding.workerName,
+            }
+          : binding.Type === "Cloudflare.D1Database"
+            ? {
+                type: "d1",
+                id: binding.databaseId,
+                name: bindingName,
+              }
+            : binding.Type === "Cloudflare.R2Bucket"
+              ? {
+                  type: "r2_bucket",
+                  name: bindingName,
+                  bucketName: binding.bucketName,
+                  jurisdiction: binding.jurisdiction.pipe(
+                    Output.map((jurisdiction) =>
+                      jurisdiction === "default" ? undefined : jurisdiction,
+                    ),
+                  ),
+                }
+              : binding.Type === "Cloudflare.KVNamespace"
+                ? {
+                    type: "kv_namespace",
+                    name: bindingName,
+                    namespaceId: binding.namespaceId,
+                  }
+                : binding.Type === "Cloudflare.Queue"
+                  ? {
+                      type: "queue",
+                      name: bindingName,
+                      queueName: binding.queueName,
+                    }
+                  : binding.Type === "Cloudflare.AiGateway"
+                    ? {
+                        type: "ai",
+                        name: bindingName,
+                      }
+                    : undefined;
 
 export interface WorkerProps<
   Bindings extends WorkerBindingProps = any,
@@ -716,61 +780,7 @@ export const Worker: Platform<
           ? yield* bindingEff
           : bindingEff;
 
-        const bindingMeta: InputProps<WorkerBinding> | undefined = isAssets(
-          binding,
-        )
-          ? {
-              type: "assets",
-              name: bindingName,
-            }
-          : isArtifactsBinding(binding)
-            ? ({
-                type: "artifacts",
-                name: bindingName,
-                namespace: binding.namespace,
-              } as any)
-            : isDurableObjectNamespaceLike(binding)
-              ? {
-                  type: "durable_object_namespace",
-                  name: bindingName,
-                  className: binding.className ?? binding.name,
-                }
-              : binding.Type === "Cloudflare.D1Database"
-                ? {
-                    type: "d1",
-                    id: binding.databaseId,
-                    name: bindingName,
-                  }
-                : binding.Type === "Cloudflare.R2Bucket"
-                  ? {
-                      type: "r2_bucket",
-                      name: bindingName,
-                      bucketName: binding.bucketName,
-                      jurisdiction: binding.jurisdiction.pipe(
-                        Output.map((jurisdiction) =>
-                          jurisdiction === "default" ? undefined : jurisdiction,
-                        ),
-                      ),
-                    }
-                  : binding.Type === "Cloudflare.KVNamespace"
-                    ? {
-                        type: "kv_namespace",
-                        name: bindingName,
-                        namespaceId: binding.namespaceId,
-                      }
-                    : binding.Type === "Cloudflare.Queue"
-                      ? {
-                          type: "queue",
-                          name: bindingName,
-                          queueName: binding.queueName,
-                        }
-                      : binding.Type === "Cloudflare.AiGateway"
-                        ? {
-                            type: "ai",
-                            name: bindingName,
-                          }
-                        : // TODO(sam): handle others
-                          undefined;
+        const bindingMeta = toWorkerBinding(bindingName, binding);
 
         if (bindingMeta) {
           yield* resource.bind`${bindingName}`({

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -76,7 +76,10 @@ import { workersHttpHandler } from "./HttpServer.ts";
 import { LocalWorkerProvider } from "./LocalWorkerProvider.ts";
 import { Request } from "./Request.ts";
 import { makeRpcStub } from "./Rpc.ts";
-import { makeEffectVirtualEntry } from "./WorkerBundle.ts";
+import {
+  makeEffectVirtualEntry,
+  normalizeWorkerMain,
+} from "./WorkerBundle.ts";
 
 const WorkerTypeId = "Cloudflare.Worker";
 type WorkerTypeId = typeof WorkerTypeId;
@@ -321,6 +324,7 @@ export interface WorkerProps<
    */
   observability?: WorkerObservability;
   tags?: string[];
+  /** Worker entrypoint path. File URLs from `import.meta.url` are supported. */
   main: string;
   compatibility?: {
     date?: string;
@@ -1401,7 +1405,7 @@ export const LiveWorkerProvider = () =>
 
       const prepareBundle = (id: string, props: WorkerProps) =>
         Effect.gen(function* () {
-          const main = yield* fs.realPath(props.main);
+          const main = yield* fs.realPath(normalizeWorkerMain(props.main));
           const cwd = yield* findCwdForBundle(main);
           const { compatibilityDate, compatibilityFlags } =
             getCompatibility(props);
@@ -1449,56 +1453,66 @@ export const LiveWorkerProvider = () =>
           getCompatibility(props);
 
         yield* Effect.promise(async () => {
-          const vite = await loadVite(props.vite?.rootDir);
-          const builder = await vite.createBuilder(
-            {
-              root: props.vite?.rootDir,
-              // Declare the ssr environment so Vite 8+ creates it.
-              // The cloudflare-vite-plugin config hook merges its
-              // SSR-specific settings on top of this stub.
-              environments: {
-                ssr: {
-                  build: {
-                    // Prevent the SSR build from wiping the client
-                    // build's output (both share the dist/ directory).
-                    emptyOutDir: false,
+          const previousAlchemyBuild = process.env.ALCHEMY_BUILD;
+          process.env.ALCHEMY_BUILD = "1";
+          try {
+            const vite = await loadVite(props.vite?.rootDir);
+            const builder = await vite.createBuilder(
+              {
+                root: props.vite?.rootDir,
+                // Declare the ssr environment so Vite 8+ creates it.
+                // The cloudflare-vite-plugin config hook merges its
+                // SSR-specific settings on top of this stub.
+                environments: {
+                  ssr: {
+                    build: {
+                      // Prevent the SSR build from wiping the client
+                      // build's output (both share the dist/ directory).
+                      emptyOutDir: false,
+                    },
                   },
                 },
+                builder: {
+                  sharedConfigBuild: true,
+                },
+                plugins: [
+                  cloudflareVite({
+                    compatibilityDate,
+                    compatibilityFlags,
+                  }),
+                  {
+                    name: "output:ssr",
+                    applyToEnvironment(environment) {
+                      return environment.name === "ssr";
+                    },
+                    generateBundle(_outputOptions, bundle) {
+                      serverBundle = bundle;
+                    },
+                  },
+                  {
+                    name: "output:client",
+                    applyToEnvironment(environment) {
+                      return environment.name === "client";
+                    },
+                    generateBundle(outputOptions) {
+                      assetsDirectory = outputOptions.dir;
+                    },
+                  },
+                ],
               },
-              builder: {
-                sharedConfigBuild: true,
-              },
-              plugins: [
-                cloudflareVite({
-                  compatibilityDate,
-                  compatibilityFlags,
-                }),
-                {
-                  name: "output:ssr",
-                  applyToEnvironment(environment) {
-                    return environment.name === "ssr";
-                  },
-                  generateBundle(_outputOptions, bundle) {
-                    serverBundle = bundle;
-                  },
-                },
-                {
-                  name: "output:client",
-                  applyToEnvironment(environment) {
-                    return environment.name === "client";
-                  },
-                  generateBundle(outputOptions) {
-                    assetsDirectory = outputOptions.dir;
-                  },
-                },
-              ],
-            },
-            // This is the `useLegacyBuilder` option. The Vite CLI implementation uses `null` here.
-            // Originally we used `undefined` here, but this caused the static site build to fail.
-            // https://github.com/vitejs/vite/blob/a07a4bd052ac75f916391c999c408ad5f2867e61/packages/vite/src/node/cli.ts#L367
-            null,
-          );
-          await builder.buildApp();
+              // This is the `useLegacyBuilder` option. The Vite CLI implementation uses `null` here.
+              // Originally we used `undefined` here, but this caused the static site build to fail.
+              // https://github.com/vitejs/vite/blob/a07a4bd052ac75f916391c999c408ad5f2867e61/packages/vite/src/node/cli.ts#L367
+              null,
+            );
+            await builder.buildApp();
+          } finally {
+            if (previousAlchemyBuild === undefined) {
+              delete process.env.ALCHEMY_BUILD;
+            } else {
+              process.env.ALCHEMY_BUILD = previousAlchemyBuild;
+            }
+          }
         });
         if (!assetsDirectory && !serverBundle) {
           return yield* Effect.die(
@@ -2386,7 +2400,7 @@ async function loadVite(
   projectRoot: string = process.cwd(),
 ): Promise<ViteModule> {
   try {
-    const require = createRequire(path.join(projectRoot, "package.json"));
+    const require = createRequire(path.resolve(projectRoot, "package.json"));
     const vitePath = require.resolve("vite");
     // On Windows, absolute paths must be file:// URLs for ESM import().
     const viteUrl = pathToFileURL(vitePath);

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
@@ -4,6 +4,7 @@ import * as FileSystem from "effect/FileSystem";
 import { flow } from "effect/Function";
 import type * as Path from "effect/Path";
 import * as Stream from "effect/Stream";
+import { fileURLToPath } from "node:url";
 import type * as rolldown from "rolldown";
 import * as Artifacts from "../../Artifacts.ts";
 import * as Bundle from "../../Bundle/Bundle.ts";
@@ -41,7 +42,7 @@ export const WorkerBundle = Effect.gen(function* () {
   const makeOptions = Effect.fnUntraced(function* (
     options: WorkerBundleOptions,
   ) {
-    const realMain = yield* fs.realPath(options.main).pipe(
+    const realMain = yield* fs.realPath(normalizeWorkerMain(options.main)).pipe(
       Effect.mapError(
         (cause) =>
           new Bundle.BundleError({
@@ -105,6 +106,9 @@ export const WorkerBundle = Effect.gen(function* () {
     ),
   };
 });
+
+export const normalizeWorkerMain = (main: string) =>
+  main.startsWith("file:") ? fileURLToPath(main) : main;
 
 export const makeEffectVirtualEntry = (
   exports: Record<string, DurableObjectExport | WorkflowExport>,

--- a/packages/alchemy/src/Platform.ts
+++ b/packages/alchemy/src/Platform.ts
@@ -243,7 +243,10 @@ export const Platform = <
             )
         ).pipe(
           Effect.tap(
-            (resource) => hooks.onCreate?.(resource as R, props) ?? Effect.void,
+            (resource) => {
+              const resolved = resource as R;
+              return hooks.onCreate?.(resolved, resolved.Props) ?? Effect.void;
+            },
           ),
         );
       return Object.assign(

--- a/packages/alchemy/src/Platform.ts
+++ b/packages/alchemy/src/Platform.ts
@@ -242,12 +242,10 @@ export const Platform = <
               }),
             )
         ).pipe(
-          Effect.tap(
-            (resource) => {
-              const resolved = resource as R;
-              return hooks.onCreate?.(resolved, resolved.Props) ?? Effect.void;
-            },
-          ),
+          Effect.tap((resource) => {
+            const resolved = resource as R;
+            return hooks.onCreate?.(resolved, resolved.Props) ?? Effect.void;
+          }),
         );
       return Object.assign(
         function (impl: Impl) {

--- a/packages/alchemy/src/Sidecar/Lock.ts
+++ b/packages/alchemy/src/Sidecar/Lock.ts
@@ -159,7 +159,7 @@ const make = Effect.gen(function* () {
 
   const touchLock = assertOwnLock.pipe(
     Effect.flatMap(() => {
-      const now = Date.now();
+      const now = new Date();
       return fs.utimes(paths.lock, now, now).pipe(
         Effect.mapError(
           (e) =>

--- a/packages/alchemy/src/Sidecar/RpcClient.ts
+++ b/packages/alchemy/src/Sidecar/RpcClient.ts
@@ -83,7 +83,7 @@ const maybeStartRpcServer = Effect.fn(function* (main: string) {
     yield* ChildProcess.make(command, args, {
       stdout: "inherit",
       stderr: "inherit",
-      detached: true,
+      detached: false,
     });
   } else {
     yield* Effect.logDebug("[RpcClient] RPC server already running", main);

--- a/packages/alchemy/src/Sidecar/RpcClient.ts
+++ b/packages/alchemy/src/Sidecar/RpcClient.ts
@@ -70,7 +70,17 @@ const maybeStartRpcServer = Effect.fn(function* (main: string) {
   const lock = yield* Lock.Lock;
   if (!(yield* lock.check)) {
     yield* Effect.logDebug("[RpcClient] Starting RPC server", main);
-    yield* ChildProcess.make("bun", ["run", main], {
+    const command = main.endsWith(".ts")
+      ? "node"
+      : typeof Bun === "undefined"
+        ? process.execPath
+        : "bun";
+    const args = main.endsWith(".ts")
+      ? ["--conditions=worker", "--import", "tsx", main]
+      : typeof Bun === "undefined"
+        ? [...process.execArgv, main]
+        : ["run", main];
+    yield* ChildProcess.make(command, args, {
       stdout: "inherit",
       stderr: "inherit",
       detached: true,

--- a/packages/alchemy/src/Sidecar/RpcTransport.ts
+++ b/packages/alchemy/src/Sidecar/RpcTransport.ts
@@ -1,10 +1,17 @@
 import type { ServerWebSocket } from "bun";
 import type { RpcCompatible, RpcTransport } from "capnweb";
 import { RpcSession } from "capnweb";
+import { Buffer } from "node:buffer";
+import http from "node:http";
+import { WebSocketServer, type WebSocket } from "ws";
 
 export function makeBunWebSocketRpcServer<T extends RpcCompatible<T>>(
   main: () => T,
 ) {
+  if (typeof Bun === "undefined") {
+    return makeNodeWebSocketRpcServer(main);
+  }
+
   return Bun.serve<{
     transport: BunWebSocketRpcTransport;
     session: RpcSession<T>;
@@ -30,6 +37,147 @@ export function makeBunWebSocketRpcServer<T extends RpcCompatible<T>>(
       },
     },
   });
+}
+
+function makeNodeWebSocketRpcServer<T extends RpcCompatible<T>>(main: () => T) {
+  const hostname = "127.0.0.1";
+  const port = 30_000 + Math.floor(Math.random() * 20_000);
+  const pendingUpgrades = new WeakMap<
+    Request,
+    { req: http.IncomingMessage; socket: any; head: Buffer }
+  >();
+  const wss = new WebSocketServer({ noServer: true });
+
+  const server = {
+    hostname,
+    port,
+    upgrade(request: Request, init: { data?: unknown } = {}) {
+      const pending = pendingUpgrades.get(request);
+      if (!pending) return false;
+      pendingUpgrades.delete(request);
+
+      wss.handleUpgrade(pending.req, pending.socket, pending.head, (ws) => {
+        (ws as any).data = init.data;
+        const transport = new NodeWebSocketRpcTransport(ws);
+        const session = new RpcSession<T>(transport, main());
+        (ws as any).data = { transport, session };
+        ws.on("message", (message) => {
+          transport.dispatchMessage(toNodeMessage(message));
+        });
+        ws.on("close", (code, reason) => {
+          transport.dispatchClose(code, reason.toString());
+        });
+      });
+
+      return true;
+    },
+    stop(force?: boolean) {
+      return new Promise<void>((resolve) => {
+        let resolved = false;
+        const done = () => {
+          if (!resolved) {
+            resolved = true;
+            resolve();
+          }
+        };
+        for (const client of wss.clients) {
+          force ? client.terminate() : client.close();
+        }
+        wss.close(done);
+        httpServer.close(done);
+        setTimeout(done, 100).unref?.();
+      });
+    },
+  };
+
+  const httpServer = http.createServer((_, response) => {
+    response.statusCode = 400;
+    response.end("Upgrade failed");
+  });
+
+  httpServer.on("upgrade", async (req, socket, head) => {
+    const request = new Request(
+      `http://${req.headers.host ?? hostname}${req.url}`,
+      { headers: req.headers as HeadersInit },
+    );
+    pendingUpgrades.set(request, { req, socket, head });
+    const response = await Promise.resolve(
+      server.upgrade(request, { data: undefined }),
+    );
+    if (!response && pendingUpgrades.has(request)) {
+      pendingUpgrades.delete(request);
+      socket.write("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
+      socket.destroy();
+    }
+  });
+
+  httpServer.listen(port, hostname);
+  return server;
+}
+
+function toNodeMessage(message: WebSocket.RawData): string | Buffer<ArrayBuffer> {
+  if (typeof message === "string") return message;
+  if (Buffer.isBuffer(message)) return message as Buffer<ArrayBuffer>;
+  if (Array.isArray(message)) return Buffer.concat(message) as Buffer<ArrayBuffer>;
+  return Buffer.from(message) as Buffer<ArrayBuffer>;
+}
+
+class NodeWebSocketRpcTransport implements RpcTransport {
+  private receiveQueue: Array<string> = [];
+  private receiveResolver?: (value: string) => void;
+  private receiveRejecter?: (reason: unknown) => void;
+  private error?: unknown;
+
+  constructor(private readonly ws: WebSocket) {}
+
+  async send(message: string): Promise<void> {
+    this.ws.send(message);
+  }
+
+  async receive(): Promise<string> {
+    const next = this.receiveQueue.shift();
+    if (next) {
+      return next;
+    } else if (this.error) {
+      throw this.error;
+    }
+    return new Promise((resolve, reject) => {
+      this.receiveResolver = resolve;
+      this.receiveRejecter = reject;
+    });
+  }
+
+  abort?(reason: any): void {
+    const message = reason instanceof Error ? reason.message : String(reason);
+    this.ws.close(3000, message);
+    this.error ??= reason;
+  }
+
+  dispatchMessage(data: string | Buffer<ArrayBuffer>): void {
+    if (this.error) {
+      return;
+    }
+    data = typeof data === "string" ? data : data.toString("utf-8");
+
+    if (this.receiveResolver) {
+      this.receiveResolver(data);
+      this.receiveResolver = undefined;
+      this.receiveRejecter = undefined;
+    } else {
+      this.receiveQueue.push(data);
+    }
+  }
+
+  dispatchClose(code: number, reason: string): void {
+    if (!this.error) {
+      this.error = new Error(`WebSocket closed with code ${code}: ${reason}`);
+      if (this.receiveRejecter) {
+        this.receiveRejecter(this.error);
+        this.receiveRejecter = undefined;
+        this.receiveResolver = undefined;
+      }
+    }
+  }
 }
 
 class BunWebSocketRpcTransport implements RpcTransport {

--- a/packages/alchemy/src/Sidecar/RpcTransport.ts
+++ b/packages/alchemy/src/Sidecar/RpcTransport.ts
@@ -115,10 +115,13 @@ function makeNodeWebSocketRpcServer<T extends RpcCompatible<T>>(main: () => T) {
   return server;
 }
 
-function toNodeMessage(message: WebSocket.RawData): string | Buffer<ArrayBuffer> {
+function toNodeMessage(
+  message: WebSocket.RawData,
+): string | Buffer<ArrayBuffer> {
   if (typeof message === "string") return message;
   if (Buffer.isBuffer(message)) return message as Buffer<ArrayBuffer>;
-  if (Array.isArray(message)) return Buffer.concat(message) as Buffer<ArrayBuffer>;
+  if (Array.isArray(message))
+    return Buffer.concat(message) as Buffer<ArrayBuffer>;
   return Buffer.from(message) as Buffer<ArrayBuffer>;
 }
 

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -1,4 +1,6 @@
 import { AdoptPolicy, Unowned } from "@/AdoptPolicy";
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import { workerBindingsToWranglerConfig } from "@/Cloudflare/Workers/LocalWorkerProvider";
 import * as Construct from "@/Construct";
 import type { Input, InputProps } from "@/Input";
 import * as Output from "@/Output";
@@ -113,6 +115,142 @@ const makePlanWithCustomStack =
         Effect.provide(TestLayers()),
       );
     });
+
+const compileStack = <A, Err = never, Req = never>(
+  effect: Effect.Effect<A, Err, Req>,
+): Effect.Effect<Stack.CompiledStack<A>, Err, never> =>
+  effect.pipe(
+    // @ts-expect-error - these tests only inspect stack registration; providers are not used.
+    Stack.make({
+      name: TEST_STACK,
+      providers: Layer.empty,
+      state: inMemoryState(),
+    }),
+    Effect.provideService(Stage, TEST_STAGE),
+  );
+
+test(
+  "Cloudflare.Vite records bindings from Effect props",
+  Effect.gen(function* () {
+    const stack = yield* compileStack(
+      Effect.gen(function* () {
+        const db = yield* Cloudflare.D1Database("DB");
+        return yield* Cloudflare.Vite(
+          "App",
+          Effect.succeed({
+            rootDir: ".",
+            bindings: { DB: db },
+          }),
+        );
+      }),
+    );
+
+    expect(stack.bindings.App).toMatchObject([
+      {
+        sid: "DB",
+        data: {
+          bindings: [
+            {
+              type: "d1",
+              name: "DB",
+            },
+          ],
+        },
+      },
+    ]);
+  }),
+);
+
+test(
+  "Cloudflare.Worker props bindings support service bindings",
+  Effect.gen(function* () {
+    const stack = yield* compileStack(
+      Effect.gen(function* () {
+        const api = yield* Cloudflare.Worker("API", {
+          main: "./api.ts",
+        });
+        return yield* Cloudflare.Worker("Web", {
+          main: "./web.ts",
+          bindings: { API: api },
+        });
+      }),
+    );
+
+    expect(stack.bindings.Web).toMatchObject([
+      {
+        sid: "API",
+        data: {
+          bindings: [
+            {
+              type: "service",
+              name: "API",
+            },
+          ],
+        },
+      },
+    ]);
+  }),
+);
+
+test(
+  "Cloudflare Vite dev wrangler config uses remote bindings",
+  Effect.sync(() => {
+    expect(
+      workerBindingsToWranglerConfig({
+        name: "app",
+        compatibility: { date: "2026-03-17", flags: ["nodejs_compat"] },
+        bindings: [
+          { type: "d1", name: "DB", id: "database-id" },
+          { type: "kv_namespace", name: "KV", namespaceId: "namespace-id" },
+          { type: "r2_bucket", name: "BUCKET", bucketName: "bucket" },
+          { type: "queue", name: "QUEUE", queueName: "queue" },
+          { type: "service", name: "API", service: "api-worker" },
+        ] as any,
+      }),
+    ).toMatchObject({
+      name: "app",
+      compatibility_date: "2026-03-17",
+      compatibility_flags: ["nodejs_compat"],
+      d1_databases: [
+        {
+          binding: "DB",
+          database_id: "database-id",
+          remote: true,
+        },
+      ],
+      kv_namespaces: [
+        {
+          binding: "KV",
+          id: "namespace-id",
+          remote: true,
+        },
+      ],
+      r2_buckets: [
+        {
+          binding: "BUCKET",
+          bucket_name: "bucket",
+          remote: true,
+        },
+      ],
+      queues: {
+        producers: [
+          {
+            binding: "QUEUE",
+            queue: "queue",
+            remote: true,
+          },
+        ],
+      },
+      services: [
+        {
+          binding: "API",
+          service: "api-worker",
+          remote: true,
+        },
+      ],
+    });
+  }),
+);
 
 test(
   "artifacts are isolated by FQN during plan diff for namespaced resources",

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -205,7 +205,19 @@ test(
           { type: "r2_bucket", name: "BUCKET", bucketName: "bucket" },
           { type: "queue", name: "QUEUE", queueName: "queue" },
           { type: "service", name: "API", service: "api-worker" },
+          { type: "hyperdrive", name: "HYPERDRIVE", id: "hyperdrive-id" },
         ] as any,
+        hyperdrives: {
+          "hyperdrive-id": {
+            scheme: "postgres",
+            host: "localhost",
+            port: 5432,
+            user: "app",
+            password: "secret",
+            database: "app",
+            sslmode: "prefer",
+          },
+        },
       }),
     ).toMatchObject({
       name: "app",
@@ -246,6 +258,14 @@ test(
           binding: "API",
           service: "api-worker",
           remote: true,
+        },
+      ],
+      hyperdrive: [
+        {
+          binding: "HYPERDRIVE",
+          id: "hyperdrive-id",
+          localConnectionString:
+            "postgres://app:secret@localhost:5432/app?sslmode=prefer",
         },
       ],
     });


### PR DESCRIPTION
- Simplifies Cloudflare.Vite usage with TanStack Start
- Auto-injects the Cloudflare Vite plugin in dev mode
- Makes Alchemy bindings work without a manual wrangler.jsonc
- Fixes local dev rootDir resolution
- Supports main: import.meta.url
- Scopes ALCHEMY_BUILD to builds started by Alchemy