### PR TITLE
docs(blog): release walkthroughs (beta.35–37) + draft deep-dives

### DIFF
--- a/website/src/content/docs/blog/2026-04-25-circular-references.md
+++ b/website/src/content/docs/blog/2026-04-25-circular-references.md
@@ -1,0 +1,300 @@
+---
+title: Circular references, without the deadlock
+date: 2026-04-25
+excerpt: Two Workers can call each other. A Lambda's role and the KMS key it uses can grant each other access. Alchemy plans these as graphs with cycles — at both the runtime layer and the type system layer.
+---
+
+Say you have two services that need to talk to each other.
+A web app handles login, an internal service handles
+billing, and each one calls the other.
+
+To deploy them, you need to tell each service where to
+find the other. Easy enough if you're deploying by hand —
+deploy the first, copy its URL, paste it into the second,
+deploy that, copy its URL back into the first. Done.
+
+But you want this in your infra code, so it's repeatable.
+And now you have a problem: which one does the deployer
+create first? Whichever you pick, you don't yet have the
+other one's URL to give it.
+
+This is a **circular dependency**, and most infrastructure
+tools refuse to handle it. They'll plan your resources in
+order, and the moment they detect a cycle they stop and
+ask you to break it manually.
+
+Alchemy doesn't. It plans the cycle in two passes.
+
+## The observation that makes it work
+
+When two resources depend on each other, they almost never
+need the *whole* other resource. They need one piece of
+identifying information — a URL, an ARN, a name. Something
+short and stable that's known the moment the resource
+exists, even before it's fully configured.
+
+That's the wedge. If we can produce identifiers before we
+do the rest of the work, we can plan the cycle as two
+passes:
+
+1. Reserve the identifiers for both resources.
+2. Now that both identifiers exist, finish configuring each
+   one — including the cross-reference to the other side.
+
+Alchemy gives providers a lifecycle hook for step 1 called
+**`precreate`**, and a regular lifecycle hook for step 2
+called **`reconcile`**.
+
+## `precreate` — reserving identifiers before reconcile
+
+When the planner sees a cycle, it asks each participating
+resource: *can you produce your stable identifiers without
+needing the other side?* If the provider implements
+`precreate`, the answer is yes.
+
+Here's the Cloudflare `Worker` provider's `precreate`
+(abbreviated from [`Worker.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cloudflare/Workers/Worker.ts)):
+
+```typescript
+precreate: Effect.fnUntraced(function* ({ id, news, session }) {
+  const name = yield* createWorkerName(id, news.name);
+
+  // Upload a placeholder script. Just enough to reserve the
+  // worker name and any Durable Object class IDs the cycle
+  // might reference.
+  yield* putScript({
+    accountId,
+    scriptName: name,
+    metadata: { mainModule: "main.js", /* ...DO stubs... */ },
+    files: [new File([placeholderScript], "main.js")],
+  });
+
+  return {
+    workerId: name,
+    workerName: name,
+    url: undefined,                          // not yet — filled in by reconcile
+    durableObjectNamespaces,
+    // ...
+  } satisfies Worker["Attributes"];
+}),
+```
+
+The placeholder script is a no-op. It returns
+`"Alchemy worker is being deployed..."`. That's fine — its
+job isn't to handle traffic, it's to reserve a script name
+and (if there are Durable Objects) generate stable namespace
+IDs that other resources can refer to.
+
+In alchemy v1 this was an explicit `WorkerStub` resource you
+had to declare in your stack. In v2 it's invisible — the
+planner detects the cycle, calls `precreate` on the
+participating resources first, and then runs `reconcile` on
+all of them with the cross-references resolved.
+
+For [`AWS/S3/Bucket.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/S3/Bucket.ts)
+the `precreate` is even shorter — it just calls
+`ensureBucketExists`, since for the BucketPolicy → Lambda
+cycle all the other side needs is the bucket ARN, which is
+known the moment the bucket exists.
+
+If a provider *doesn't* implement `precreate`, the planner
+still works — it just can't participate in a cycle. You'd
+get the same DAG-only behavior as Terraform. `precreate` is
+an opt-in for the resources where the cycle pattern matters.
+
+## The type-system problem
+
+Engine support is half the battle. The other half is
+authoring code that *expresses* the cycle without the
+TypeScript compiler exploding.
+
+The naive thing to write looks like this:
+
+```typescript
+// src/A.ts
+import { B } from "./B.ts";
+
+export const A = Cloudflare.Worker("A", { main: import.meta.path },
+  Effect.gen(function* () {
+    const b = yield* Cloudflare.Worker.bind(B);
+    return { fetch: ... };
+  }),
+);
+
+// src/B.ts
+import { A } from "./A.ts";
+
+export const B = Cloudflare.Worker("B", { main: import.meta.path },
+  Effect.gen(function* () {
+    const a = yield* Cloudflare.Worker.bind(A);
+    return { fetch: ... };
+  }),
+);
+```
+
+Three things go wrong:
+
+1. **Bundle bloat.** Each Worker's `import` pulls in the
+   other Worker's entire implementation. When you bundle `A`
+   for deployment, you also bundle `B`'s handler code — and
+   vice versa. The Cloudflare Worker that's supposed to be
+   small now contains both implementations.
+
+2. **Circular type inference.** TypeScript needs `B`'s type
+   to type-check `A`, but `B`'s type depends on `A`'s type
+   (because the Effect inside `B` references `A`). The
+   compiler usually gives up here with the cheerful
+   ["function lacks ending return statement and return type
+   does not include 'undefined'"](https://github.com/microsoft/TypeScript/issues/43053)
+   genre of error.
+
+3. **Runtime initialization order.** Even if the types
+   resolved, the module loader has to execute *something*
+   first. Whichever module loads first sees `undefined` on
+   the other side.
+
+## Tag-based design
+
+The fix is to separate **identity** from **implementation**.
+The class is the Tag — it carries the type, the resource ID,
+the binding contract — and it's cheap to import. The
+implementation is attached via a separate `.make()` call
+that runs only when the Stack provides it.
+
+```typescript
+// src/A.ts — just the Tag
+import * as Cloudflare from "alchemy/Cloudflare";
+
+export class A extends Cloudflare.Worker<A>()("A", {
+  main: import.meta.path,
+}) {}
+```
+
+That's the whole identity declaration. Importing `A` from
+another file gets you the type and the resource ID. It does
+*not* pull in any handler code — there is no handler code
+yet. The class is the Tag.
+
+The runtime piece is a second file-level export:
+
+```diff lang="typescript"
+  // src/A.ts
+  import * as Cloudflare from "alchemy/Cloudflare";
++ import * as Effect from "effect/Effect";
++ import { B } from "./B.ts";
+
+  export class A extends Cloudflare.Worker<A>()("A", {
+    main: import.meta.path,
+  }) {}
+
++ export default A.make(
++   Effect.gen(function* () {
++     const b = yield* Cloudflare.Worker.bind(B);
++     return {
++       fetch: Effect.gen(function* () {
++         return yield* b.fetch(new Request("https://b/work"));
++       }),
++     };
++   }),
++ );
+```
+
+The `import { B }` here imports B's Tag only — its identity
+and binding contract. `Worker.bind(B)` returns a typed
+callable; at plan time the URL is an `Output<URL>`
+placeholder, at runtime it's a real `fetch` stub.
+
+`B.ts` mirrors the pattern: imports `A`'s Tag, binds it
+inside its own `.make()`. Each file's `Effect.gen` references
+the *other* class as a Tag, not as a value that has to be
+initialized. The bundler sees the Tag import as type-only
+and tree-shakes it from the runtime bundle. The TypeScript
+compiler can resolve the types because each Tag is a single
+class declaration with no dependencies on the other side's
+implementation.
+
+### Why `.make()` and not the inline form
+
+For the non-cyclic case Alchemy lets you write the resource
+and its implementation in a single expression:
+
+```typescript
+export default Cloudflare.Worker("MyWorker", { main: import.meta.path },
+  Effect.gen(function* () { /* ... */ }),
+);
+```
+
+This is the convenient default — one file, one expression,
+type inference flows in one direction. But the moment the
+generator references *itself*'s tag (`yield* MyWorker`), TS
+trips on the self-reference. The class-form-plus-`.make()`
+splits the declaration from the inferred body, which is
+what unblocks both self-references and cross-references.
+
+The rule of thumb: use the inline form for DAG-shaped
+resources, use the class form when something else
+references the resource before its implementation is in
+scope — including the resource itself.
+
+## How the two pieces compose
+
+At plan time, the engine builds a dependency graph from the
+Stack expression. When it sees a cycle, it routes the
+participating resources through a two-pass lifecycle:
+
+```
+1. precreate — reserve identifiers (placeholder Worker scripts,
+                empty Buckets, KMS keys without policies).
+                Cross-references now have valid Output<…> values.
+2. reconcile — every resource runs with the resolved bindings.
+                For Worker A this means a real putScript with
+                the binding to B's reserved URL; for the KMS
+                key, the full resource policy referencing the
+                role's ARN.
+```
+
+The Tag/Layer split is what makes step 2 *authorable* — the
+generator inside `A.make(...)` can `yield* Worker.bind(B)`
+without anyone needing to evaluate `B`'s `.make()` body. The
+`precreate` hook is what makes step 2 *executable* — by the
+time the generator runs, `B` already has a reserved URL.
+
+You need both layers. Engine support without the Tag/Layer
+split leaves you writing un-bundle-able, un-type-checkable
+code. The Tag/Layer split without engine support leaves you
+with code that type-checks but deadlocks at deploy time.
+
+## When you don't need any of this
+
+If your services form a DAG, write them inline. The
+machinery exists for the cases where the natural shape of
+your system has cycles — bidirectional resource policies,
+mutually-recursive services, queue-mediated callbacks. For
+everything else, the simple form is still simple:
+
+```typescript
+export default Cloudflare.Worker("Web", { main: import.meta.path },
+  Effect.gen(function* () {
+    const db = yield* Database;
+    return { fetch: /* ... */ };
+  }),
+);
+```
+
+The interesting design choice is that the *engine*
+capability — `precreate` and cycle-aware planning — is
+opt-in per provider, not part of the framework's core
+contract. Most providers don't need it. The ones that do
+(Cloudflare `Worker`, AWS `Bucket`, KMS `Key`, IAM `Role`,
+Lambda `Function`) implement it explicitly, and the planner
+only invokes it when a cycle is actually present.
+
+## Where to go next
+
+- [Guides › Circular Bindings](/guides/circular-bindings) —
+  the step-by-step Worker A ↔ Worker B walkthrough.
+- [`Cloudflare/Workers/Worker.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cloudflare/Workers/Worker.ts)
+  — the canonical `precreate` reference, including Durable
+  Object namespace reservation.
+- [`AWS/S3/Bucket.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/S3/Bucket.ts)
+  — `precreate` for the BucketPolicy ↔ Lambda Role cycle.

--- a/website/src/content/docs/blog/2026-04-25-circular-references.md
+++ b/website/src/content/docs/blog/2026-04-25-circular-references.md
@@ -143,10 +143,9 @@ Three things go wrong:
 2. **Circular type inference.** TypeScript needs `B`'s type
    to type-check `A`, but `B`'s type depends on `A`'s type
    (because the Effect inside `B` references `A`). The
-   compiler usually gives up here with the cheerful
-   ["function lacks ending return statement and return type
-   does not include 'undefined'"](https://github.com/microsoft/TypeScript/issues/43053)
-   genre of error.
+   compiler bails with:
+
+   > `'A' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.ts(7023)`
 
 3. **Runtime initialization order.** Even if the types
    resolved, the module loader has to execute *something*

--- a/website/src/content/docs/blog/2026-04-25-circular-references.md
+++ b/website/src/content/docs/blog/2026-04-25-circular-references.md
@@ -1,6 +1,7 @@
 ---
 title: Circular references, without the deadlock
 date: 2026-04-25
+draft: true
 excerpt: Two Workers can call each other. A Lambda's role and the KMS key it uses can grant each other access. Alchemy plans these as graphs with cycles — at both the runtime layer and the type system layer.
 ---
 

--- a/website/src/content/docs/blog/2026-04-30-bindings.md
+++ b/website/src/content/docs/blog/2026-04-30-bindings.md
@@ -20,6 +20,16 @@ Effect.gen(function* () {
 });
 ```
 
+The shape is borrowed from Effect's
+[`Layer`](https://effect.website/docs/requirements-management/layers/)
+constructor pattern: the outer `Effect.gen` is the
+constructor — `yield* X` once at the top to acquire each
+dependency, then return a record whose methods close over
+them. Every request that hits `fetch` reuses the same
+`getPhoto` callable; the bind happens once. Alchemy adopts
+this pattern wholesale for Worker and Function bodies, which
+is what makes the next two sections possible.
+
 Two things have to happen for that line to work.
 
 - **At deploy time**, the Worker's IAM role needs

--- a/website/src/content/docs/blog/2026-04-30-bindings.md
+++ b/website/src/content/docs/blog/2026-04-30-bindings.md
@@ -1,6 +1,7 @@
 ---
 title: Bindings — one line, two phases
 date: 2026-04-30
+draft: true
 excerpt: A single `yield* S3.GetObject.bind(Photos)` in your handler grants the IAM policy at deploy and calls the SDK at runtime. The IAM logic never lands in your bundle.
 ---
 

--- a/website/src/content/docs/blog/2026-04-30-bindings.md
+++ b/website/src/content/docs/blog/2026-04-30-bindings.md
@@ -6,7 +6,7 @@ excerpt: A single `yield* S3.GetObject.bind(Photos)` in your handler grants the 
 
 You're writing a Cloudflare Worker (or an AWS Lambda — same
 story). It needs to read an object from an S3 bucket. In
-Alchemy that's one line in your handler:
+Alchemy it looks like this:
 
 ```typescript
 Effect.gen(function* () {
@@ -30,7 +30,8 @@ them. Every request that hits `fetch` reuses the same
 this pattern wholesale for Worker and Function bodies, which
 is what makes the next two sections possible.
 
-Two things have to happen for that line to work.
+Focus on the `S3.GetObject.bind(Photos)` call. Two things
+have to happen for it to work.
 
 - **At deploy time**, the Worker's IAM role needs
   `s3:GetObject` on the `Photos` bucket. If it doesn't, the

--- a/website/src/content/docs/blog/2026-04-30-bindings.md
+++ b/website/src/content/docs/blog/2026-04-30-bindings.md
@@ -9,9 +9,15 @@ story). It needs to read an object from an S3 bucket. In
 Alchemy that's one line in your handler:
 
 ```typescript
-const getPhoto = yield* S3.GetObject.bind(Photos);
-// …later, inside fetch:
-const photo = yield* getPhoto({ Key: "cover.jpg" });
+Effect.gen(function* () {
+  const getPhoto = yield* S3.GetObject.bind(Photos);
+  return {
+    fetch: Effect.gen(function* () {
+      const photo = yield* getPhoto({ Key: "cover.jpg" });
+      return HttpServerResponse.raw(photo.Body);
+    }),
+  };
+});
 ```
 
 Two things have to happen for that line to work.

--- a/website/src/content/docs/blog/2026-04-30-bindings.md
+++ b/website/src/content/docs/blog/2026-04-30-bindings.md
@@ -1,7 +1,7 @@
 ---
 title: Bindings — one line, two phases
 date: 2026-04-30
-excerpt: A single `yield* s3.getObject(Photos, …)` in your handler grants the IAM policy at deploy and calls the SDK at runtime. The IAM logic never lands in your bundle.
+excerpt: A single `yield* S3.GetObject.bind(Photos)` in your handler grants the IAM policy at deploy and calls the SDK at runtime. The IAM logic never lands in your bundle.
 ---
 
 You're writing a Cloudflare Worker (or an AWS Lambda — same
@@ -9,7 +9,9 @@ story). It needs to read an object from an S3 bucket. In
 Alchemy that's one line in your handler:
 
 ```typescript
-const photo = yield* s3.getObject(Photos, { Key: "cover.jpg" });
+const getPhoto = yield* S3.GetObject.bind(Photos);
+// …later, inside fetch:
+const photo = yield* getPhoto({ Key: "cover.jpg" });
 ```
 
 Two things have to happen for that line to work.
@@ -36,8 +38,8 @@ runtime bundle.
 
 ## Capabilities have two halves
 
-Every capability in Alchemy — `s3.getObject`, `s3.putObject`,
-`sqs.sendMessage`, `dynamodb.getItem`, and so on — is
+Every capability in Alchemy — `S3.GetObject`, `S3.PutObject`,
+`SQS.SendMessage`, `DynamoDB.GetItem`, and so on — is
 implemented as a pair of Effect Services:
 
 ```typescript
@@ -79,8 +81,8 @@ The interesting bit is how Alchemy distinguishes "this
 service must be provided" from "this service is allowed to
 be absent."
 
-When you `yield* s3.getObject(...)` inside a Worker, the
-Effect's `R` channel picks up `GetObject` (the runtime
+When you `yield* S3.GetObject.bind(Photos)` inside a Worker,
+the Effect's `R` channel picks up `GetObject` (the runtime
 service) as a hard requirement. If you forget to attach the
 `GetObjectLive` layer to the Worker, the compiler tells you:
 
@@ -105,9 +107,9 @@ The relevant snippet is the comment right in
 
 The runtime layer must be provided or TypeScript breaks
 your build. The policy layer is allowed to be missing —
-and at runtime, it is. The same `s3.getObject(...)`
-expression is a real SDK call at runtime and a no-op at
-runtime *for the policy half*.
+and at runtime, it is. The same `S3.GetObject.bind(...)`
+expression is a real SDK-client construction at runtime and
+a no-op at runtime *for the policy half*.
 
 ## What happens if the policy *is* needed but missing
 
@@ -176,7 +178,7 @@ export default Alchemy.Stack(
 `PutObjectPolicyLive`, `SendMessagePolicyLive`, etc. The
 Stack runs your generator in plan phase with those
 provided. When the planner walks into your Worker's
-generator and reaches `s3.getObject(Photos, ...)`, the
+generator and reaches `S3.GetObject.bind(Photos)`, the
 policy lookup succeeds, the role gets the right statement,
 the deploy proceeds.
 
@@ -225,8 +227,13 @@ when nothing else references this Worker:
 ```typescript
 export const Api = Cloudflare.Worker("Api", { main: "./src/api.ts" },
   Effect.gen(function* () {
-    const photos = yield* s3.getObject(Photos, { Key: "cover.jpg" });
-    return { fetch: /* ... */ };
+    const getPhoto = yield* S3.GetObject.bind(Photos);
+    return {
+      fetch: Effect.gen(function* () {
+        const photo = yield* getPhoto({ Key: "cover.jpg" });
+        /* ... */
+      }),
+    };
   }),
 );
 ```
@@ -242,8 +249,13 @@ export class Api extends Cloudflare.Worker<Api>()("Api", {
 
 export default Api.make(
   Effect.gen(function* () {
-    const photos = yield* s3.getObject(Photos, { Key: "cover.jpg" });
-    return { fetch: /* ... */ };
+    const getPhoto = yield* S3.GetObject.bind(Photos);
+    return {
+      fetch: Effect.gen(function* () {
+        const photo = yield* getPhoto({ Key: "cover.jpg" });
+        /* ... */
+      }),
+    };
   }),
 );
 ```
@@ -267,7 +279,7 @@ IAM right for free; the Workers inside the feature bundle
 exactly their own runtime code, nothing else.
 
 We'll get into that pattern in a separate post. For now,
-the takeaway is: the line you write — `yield* s3.getObject(Photos, ...)`
+the takeaway is: the line you write — `yield* S3.GetObject.bind(Photos)`
 — is a complete specification of what your Worker needs.
 The framework handles the rest, in the right phase, without
 mixing the two phases' code together.

--- a/website/src/content/docs/blog/2026-04-30-bindings.md
+++ b/website/src/content/docs/blog/2026-04-30-bindings.md
@@ -1,0 +1,284 @@
+---
+title: Bindings — one line, two phases
+date: 2026-04-30
+excerpt: A single `yield* s3.getObject(Photos, …)` in your handler grants the IAM policy at deploy and calls the SDK at runtime. The IAM logic never lands in your bundle.
+---
+
+You're writing a Cloudflare Worker (or an AWS Lambda — same
+story). It needs to read an object from an S3 bucket. In
+Alchemy that's one line in your handler:
+
+```typescript
+const photo = yield* s3.getObject(Photos, { Key: "cover.jpg" });
+```
+
+Two things have to happen for that line to work.
+
+- **At deploy time**, the Worker's IAM role needs
+  `s3:GetObject` on the `Photos` bucket. If it doesn't, the
+  call fails at runtime with `AccessDenied`.
+- **At runtime**, the Worker process needs a real S3 SDK
+  client that knows how to talk to AWS, signs the request,
+  and gets back bytes.
+
+These are very different jobs. The first is infrastructure
+authoring — IAM policy documents, role attachments, deploy
+orchestration. The second is application code — SDK calls,
+retries, response parsing. Most frameworks make you write
+them in two separate places: the IAM in your IaC config,
+the SDK call in your handler. You're responsible for
+keeping the two in sync.
+
+Alchemy lets you write *one* line for both, then arranges
+for each half to run in the right phase — and crucially,
+arranges for the *deploy-side* half to never end up in your
+runtime bundle.
+
+## Capabilities have two halves
+
+Every capability in Alchemy — `s3.getObject`, `s3.putObject`,
+`sqs.sendMessage`, `dynamodb.getItem`, and so on — is
+implemented as a pair of Effect Services:
+
+```typescript
+// AWS/S3/GetObject.ts
+export class GetObject extends Binding.Service<GetObject, ...>()
+  ("AWS.S3.GetObject") {}
+
+export class GetObjectPolicy extends Binding.Policy<GetObjectPolicy, ...>()
+  ("AWS.S3.GetObject") {}
+```
+
+The `Binding.Service` is the runtime half — an Effect
+service whose `Live` layer wraps the actual SDK client.
+When you `yield*` it, you get back a typed callable that
+takes a bucket and a request and gives you back the
+response.
+
+The `Binding.Policy` is the deploy-time half — an Effect
+service whose `Live` layer doesn't do any I/O at all. It
+takes the bucket your handler referenced and records a
+policy statement onto the calling Worker's role:
+
+```typescript
+yield* host.bind`Allow(${host}, AWS.S3.GetObject(${bucket}))`({
+  policyStatements: [{
+    Effect: "Allow",
+    Action: ["s3:GetObject", "s3:GetObjectVersion"],
+    Resource: [Output.interpolate`${bucket.bucketArn}/*`],
+  }, /* + s3:ListBucket so 404s aren't 403s */],
+});
+```
+
+Two services, one capability name (`AWS.S3.GetObject`). One
+gets bundled into your Worker; one runs only during plan.
+
+## The TypeScript trick
+
+The interesting bit is how Alchemy distinguishes "this
+service must be provided" from "this service is allowed to
+be absent."
+
+When you `yield* s3.getObject(...)` inside a Worker, the
+Effect's `R` channel picks up `GetObject` (the runtime
+service) as a hard requirement. If you forget to attach the
+`GetObjectLive` layer to the Worker, the compiler tells you:
+
+```
+Argument of type 'Effect<…, …, GetObject>' is not assignable to
+parameter of type 'Effect<…, …, never>'.
+```
+
+`GetObjectPolicy` (the deploy-time service) is also
+referenced by the same line. But it doesn't show up in `R`,
+because the framework resolves it via
+`Effect.serviceOption` — it's *optional* at the type level.
+
+The relevant snippet is the comment right in
+[`Binding.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Binding.ts):
+
+```typescript
+// we use a service option because at runtime (e.g. in a Lambda
+// Function or Cloudflare Worker) the Policy Layer is not provided
+// and this becomes a no-op
+```
+
+The runtime layer must be provided or TypeScript breaks
+your build. The policy layer is allowed to be missing —
+and at runtime, it is. The same `s3.getObject(...)`
+expression is a real SDK call at runtime and a no-op at
+runtime *for the policy half*.
+
+## What happens if the policy *is* needed but missing
+
+If you forget to provide `GetObjectPolicyLive` at deploy
+time, you don't want a silent no-op — you want a loud
+failure that tells you the role won't get the right IAM.
+
+Alchemy checks the deploy phase explicitly. From
+`Binding.ts`:
+
+```typescript
+service
+  ? Effect.succeed(service)
+  : Effect.all([CurrentStack, ALCHEMY_PHASE.asEffect()]).pipe(
+      Effect.flatMap(([stack, phase]) =>
+        stack && phase === "plan"
+          ? Effect.die(
+              `Binding.Policy provider 'Policy<${Identifier}>' was not provided at Plan Time in Stack '${stack.name}'`,
+            )
+          : Effect.succeed((() => Effect.void) as any as Shape),
+      ),
+    ),
+```
+
+In plan phase + with a Stack in scope, missing the policy
+layer dies with a clear message. Outside plan (e.g. inside
+the deployed Worker), it falls through to `Effect.void` and
+is invisible. Same expression, different behavior, scoped
+to the phase that needs each half.
+
+## The Stack is where policies live
+
+A `Cloudflare.Worker` (or `Lambda.Function`) lets you
+provide the runtime layers it needs *on the Worker itself*:
+
+```typescript
+const Photos = yield* Cloudflare.R2Bucket("Photos");
+const Api = yield* Cloudflare.Worker("Api", { main: "./src/api.ts" },
+  Effect.gen(function* () {
+    return { fetch: handler };
+  }).pipe(
+    Effect.provide(GetObjectLive),     // ← Binding.Service: bundled
+  ),
+);
+```
+
+`GetObjectLive` (the runtime service) gets bundled into the
+Worker. Nothing else here mentions IAM.
+
+The Stack is where the *Policy* layers live:
+
+```typescript
+export default Alchemy.Stack(
+  "MyApp",
+  { providers: AWS.providers() },        // ← Binding.Policy layers: NOT bundled
+  Effect.gen(function* () {
+    const photos = yield* Photos;
+    const api = yield* Api;
+    return { url: api.url };
+  }),
+);
+```
+
+`AWS.providers()` is a Layer that bundles every
+`Binding.Policy` AWS exposes — `GetObjectPolicyLive`,
+`PutObjectPolicyLive`, `SendMessagePolicyLive`, etc. The
+Stack runs your generator in plan phase with those
+provided. When the planner walks into your Worker's
+generator and reaches `s3.getObject(Photos, ...)`, the
+policy lookup succeeds, the role gets the right statement,
+the deploy proceeds.
+
+Then the planner walks back out. Your Worker bundle is
+written. The bundle has `GetObjectLive` (runtime SDK) but
+*not* `GetObjectPolicyLive` (IAM logic) — because the
+Worker's `R` never required it.
+
+## What ends up in your bundle
+
+The mental model is: **the Worker bundle is whatever its
+Effect's `R` channel demands, and nothing else.**
+
+In the bundle:
+
+- Your handler.
+- `Binding.Service` runtime layers (SDK wrappers) — every
+  `getObject`/`putObject`/`sendMessage` you actually call.
+- Resource data structures — `{ LogicalId: "Photos", ... }`
+  is all the runtime needs to identify a bucket. The
+  *output values* (bucket name, ARN) get resolved at deploy
+  time and inlined as constants by the bundler.
+
+Not in the bundle:
+
+- `Binding.Policy` layers — they're optional services, so
+  the Worker's `R` never required them.
+- Provider implementations — the code that knows how to
+  `reconcile` a Bucket lives in `AWS.providers()`, which
+  is provided to the Stack, not the Worker.
+- Other Workers' handlers — same reasoning, different
+  resource type. Worker A binding Worker B only needs B's
+  Tag (its `LogicalId` and binding contract), not B's
+  handler code.
+
+The tree-shake property falls out of the type system. You
+didn't have to opt in; you'd have to opt *out* to leak
+deploy-time code into a runtime bundle, by explicitly
+providing the Policy layer where it isn't needed.
+
+## Inline and Tag forms produce the same bundle
+
+There are two ways to author a Worker. The inline form, for
+when nothing else references this Worker:
+
+```typescript
+export const Api = Cloudflare.Worker("Api", { main: "./src/api.ts" },
+  Effect.gen(function* () {
+    const photos = yield* s3.getObject(Photos, { Key: "cover.jpg" });
+    return { fetch: /* ... */ };
+  }),
+);
+```
+
+The Tag-and-Layer form, for when this Worker has to be
+referenced before its implementation is in scope (a cycle,
+self-reference, or just a Worker exported across files):
+
+```typescript
+export class Api extends Cloudflare.Worker<Api>()("Api", {
+  main: import.meta.path,
+}) {}
+
+export default Api.make(
+  Effect.gen(function* () {
+    const photos = yield* s3.getObject(Photos, { Key: "cover.jpg" });
+    return { fetch: /* ... */ };
+  }),
+);
+```
+
+Both produce the same runtime bundle. The Tag form just
+splits identity (the class declaration) from implementation
+(the `.make()` call), so other files can import the Tag
+without pulling in the handler. See
+[Circular references, without the deadlock](/blog/2026-04-25-circular-references)
+for the full story on when each form pays off.
+
+## Composable units of infrastructure
+
+The same shape — Binding.Service required, Binding.Policy
+optional — is what makes pieces of infrastructure composable
+as Effect Layers. A "feature" can be a Layer that brings
+its own Workers, Tables, and bindings, with all the
+internal cross-references already wired. The Stack that
+consumes the feature provides `providers()` and gets the
+IAM right for free; the Workers inside the feature bundle
+exactly their own runtime code, nothing else.
+
+We'll get into that pattern in a separate post. For now,
+the takeaway is: the line you write — `yield* s3.getObject(Photos, ...)`
+— is a complete specification of what your Worker needs.
+The framework handles the rest, in the right phase, without
+mixing the two phases' code together.
+
+## Where to go next
+
+- [`Binding.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Binding.ts)
+  — the `Binding.Service` / `Binding.Policy` machinery.
+- [`AWS/S3/GetObject.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/S3/GetObject.ts)
+  — a canonical capability: runtime layer + policy layer
+  in one file.
+- [Circular references, without the deadlock](/blog/2026-04-25-circular-references)
+  — the Tag-and-Layer pattern for cyclic and self-referential
+  bindings.

