### PR TITLE
fix(cloudflare/local): resolve *.localhost via undici dispatcher

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -343,7 +343,7 @@
         "react": "^19.2.0",
         "rolldown": "catalog:",
         "sonda": "catalog:",
-        "undici": "^8.2.0",
+        "undici": "^7.16.0",
         "web-tree-sitter": "catalog:",
         "yaml": "catalog:",
       },
@@ -3524,7 +3524,7 @@
 
     "unctx": ["unctx@2.5.0", "", { "dependencies": { "acorn": "^8.15.0", "estree-walker": "^3.0.3", "magic-string": "^0.30.21", "unplugin": "^2.3.11" } }, "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg=="],
 
-    "undici": ["undici@8.2.0", "", {}, "sha512-Z+4Hx9GE26Lh9Upwfnc8C7SsrpBPGaM/Gm6kMFtiG7c+5IvQKlXi/t+9x9DrrCh29cww5TSP9YdVaBcnLDs5fQ=="],
+    "undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
@@ -3780,6 +3780,8 @@
 
     "@distilled.cloud/cloudflare-vite-plugin/@distilled.cloud/cloudflare-rolldown-plugin": ["@distilled.cloud/cloudflare-rolldown-plugin@0.2.0", "", { "dependencies": { "@cloudflare/unenv-preset": "^2.16.0", "unenv": "^2.0.0-rc.24" }, "peerDependencies": { "rolldown": "^1.0.0-rc.9" } }, "sha512-zZFzGzp+6sy+zP3fOxkJ0pXyTXd08pLrOw/9ooIR4NkcyL1D1k2NxNPuan0X5pttebigTVCP8Ny3e62gUe9MBg=="],
 
+    "@effect/platform-node/undici": ["undici@8.2.0", "", {}, "sha512-Z+4Hx9GE26Lh9Upwfnc8C7SsrpBPGaM/Gm6kMFtiG7c+5IvQKlXi/t+9x9DrrCh29cww5TSP9YdVaBcnLDs5fQ=="],
+
     "@effect/sql-pg/pg-types": ["pg-types@4.1.0", "", { "dependencies": { "pg-int8": "1.0.1", "pg-numeric": "1.0.2", "postgres-array": "~3.0.1", "postgres-bytea": "~3.0.0", "postgres-date": "~2.1.0", "postgres-interval": "^3.0.0", "postgres-range": "^1.1.1" } }, "sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
@@ -3956,8 +3958,6 @@
 
     "changelogen/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
-    "cheerio/undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
-
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -4031,8 +4031,6 @@
     "mermaid/uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
-
-    "miniflare/undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
 
     "miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -299,7 +299,7 @@
     },
     "packages/alchemy": {
       "name": "alchemy",
-      "version": "2.0.0-beta.34",
+      "version": "2.0.0-beta.35",
       "bin": {
         "alchemy": "./bin/cli.js",
       },
@@ -343,6 +343,7 @@
         "react": "^19.2.0",
         "rolldown": "catalog:",
         "sonda": "catalog:",
+        "undici": "^8.2.0",
         "web-tree-sitter": "catalog:",
         "yaml": "catalog:",
       },
