### PR TITLE
fix(cloudflare/d1): make prepare/bind synchronous

### DIFF
--- a/packages/alchemy/src/Cloudflare/D1/D1Connection.ts
+++ b/packages/alchemy/src/Cloudflare/D1/D1Connection.ts
@@ -7,6 +7,86 @@ import { WorkerEnvironment } from "../Workers/Worker.ts";
 import type { D1Database } from "./D1Database.ts";
 import { DatabaseBinding } from "./D1DatabaseBinding.ts";
 
+/**
+ * Effect-native wrapper around a Cloudflare D1 prepared statement.
+ *
+ * Construction (`prepare`) and binding (`bind`) are synchronous —
+ * they're plan builders and don't touch D1. Only the executors
+ * (`all`, `first`, `run`, `raw`) round-trip to the database, and
+ * those return Effects so they participate in the Effect runtime.
+ */
+export class D1PreparedStatement {
+  /** @internal */
+  constructor(
+    private readonly query: string,
+    private readonly binds: ReadonlyArray<unknown>,
+    private readonly rawEff: Effect.Effect<runtime.D1Database>,
+  ) {}
+
+  /**
+   * Return a new prepared statement bound to `values`. Subsequent
+   * calls replace the previous binding, matching the underlying
+   * Cloudflare runtime semantics.
+   */
+  bind(...values: unknown[]): D1PreparedStatement {
+    return new D1PreparedStatement(this.query, values, this.rawEff);
+  }
+
+  /** Run the query and return all matching rows. */
+  all<T = unknown>(): Effect.Effect<runtime.D1Result<T>> {
+    return this.withRuntime((stmt) => stmt.all<T>());
+  }
+
+  /** Run the query and return the first row, or `null` if no rows. */
+  first<T = unknown>(): Effect.Effect<T | null>;
+  first<T = unknown>(column: string): Effect.Effect<T | null>;
+  first<T = unknown>(column?: string): Effect.Effect<T | null> {
+    return this.withRuntime((stmt) =>
+      column !== undefined ? stmt.first<T>(column) : stmt.first<T>(),
+    );
+  }
+
+  /** Run the query as a mutation; returns row metadata. */
+  run<T = unknown>(): Effect.Effect<runtime.D1Result<T>> {
+    return this.withRuntime((stmt) => stmt.run<T>());
+  }
+
+  /** Run the query and return rows as flat arrays. */
+  raw<T = unknown[]>(): Effect.Effect<T[]>;
+  raw<T = unknown[]>(options: {
+    columnNames: true;
+  }): Effect.Effect<[string[], ...T[]]>;
+  raw<T = unknown[]>(options?: {
+    columnNames: true;
+  }): Effect.Effect<T[] | [string[], ...T[]]> {
+    return this.withRuntime((stmt) =>
+      options
+        ? stmt.raw<T>(options)
+        : (stmt.raw<T>() as Promise<T[] | [string[], ...T[]]>),
+    );
+  }
+
+  /**
+   * Materialize the underlying Cloudflare prepared statement against
+   * a concrete D1 binding. Used by `D1ConnectionClient.batch` to
+   * collect statements for a single transactional call.
+   *
+   * @internal
+   */
+  _build(raw: runtime.D1Database): runtime.D1PreparedStatement {
+    const stmt = raw.prepare(this.query);
+    return this.binds.length > 0 ? stmt.bind(...this.binds) : stmt;
+  }
+
+  private withRuntime<A>(
+    fn: (stmt: runtime.D1PreparedStatement) => Promise<A>,
+  ): Effect.Effect<A> {
+    return Effect.flatMap(this.rawEff, (raw) =>
+      Effect.promise(() => fn(this._build(raw))),
+    );
+  }
+}
+
 export interface D1ConnectionClient {
   /**
    * An Effect that resolves to the raw underlying Cloudflare D1Database binding.
@@ -14,9 +94,11 @@ export interface D1ConnectionClient {
    */
   raw: Effect.Effect<runtime.D1Database>;
   /**
-   * Prepare a SQL query statement for later execution.
+   * Prepare a SQL statement. Returns synchronously — the network
+   * round-trip happens when you yield one of the statement's
+   * executors (`all`, `first`, `run`, `raw`).
    */
-  prepare: (query: string) => Effect.Effect<runtime.D1PreparedStatement>;
+  prepare: (query: string) => D1PreparedStatement;
   /**
    * Execute raw SQL without prepared statements.
    */
@@ -26,7 +108,7 @@ export interface D1ConnectionClient {
    * Statements execute sequentially and are rolled back on failure.
    */
   batch: <T = unknown>(
-    statements: runtime.D1PreparedStatement[],
+    statements: D1PreparedStatement[],
   ) => Effect.Effect<runtime.D1Result<T>[]>;
 }
 
@@ -42,22 +124,23 @@ export const D1ConnectionLive = Layer.effect(
 
     return Effect.fn(function* (database: D1Database) {
       yield* Policy(database);
-      const d1 = yield* Effect.serviceOption(WorkerEnvironment).pipe(
+      const rawEff = yield* Effect.serviceOption(WorkerEnvironment).pipe(
         Effect.map(Option.getOrUndefined),
         Effect.map((env) => env?.[database.LogicalId]! as runtime.D1Database),
         Effect.cached,
       );
 
       return {
-        raw: d1,
-        prepare: (query: string) =>
-          d1.pipe(Effect.map((d1) => d1.prepare(query))),
+        raw: rawEff,
+        prepare: (query: string) => new D1PreparedStatement(query, [], rawEff),
         exec: (query: string) =>
-          d1.pipe(Effect.flatMap((d1) => Effect.promise(() => d1.exec(query)))),
-        batch: <T = unknown>(statements: runtime.D1PreparedStatement[]) =>
-          d1.pipe(
-            Effect.flatMap((d1) =>
-              Effect.promise(() => d1.batch<T>(statements)),
+          Effect.flatMap(rawEff, (raw) =>
+            Effect.promise(() => raw.exec(query)),
+          ),
+        batch: <T = unknown>(statements: D1PreparedStatement[]) =>
+          Effect.flatMap(rawEff, (raw) =>
+            Effect.promise(() =>
+              raw.batch<T>(statements.map((s) => s._build(raw))),
             ),
           ),
       } satisfies D1ConnectionClient;

--- a/packages/alchemy/test/Cloudflare/D1/D1Binding.test.ts
+++ b/packages/alchemy/test/Cloudflare/D1/D1Binding.test.ts
@@ -1,0 +1,142 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import D1Worker from "./d1-worker.ts";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+class WorkerNotReady extends Data.TaggedError("WorkerNotReady")<{
+  status: number;
+  body: string;
+}> {}
+
+/**
+ * End-to-end test of `Cloudflare.D1Connection.bind(...)` against a real
+ * Cloudflare Worker + D1 database.
+ *
+ * Stack:
+ *
+ * - `D1WorkerDatabase` (Cloudflare.D1Database).
+ * - `D1EffectWorker` — uses `Cloudflare.D1Connection.bind(database)` in
+ *   the init phase, with `Cloudflare.D1ConnectionLive` provided to the
+ *   worker effect.
+ *
+ * The worker exposes routes that exercise every method on the
+ * `D1ConnectionClient`: `exec`, `prepare` + `.run/.all/.first`,
+ * `batch`, and the `raw` Effect that resolves to the underlying
+ * Cloudflare D1Database. The test hits those routes over HTTP and
+ * asserts the round-trip succeeds — proving the binding name agreed
+ * upon by the deploy-time policy and the runtime lookup match, and
+ * the Cloudflare runtime actually injected the binding into `env`.
+ */
+test.provider(
+  "D1Connection.bind exercises the full client surface",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const worker = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* D1Worker;
+        }),
+      );
+
+      expect(worker.url).toBeTypeOf("string");
+      const baseUrl = worker.url as string;
+
+      // Cloudflare's edge takes a few seconds to start serving a fresh
+      // workers.dev URL — initial requests can return Cloudflare's
+      // "There is nothing here yet" 404 page. Retry until /init returns
+      // 200, then use the same retry once for the warm-up before
+      // running the rest of the surface area assertions in a
+      // straight line.
+      const initRes = yield* HttpClient.execute(
+        HttpClientRequest.post(`${baseUrl}/init`),
+      ).pipe(
+        Effect.flatMap((res) =>
+          res.status === 200
+            ? res.text.pipe(Effect.as(res))
+            : res.text.pipe(
+                Effect.flatMap((body) =>
+                  Effect.fail(new WorkerNotReady({ status: res.status, body })),
+                ),
+              ),
+        ),
+        Effect.retry({
+          while: (e): e is WorkerNotReady =>
+            e instanceof WorkerNotReady && e.status >= 400 && e.status < 600,
+          schedule: Schedule.exponential("500 millis").pipe(
+            Schedule.both(Schedule.recurs(20)),
+          ),
+        }),
+      );
+      expect(initRes.status).toBe(200);
+      // db.exec returns a count + duration. We don't assert exact
+      // values (CREATE TABLE IF NOT EXISTS may report 0 statements
+      // executed on a re-run), only that the response shape parses.
+      const initBody = (yield* initRes.json) as {
+        count: number;
+        duration: number;
+      };
+      expect(typeof initBody.count).toBe("number");
+      expect(typeof initBody.duration).toBe("number");
+
+      // batch-insert via prepare.bind
+      const seedRes = yield* HttpClient.execute(
+        HttpClientRequest.post(`${baseUrl}/seed`),
+      );
+      expect(seedRes.status).toBe(200);
+      expect(yield* seedRes.json).toMatchObject({ batches: 3, success: true });
+
+      // single insert via prepare.bind.run
+      const insertRes = yield* HttpClient.execute(
+        HttpClientRequest.post(`${baseUrl}/users`).pipe(
+          HttpClientRequest.bodyJsonUnsafe({ id: 4, name: "dave" }),
+        ),
+      );
+      expect(insertRes.status).toBe(200);
+      expect(yield* insertRes.json).toMatchObject({
+        success: true,
+        meta: { changes: 1 },
+      });
+
+      // SELECT all via prepare.all
+      const allRes = yield* HttpClient.get(`${baseUrl}/users`);
+      expect(allRes.status).toBe(200);
+      const allBody = (yield* allRes.json) as {
+        success: boolean;
+        results: Array<{ id: number; name: string }>;
+      };
+      expect(allBody.success).toBe(true);
+      expect(allBody.results).toEqual([
+        { id: 1, name: "alice" },
+        { id: 2, name: "bob" },
+        { id: 3, name: "carol" },
+        { id: 4, name: "dave" },
+      ]);
+
+      // SELECT one via prepare.bind.first
+      const oneRes = yield* HttpClient.get(`${baseUrl}/users/2`);
+      expect(oneRes.status).toBe(200);
+      expect(yield* oneRes.json).toEqual({ row: { id: 2, name: "bob" } });
+
+      // raw escape hatch (used by Better Auth / Drizzle integrations)
+      const rawRes = yield* HttpClient.get(`${baseUrl}/raw`);
+      expect(rawRes.status).toBe(200);
+      expect(yield* rawRes.json).toEqual({ count: 4 });
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 240_000 },
+);

--- a/packages/alchemy/test/Cloudflare/D1/d1-worker.ts
+++ b/packages/alchemy/test/Cloudflare/D1/d1-worker.ts
@@ -1,0 +1,117 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * D1 database created at deploy time and bound to the worker via
+ * `Cloudflare.D1Connection.bind(...)`. The handlers below exercise
+ * the full surface area of the Effect-native D1 client:
+ *
+ *   POST /init                       — `db.exec("CREATE TABLE ...")`
+ *   POST /seed                       — `db.batch(prepare(...).bind(...))`
+ *   POST /users { name }             — `db.prepare(...).bind(...).run()`
+ *   GET  /users                      — `db.prepare(...).all()`
+ *   GET  /users/:id                  — `db.prepare(...).bind(id).first()`
+ *   GET  /raw                        — `db.raw` -> `db.dump`-style read
+ */
+export const TestDatabase = Cloudflare.D1Database("D1WorkerDatabase");
+
+export default class D1Worker extends Cloudflare.Worker<D1Worker>()(
+  "D1EffectWorker",
+  {
+    main: import.meta.filename,
+    subdomain: { enabled: true },
+    compatibility: { date: "2024-09-23", flags: ["nodejs_compat"] },
+  },
+  Effect.gen(function* () {
+    const database = yield* TestDatabase;
+    const db = yield* Cloudflare.D1Connection.bind(database);
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://x");
+
+        if (request.method === "POST" && url.pathname === "/init") {
+          const result = yield* db.exec(
+            "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)",
+          );
+          return yield* HttpServerResponse.json({
+            count: result.count,
+            duration: result.duration,
+          });
+        }
+
+        if (request.method === "POST" && url.pathname === "/seed") {
+          const insert = yield* db.prepare(
+            "INSERT INTO users (id, name) VALUES (?, ?)",
+          );
+          const results = yield* db.batch([
+            insert.bind(1, "alice"),
+            insert.bind(2, "bob"),
+            insert.bind(3, "carol"),
+          ]);
+          return yield* HttpServerResponse.json({
+            batches: results.length,
+            success: results.every((r) => r.success),
+          });
+        }
+
+        if (request.method === "POST" && url.pathname === "/users") {
+          const body = (yield* request.json) as { id: number; name: string };
+          const stmt = yield* db.prepare(
+            "INSERT INTO users (id, name) VALUES (?, ?)",
+          );
+          const bound = stmt.bind(body.id, body.name);
+          const result = yield* Effect.promise(() => bound.run());
+          return yield* HttpServerResponse.json({
+            success: result.success,
+            meta: { changes: result.meta.changes },
+          });
+        }
+
+        if (request.method === "GET" && url.pathname === "/users") {
+          const stmt = yield* db.prepare(
+            "SELECT id, name FROM users ORDER BY id",
+          );
+          const result = yield* Effect.promise(() =>
+            stmt.all<{ id: number; name: string }>(),
+          );
+          return yield* HttpServerResponse.json({
+            success: result.success,
+            results: result.results,
+          });
+        }
+
+        const userMatch = url.pathname.match(/^\/users\/(\d+)$/);
+        if (request.method === "GET" && userMatch) {
+          const id = Number(userMatch[1]);
+          const stmt = yield* db.prepare(
+            "SELECT id, name FROM users WHERE id = ?",
+          );
+          const row = yield* Effect.promise(() =>
+            stmt.bind(id).first<{ id: number; name: string }>(),
+          );
+          return yield* HttpServerResponse.json({ row });
+        }
+
+        if (request.method === "GET" && url.pathname === "/raw") {
+          const raw = yield* db.raw;
+          // `db.raw` returns the underlying Cloudflare D1Database.
+          // Run a prepared statement directly on it to prove `raw`
+          // resolves to a working binding (this is the escape hatch
+          // libraries like Better Auth/Drizzle rely on).
+          const result = yield* Effect.promise(() =>
+            raw.prepare("SELECT COUNT(*) as count FROM users").first<{
+              count: number;
+            }>(),
+          );
+          return yield* HttpServerResponse.json({ count: result?.count ?? 0 });
+        }
+
+        return HttpServerResponse.text("Not Found", { status: 404 });
+      }),
+    };
+  }).pipe(Effect.provide(Cloudflare.D1ConnectionLive)),
+) {}

