### PR TITLE
feat(cloudflare): add SendEmail Worker binding

### DIFF
--- a/packages/alchemy/src/Cloudflare/Email/SendEmail.ts
+++ b/packages/alchemy/src/Cloudflare/Email/SendEmail.ts
@@ -1,0 +1,211 @@
+import type * as runtime from "@cloudflare/workers-types";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Binding from "../../Binding.ts";
+import type { ResourceLike } from "../../Resource.ts";
+import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
+
+/**
+ * Configuration for a `send_email` binding on a Worker.
+ *
+ * `name` becomes the env key (e.g. `env.EMAIL`) and uniquely identifies
+ * the binding within the Worker. Use either `destinationAddress` or
+ * `allowedDestinationAddresses` to restrict where the Worker can send.
+ * Omit both to allow sending to any verified destination address on the
+ * account. Destination and sender addresses must be verified in the
+ * Cloudflare Email Routing dashboard before they can be used.
+ */
+export interface SendEmailConfig {
+  /**
+   * Binding name. This is the key used to access the binding from the
+   * Worker's `env` (e.g. `env.EMAIL`). Must match
+   * `[A-Za-z][A-Za-z0-9_]*`.
+   */
+  name: string;
+  /**
+   * Restrict the Worker to send to a single verified destination
+   * address.
+   */
+  destinationAddress?: string;
+  /**
+   * Restrict the Worker to send to one of these verified destination
+   * addresses.
+   */
+  allowedDestinationAddresses?: string[];
+  /**
+   * Restrict the Worker to send from one of these sender addresses. The
+   * sender domain must be configured for Email Routing on the account.
+   */
+  allowedSenderAddresses?: string[];
+}
+
+/**
+ * Email body shape for the builder-form `send` call. Either `text`,
+ * `html`, or both must be provided.
+ */
+export interface SendEmailMessage {
+  from: string | runtime.EmailAddress;
+  to: string | string[];
+  subject: string;
+  replyTo?: string | runtime.EmailAddress;
+  cc?: string | string[];
+  bcc?: string | string[];
+  headers?: Record<string, string>;
+  text?: string;
+  html?: string;
+  attachments?: runtime.EmailAttachment[];
+}
+
+export class SendEmailError extends Data.TaggedError("SendEmailError")<{
+  message: string;
+  cause?: unknown;
+}> {}
+
+export interface SendEmailClient {
+  /**
+   * The raw runtime `SendEmail` binding. Use this when you need to send
+   * a pre-built `EmailMessage` from `cloudflare:email`.
+   */
+  raw: Effect.Effect<runtime.SendEmail, never, WorkerEnvironment>;
+  /**
+   * Send an email using the builder form. Equivalent to
+   * `env.<name>.send({ from, to, subject, text, html, ... })`.
+   */
+  send(
+    message: SendEmailMessage,
+  ): Effect.Effect<runtime.EmailSendResult, SendEmailError, WorkerEnvironment>;
+  /**
+   * Send a raw `EmailMessage` (constructed via `cloudflare:email`).
+   * Equivalent to `env.<name>.send(emailMessage)`.
+   */
+  sendRaw(
+    message: runtime.EmailMessage,
+  ): Effect.Effect<runtime.EmailSendResult, SendEmailError, WorkerEnvironment>;
+}
+
+/**
+ * Cloudflare `send_email` Worker binding.
+ *
+ * Lets a Worker send transactional email via Cloudflare Email Routing.
+ * The destination addresses (and optionally the sender domain) must be
+ * verified in the Cloudflare dashboard before the binding will deliver.
+ *
+ * @section Sending Email
+ * @example Bind and send to any verified destination
+ * ```typescript
+ * const email = yield* Cloudflare.SendEmail.bind({ name: "EMAIL" });
+ *
+ * return {
+ *   fetch: Effect.gen(function* () {
+ *     yield* email.send({
+ *       from: "noreply@example.com",
+ *       to: "user@example.com",
+ *       subject: "Hello",
+ *       text: "Hi from Alchemy",
+ *     });
+ *     return HttpServerResponse.empty({ status: 202 });
+ *   }),
+ * };
+ * ```
+ *
+ * @example Restrict to a single destination
+ * ```typescript
+ * const email = yield* Cloudflare.SendEmail.bind({
+ *   name: "EMAIL",
+ *   destinationAddress: "ops@example.com",
+ * });
+ * ```
+ *
+ * @example Restrict to a list of destinations
+ * ```typescript
+ * const email = yield* Cloudflare.SendEmail.bind({
+ *   name: "EMAIL",
+ *   allowedDestinationAddresses: [
+ *     "ops@example.com",
+ *     "alerts@example.com",
+ *   ],
+ * });
+ * ```
+ *
+ * @example Send a pre-built EmailMessage
+ * ```typescript
+ * import { EmailMessage } from "cloudflare:email";
+ *
+ * const email = yield* Cloudflare.SendEmail.bind({ name: "EMAIL" });
+ *
+ * yield* email.sendRaw(
+ *   new EmailMessage("noreply@example.com", "user@example.com", mimeText),
+ * );
+ * ```
+ *
+ * @binding
+ */
+export class SendEmail extends Binding.Service<
+  SendEmail,
+  (config: SendEmailConfig) => Effect.Effect<SendEmailClient>
+>()("Cloudflare.SendEmail") {}
+
+export const SendEmailLive = Layer.effect(
+  SendEmail,
+  Effect.gen(function* () {
+    const bind = yield* SendEmailPolicy;
+
+    return Effect.fn(function* (config: SendEmailConfig) {
+      yield* bind(config);
+      const env = WorkerEnvironment.asEffect();
+      const raw = env.pipe(
+        Effect.map(
+          (env) => (env as Record<string, runtime.SendEmail>)[config.name],
+        ),
+      );
+
+      const tryPromise = <T>(
+        fn: () => Promise<T>,
+      ): Effect.Effect<T, SendEmailError> =>
+        Effect.tryPromise({
+          try: fn,
+          catch: (error: any) =>
+            new SendEmailError({
+              message: error?.message ?? "Unknown send_email error",
+              cause: error,
+            }),
+        });
+
+      return {
+        raw,
+        send: (message: SendEmailMessage) =>
+          raw.pipe(Effect.flatMap((s) => tryPromise(() => s.send(message)))),
+        sendRaw: (message: runtime.EmailMessage) =>
+          raw.pipe(Effect.flatMap((s) => tryPromise(() => s.send(message)))),
+      } satisfies SendEmailClient;
+    });
+  }),
+);
+
+export class SendEmailPolicy extends Binding.Policy<
+  SendEmailPolicy,
+  (config: SendEmailConfig) => Effect.Effect<void>
+>()("Cloudflare.SendEmail") {}
+
+export const SendEmailPolicyLive = SendEmailPolicy.layer.succeed(
+  Effect.fnUntraced(function* (host: ResourceLike, config: SendEmailConfig) {
+    if (isWorker(host)) {
+      yield* host.bind`${config.name}`({
+        bindings: [
+          {
+            type: "send_email",
+            name: config.name,
+            destinationAddress: config.destinationAddress,
+            allowedDestinationAddresses: config.allowedDestinationAddresses,
+            allowedSenderAddresses: config.allowedSenderAddresses,
+          },
+        ],
+      });
+    } else {
+      return yield* Effect.die(
+        new Error(`SendEmail does not support runtime '${host.Type}'`),
+      );
+    }
+  }),
+);

