### PR TITLE
feat(cloudflare): support Hyperdrive in Worker bindings

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
@@ -27,6 +27,8 @@ type GetBindingType<T> = T extends Cloudflare.Assets
             ? Ai
             : T extends Cloudflare.Artifacts
               ? Artifacts
-              : T extends Cloudflare.DurableObjectNamespaceLike
-                ? DurableObjectNamespace<Exclude<T["Shape"], undefined>>
-                : never;
+              : T extends Cloudflare.Hyperdrive
+                ? Hyperdrive
+                : T extends Cloudflare.DurableObjectNamespaceLike
+                  ? DurableObjectNamespace<Exclude<T["Shape"], undefined>>
+                  : never;

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -46,7 +46,10 @@ import {
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import { D1Database } from "../D1/D1Database.ts";
 import { fromCloudflareFetcher } from "../Fetcher.ts";
-import type { HyperdriveDevOrigin } from "../Hyperdrive/Hyperdrive.ts";
+import type {
+  Hyperdrive,
+  HyperdriveDevOrigin,
+} from "../Hyperdrive/Hyperdrive.ts";
 import type { KVNamespace } from "../KV/KVNamespace.ts";
 import { SidecarLive } from "../Local/Sidecar.ts";
 import { CloudflareLogs } from "../Logs.ts";
@@ -182,6 +185,7 @@ export type WorkerBindingResource =
   | CloudflareQueue
   | AiGateway
   | ArtifactsBinding
+  | Hyperdrive
   | DurableObjectNamespaceLike<any>;
 
 export type WorkerBindings = {
@@ -774,8 +778,14 @@ export const Worker: Platform<
                             type: "ai",
                             name: bindingName,
                           }
-                        : // TODO(sam): handle others
-                          undefined;
+                        : binding.Type === "Cloudflare.Hyperdrive"
+                          ? {
+                              type: "hyperdrive",
+                              name: bindingName,
+                              id: binding.hyperdriveId,
+                            }
+                          : // TODO(sam): handle others
+                            undefined;
 
         if (bindingMeta) {
           yield* resource.bind`${bindingName}`({


### PR DESCRIPTION
Closes #263.

Add `Hyperdrive` to `WorkerBindingResource` so it typechecks in `Cloudflare.Worker` / `Cloudflare.Vite` bindings, and emit the binding metadata in `onCreate`.

```ts
const hyperdrive = yield* Cloudflare.Hyperdrive("DB", { origin, caching: { disabled: true } })

const worker = yield* Cloudflare.Vite("Builder", {
  rootDir: "./apps/builder",
  bindings: { DB: hyperdrive }, // typechecks, env.DB inferred as Hyperdrive
})
```

Note: this shortcut only emits the deploy-time binding. The dev-mode `hyperdrives` override (local origin) still goes through `HyperdriveBindingPolicy` when you use `yield* Cloudflare.Hyperdrive.bind(hd)` inside the Worker code, same as before.
