### PR TITLE
feat(website): add Blog link to marketing nav

### DIFF
--- a/website/src/components/marketing/Nav.astro
+++ b/website/src/components/marketing/Nav.astro
@@ -13,6 +13,7 @@ import Logo from "./Logo.astro";
     <Search />
   </div>
   <a href="/getting-started" class="alc-nav__link">Docs</a>
+  <a href="/blog" class="alc-nav__link">Blog</a>
   <a
     href="https://github.com/alchemy-run/alchemy-effect"
     class="alc-nav__link alc-nav__link--icon"


### PR DESCRIPTION
Add a `Blog` link next to `Docs` in the marketing nav.

```diff
   <a href="/getting-started" class="alc-nav__link">Docs</a>
+  <a href="/blog" class="alc-nav__link">Blog</a>
```