--- a/packages/alchemy/src/Cloudflare/Email/index.ts
+++ b/packages/alchemy/src/Cloudflare/Email/index.ts
@@ -1,0 +1,1 @@
+export * from "./SendEmail.ts";

--- a/packages/alchemy/src/Cloudflare/Providers.ts
+++ b/packages/alchemy/src/Cloudflare/Providers.ts
@@ -20,6 +20,7 @@ import * as CloudflareEnvironment from "./CloudflareEnvironment.ts";
 import * as Containers from "./Container/index.ts";
 import * as Credentials from "./Credentials.ts";
 import * as D1 from "./D1/index.ts";
+import * as Email from "./Email/index.ts";
 import * as Hyperdrive from "./Hyperdrive/index.ts";
 import * as KV from "./KV/index.ts";
 import * as Queue from "./Queue/index.ts";
@@ -54,6 +55,7 @@ export const providers = () =>
       Containers.Container,
       D1.D1ConnectionPolicy,
       D1.D1Database,
+      Email.SendEmailPolicy,
       Hyperdrive.Hyperdrive,
       Hyperdrive.HyperdriveBindingPolicy,
       KV.KVNamespace,
@@ -86,6 +88,7 @@ export const providers = () =>
         Containers.ContainerProvider(),
         D1.D1ConnectionPolicyLive,
         D1.DatabaseProvider(),
+        Email.SendEmailPolicyLive,
         Hyperdrive.HyperdriveBindingPolicyLive,
         Hyperdrive.HyperdriveProvider(),
         KV.KVNamespaceBindingPolicyLive,

--- a/packages/alchemy/src/Cloudflare/index.ts
+++ b/packages/alchemy/src/Cloudflare/index.ts
@@ -5,6 +5,7 @@ export * from "./CloudflareEnvironment.ts";
 export * from "./Container/index.ts";
 export * from "./D1/index.ts";
 export * from "./EdgeSession.ts";
+export * from "./Email/index.ts";
 export * from "./Hyperdrive/index.ts";
 export * from "./KV/index.ts";
 export * from "./Providers.ts";

