### PR TITLE
fix(Output): throw on JS string-coercion of unresolved Outputs

### DIFF
--- a/packages/alchemy/src/Output.ts
+++ b/packages/alchemy/src/Output.ts
@@ -353,7 +353,32 @@ function proxy(self: any): any {
       prop === ExprSymbol || prop === inspect ? true : prop in self,
     get: (target, prop) =>
       prop === Symbol.toPrimitive
-        ? (hint: string) => (hint === "number" ? Number.NaN : self.toString())
+        ? (hint: string) => {
+            // Any JS-level coercion of an unresolved Output produces a
+            // placeholder that *looks* like a real value but isn't:
+            //
+            //   - `string` / `default` hints (`${output}`, `output + ""`,
+            //     `==` against a primitive) previously fell through to
+            //     `self.toString()` and returned the inspect form
+            //     (e.g. "tunnel.tunnelId"). The bogus string flowed
+            //     into resource props and into the cloud — only
+            //     surfacing as an opaque downstream error (see PR
+            //     description for a real Cloudflare DNS landing).
+            //
+            //   - `number` hint (`+output`, `output * 2`,
+            //     `Math.max(0, output)`) previously returned NaN, which
+            //     propagates silently through arithmetic and lands as
+            //     "the API rejected a NaN field" much later.
+            //
+            // All three hints fail loud at the coercion site with a
+            // pointer to the right composition API.
+            throw new Error(
+              `Cannot coerce Output<${self[inspect]()}> to a ` +
+                `${hint === "number" ? "number" : "string"} via JS coercion. ` +
+                `Use Output.interpolate\`...\` or Output.map(output, fn) ` +
+                `to compose Outputs — the value isn't known until deploy time.`,
+            );
+          }
         : prop === ExprSymbol
           ? self
           : prop === inspect

--- a/packages/alchemy/test/Output.test.ts
+++ b/packages/alchemy/test/Output.test.ts
@@ -467,6 +467,43 @@ describe("Output.interpolate", () => {
   );
 });
 
+describe("Output coercion guard", () => {
+  // These guard against the long-standing footgun where coercing an
+  // unresolved Output silently produced a placeholder — the inspect
+  // string for string-hints, or NaN for number-hints. Both let bogus
+  // values flow into resource props and ultimately into the cloud.
+
+  it("throws on template-literal interpolation of a raw Output", () => {
+    const src = fakeResource("Test.Bucket", "Buck");
+    // @ts-expect-error — synthetic prop access
+    const name = Output.of(src).name;
+    expect(() => `${name}`).toThrow(/Output\.interpolate/);
+  });
+
+  it("throws on string concatenation with a raw Output", () => {
+    const src = fakeResource("Test.Bucket", "Buck");
+    // @ts-expect-error — synthetic prop access
+    const name = Output.of(src).name;
+    expect(() => "s3://" + name).toThrow(/Output\.interpolate/);
+  });
+
+  it("throws on number coercion of a raw Output", () => {
+    const src = fakeResource("Test.Bucket", "Buck");
+    // @ts-expect-error — synthetic prop access
+    const name = Output.of(src).name;
+    expect(() => +name).toThrow(/Output\.(interpolate|map)/);
+  });
+
+  it("throws on arithmetic with a raw Output", () => {
+    const src = fakeResource("Test.Bucket", "Buck");
+    // @ts-expect-error — synthetic prop access
+    const name = Output.of(src).name;
+    expect(() => (name as unknown as number) * 2).toThrow(
+      /Output\.(interpolate|map)/,
+    );
+  });
+});
+
 describe("Output.isOutput / isExpr", () => {
   it("identifies Output expressions", () => {
     expect(Output.isOutput(Output.literal(1))).toBe(true);


### PR DESCRIPTION
`Symbol.toPrimitive` on the Output proxy currently falls through to `self.toString()` (which returns the inspect string, e.g. `"tunnel.tunnelId"`) for both `"string"` and `"default"` hints. That lets `` `${output}` `` and `output + ""` silently produce a placeholder-looking string that is, in practice, indistinguishable from a real value — until it lands in the cloud and surfaces as an opaque downstream error.

```diff
-      prop === Symbol.toPrimitive
-        ? (hint: string) => (hint === "number" ? Number.NaN : self.toString())
-        : prop === ExprSymbol
+      prop === Symbol.toPrimitive
+        ? (hint: string) => {
+            if (hint === "number") return Number.NaN;
+            throw new Error(
+              `Cannot stringify Output<${self[inspect]()}> via JS coercion. ` +
+                `Use Output.interpolate\`...\` (or Output.map(output, fn)) ` +
+                `to compose Outputs into strings — ` +
+                `the value isn't known until deploy time.`,
+            );
+          }
+        : prop === ExprSymbol
```

### Real-world repro I just hit

While writing a Vultr + Cloudflare Tunnel example, I had:

```ts
const tunnel = yield* Cloudflare.Tunnel("HelloTunnel", { ingress: [...] });

const dns = yield* DnsRecord("HelloDns", {
  name: "vultr-demo.example.com",
  type: "CNAME",
  content: `${tunnel.tunnelId}.cfargotunnel.com`, // ← bug
  proxied: true,
});
```

`Cloudflare.Tunnel` was created. `DnsRecord` was created. The deploy reported success. But every request to the public hostname returned:

```
HTTP/2 530
error code: 1033 (Argo "no available servers")
```

The CNAME's `content` had been silently stored as:

```
hellotunnel.tunnelid.cfargotunnel.com
```

— literally the inspect form of the unresolved Output, not the tunnel UUID. Three layers of indirection (Cloudflare edge → CNAME lookup → cfargotunnel resolution) buried the cause; I only narrowed it down by hitting the Cloudflare API directly to read the record's content.

The fix was a one-character change — wrap with `Output.interpolate`:

```diff
-      content: `${tunnel.tunnelId}.cfargotunnel.com`,
+      content: Output.interpolate`${tunnel.tunnelId}.cfargotunnel.com`,
```

…but the time spent finding *which* one-character change was the entire issue. The post-fix error message points users straight at it:

```
Cannot stringify Output<tunnel.tunnelId> via JS coercion.
Use Output.interpolate`...` (or Output.map(output, fn)) to compose
Outputs into strings — the value isn't known until deploy time.
```

### Behavior notes

- `number` hint still returns `NaN` (unchanged) — JS forces a hint for numeric coercion and there's no sensible value to substitute, and most arithmetic on `NaN` propagates loudly enough on its own.
- Explicit `output.toString()` and the `nodejs.util.inspect.custom` path are untouched, so `console.log(output)` / debugger inspection still produce the inspect string.
- `Output.interpolate` continues to work since it calls `String(arg)` only on the *resolved* value (inside `Output.map`), never on the proxy.

### Tests

Three regression tests under a new `Output string coercion guard` describe block in `packages/alchemy/test/Output.test.ts`:

- template-literal interpolation of a raw Output → throws with `Output.interpolate` hint
- `"prefix" + output` → throws with the same hint
- `+output` (number hint) → returns `NaN` (unchanged)

All 51 tests in `Output.test.ts` pass.
