### PR TITLE
feat(cloudflare): add Rate Limit binding

### DIFF
--- a/packages/alchemy/src/Cloudflare/RateLimit/RateLimit.ts
+++ b/packages/alchemy/src/Cloudflare/RateLimit/RateLimit.ts
@@ -1,0 +1,76 @@
+import * as Effect from "effect/Effect";
+
+type RateLimitTypeId = "Cloudflare.RateLimit";
+const RateLimitTypeId: RateLimitTypeId = "Cloudflare.RateLimit";
+
+export type RateLimitProps = {
+  /**
+   * Positive integer string that identifies this rate limit namespace within
+   * the Cloudflare account. Bindings with the same namespace share counters.
+   */
+  namespaceId: string;
+  /**
+   * Simple rate limit configuration.
+   */
+  simple: {
+    /**
+     * Number of allowed calls to `limit()` within the period.
+     */
+    limit: number;
+    /**
+     * Rate limit window in seconds.
+     */
+    period: 10 | 60;
+  };
+};
+
+/**
+ * A Cloudflare Workers Rate Limiting binding.
+ *
+ * Rate limits are configured as Worker bindings. The binding exposes
+ * `limit({ key })` at runtime and does not require a separate Cloudflare
+ * resource to be provisioned.
+ *
+ * @resource
+ *
+ * @section Binding to a Worker
+ * @example Basic rate limit
+ * ```typescript
+ * const RateLimit = yield* Cloudflare.RateLimit("RateLimit", {
+ *   namespaceId: "1001",
+ *   simple: { limit: 100, period: 60 },
+ * });
+ *
+ * export const Worker = Cloudflare.Worker("Worker", {
+ *   main: "./src/worker.ts",
+ *   bindings: { RateLimit },
+ * });
+ * ```
+ */
+export type RateLimit = {
+  Type: RateLimitTypeId;
+  name: string;
+  namespaceId: string;
+  simple: {
+    limit: number;
+    period: 10 | 60;
+  };
+};
+
+export const isRateLimit = (value: unknown): value is RateLimit =>
+  typeof value === "object" &&
+  value !== null &&
+  "Type" in value &&
+  (value as RateLimit).Type === RateLimitTypeId;
+
+export const RateLimit = Effect.fnUntraced(function* (
+  name: string,
+  props: RateLimitProps,
+) {
+  return {
+    Type: RateLimitTypeId,
+    name,
+    namespaceId: props.namespaceId,
+    simple: props.simple,
+  } satisfies RateLimit;
+});

--- a/packages/alchemy/src/Cloudflare/RateLimit/index.ts
+++ b/packages/alchemy/src/Cloudflare/RateLimit/index.ts
@@ -1,0 +1,1 @@
+export * from "./RateLimit.ts";

--- a/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
@@ -25,8 +25,10 @@ type GetBindingType<T> = T extends Cloudflare.Assets
           ? Queue<unknown>
           : T extends Cloudflare.AiGateway
             ? Ai
-            : T extends Cloudflare.Artifacts
-              ? Artifacts
-              : T extends Cloudflare.DurableObjectNamespaceLike
-                ? DurableObjectNamespace<Exclude<T["Shape"], undefined>>
-                : never;
+            : T extends Cloudflare.RateLimit
+              ? RateLimit
+              : T extends Cloudflare.Artifacts
+                ? Artifacts
+                : T extends Cloudflare.DurableObjectNamespaceLike
+                  ? DurableObjectNamespace<Exclude<T["Shape"], undefined>>
+                  : never;

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -53,6 +53,7 @@ import { CloudflareLogs } from "../Logs.ts";
 import type { Providers } from "../Providers.ts";
 import type { Queue as CloudflareQueue } from "../Queue/Queue.ts";
 import type { R2Bucket } from "../R2/R2Bucket.ts";
+import { isRateLimit, type RateLimit } from "../RateLimit/RateLimit.ts";
 import {
   isAssets,
   readAssets,
@@ -181,6 +182,7 @@ export type WorkerBindingResource =
   | KVNamespace
   | CloudflareQueue
   | AiGateway
+  | RateLimit
   | ArtifactsBinding
   | DurableObjectNamespaceLike<any>;
 
@@ -774,8 +776,20 @@ export const Worker: Platform<
                             type: "ai",
                             name: bindingName,
                           }
-                        : // TODO(sam): handle others
-                          undefined;
+                        : isRateLimit(binding)
+                          ? {
+                              type: "ratelimit",
+                              name: bindingName,
+                              namespaceId: binding.namespaceId,
+                              simple: {
+                                limit: binding.simple.limit,
+                                period: String(binding.simple.period) as
+                                  | "10"
+                                  | "60",
+                              },
+                            }
+                          : // TODO(sam): handle others
+                            undefined;
 
         if (bindingMeta) {
           yield* resource.bind`${bindingName}`({

--- a/packages/alchemy/src/Cloudflare/index.ts
+++ b/packages/alchemy/src/Cloudflare/index.ts
@@ -10,6 +10,7 @@ export * from "./KV/index.ts";
 export * from "./Providers.ts";
 export * from "./Queue/index.ts";
 export * from "./R2/index.ts";
+export * from "./RateLimit/index.ts";
 export * from "./SecretsStore/index.ts";
 export * from "./StateStore/index.ts";
 export * from "./Tunnel/index.ts";


### PR DESCRIPTION
## Issue

Alchemy v2 could not model a Cloudflare Workers Rate Limiting binding. Cloudflare configures this through Worker metadata as a `ratelimit` binding with `namespace_id` and a `simple` limit window. The runtime binding exposes `limit({ key })`.

Docs:
- https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/

## Solution

- Add `Cloudflare.RateLimit` as a pure Worker binding marker.
- Emit `{ type: "ratelimit", name, namespaceId, simple }` in Worker metadata.
- Include Rate Limit in `Cloudflare.InferEnv` as `RateLimit`.

## Validation

- `node_modules/.bin/oxfmt packages/alchemy/src/Cloudflare/RateLimit/RateLimit.ts packages/alchemy/src/Cloudflare/RateLimit/index.ts packages/alchemy/src/Cloudflare/index.ts packages/alchemy/src/Cloudflare/Workers/Worker.ts packages/alchemy/src/Cloudflare/Workers/InferEnv.ts`
- `node_modules/.bin/tsc -b packages/alchemy/tsconfig.json --pretty false`
- `git diff --check`
