### PR TITLE
fix(build): remove deprecated libsodium wrapper types

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -324,7 +324,6 @@
         "@smithy/shared-ini-file-loader": "catalog:",
         "@smithy/types": "catalog:",
         "@types/aws-lambda": "catalog:",
-        "@types/libsodium-wrappers": "^0.8.2",
         "ai": "catalog:",
         "aws4fetch": "catalog:",
         "capnweb": "^0.6.1",
@@ -1659,8 +1658,6 @@
     "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
-
-    "@types/libsodium-wrappers": ["@types/libsodium-wrappers@0.8.2", "", { "dependencies": { "libsodium-wrappers": "*" } }, "sha512-+2IDfSULPUskSjIYfZl9suIUsIE5PXwoKZiE/j0MZWd+M9nEGvJDsk/ztMZKNhL1lBL+1CaypW0dQSjqPW2dMg=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 

--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -291,7 +291,6 @@
     "@smithy/shared-ini-file-loader": "catalog:",
     "@smithy/types": "catalog:",
     "@types/aws-lambda": "catalog:",
-    "@types/libsodium-wrappers": "^0.8.2",
     "ai": "catalog:",
     "aws4fetch": "catalog:",
     "capnweb": "^0.6.1",


### PR DESCRIPTION
Removes `@types/libsodium-wrappers` from the `alchemy` package dependencies.

`libsodium-wrappers` ships its own TypeScript declarations, and the `@types/libsodium-wrappers` package is a deprecated stub that produces deprecation noise for downstream installs. The runtime `libsodium-wrappers` dependency remains because `GitHub/Secret.ts` imports it for GitHub secret encryption.

Verified with:

```bash
bun run --filter alchemy build