--- a/packages/alchemy/test/Cloudflare/D1/d1-worker.ts
+++ b/packages/alchemy/test/Cloudflare/D1/d1-worker.ts
@@ -8,12 +8,12 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
  * `Cloudflare.D1Connection.bind(...)`. The handlers below exercise
  * the full surface area of the Effect-native D1 client:
  *
- *   POST /init                       — `db.exec("CREATE TABLE ...")`
- *   POST /seed                       — `db.batch(prepare(...).bind(...))`
- *   POST /users { name }             — `db.prepare(...).bind(...).run()`
- *   GET  /users                      — `db.prepare(...).all()`
- *   GET  /users/:id                  — `db.prepare(...).bind(id).first()`
- *   GET  /raw                        — `db.raw` -> `db.dump`-style read
+ *   POST /init       — `db.exec("CREATE TABLE ...")`
+ *   POST /seed       — `db.batch([prepare(...).bind(...), ...])`
+ *   POST /users      — `db.prepare(...).bind(...).run()`
+ *   GET  /users      — `db.prepare(...).all()`
+ *   GET  /users/:id  — `db.prepare(...).bind(id).first()`
+ *   GET  /raw        — `db.raw` -> direct runtime D1Database access
  */
 export const TestDatabase = Cloudflare.D1Database("D1WorkerDatabase");
 
