### PR TITLE
fix(cli): fall back to plain logging when plan exceeds terminal height

### DIFF
--- a/packages/alchemy/src/Cli/LoggingCli.ts
+++ b/packages/alchemy/src/Cli/LoggingCli.ts
@@ -2,7 +2,7 @@ import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import type { CRUD, Plan } from "../Plan.ts";
-import { Cli } from "./Cli.ts";
+import { type PlanStatusSession, Cli } from "./Cli.ts";
 import type { ApplyEvent, ApplyStatus } from "./Event.ts";
 
 const ESC = "\x1b[";
@@ -88,6 +88,39 @@ const formatPlanLines = (plan: Plan): string[] => {
   return lines;
 };
 
+export const startLoggingApplySession = (
+  plan: Plan,
+): Effect.Effect<PlanStatusSession> =>
+  Effect.gen(function* () {
+    for (const line of formatPlanLines(plan)) yield* Console.log(line);
+    yield* Console.log("");
+
+    const counts = { ok: 0, fail: 0 };
+    return {
+      emit: (event: ApplyEvent) =>
+        Effect.sync(() => {
+          if (event.kind === "annotate") {
+            console.log(`${tag(event.id)} ${blue(event.message)}`);
+            return;
+          }
+          const id = event.bindingId
+            ? `${event.id}/${event.bindingId}`
+            : event.id;
+          const status = statusColor(event.status)(event.status);
+          const msg = event.message ? ` ${dim("—")} ${event.message}` : "";
+          console.log(`${tag(id)} ${status}${msg}`);
+          if (isTerminal(event.status)) {
+            if (event.status === "fail") counts.fail++;
+            else counts.ok++;
+          }
+        }),
+      done: () =>
+        Console.log(
+          `\n${bold("Done:")} ${green(`${counts.ok} succeeded`)}${counts.fail ? dim(", ") + red(`${counts.fail} failed`) : ""}`,
+        ),
+    };
+  });
+
 export const LoggingCli = Layer.succeed(
   Cli,
   Cli.of({
@@ -103,35 +136,6 @@ export const LoggingCli = Layer.succeed(
       Effect.gen(function* () {
         for (const line of formatPlanLines(plan)) yield* Console.log(line);
       }),
-    startApplySession: (plan) =>
-      Effect.gen(function* () {
-        for (const line of formatPlanLines(plan)) yield* Console.log(line);
-        yield* Console.log("");
-
-        const counts = { ok: 0, fail: 0 };
-        return {
-          emit: (event: ApplyEvent) =>
-            Effect.sync(() => {
-              if (event.kind === "annotate") {
-                console.log(`${tag(event.id)} ${blue(event.message)}`);
-                return;
-              }
-              const id = event.bindingId
-                ? `${event.id}/${event.bindingId}`
-                : event.id;
-              const status = statusColor(event.status)(event.status);
-              const msg = event.message ? ` ${dim("—")} ${event.message}` : "";
-              console.log(`${tag(id)} ${status}${msg}`);
-              if (isTerminal(event.status)) {
-                if (event.status === "fail") counts.fail++;
-                else counts.ok++;
-              }
-            }),
-          done: () =>
-            Console.log(
-              `\n${bold("Done:")} ${green(`${counts.ok} succeeded`)}${counts.fail ? dim(", ") + red(`${counts.fail} failed`) : ""}`,
-            ),
-        };
-      }),
+    startApplySession: startLoggingApplySession,
   }),
 );

--- a/packages/alchemy/src/Cli/tui/InkCLI.tsx
+++ b/packages/alchemy/src/Cli/tui/InkCLI.tsx
@@ -5,9 +5,28 @@ import { render } from "ink";
 import type { Plan } from "../../Plan.ts";
 import { type PlanStatusSession, Cli } from "../Cli.ts";
 import type { ApplyEvent } from "../Event.ts";
+import { startLoggingApplySession } from "../LoggingCli.ts";
 import { ApprovePlan } from "./components/ApprovePlan.tsx";
 import { Plan as PlanComponent } from "./components/Plan.tsx";
-import { PlanProgress } from "./components/PlanProgress.tsx";
+import { buildProgressRows, PlanProgress } from "./components/PlanProgress.tsx";
+
+/**
+ * Lines we reserve at the bottom of the viewport for the shell prompt and a
+ * little headroom. Ink redraws by moving the cursor up by the previous frame's
+ * line count; if the live region is taller than the viewport, the cursor can't
+ * reach the top of the frame and each tick gets appended to scrollback rather
+ * than overwriting in place. Stricter terminals like Ghostty preserve those
+ * orphaned frames, producing visible duplication.
+ *
+ * See ink#382, ink#621, ink#907.
+ */
+const VIEWPORT_RESERVED_LINES = 4;
+
+const fitsInViewport = (rowCount: number): boolean => {
+  const viewportRows = process.stdout.rows;
+  if (!viewportRows) return true; // unknown size, assume it fits
+  return rowCount + VIEWPORT_RESERVED_LINES <= viewportRows;
+};
 
 export const inkCLI = () =>
   Layer.succeed(
@@ -35,6 +54,9 @@ const displayPlan = <P extends Plan>(plan: P): Effect.Effect<void> =>
   });
 
 const startApplySession = Effect.fn(function* <P extends Plan>(plan: P) {
+  if (!fitsInViewport(buildProgressRows(plan).length)) {
+    return yield* startLoggingApplySession(plan);
+  }
   const listeners = new Set<(event: ApplyEvent) => void>();
   const { unmount } = render(
     <PlanProgress


### PR DESCRIPTION
On Ghostty (and any short-enough terminal), the Ink-based apply session was duplicating every row in the scrollback as the spinner ticked.

Root cause: Ink redraws by moving the cursor up by the previous frame's line count. When the live region is taller than the viewport, the cursor can't reach the top of the frame, so each tick gets appended below instead of overwriting in place. iTerm and Terminal.app silently mask this by trimming the orphaned frames, Ghostty preserves them. Known Ink issue, see [ink#382](https://github.com/vadimdemedes/ink/issues/382), [#621](https://github.com/vadimdemedes/ink/discussions/621), [#907](https://github.com/vadimdemedes/ink/issues/907).

Fix: at the start of an apply session, if the plan rows plus a small reserve don't fit in `process.stdout.rows`, fall back to `LoggingCli`'s line-based session. Refactored `LoggingCli` to export `startLoggingApplySession` so `InkCLI` can reuse it.

```ts
const startApplySession = Effect.fn(function* (plan) {
  if (!fitsInViewport(buildProgressRows(plan).length)) {
    return yield* startLoggingApplySession(plan);
  }
  // ...existing Ink path
});
```