--- a/website/src/content/docs/blog/2026-04-30-bindings.md
+++ b/website/src/content/docs/blog/2026-04-30-bindings.md
@@ -20,15 +20,11 @@ Effect.gen(function* () {
 });
 ```
 
-The shape is borrowed from Effect's
+The shape is "bind and use" — the standard
 [`Layer`](https://effect.website/docs/requirements-management/layers/)
-constructor pattern: the outer `Effect.gen` is the
-constructor — `yield* X` once at the top to acquire each
-dependency, then return a record whose methods close over
-them. Every request that hits `fetch` reuses the same
-`getPhoto` callable; the bind happens once. Alchemy adopts
-this pattern wholesale for Worker and Function bodies, which
-is what makes the next two sections possible.
+constructor pattern from Effect. `yield*` your dependencies
+at the top, then return a `fetch` Effect that uses them.
+Bind runs once; `fetch` runs per request.
 
 Focus on the `S3.GetObject.bind(Photos)` call. Two things
 have to happen for it to work.

--- a/website/src/content/docs/blog/2026-05-04-reconcile.md
+++ b/website/src/content/docs/blog/2026-05-04-reconcile.md
@@ -1,0 +1,484 @@
+---
+title: One reconcile, no create vs. update
+date: 2026-05-04
+excerpt: We replaced `create` and `update` with a single `reconcile` function. Both halves were already converging on the same defensive code.
+---
+
+Most IaC tools you've probably used are CRUD-based.
+CloudFormation, Terraform, Pulumi, SST, and the CDK all
+model a resource's lifecycle as four distinct operations:
+**Create**, **Read**, **Update**, **Delete**. When you write
+a provider, you write four functions, and the engine picks
+which one to call based on whether prior state exists.
+
+Kubernetes took a different approach. A controller doesn't
+"create" or "update" — it *reconciles*. It looks at desired
+state, looks at actual state, and does whatever it takes to
+make them match. Same function, every time. But Kubernetes
+pays for that simplicity with a **continuous control loop**:
+controllers run forever, polling and reconciling on every
+tick. There's no `plan` step, no `apply` step, no human in
+the loop telling it "yes, do that now."
+
+Alchemy wants both halves. We keep Terraform's *plan and
+apply* model — you run `alchemy deploy`, the engine computes
+a diff, shows you what's about to change, and applies it
+once. But inside that apply step, each resource runs a
+Kubernetes-style reconcile instead of a CRUD branch. One
+shot, not a loop; but the function itself doesn't care
+whether the resource is new, stale, drifted, or adopted —
+it just makes the cloud match desired state and returns.
+
+This post is about why we made that switch, and why the
+providers got noticeably smaller for it.
+
+## What `create` and `update` actually look like
+
+If you've written an SST or CDK custom resource, or a
+Terraform provider, you've seen the shape. Two functions —
+`create` provisions from nothing, `update` mutates toward
+new props.
+
+Let's build one up for a DynamoDB `Table`, which we'll keep
+using as the running example. Alchemy is Effect-native, so
+the lifecycle functions are written as `Effect.fn` generators
+that `yield*` AWS SDK calls instead of awaiting promises —
+but the *shape* is the same as any CRUD provider. Start
+with the skeleton:
+
+```typescript
+{
+  create: Effect.fn(function* ({ id, news }) {
+    // resource doesn't exist. provision it from `news`.
+  }),
+  update: Effect.fn(function* ({ id, news, olds, output }) {
+    // resource exists. mutate it from `olds` toward `news`.
+  }),
+}
+```
+
+`create` runs once, when the engine has no prior state.
+`update` runs every time after, with the previous props
+(`olds`), the new props (`news`), and the attributes the
+resource returned last time (`output`).
+
+### Fill in `create`
+
+DynamoDB's `CreateTable` call takes the whole table shape
+in a single round trip — key schema, attributes, billing
+mode, tags, all of it:
+
+```diff lang="typescript"
+  create: Effect.fn(function* ({ id, news }) {
++   const tableName = yield* createTableName(id, news);
++   const desiredTags = yield* createTags(id, news.tags);
++
++   yield* dynamodb.createTable({
++     TableName: tableName,
++     KeySchema: toKeySchema(news),
++     AttributeDefinitions: toAttributeDefinitions(news.attributes),
++     BillingMode: news.billingMode ?? "PAY_PER_REQUEST",
++     StreamSpecification: news.stream,
++     Tags: createTagsList(desiredTags),
++   });
++
++   yield* waitForTableActive(tableName);
++   return { tableName, tableArn: ... };
+  }),
+```
+
+Notice `Tags` is a field on `CreateTable` itself — there's
+no follow-up `TagResource` call. AWS designed it so a fresh
+table comes out of the API fully tagged in one round trip.
+This is the natural shape of `create`: take props, hand them
+to the cloud, return attributes.
+
+### Fill in `update` — tags
+
+After the table exists, AWS won't let you change tags via
+`UpdateTable`. There are separate `TagResource` and
+`UntagResource` APIs, so `update` has to *diff* old props
+against new props:
+
+```diff lang="typescript"
+  update: Effect.fn(function* ({ id, news, olds, output }) {
++   const desiredTags = yield* createTags(id, news.tags);
++   const oldTags = yield* createTags(id, olds.tags);
++   const { removed, upsert } = diffTags(oldTags, desiredTags);
++
++   if (upsert.length > 0) {
++     yield* dynamodb.tagResource({
++       ResourceArn: output.tableArn,
++       Tags: upsert,
++     });
++   }
++   if (removed.length > 0) {
++     yield* dynamodb.untagResource({
++       ResourceArn: output.tableArn,
++       TagKeys: removed,
++     });
++   }
+  }),
+```
+
+This is the line we'll keep coming back to:
+`diffTags(oldTags, desiredTags)`, where `oldTags` is derived
+from `olds`. `update` is using `olds` as its baseline —
+*the props we last wrote down* — rather than what's actually
+attached to the table in AWS right now. Hold onto that.
+
+### Fill in `update` — stream config
+
+Stream configuration is mutable, but via `UpdateTable`
+rather than `CreateTable`:
+
+```diff lang="typescript"
+  update: Effect.fn(function* ({ id, news, olds, output }) {
+    // ...tag sync above...
++   if (news.stream !== olds.stream) {
++     yield* dynamodb.updateTable({
++       TableName: output.tableName,
++       StreamSpecification: news.stream,
++     });
++     yield* waitForTableActive(output.tableName);
++   }
++   return output;
+  }),
+```
+
+Same shape: compare `news` to `olds`, fire the delta API if
+they differ. Every mutable aspect of the table — tags,
+stream, TTL, PITR, GSIs — is its own `if (news.X !== olds.X)`
+branch.
+
+That's a textbook CRUD provider — `create` is a single-shot
+bootstrap that consumes every prop at once, `update` is a
+per-aspect diff between `news` and `olds`. Clean.
+Reasonable. It falls apart in three places.
+
+## Break #1 — adoption
+
+A user has an existing DynamoDB table called `Orders` in
+their account. They want to start managing it with Alchemy
+without re-creating it:
+
+```sh
+alchemy deploy --adopt
+```
+
+The engine has no prior state for `Orders`. Whichever of
+the two lifecycle functions we call, we end up writing the
+same defensive code.
+
+### If we call `create`
+
+The first `yield*` hits `dynamodb.createTable(...)`. AWS
+rejects it with `ResourceInUseException`. So we catch it.
+Now we're inside the `create` body holding a table we may
+or may not own, and we need to figure out which:
+
+```typescript
+yield* dynamodb.createTable({ ... }).pipe(
+  Effect.catchTag("ResourceInUseException", () =>
+    Effect.gen(function* () {
+      // It already exists — is it ours?
+      const liveTags = yield* dynamodb.listTagsOfResource({ ResourceArn });
+      if (yield* hasAlchemyTags(id, liveTags)) {
+        return; // ours — silent adopt, fall through to sync
+      }
+      // Foreign — gate on AdoptPolicy
+      const allowed = yield* AdoptPolicy;
+      if (!allowed) return yield* Effect.fail(new OwnedBySomeoneElse({ ... }));
+    }),
+  ),
+);
+
+// ...and now what? We passed `BillingMode`, `StreamSpecification`,
+// `Tags`, GSIs — none of them got applied, because we didn't actually
+// create the table. We have to read live state and diff every aspect
+// against desired, applying deltas where they differ.
+```
+
+By the time we're done, `create` contains:
+
+1. A creation attempt.
+2. A conflict-recovery branch with an ownership check.
+3. An `AdoptPolicy` gate.
+4. A per-aspect sync against live cloud state.
+
+Steps 2-4 are exactly what `update` would have done.
+
+### If we call `update`
+
+Wait — we *can* route here, sort of. The engine has a `read`
+lifecycle op precisely for this: when there's no prior state
+but `--adopt` is set, `read` fetches live attributes and
+seeds `output` before any lifecycle call. So `output` is
+populated.
+
+But `olds` is still `undefined` — there are no "previous
+props" for a table we just met. And `update`'s tag-sync
+line was:
+
+```typescript
+const oldTags = yield* createTags(id, olds.tags); // 💥 olds is undefined
+```
+
+The fix is the same shape as in `create`: don't trust
+`olds`. Read tags from the cloud, diff observed against
+desired:
+
+```typescript
+const observedTags = yield* dynamodb.listTagsOfResource({ ResourceArn });
+const { removed, upsert } = diffTags(observedTags, desiredTags);
+```
+
+And every other `if (news.X !== olds.X)` branch in
+`update` has to be rewritten the same way: read the live
+value from the cloud, diff observed against desired, fire
+the delta API.
+
+Compare that to step 4 of the `create` body above. It's
+the same code. `create` ended up needing it because the
+table already existed when it tried to make one; `update`
+needs it because `olds` is gone. Different reasons,
+identical implementation.
+
+### The point
+
+Both branches converge on the same shape because **both
+need to assume nothing and observe everything.** You can't
+trust `olds` (it may be missing on adoption, or stale after
+drift). You can't trust that `createTable` will succeed
+(it'll conflict on adoption). The only thing that's
+authoritative is what the cloud says right now.
+
+Once `create` and `update` have both grown an "observe live
+state, then converge per-aspect" prefix, the split is
+purely cosmetic. This is the actual reconciler in
+[`AWS/DynamoDB/Table.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/DynamoDB/Table.ts),
+which collapses both into one flow:
+
+```typescript
+let state = yield* readTableState(tableName);
+
+if (state === undefined) {
+  yield* dynamodb.createTable({ /* ...full props, tags inline... */ }).pipe(
+    // Race: a peer reconciler created the table between our observe and create.
+    Effect.catchTag("ResourceInUseException", () => adoptExistingTable(tableName)),
+  );
+  state = yield* readTableState(tableName);
+}
+
+// From here on, every aspect (tags, GSIs, PITR, TTL, stream) is synced
+// against `state` — the OBSERVED cloud state — not against `olds`.
+```
+
+`create` is now just one step inside the flow ("if it
+doesn't exist yet, make it"). The rest is sync. Adoption
+just means `state` was already populated when the function
+started — no separate code path.
+
+## Break #2 — partial creates
+
+A Cloudflare `Worker` is more than a script. It's a script,
+plus a workers.dev subdomain toggle, plus any custom
+domains, plus the binding/migration metadata for Durable
+Objects. The `create` body has to:
+
+1. `PUT` the script (`putWorker`)
+2. Toggle the `workers.dev` subdomain on or off
+3. Attach each custom domain via `putDomain`
+4. Persist returned IDs (domain IDs, zone IDs) into state
+
+Now imagine the process gets `SIGKILL`'d between step 1 and
+step 3 — laptop lid closes, CI runner gets evicted, network
+times out. The script is uploaded. The domain isn't. State
+hasn't been persisted, because we crashed before returning.
+
+Next deploy, the engine still has no prior state, so it
+routes to `create` again. `putWorker` runs and succeeds
+(it's an upsert). Then `putDomain` runs and tries to attach
+the hostname — except now Cloudflare may already know
+about it from the partial run, or it may not, or it may be
+attached to a *different* Worker because someone retried
+elsewhere. The `create` body wasn't written for any of those
+cases; it was written assuming a clean account.
+
+The textbook fix is "make `create` idempotent." But the
+moment you do that — catch `WorkerAlreadyExists`, query the
+domain table to see what's attached, conditionally PUT —
+your `create` body is *already* a reconciler. It's reading
+observed state and applying deltas. It just happens to be
+named `create`.
+
+[`Cloudflare/Workers/Worker.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cloudflare/Workers/Worker.ts)
+makes the reconciler explicit. `putWorker` is a true upsert;
+`reconcileDomains` queries the live domain list and computes
+attach/detach deltas. There's no "first time" path. Crash
+anywhere, re-run, converge.
+
+## Break #3 — drift
+
+Same Worker, fully deployed, state persisted, everyone
+happy. Between deploys, a teammate opens the Cloudflare
+dashboard and detaches `api.example.com` because they
+were debugging something.
+
+Next deploy, the engine has prior state, so it routes to
+`update`. `update` compares `news.domain` to `olds.domain`,
+sees no diff, and skips the domain logic. The cloud is
+wrong, but `update` thinks everything is fine because
+**`olds` is not the cloud — it's our cached belief about
+the cloud.**
+
+The fix, again, is to query live state instead of trusting
+`olds`. From the real reconciler:
+
+```typescript
+// Always query the live state of domains attached to *this*
+// Worker rather than trusting `_previous` from local state.
+// State may have been wiped, populated by another machine, or
+// simply be out of date. Without this we PUT domains that are
+// already registered to this same Worker and Cloudflare
+// returns a confusing "hostname already in use" error.
+const liveAll = yield* listDomains({ accountId, service: scriptName });
+```
+
+Once you're querying live state and diffing against it,
+`olds` has no role left to play. It's at best a hint to skip
+a no-op API call, never the source of truth.
+
+## The split was always a state machine
+
+In all three breaks, the underlying problem is the same:
+`create` and `update` form a two-state machine where
+`update` assumes `create`'s postcondition holds. The cloud
+doesn't honor that assumption. Adoption skips `create`
+entirely. Partial creates leave the postcondition unmet.
+Drift invalidates the postcondition after the fact.
+
+By the time you've handled all three, `create` reads
+observed state before doing anything, and `update` reads
+observed state before doing anything. The two functions
+have converged on the same shape — just under different
+names, with different sets of edge cases papered over.
+
+## The new shape
+
+The provider surface is now three operations:
+
+```typescript
+{
+  diff,       // replace? update? skip?
+  read,       // load actual cloud state into the store
+  reconcile,  // converge cloud → desired
+  delete: ...,
+}
+```
+
+`read` is called first whenever there's no prior state. If
+it finds a resource, the engine checks the
+[`AdoptPolicy`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AdoptPolicy.ts)
+— set globally with `--adopt`, or per-scope with
+`.pipe(adopt(true))`. If adoption is allowed (or the
+resource carries our ownership tags), the engine seeds state
+from `read`'s output and proceeds. If not, it fails with
+`OwnedBySomeoneElse` and tells the user how to opt in.
+
+Then `reconcile` runs. Its contract is one sentence:
+
+> Given desired state and current state, make the current
+> state match.
+
+It receives `output: Attributes | undefined` and
+`olds: Props | undefined`. All three combinations are valid:
+
+| `output`    | `olds`      | meaning                          |
+| ----------- | ----------- | -------------------------------- |
+| `undefined` | `undefined` | greenfield create                |
+| defined     | defined     | routine update                   |
+| defined     | `undefined` | adoption — first time we own it  |
+
+The body must work for all three. It's written as one flow:
+
+```
+1. Observe — derive the physical id; read live cloud state
+2. Ensure  — if missing, create it; tolerate AlreadyExists races
+3. Sync    — for each mutable aspect:
+             • read OBSERVED cloud state
+             • compute desired state
+             • diff observed vs. desired
+             • apply the delta (skip the API on no-op)
+```
+
+The forbidden pattern is `if (output === undefined) {
+/* create body */ } else { /* update body */ }`. That's
+rename-and-branch — it brings back every false assumption
+we just deleted.
+
+## Why this is easier for AI to write
+
+Alchemy has 50+ resources. We migrated all of them in a
+single afternoon with one AI prompt run in parallel across
+the codebase.
+
+That's not because the model got smarter. It's because
+`reconcile` is a *strictly easier* function to generate
+than `create` + `update`.
+
+`create` is a minefield of "what if it half-existed already"
+edge cases. `update` is a minefield of "what if `olds` is
+stale" edge cases. Both demand the author keep an implicit
+state-machine in their head and write defensively against
+the cases the other function was *supposed* to handle.
+
+`reconcile` collapses that into one mental model: read the
+cloud, compute the delta, apply the delta. Each sync step is
+independently idempotent. Crash mid-reconcile, re-run,
+converge. The AI doesn't have to reason about which function
+it's in or what the other one already did — there is no
+other one.
+
+The diffs were also smaller. A typical provider lost 30-40%
+of its lifecycle code. The DynamoDB `Table` provider, which
+had the gnarliest create/update split (GSIs, PITR, TTL, tags,
+stream config — each with its own update API), dropped about
+200 lines and got *more* correct in the process.
+
+## What you do as a provider author
+
+If you're writing a new resource, the recipe is:
+
+```typescript
+reconcile: Effect.fn(function* ({ id, news, olds, output, session }) {
+  // 1. Observe
+  const observed = yield* describeX(physicalNameFrom(news, output))
+    .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined)));
+
+  // 2. Ensure
+  const current = observed ?? (yield* createX(news));
+
+  // 3. Sync each mutable aspect against `current`, not `olds`
+  yield* syncTags(current, news);
+  yield* syncSettings(current, news);
+
+  // 4. Return fresh attributes
+  return toAttrs(current);
+}),
+```
+
+The canonical references in the repo are
+[`AWS/S3/Bucket.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/S3/Bucket.ts),
+[`AWS/Kinesis/Stream.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/Kinesis/Stream.ts),
+and
+[`AWS/DynamoDB/Table.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/DynamoDB/Table.ts)
+— the last one is the multi-aspect case study.
+
+## Where to go next
+
+- [`AdoptPolicy`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AdoptPolicy.ts)
+  — the source file is the spec. It documents the
+  `read` → `Unowned` → adopt/fail routing in detail.
+- [PR #179](https://github.com/alchemy-run/alchemy-effect/issues/179)
+  — the migration itself, every provider in one diff.

--- a/website/src/content/docs/blog/2026-05-04-reconcile.md
+++ b/website/src/content/docs/blog/2026-05-04-reconcile.md
@@ -1,6 +1,7 @@
 ---
 title: One reconcile, no create vs. update
 date: 2026-05-04
+draft: true
 excerpt: We replaced `create` and `update` with a single `reconcile` function. Both halves were already converging on the same defensive code.
 ---
 

--- a/website/src/content/docs/blog/2026-05-04-reconcile.md
+++ b/website/src/content/docs/blog/2026-05-04-reconcile.md
@@ -417,68 +417,50 @@ The forbidden pattern is `if (output === undefined) {
 rename-and-branch — it brings back every false assumption
 we just deleted.
 
-## Why this is easier for AI to write
+## Plan didn't change
 
-Alchemy has 50+ resources. We migrated all of them in a
-single afternoon with one AI prompt run in parallel across
-the codebase.
-
-That's not because the model got smarter. It's because
-`reconcile` is a *strictly easier* function to generate
-than `create` + `update`.
-
-`create` is a minefield of "what if it half-existed already"
-edge cases. `update` is a minefield of "what if `olds` is
-stale" edge cases. Both demand the author keep an implicit
-state-machine in their head and write defensively against
-the cases the other function was *supposed* to handle.
-
-`reconcile` collapses that into one mental model: read the
-cloud, compute the delta, apply the delta. Each sync step is
-independently idempotent. Crash mid-reconcile, re-run,
-converge. The AI doesn't have to reason about which function
-it's in or what the other one already did — there is no
-other one.
-
-The diffs were also smaller. A typical provider lost 30-40%
-of its lifecycle code. The DynamoDB `Table` provider, which
-had the gnarliest create/update split (GSIs, PITR, TTL, tags,
-stream config — each with its own update API), dropped about
-200 lines and got *more* correct in the process.
-
-## What you do as a provider author
-
-If you're writing a new resource, the recipe is:
+This is important: the *plan* still talks about create and
+update. Open [`Plan.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Plan.ts)
+and you'll find an `action` field on every node, with the
+same values as before:
 
 ```typescript
-reconcile: Effect.fn(function* ({ id, news, olds, output, session }) {
-  // 1. Observe
-  const observed = yield* describeX(physicalNameFrom(news, output))
-    .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined)));
-
-  // 2. Ensure
-  const current = observed ?? (yield* createX(news));
-
-  // 3. Sync each mutable aspect against `current`, not `olds`
-  yield* syncTags(current, news);
-  yield* syncSettings(current, news);
-
-  // 4. Return fresh attributes
-  return toAttrs(current);
-}),
+type Action = "create" | "update" | "replace" | "delete" | "noop";
 ```
 