--- a/packages/alchemy/test/Cloudflare/Email/SendEmail.test.ts
+++ b/packages/alchemy/test/Cloudflare/Email/SendEmail.test.ts
@@ -1,0 +1,81 @@
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import * as Cloudflare from "@/Cloudflare";
+import * as Test from "@/Test/Vitest";
+import * as workers from "@distilled.cloud/cloudflare/workers";
+import { describe, expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import { waitForWorkerToBeDeleted } from "../Utils/Worker.ts";
+import SendEmailWorker from "./send-email-worker.ts";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+describe.concurrent("Cloudflare.SendEmail", () => {
+  test.provider(
+    "registers send_email bindings on the deployed Worker",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        const worker = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* SendEmailWorker;
+          }),
+        );
+
+        const settings = yield* workers.getScriptScriptAndVersionSetting({
+          accountId,
+          scriptName: worker.workerName,
+        });
+
+        const sendEmailBindings = (settings.bindings ?? []).filter(
+          (b): b is Extract<typeof b, { type: "send_email" }> =>
+            b.type === "send_email",
+        );
+
+        expect(sendEmailBindings).toHaveLength(4);
+
+        expect(sendEmailBindings).toContainEqual(
+          expect.objectContaining({
+            type: "send_email",
+            name: "EMAIL_UNRESTRICTED",
+          }),
+        );
+        expect(sendEmailBindings).toContainEqual(
+          expect.objectContaining({
+            type: "send_email",
+            name: "EMAIL_DESTINATION",
+            destinationAddress: "ops@example.com",
+          }),
+        );
+        expect(sendEmailBindings).toContainEqual(
+          expect.objectContaining({
+            type: "send_email",
+            name: "EMAIL_ALLOWED_DESTS",
+            allowedDestinationAddresses: [
+              "ops@example.com",
+              "alerts@example.com",
+            ],
+          }),
+        );
+        expect(sendEmailBindings).toContainEqual(
+          expect.objectContaining({
+            type: "send_email",
+            name: "EMAIL_ALLOWED_SENDERS",
+            allowedSenderAddresses: ["noreply@example.com"],
+          }),
+        );
+
+        yield* stack.destroy();
+
+        yield* waitForWorkerToBeDeleted(worker.workerName, accountId);
+      }).pipe(logLevel),
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Email/send-email-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Email/send-email-worker.ts
@@ -1,0 +1,42 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * Test fixture that binds four `send_email` variants on the same
+ * Worker so the deploy assertion can read every shape back from
+ * Cloudflare in a single round-trip.
+ *
+ * - `EMAIL_UNRESTRICTED`     — no destination/sender filter
+ * - `EMAIL_DESTINATION`      — single `destinationAddress`
+ * - `EMAIL_ALLOWED_DESTS`    — list of `allowedDestinationAddresses`
+ * - `EMAIL_ALLOWED_SENDERS`  — list of `allowedSenderAddresses`
+ */
+export default class SendEmailWorker extends Cloudflare.Worker<SendEmailWorker>()(
+  "SendEmailTestWorker",
+  {
+    main: import.meta.filename,
+    compatibility: { date: "2024-09-23" },
+  },
+  Effect.gen(function* () {
+    yield* Cloudflare.SendEmail.bind({ name: "EMAIL_UNRESTRICTED" });
+    yield* Cloudflare.SendEmail.bind({
+      name: "EMAIL_DESTINATION",
+      destinationAddress: "ops@example.com",
+    });
+    yield* Cloudflare.SendEmail.bind({
+      name: "EMAIL_ALLOWED_DESTS",
+      allowedDestinationAddresses: ["ops@example.com", "alerts@example.com"],
+    });
+    yield* Cloudflare.SendEmail.bind({
+      name: "EMAIL_ALLOWED_SENDERS",
+      allowedSenderAddresses: ["noreply@example.com"],
+    });
+
+    return {
+      fetch: Effect.gen(function* () {
+        return HttpServerResponse.text("ok");
+      }),
+    };
+  }).pipe(Effect.provide(Cloudflare.SendEmailLive)),
+) {}


### PR DESCRIPTION
Adds a `SendEmail` capability for Cloudflare Workers, wrapping the native `send_email` binding.

Closes #243.

```ts
const email = yield* Cloudflare.SendEmail.bind({
  name: "EMAIL",
  destinationAddress: "ops@example.com",
});

yield* email.send({
  from: "noreply@example.com",
  to: "ops@example.com",
  subject: "Hello",
  text: "Hi",
});
```

Provide `Cloudflare.SendEmailLive` on the Worker effect (same pattern as `QueueBindingLive`, `HyperdriveBindingLive`). `sendRaw` is also exposed for the `cloudflare:email` `EmailMessage` form.

Naming note: alchemy v1 called this `EmailSender`. Renamed to `SendEmail` to match the Cloudflare runtime binding type (`cf.SendEmail`) and the action-based naming used by other capabilities (`SendMessage`, `PutObject`, `Fetch`).

No dedicated test. Pure binding capabilities like `Workers.Fetch` don't have one either, and an integration test couldn't exercise actual delivery without a manually-verified destination address on the test account. Manually checked that `bun tsc -b` and `bun generate:api-reference` pass.