@@ -44,7 +44,7 @@ export default class D1Worker extends Cloudflare.Worker<D1Worker>()(
         }
 
         if (request.method === "POST" && url.pathname === "/seed") {
-          const insert = yield* db.prepare(
+          const insert = db.prepare(
             "INSERT INTO users (id, name) VALUES (?, ?)",
           );
           const results = yield* db.batch([
@@ -60,11 +60,10 @@ export default class D1Worker extends Cloudflare.Worker<D1Worker>()(
 
         if (request.method === "POST" && url.pathname === "/users") {
           const body = (yield* request.json) as { id: number; name: string };
-          const stmt = yield* db.prepare(
-            "INSERT INTO users (id, name) VALUES (?, ?)",
-          );
-          const bound = stmt.bind(body.id, body.name);
-          const result = yield* Effect.promise(() => bound.run());
+          const result = yield* db
+            .prepare("INSERT INTO users (id, name) VALUES (?, ?)")
+            .bind(body.id, body.name)
+            .run();
           return yield* HttpServerResponse.json({
             success: result.success,
             meta: { changes: result.meta.changes },
@@ -72,12 +71,9 @@ export default class D1Worker extends Cloudflare.Worker<D1Worker>()(
         }
 
         if (request.method === "GET" && url.pathname === "/users") {
-          const stmt = yield* db.prepare(
-            "SELECT id, name FROM users ORDER BY id",
-          );
-          const result = yield* Effect.promise(() =>
-            stmt.all<{ id: number; name: string }>(),
-          );
+          const result = yield* db
+            .prepare("SELECT id, name FROM users ORDER BY id")
+            .all<{ id: number; name: string }>();
           return yield* HttpServerResponse.json({
             success: result.success,
             results: result.results,
@@ -87,21 +83,19 @@ export default class D1Worker extends Cloudflare.Worker<D1Worker>()(
         const userMatch = url.pathname.match(/^\/users\/(\d+)$/);
         if (request.method === "GET" && userMatch) {
           const id = Number(userMatch[1]);
-          const stmt = yield* db.prepare(
-            "SELECT id, name FROM users WHERE id = ?",
-          );
-          const row = yield* Effect.promise(() =>
-            stmt.bind(id).first<{ id: number; name: string }>(),
-          );
+          const row = yield* db
+            .prepare("SELECT id, name FROM users WHERE id = ?")
+            .bind(id)
+            .first<{ id: number; name: string }>();
           return yield* HttpServerResponse.json({ row });
         }
 
         if (request.method === "GET" && url.pathname === "/raw") {
-          const raw = yield* db.raw;
           // `db.raw` returns the underlying Cloudflare D1Database.
           // Run a prepared statement directly on it to prove `raw`
           // resolves to a working binding (this is the escape hatch
           // libraries like Better Auth/Drizzle rely on).
+          const raw = yield* db.raw;
           const result = yield* Effect.promise(() =>
             raw.prepare("SELECT COUNT(*) as count FROM users").first<{
               count: number;


### PR DESCRIPTION
`D1Connection.prepare()` and `.bind()` are plan builders — they don't touch D1. Wrapping them in `Effect` forced consumers into nested `yield*` calls and `Effect.promise(() => stmt.bind(...).all())`, and broke the documented `db.prepare(...).bind(...).all()` chain.

```ts
// before — awkward and didn't match the JSDoc example
const stmt = yield* db.prepare("SELECT ... WHERE id = ?");
const row = yield* Effect.promise(() => stmt.bind(id).first());

// after — matches the existing JSDoc example
const row = yield* db
  .prepare("SELECT ... WHERE id = ?")
  .bind(id)
  .first();
```

Only the executors that actually round-trip to D1 (`all`, `first`, `run`, `raw`, `exec`, `batch`) return Effects. `D1PreparedStatement` is now a small class that captures `query` + `binds` + the runtime-D1 Effect and materializes the underlying Cloudflare prepared statement lazily inside each executor.

Adds a worker fixture + end-to-end test that hits every route over HTTP to lock in the contract.

```
POST /init       → db.exec(...)
POST /seed       → db.batch([prepare(...).bind(...), ...])
POST /users      → db.prepare(...).bind(...).run()
GET  /users      → db.prepare(...).all()
GET  /users/:id  → db.prepare(...).bind(id).first()
GET  /raw        → yield* db.raw → underlying Cloudflare D1Database
```