-The canonical references in the repo are
-[`AWS/S3/Bucket.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/S3/Bucket.ts),
-[`AWS/Kinesis/Stream.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/Kinesis/Stream.ts),
-and
-[`AWS/DynamoDB/Table.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/DynamoDB/Table.ts)
-— the last one is the multi-aspect case study.
+The planner still computes a diff and decides, per resource,
+which of those actions applies. The terraform-style preview
+you see in your terminal still says "Plan: 4 to create,
+2 to update, 1 to replace, 0 to destroy."
+
+What changed is what happens at *apply* time. Both `create`
+and `update` actions now route into the same provider
+function — `reconcile`. The distinction lives in the plan
+(because users want to know "is this a fresh resource or a
+modification?"), but it doesn't live in the provider. The
+provider's job is identical either way: read live state,
+converge it toward desired.
+
+In other words, the create/update split was useful as a
+*user-facing concept* — "tell me what's about to change" —
+but harmful as a *provider-authoring concept*. We kept the
+former and deleted the latter.
 
 ## Where to go next
 
+This is part 1 of two. Part 2 covers how we actually
+migrated all 50+ providers from `create` + `update` to
+`reconcile`: we used a single AI prompt run in parallel
+across the codebase, with the existing per-resource tests as
+the ground truth, and the apply/plan integration tests as
+the safety net for the engine changes themselves.
+
+- [Part 2 — Migrating 50+ providers in an afternoon](/blog/2026-05-06-reconcile-ai-migration)
 - [`AdoptPolicy`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AdoptPolicy.ts)
-  — the source file is the spec. It documents the
-  `read` → `Unowned` → adopt/fail routing in detail.
+  — the engine-side spec for `read` → `Unowned` → adopt/fail routing.
+- Canonical reconcilers:
+  [`AWS/S3/Bucket.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/S3/Bucket.ts),
+  [`AWS/Kinesis/Stream.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/Kinesis/Stream.ts),
+  [`AWS/DynamoDB/Table.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/AWS/DynamoDB/Table.ts).
 - [PR #179](https://github.com/alchemy-run/alchemy-effect/issues/179)
   — the migration itself, every provider in one diff.

--- a/website/src/content/docs/blog/2026-05-06-reconcile-ai-migration.md
+++ b/website/src/content/docs/blog/2026-05-06-reconcile-ai-migration.md
@@ -1,6 +1,7 @@
 ---
 title: How we migrated 50+ providers to reconcile in an afternoon
 date: 2026-05-06
+draft: true
 excerpt: One prompt, fifty resources, run in parallel. Tests were the ground truth. The engine got the same treatment.
 ---
 

--- a/website/src/content/docs/blog/2026-05-06-reconcile-ai-migration.md
+++ b/website/src/content/docs/blog/2026-05-06-reconcile-ai-migration.md
@@ -1,0 +1,147 @@
+---
+title: How we migrated 50+ providers to reconcile in an afternoon
+date: 2026-05-06
+excerpt: One prompt, fifty resources, run in parallel. Tests were the ground truth. The engine got the same treatment.
+---
+
+[Part 1](/blog/2026-05-04-reconcile) covered why we replaced
+`create` and `update` with a single `reconcile` function.
+This post is about the part that surprised us: how
+unreasonably fast it was to actually do the migration.
+
+Alchemy has 50+ provider files in [`packages/alchemy/src/`](https://github.com/alchemy-run/alchemy-effect/tree/main/packages/alchemy/src).
+The old shape was two functions per resource — `create` and
+`update` — both written defensively against each other's
+edge cases. The new shape is one function. Rewriting every
+provider by hand would have been a multi-week slog.
+
+It took one afternoon, with a single AI prompt fanned out
+across the codebase in parallel. The existing tests were
+the ground truth.
+
+## Why `reconcile` is easier to *generate* than `create` + `update`
+
+The reason this worked isn't that the model got smarter. It's
+that `reconcile` is a strictly easier function to write
+correctly — for a human or an AI — than the pair it
+replaced.
+
+To write `create` correctly you need to hold in your head:
+
+- What happens if the resource half-exists from a prior
+  crash? (probably need to catch `AlreadyExists` and read
+  what's there)
+- What happens if it fully exists and we're adopting? (need
+  an ownership check)
+- What does `update` assume `create` left behind? (because
+  if `create` skips a step, `update` will silently skip it
+  too)
+
+To write `update` correctly you need to hold in your head:
+
+- What if `olds` is stale because someone clicked in the
+  console? (need to query live state instead of trusting it)
+- What if a previous `update` half-completed? (need every
+  step to be independently idempotent)
+- What did `create` guarantee about the starting state?
+  (because every assumption you make has to match)
+
+`reconcile` collapses both into one mental model:
+**read live state, compute the delta, apply the delta.**
+There's no other function whose behavior you have to
+predict. There's no postcondition to maintain across calls.
+Each sync step is independently idempotent — crash, re-run,
+converge.
+
+The AI doesn't have to reason about which function it's in
+or what the other one already did. There is no other one.
+
+## Tests were the ground truth
+
+Every provider already had test coverage:
+[`test/AWS/S3/Bucket.test.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/test/AWS/S3/Bucket.test.ts),
+[`test/AWS/DynamoDB/Table.test.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/test/AWS/DynamoDB/Table.test.ts),
+and so on. These weren't unit tests with mocked SDKs — they
+hit the real cloud, run through the full apply path, and
+assert on the actual state of the resource.
+
+That made them perfect as a migration substrate. The AI's
+contract for each provider was:
+
+1. Fold `create` and `update` into one `reconcile` function.
+2. The existing tests must still pass.
+
+Behavior changes that survived the tests were fine.
+Behavior changes that broke them were rejected and retried.
+We weren't reviewing the AI's prose about what it intended
+to do — we were running its output against scenarios that
+already encoded "the bucket must have these tags after step
+3," "this update must not replace the resource," "adoption
+of a tagged bucket must be silent."
+
+For aspects that weren't yet covered, we added tests
+*first*, then asked the AI to migrate. The new tests acted
+as an executable spec for the gap.
+
+## The engine got the same treatment
+
+The provider-side change was the visible half. The other
+half was inside the engine — [`Plan.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Plan.ts)
+and [`Apply.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Apply.ts) —
+which decide *which* provider function to call and route
+the lifecycle.
+
+`Plan.ts` kept its `"create" | "update" | "replace"` action
+shape (see part 1 for why). `Apply.ts` is what changed:
+both `create` and `update` actions now dispatch into the
+same provider function, with the action distinction
+preserved only for telemetry, terminal output, and `read`
+gating.
+
+The engine has its own integration tests — apply/plan
+fixtures that simulate the full lifecycle including
+adoption, drift, partial failures, retries. Those tests
+became the ground truth for the engine rewrite, the same
+way per-resource tests were the ground truth for providers.
+The AI modified `Plan.ts` and `Apply.ts` against that test
+surface; what passed shipped.
+
+## What you get out of this
+
+The headline number — 50 providers in an afternoon — is a
+function of two things, not one.
+
+The first is that AI is unreasonably good at translating
+between two function shapes when both are well-specified
+and the translation is mechanical. That's table stakes for
+the model now.
+
+The second is that **the target shape was simpler than what
+it replaced.** That's the part you can engineer for. If the
+migration had been the other direction — splitting one
+function into two, with the AI having to invent the
+boundary — it would have been slow and fragile and full of
+incorrect assumptions about who owns what postcondition.
+Going the other way, toward less structure and more
+observation, was a downhill walk.
+
+The other measurable outcome: providers got shorter. A
+typical file lost 30-40% of its lifecycle code. The
+DynamoDB `Table` provider, which had the gnarliest split
+(GSIs, PITR, TTL, tags, stream config — each with its own
+update API), dropped about 200 lines and got *more* correct
+in the process. There's a generalizable lesson there:
+**framework changes that make code easier to AI-generate
+tend to make code easier to read and maintain too**, because
+both are downstream of the same thing — fewer hidden
+assumptions, fewer postconditions, fewer state machines in
+your head.
+
+## Where to go next
+
+- [Part 1 — One reconcile, no create vs. update](/blog/2026-05-04-reconcile)
+- [PR #179](https://github.com/alchemy-run/alchemy-effect/issues/179)
+  — the migration in one diff.
+- Per-resource test conventions:
+  [`test/AWS/DynamoDB/Table.test.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/test/AWS/DynamoDB/Table.test.ts),
+  [`test/Cloudflare/Workers/Worker.test.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts).

--- a/website/src/content/docs/blog/2026-05-08-beta-35.md
+++ b/website/src/content/docs/blog/2026-05-08-beta-35.md
@@ -1,0 +1,127 @@
+---
+title: What's new in beta.35
+date: 2026-05-08
+excerpt: A new Effect-native queue consumer API, R2 custom domains, Neon logical replication, non-string env bindings, and CLI quality-of-life.
+---
+
+`v2.0.0-beta.35` is out. The headline addition is a
+Stream-shaped consumer API for Cloudflare Queues, plus a
+handful of new resource options and CLI polish.
+
+## `Cloudflare.messages(queue).subscribe(...)` — Effect consumer API
+
+Process Cloudflare Queue batches as a typed Effect `Stream`,
+with `ack`/`retry` exposed per message. The handler returns
+when the batch is done; failed messages get retried up to
+`maxRetries`.
+
+```typescript
+yield* Cloudflare.messages<MyEvent>(queueResource, {
+  batchSize: 25,
+  maxRetries: 3,
+}).subscribe((stream) =>
+  Stream.runForEach(stream, (msg) =>
+    Effect.log(`event ${msg.body.id}`),
+  ),
+);
+```
+
+[Tutorial › Queue consumer](/tutorial/cloudflare/queue-consumer)
+
+## R2 bucket custom domains
+
+Attach custom hostnames to an R2 bucket directly from the
+resource declaration. Add or remove entries by editing the
+array — Alchemy reconciles the live attachments.
+
+```typescript
+const Bucket = yield* Cloudflare.R2Bucket("Assets", {
+  customDomains: ["assets.example.com"],
+});
+```
+
+## Non-string env bindings on Workers
+
+Worker `bindings` now accept non-string values directly —
+numbers, booleans, objects — without manual JSON encoding
+on either side. Alchemy serializes at deploy and the typed
+runtime binding gives you the original shape back.
+
+```typescript
+const Worker = yield* Cloudflare.Worker("Api", {
+  main: "./src/worker.ts",
+  bindings: {
+    MAX_ITEMS: 100,
+    FEATURES: { beta: true, experimental: false },
+  },
+});
+```
+
+## Neon logical replication
+
+Opt-in flag on `Neon.Project` for enabling logical
+replication — needed for downstream CDC tools, change-data
+pipelines, and some replicas.
+
+```typescript
+const Project = yield* Neon.Project("App", {
+  enableLogicalReplication: true,
+});
+```
+
+## CLI: version-on-npm warning
+
+`alchemy` now checks the latest version on npm at startup
+and prints a one-line nudge when you're behind. Skips in
+CI / non-TTY automatically.
+
+```text
+$ alchemy deploy
+ℹ A newer version of alchemy (2.0.0-beta.36) is available.
+  Run `bun add alchemy@latest` to upgrade.
+```
+
+## CLI: plain-text renderer in non-interactive terminals
+
+The interactive deploy UI now downgrades to a plain-text
+progress renderer when run outside a TTY (CI logs, piped
+output). No more ANSI control sequences cluttering CI logs.
+
+## CLI: `alchemy cloudflare` / `alchemy aws` namespaces
+
+Cloud-scoped subcommands are now grouped under provider
+namespaces — e.g. `alchemy cloudflare state` for inspecting
+the Cloudflare-backed state store. Top-level commands
+(`deploy`, `destroy`, `plan`, `dev`, `test`) are unchanged.
+
+```sh
+alchemy cloudflare state ls       # list state entries
+```
+
+## Fixes worth knowing about
+
+- **Auth providers moved into layers.** The `R` requirement
+  on stack effects is now `never` again — credential
+  resolution is internal to the provider layer.
+- **Dev mode Node compatibility & profiles.** Several
+  Node-specific runtime issues in `alchemy dev` fixed,
+  including profile handling for AWS/Cloudflare credentials.
+- **`QueueConsumer.listConsumers` pagination.** Previously
+  truncated at the API's default page size when a Worker
+  was listed as a consumer on many queues. Now paginates
+  and surfaces conflicting consumer registrations with a
+  clear error.
+- **R2 custom domain interface simplified** to a plain
+  string array (was a verbose object shape).
+- **Drizzle schema flag tightened** — only marked as
+  updated when migrations actually drift, not on every
+  `drizzle-kit generate` run.
+- **Vite `builder.sharedConfigBuild` disabled.** Fixes a
+  class of build failures when bundling Workers via the
+  Vite plugin.
+- **Distilled Cloudflare runtime bumped to 0.3.1.**
+
+## Where to go next
+
+- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta35)
+- [Compare v2.0.0-beta.34 → v2.0.0-beta.35](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.34...v2.0.0-beta.35)

--- a/website/src/content/docs/blog/2026-05-09-beta-36.md
+++ b/website/src/content/docs/blog/2026-05-09-beta-36.md
@@ -1,0 +1,103 @@
+---
+title: What's new in beta.36
+date: 2026-05-09
+excerpt: Cloudflare Images binding, Hyperdrive as a Worker binding, R2 lifecycle rules, and a few sharp-edge fixes.
+---
+
+`v2.0.0-beta.36` is out. Three new Cloudflare features and
+a dev-mode networking fix.
+
+## Cloudflare Images binding
+
+Cloudflare's image transformation runtime, exposed as a
+Worker binding. The Effect-native client takes Effect
+`Stream<Uint8Array>` inputs and chains transforms before
+emitting a `Response`.
+
+```typescript
+const Pipeline = yield* Cloudflare.Images({ name: "PIPELINE" });
+
+Cloudflare.Worker("ImageWorker", { main: import.meta.filename },
+  Effect.gen(function* () {
+    const images = yield* Cloudflare.Images.bind(Pipeline);
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const info = yield* images.info(request.stream);
+        return yield* HttpServerResponse.json(info);
+      }),
+    };
+  }).pipe(Effect.provide(Cloudflare.ImagesBindingLive)),
+);
+```
+
+[`Images.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cloudflare/Images/Images.ts)
+
+## Hyperdrive in Worker bindings
+
+`Hyperdrive` resources can now be attached as Worker
+bindings the same way as R2, KV, D1. Connect through the
+binding's pooled connection string instead of going direct
+to the origin database.
+
+```typescript
+const Hyperdrive = yield* Cloudflare.Hyperdrive("DbPool", {
+  origin: { connectionString: process.env.POSTGRES_URL! },
+});
+
+export const Worker = Cloudflare.Worker("Api", {
+  main: "./src/worker.ts",
+  bindings: { DB: Hyperdrive },
+});
+```
+
+[Tutorial › Neon + Hyperdrive](/tutorial/cloudflare/neon-hyperdrive)
+
+## R2 lifecycle rules
+
+Object lifecycle policies on `R2Bucket` — age-based
+deletion, storage-class transitions, multipart-upload
+abort — declared inline.
+
+```typescript
+const Logs = yield* Cloudflare.R2Bucket("Logs", {
+  lifecycleRules: [
+    {
+      id: "archive-then-delete",
+      prefix: "logs/",
+      storageClassTransitions: [
+        {
+          condition: { type: "Age", maxAge: 60 * 60 * 24 * 60 },
+          storageClass: "InfrequentAccess",
+        },
+      ],
+      deleteObjectsTransition: {
+        condition: { type: "Age", maxAge: 60 * 60 * 24 * 365 },
+      },
+    },
+  ],
+});
+```
+
+Max 1000 rules per bucket. Pass an empty array (or omit)
+to clear all rules.
+[Cloudflare R2 docs › Object lifecycles](https://developers.cloudflare.com/r2/buckets/object-lifecycles/).
+
+## Fixes worth knowing about
+
+- **`*.localhost` resolution in dev mode.** `bun alchemy
+  dev` now routes `*.localhost` hostnames through a custom
+  undici dispatcher, so cross-Worker `fetch` calls to e.g.
+  `https://backend.localhost` resolve to the local sidecar
+  instead of failing DNS.
+
+## Performance
+
+- **Smoke tests install canaries at the workspace root**
+  rather than per-fixture. Batched smoke runs are
+  noticeably faster on cold caches.
+
+## Where to go next
+
+- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta36)
+- [Compare v2.0.0-beta.35 → v2.0.0-beta.36](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.35...v2.0.0-beta.36)

--- a/website/src/content/docs/blog/2026-05-12-beta-37.md
+++ b/website/src/content/docs/blog/2026-05-12-beta-37.md
@@ -1,0 +1,164 @@
+---
+title: What's new in beta.37
+date: 2026-05-12
+excerpt: Cross-stack references, Worker-to-Worker bindings, Workflows with typed I/O, cron triggers, Analytics Engine, R2 empty-on-destroy, and a few sharp-edge fixes.
+---
+
+`v2.0.0-beta.37` is out. A handful of new resources and
+bindings, one substantial new core feature (cross-stack /
+cross-stage references), and some quality-of-life fixes.
+
+## Cross-stack and cross-stage references
+
+Lazy, typed references to resources deployed by a
+*different* stack or stage. Useful for long-lived `staging`
+/ `prod` infra that ephemeral PR previews point at, or for
+sharing one team's `Database` across many app stacks.
+
+```typescript
+const project = yield* Neon.Project.ref("app-db", {
+  stage: "staging",
+});
+// project: Neon.Project — same shape as `yield* Neon.Project(...)`
+```
+
+Resolved at plan time from the persisted [state
+store](/concepts/state-store) — fails loudly with
+`InvalidReferenceError` if the upstream hasn't been
+deployed.
+
+[Concepts › References](/concepts/references) ·
+[Guides › Shared database](/guides/shared-database) ·
+[Tutorial › Branch from a shared database](/tutorial/cloudflare/branch-from-shared-database)
+
+## Worker-to-Worker bindings, fully typed
+
+A Worker can now be bound as a binding on another Worker,
+and the caller gets full RPC types on the other side — no
+codegen, no manual interfaces. Three call shapes are
+supported: the async binding (`env.BACKEND.fetch`), the
+typed RPC client (`Cloudflare.toPromiseApi<Backend>`), and
+the Effect-native `Backend.bind(...)`.
+
+```typescript
+// alchemy.run.ts
+export const Website = Cloudflare.Vite("Website", {
+  bindings: { BACKEND: Backend },
+});
+
+// inside the caller
+const backend = Cloudflare.toPromiseApi<Backend>(env.BACKEND);
+const value = await backend.hello(key);  // typed, throws on Effect.fail
+```
+
+[Tutorial › Vite SPA + Worker bridge](/tutorial/cloudflare/vite-spa)
+
+## Workflows with typed input and output
+
+`Cloudflare.Workflow` is now generic over input and output
+types. The workflow body is just an `Effect.fn` taking the
+typed input; `workflow.create(input)` is type-checked end
+to end, and `instance.status().output` carries the workflow
+return type through.
+
+```typescript
+const NotifyWorkflow = Cloudflare.Workflow(
+  "Notify",
+  { main: "./src/NotifyWorkflow.ts" },
+  Effect.gen(function* () {
+    const room = yield* Room;
+    return Effect.fn(function* (input: { orderId: string }) {
+      const result = yield* Cloudflare.task("process", doWork(input.orderId));
+      return result;
+    });
+  }),
+);
+
+// later, from a Worker:
+const instance = yield* workflow.create({ orderId: "abc" });
+```
+
+[Tutorial › Workflows](/tutorial/cloudflare/workflows)
+
+## Cron triggers via `Cloudflare.cron(...)`
+
+Subscribe to a Cloudflare Cron Trigger with an Effect
+handler. The deploy-time half attaches the cron expression
+to the host Worker; the runtime half registers a
+`scheduled` listener.
+
+```typescript
+yield* Cloudflare.cron("0 12 * * *").subscribe((controller) =>
+  Effect.log(`scheduled at ${controller.scheduledTime}`),
+);
+```
+
+[`CronEventSource.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cloudflare/Workers/CronEventSource.ts)
+
+## Analytics Engine binding
+
+Cloudflare Workers Analytics Engine, exposed as a
+zero-provisioning binding. Bind it on a Worker and call
+`writeDataPoint(...)` from your handler.
+
+```typescript
+const Analytics = yield* Cloudflare.AnalyticsEngineDataset("Analytics", {
+  dataset: "app-events",
+});
+
+// inside the Worker
+const analytics = yield* Cloudflare.AnalyticsEngineDataset.bind(Analytics);
+yield* analytics.writeDataPoint({ blobs: ["signup"] });
+```
+
+[`AnalyticsEngineDataset.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cloudflare/AnalyticsEngine/AnalyticsEngineDataset.ts)
+
+## R2 buckets empty on destroy
+
+`destroy` on an `R2Bucket` now drains the contents before
+deleting the bucket. No more "BucketNotEmpty" failures
+during teardown; ephemeral PR previews and integration
+tests tear cleanly.
+
+```typescript
+const Photos = Cloudflare.R2Bucket("Photos");
+// `bun alchemy destroy` now empties and deletes Photos in one go
+```
+
+## `Alchemy.Secret` and `Alchemy.Variable`
+
+Already covered in [its own
+post](/blog/2026-05-11-secrets-and-variables), but worth
+calling out here: one yield binds a value into the active
+deploy target's env and returns a typed runtime accessor.
+
+```typescript
+const apiKey = yield* Alchemy.Secret("OPENAI_API_KEY");
+//    ^? Output<Redacted<string>>
+```
+
+[Concepts › Secrets](/concepts/secrets) ·
+[Guides › Secrets and env vars](/guides/secrets)
+
+## Fixes worth knowing about
+
+- **D1 `prepare()` / `bind()` are now synchronous.** Matches
+  the upstream Cloudflare Workers API — no more `yield*` on
+  trivial statement construction.
+- **WASM modules in local sidecar bundles.** `bun alchemy
+  dev` now correctly bundles `.wasm` modules into the local
+  sidecar, fixing a class of "module not found" errors when
+  running Workers that depend on WASM.
+- **Unresolved `Output` JS-coercion throws.** Accidentally
+  using an unresolved `Output<string>` in a template literal
+  (e.g. `\`${bucket.bucketName}\`` outside an Effect)
+  previously coerced to `"[object Output]"` and shipped
+  garbage to the cloud. It now throws.
+- **Deprecated libsodium wrapper types removed.** No public
+  API impact; if you were importing internal types they're
+  gone.
+
+## Where to go next
+
+- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta37)
+- [Compare v2.0.0-beta.36 → v2.0.0-beta.37](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.36...v2.0.0-beta.37)


### PR DESCRIPTION
Release walkthroughs (publish) + deep-dive deep-dives (draft).

### Published

- **[2026-05-08 — What's new in beta.35](website/src/content/docs/blog/2026-05-08-beta-35.md)** — Cloudflare Queues `messages(...).subscribe(...)` consumer API, R2 custom domains, Neon logical replication, non-string Worker env bindings, CLI version-on-npm warning + plain-text renderer + `alchemy cloudflare` / `aws` namespaces, plus fixes.
- **[2026-05-09 — What's new in beta.36](website/src/content/docs/blog/2026-05-09-beta-36.md)** — Cloudflare Images binding, Hyperdrive as a Worker binding, R2 lifecycle rules, `*.localhost` dev-mode fix.
- **[2026-05-12 — What's new in beta.37](website/src/content/docs/blog/2026-05-12-beta-37.md)** — Cross-stack/cross-stage references, Worker-to-Worker bindings (typed RPC), typed Workflow I/O, `Cloudflare.cron(...)`, Analytics Engine binding, R2 empty-on-destroy.

### Draft (still iterating)

These are committed to main with `draft: true` so they don't render in production but are previewable in `bun dev`:

- **[2026-04-25 — Circular references, without the deadlock](website/src/content/docs/blog/2026-04-25-circular-references.md)** — `precreate` + Tag-based design.
- **[2026-04-30 — Bindings: one line, two phases](website/src/content/docs/blog/2026-04-30-bindings.md)** — `Binding.Service` / `Binding.Policy` split.
- **[2026-05-04 — One reconcile, no create vs. update](website/src/content/docs/blog/2026-05-04-reconcile.md)** — why we collapsed the lifecycle pair.
- **[2026-05-06 — How we migrated 50+ providers to reconcile in an afternoon](website/src/content/docs/blog/2026-05-06-reconcile-ai-migration.md)** — the AI fan-out story.

To publish a draft: open a one-line PR that flips `draft: true` → `draft: false`. Merging that PR is the publish event.