@@ -393,7 +394,7 @@
     },
     "packages/better-auth": {
       "name": "@alchemy.run/better-auth",
-      "version": "2.0.0-beta.34",
+      "version": "2.0.0-beta.35",
       "dependencies": {
         "alchemy": "workspace:*",
         "better-auth": "catalog:",
@@ -402,7 +403,7 @@
     },
     "packages/pr-package": {
       "name": "@alchemy.run/pr-package",
-      "version": "2.0.0-beta.34",
+      "version": "2.0.0-beta.35",
       "dependencies": {
         "alchemy": "workspace:*",
         "effect": "catalog:",

--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -309,6 +309,7 @@
     "react": "^19.2.0",
     "rolldown": "catalog:",
     "sonda": "catalog:",
+    "undici": "^8.2.0",
     "web-tree-sitter": "catalog:",
     "yaml": "catalog:"
   },

--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -309,7 +309,7 @@
     "react": "^19.2.0",
     "rolldown": "catalog:",
     "sonda": "catalog:",
-    "undici": "^8.2.0",
+    "undici": "^7.16.0",
     "web-tree-sitter": "catalog:",
     "yaml": "catalog:"
   },

--- a/packages/alchemy/src/Cli/main.ts
+++ b/packages/alchemy/src/Cli/main.ts
@@ -8,8 +8,11 @@ import { AlchemyContextLive } from "alchemy/AlchemyContext";
 import { CredentialsStoreLive } from "alchemy/Auth/Credentials";
 import { ProfileLive } from "alchemy/Auth/Profile";
 import { TelemetryLive } from "alchemy/Telemetry/Layer";
+import { installLocalhostDns } from "alchemy/Util/LocalhostDns";
 import { PlatformServices } from "alchemy/Util/PlatformServices";
 import packageJson from "../../package.json" with { type: "json" };
+
+installLocalhostDns();
 
 import { checkLatestVersion } from "./checkVersion.ts";
 import { handleCancellation } from "./commands/_shared.ts";

--- a/packages/alchemy/src/Test/Vitest.ts
+++ b/packages/alchemy/src/Test/Vitest.ts
@@ -10,7 +10,10 @@ import {
 import type { AlchemyContext } from "../AlchemyContext.ts";
 import type { CompiledStack } from "../Stack.ts";
 import type { Stage } from "../Stage.ts";
+import { installLocalhostDns } from "../Util/LocalhostDns.ts";
 import * as Core from "./Core.ts";
+
+installLocalhostDns();
 
 export type MakeOptions<ROut = any> = Core.MakeOptions<ROut>;
 export type ScratchStack = Core.ScratchStack;

--- a/packages/alchemy/src/Util/LocalhostDns.ts
+++ b/packages/alchemy/src/Util/LocalhostDns.ts
@@ -1,0 +1,58 @@
+/**
+ * Process-level DNS shim that makes `*.localhost` resolve to 127.0.0.1.
+ *
+ * Background: macOS's `getaddrinfo` does not honor RFC 6761 for arbitrary
+ * `*.localhost` names; only the bare `localhost` is mapped to loopback.
+ * workerd and browsers handle it themselves, but Node's undici-based fetch
+ * (and Bun's libcurl-based fetch on some platforms) fails with `ENOTFOUND`
+ * when calling URLs returned by the local Cloudflare worker proxy
+ * (e.g. `http://my-worker.localhost:1337`).
+ *
+ * The proxy in `@distilled.cloud/cloudflare-runtime` dispatches by the
+ * URL hostname, so we cannot rewrite the URL client-side to `127.0.0.1`
+ * (and `Host` is a forbidden fetch header). The fix is to make the host
+ * resolvable at the network layer.
+ *
+ * Calling `installLocalhostDns()` is idempotent.
+ */
+
+import { createRequire } from "node:module";
+
+let installed = false;
+
+const isLocalhost = (hostname: string): boolean =>
+  hostname === "localhost" ||
+  hostname === "[::1]" ||
+  hostname.endsWith(".localhost");
+
+export const installLocalhostDns = (): void => {
+  if (installed) return;
+  installed = true;
+  // Bun resolves `*.localhost` natively via its libcurl-based fetch on
+  // Darwin and Linux, so the shim is a no-op there. If a future Bun
+  // release changes this, install via Bun's undici-compatible global
+  // dispatcher here.
+  if (typeof (globalThis as { Bun?: unknown }).Bun !== "undefined") return;
+  try {
+    const require = createRequire(import.meta.url);
+    const undici: typeof import("undici") = require("undici");
+    const dns: typeof import("node:dns") = require("node:dns");
+    undici.setGlobalDispatcher(
+      new undici.Agent({
+        connect: {
+          lookup: (hostname, options, cb: any) => {
+            if (isLocalhost(hostname)) {
+              if (options && (options as { all?: boolean }).all) {
+                return cb(null, [{ address: "127.0.0.1", family: 4 }]);
+              }
+              return cb(null, "127.0.0.1", 4);
+            }
+            return dns.lookup(hostname, options, cb);
+          },
+        },
+      }),
+    );
+  } catch {
+    // undici not available; nothing to do.
+  }
+};

--- a/packages/alchemy/src/Util/PlatformServices.ts
+++ b/packages/alchemy/src/Util/PlatformServices.ts
@@ -9,6 +9,7 @@ import type { HttpServer } from "effect/unstable/http/HttpServer";
 import type { ServeError } from "effect/unstable/http/HttpServerError";
 import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 import type { WebSocketConstructor } from "effect/unstable/socket/Socket";
+import { installLocalhostDns } from "./LocalhostDns.ts";
 
 const isBun = typeof Bun !== "undefined";
 
@@ -52,6 +53,7 @@ export const runMain = <E, A>(
     readonly teardown?: Teardown | undefined;
   },
 ): void => {
+  installLocalhostDns();
   if (isBun) {
     void import("@effect/platform-bun/BunRuntime").then((BunRuntime) =>
       BunRuntime.runMain(effect, options),


### PR DESCRIPTION
macOS's `getaddrinfo` does not honor RFC 6761 for arbitrary `*.localhost` names; only the bare `localhost` is mapped to loopback. workerd and browsers handle it themselves, so the local Cloudflare worker proxy works internally, but Node's undici-based `fetch` (used by `HttpClient` in tests and CLI) fails with `ENOTFOUND my-worker.localhost` when calling URLs returned by `Sidecar.serve`.

Install a process-level undici dispatcher that resolves `localhost`, `[::1]`, and `*.localhost` to `127.0.0.1` and delegates everything else to `node:dns`. Bun resolves `*.localhost` natively, so the shim is a no-op there.

```ts
undici.setGlobalDispatcher(
  new undici.Agent({
    connect: {
      lookup: (hostname, options, cb) => {
        if (isLocalhost(hostname)) {
          if (options?.all) return cb(null, [{ address: "127.0.0.1", family: 4 }]);
          return cb(null, "127.0.0.1", 4);
        }
        return dns.lookup(hostname, options, cb);
      },
    },
  }),
);
```

Wired into `runMain` (sidecar + CLI), `Cli/main.ts`, and `Test/Vitest.ts` so all Alchemy-owned Node processes pick it up automatically.

`undici` is pinned to `^7.16.0` to match Node 24's bundled version. `setGlobalDispatcher` writes to a process-wide symbol that Node's bundled `fetch` reads from, so a mismatched major (e.g. v8) silently swaps the dispatcher for every fetch in the process — and v8's stricter `content-length` validation rejects payloads Effect's `HttpClient` sends (e.g. state-store PUTs).
