### PR TITLE
docs(website): point landing-page agent prompt at llms.txt

### DIFF
--- a/website/src/components/marketing-islands/agentPrompt.ts
+++ b/website/src/components/marketing-islands/agentPrompt.ts
@@ -1,11 +1,17 @@
-export const AGENT_PROMPT = `Help me build an Alchemy app on Cloudflare. Start by fetching https://v2.alchemy.run/llms.txt — it's the index of every doc, tutorial, and guide on the site. Use it to look up the specific page you need at each step instead of guessing URLs or loading docs you don't need.
+export const AGENT_PROMPT = `Help me build an Alchemy app on Cloudflare. Start by reading https://v2.alchemy.run/getting-started and follow it exactly: scaffold a fresh project, install the dependencies, create the \`alchemy.run.ts\` Stack with a single Cloudflare R2 Bucket (no Worker yet), and run \`alchemy deploy\` so I sign in to Cloudflare and provision the Bucket. Confirm the Bucket is live before moving on.
 
-First, read https://v2.alchemy.run/getting-started and follow it exactly: scaffold a fresh project, install the dependencies, create the \`alchemy.run.ts\` Stack with a single Cloudflare R2 Bucket (no Worker yet), and run \`alchemy deploy\` so I sign in to Cloudflare and provision the Bucket. Confirm the Bucket is live before moving on.
+Then STOP and ASK ME what I want to build. From there, consult only the docs you need for what I asked for — don't march me through every tutorial. A Worker only gets added later if what I want to build needs one (the tutorial covers that in part-2).
 
-Then STOP and ASK ME what I want to build. From there, consult llms.txt to find the relevant tutorial / guide / concept page for what I asked for, and fetch only those — don't march me through every tutorial. A Worker only gets added later if what I want to build needs one.
+Tutorial — foundations, work through whichever parts I haven't touched:
+  https://v2.alchemy.run/tutorial/part-1  First Stack (state store + first resource)
+  https://v2.alchemy.run/tutorial/part-2  Add a Worker
+  https://v2.alchemy.run/tutorial/part-3  Testing
+  https://v2.alchemy.run/tutorial/part-4  Local Dev (\`alchemy dev\`)
+  https://v2.alchemy.run/tutorial/part-5  CI/CD (per-PR previews from GitHub Actions)
+
+For everything else (Cloudflare deep-dives, guides, concepts, API reference), fetch https://v2.alchemy.run/llms.txt — it's the index of every doc on the site. Use it to look up the specific page you need instead of guessing URLs.
 
 Important:
-- Always consult https://v2.alchemy.run/llms.txt before fetching docs — it's faster than searching and keeps you on canonical URLs.
 - Confirm with me before each deploy. Don't batch.
 - Do NOT instruct me to export CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_API_TOKEN. Alchemy stores credentials in profiles — \`alchemy login\` (or the first \`alchemy deploy\`) prompts interactively for OAuth or an API token and saves it to ~/.alchemy/profiles.json.
 - Use \`bun alchemy deploy\` (or the npm/pnpm/yarn equivalent).

--- a/website/src/components/marketing-islands/agentPrompt.ts
+++ b/website/src/components/marketing-islands/agentPrompt.ts
@@ -1,35 +1,12 @@
-export const AGENT_PROMPT = `Help me build an Alchemy app on Cloudflare. Start by reading https://v2.alchemy.run/getting-started and follow it exactly: scaffold a fresh project, install the dependencies, create the \`alchemy.run.ts\` Stack with a single Cloudflare R2 Bucket (no Worker yet), and run \`alchemy deploy\` so I sign in to Cloudflare and provision the Bucket. Confirm the Bucket is live before moving on.
+export const AGENT_PROMPT = `Help me build an Alchemy app on Cloudflare. Start by fetching https://v2.alchemy.run/llms.txt — it's the index of every doc, tutorial, and guide on the site. Use it to look up the specific page you need at each step instead of guessing URLs or loading docs you don't need.
 
-Then STOP and ASK ME what I want to build. From there, consult only the docs you need for what I asked for — don't march me through every tutorial. A Worker only gets added later if what I want to build needs one (the tutorial covers that in part-2).
+First, read https://v2.alchemy.run/getting-started and follow it exactly: scaffold a fresh project, install the dependencies, create the \`alchemy.run.ts\` Stack with a single Cloudflare R2 Bucket (no Worker yet), and run \`alchemy deploy\` so I sign in to Cloudflare and provision the Bucket. Confirm the Bucket is live before moving on.
 
-Reference material (read on demand, skip the rest):
-
-Tutorial — foundations, work through whichever parts I haven't touched:
-  https://v2.alchemy.run/tutorial/part-1  First Stack (state store + first resource)
-  https://v2.alchemy.run/tutorial/part-2  Add a Worker
-  https://v2.alchemy.run/tutorial/part-3  Testing
-  https://v2.alchemy.run/tutorial/part-4  Local Dev (\`alchemy dev\`)
-  https://v2.alchemy.run/tutorial/part-5  CI/CD (per-PR previews from GitHub Actions)
-
-Cloudflare deep-dives — mix and match:
-  https://v2.alchemy.run/tutorial/cloudflare/durable-objects         per-key state, RPC, Effect Streams
-  https://v2.alchemy.run/tutorial/cloudflare/hibernatable-websockets WebSockets that survive hibernation
-  https://v2.alchemy.run/tutorial/cloudflare/vite-spa                Vite SPA frontend (TanStack / SolidStart / Vue / etc.)
-  https://v2.alchemy.run/tutorial/cloudflare/containers              long-lived process per Durable Object
-  https://v2.alchemy.run/tutorial/cloudflare/workflows               durable multi-step orchestration
-
-Guides — cross-cutting how-tos:
-  https://v2.alchemy.run/guides/effect-http-api     schema-validated HTTP API
-  https://v2.alchemy.run/guides/effect-rpc          typed RPC
-  https://v2.alchemy.run/guides/frontends           framework-specific Vite setup
-  https://v2.alchemy.run/concepts/testing           integration testing patterns
-  https://v2.alchemy.run/guides/ci                  alternative CI setups
-  https://v2.alchemy.run/guides/circular-bindings   two services that reference each other
-  https://v2.alchemy.run/guides/migrating-from-v1   migrating from v1 (async/await)
-  https://v2.alchemy.run/guides/cli                 CLI reference
+Then STOP and ASK ME what I want to build. From there, consult llms.txt to find the relevant tutorial / guide / concept page for what I asked for, and fetch only those — don't march me through every tutorial. A Worker only gets added later if what I want to build needs one.
 
 Important:
+- Always consult https://v2.alchemy.run/llms.txt before fetching docs — it's faster than searching and keeps you on canonical URLs.
 - Confirm with me before each deploy. Don't batch.
 - Do NOT instruct me to export CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_API_TOKEN. Alchemy stores credentials in profiles — \`alchemy login\` (or the first \`alchemy deploy\`) prompts interactively for OAuth or an API token and saves it to ~/.alchemy/profiles.json.
 - Use \`bun alchemy deploy\` (or the npm/pnpm/yarn equivalent).
-- If I'm migrating from Alchemy v1 (async/await), read https://v2.alchemy.run/guides/migrating-from-v1 first.`;
+- If I'm migrating from Alchemy v1 (async/await), find the v1 migration guide via llms.txt and read it first.`;


### PR DESCRIPTION
Point the landing-page agent prompt at `https://v2.alchemy.run/llms.txt` so the agent uses it as the index for docs/tutorials instead of carrying a hardcoded URL list.

```diff
-Reference material (read on demand, skip the rest):
-
-Tutorial — foundations, work through whichever parts I haven't touched:
-  https://v2.alchemy.run/tutorial/part-1  First Stack ...
-  ...
+Always consult https://v2.alchemy.run/llms.txt before fetching docs —
+it's faster than searching and keeps you on canonical URLs.
```
