### PR TITLE
chore: add correct repository.directory to package.json

### DIFF
--- a/examples/aws-ec2/package.json
+++ b/examples/aws-ec2/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/aws-ec2"
   },
   "scripts": {
     "build": "tsc -b",

--- a/examples/aws-ecs/package.json
+++ b/examples/aws-ecs/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/aws-ecs"
   },
   "scripts": {
     "build": "tsc -b",

--- a/examples/aws-eks/package.json
+++ b/examples/aws-eks/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/aws-eks"
   },
   "scripts": {
     "build": "tsc -b",

--- a/examples/aws-lambda-httpapi/package.json
+++ b/examples/aws-lambda-httpapi/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/aws-lambda-httpapi"
   },
   "scripts": {
     "build": "tsc -b",

--- a/examples/aws-lambda-rpc/package.json
+++ b/examples/aws-lambda-rpc/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/aws-lambda-rpc"
   },
   "scripts": {
     "build": "tsc -b",

--- a/examples/aws-lambda/package.json
+++ b/examples/aws-lambda/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/aws-lambda"
   },
   "scripts": {
     "build": "tsc -b",

--- a/examples/aws-rds/package.json
+++ b/examples/aws-rds/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/aws-rds"
   },
   "scripts": {
     "build": "tsc -b",

--- a/examples/aws-rest-api/package.json
+++ b/examples/aws-rest-api/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/aws-rest-api"
   },
   "scripts": {
     "build": "tsc -b",

--- a/examples/aws-static-site/package.json
+++ b/examples/aws-static-site/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/aws-static-site"
   },
   "type": "module",
   "scripts": {

--- a/examples/aws-vite/package.json
+++ b/examples/aws-vite/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/aws-vite"
   },
   "type": "module",
   "scripts": {

--- a/examples/cloudflare-dev/package.json
+++ b/examples/cloudflare-dev/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/cloudflare-dev"
   },
   "type": "module",
   "scripts": {

--- a/examples/cloudflare-git-artifacts/package.json
+++ b/examples/cloudflare-git-artifacts/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/cloudflare-git-artifacts"
   },
   "type": "module",
   "scripts": {

--- a/examples/cloudflare-neon-drizzle/package.json
+++ b/examples/cloudflare-neon-drizzle/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/cloudflare-neon-drizzle"
   },
   "type": "module",
   "scripts": {

--- a/examples/cloudflare-secrets-store/package.json
+++ b/examples/cloudflare-secrets-store/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/cloudflare-secrets-store"
   },
   "type": "module",
   "scripts": {

--- a/examples/cloudflare-solidjs-ssr/package.json
+++ b/examples/cloudflare-solidjs-ssr/package.json
@@ -24,5 +24,10 @@
   "dependencies": {
     "@solidjs/router": "^0.15.1",
     "solid-js": "^1.9.5"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/cloudflare-solidjs-ssr"
   }
 }

--- a/examples/cloudflare-solidstart/package.json
+++ b/examples/cloudflare-solidstart/package.json
@@ -22,5 +22,10 @@
   "engines": {
     "node": ">=22"
   },
-  "devDependencies": {}
+  "devDependencies": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/cloudflare-solidstart"
+  }
 }

--- a/examples/cloudflare-static-site/package.json
+++ b/examples/cloudflare-static-site/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/cloudflare-static-site"
   },
   "type": "module",
   "scripts": {

--- a/examples/cloudflare-tanstack/package.json
+++ b/examples/cloudflare-tanstack/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/cloudflare-tanstack"
   },
   "type": "module",
   "scripts": {

--- a/examples/cloudflare-vue/package.json
+++ b/examples/cloudflare-vue/package.json
@@ -45,5 +45,10 @@
     "@vue/server-renderer": "beta",
     "@vue/shared": "beta",
     "@vue/compat": "beta"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/cloudflare-vue"
   }
 }

--- a/examples/cloudflare-worker-async/package.json
+++ b/examples/cloudflare-worker-async/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/cloudflare-worker-async"
   },
   "type": "module",
   "scripts": {

--- a/examples/cloudflare-worker/package.json
+++ b/examples/cloudflare-worker/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/cloudflare-worker"
   },
   "type": "module",
   "scripts": {

--- a/examples/monorepo-multi-stack/backend/package.json
+++ b/examples/monorepo-multi-stack/backend/package.json
@@ -7,7 +7,8 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/monorepo-multi-stack/backend"
   },
   "dependencies": {
     "@effect/platform-bun": "catalog:",

--- a/examples/monorepo-multi-stack/frontend/package.json
+++ b/examples/monorepo-multi-stack/frontend/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/monorepo-multi-stack/frontend"
   },
   "dependencies": {
     "@effect/platform-bun": "catalog:",

--- a/examples/monorepo-single-stack/backend/package.json
+++ b/examples/monorepo-single-stack/backend/package.json
@@ -7,7 +7,8 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/monorepo-single-stack/backend"
   },
   "dependencies": {
     "@effect/platform-bun": "catalog:",

--- a/examples/monorepo-single-stack/frontend/package.json
+++ b/examples/monorepo-single-stack/frontend/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "examples/monorepo-single-stack/frontend"
   },
   "dependencies": {
     "@types/react-dom": "^19.2.3",

--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -7,7 +7,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
-    "directory": "package/alchemy"
+    "directory": "packages/alchemy"
   },
   "bin": {
     "alchemy": "./bin/cli.js"

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
-    "directory": "package/better-auth"
+    "directory": "packages/better-auth"
   },
   "files": [
     "lib",

--- a/packages/pr-package/package.json
+++ b/packages/pr-package/package.json
@@ -7,7 +7,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
-    "directory": "package/pr-package"
+    "directory": "packages/pr-package"
   },
   "files": [
     "lib",

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alchemy-run/alchemy-effect"
+    "url": "git+https://github.com/alchemy-run/alchemy-effect.git",
+    "directory": "website"
   },
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Fixed the directory key in the repository prop in all package.json files. This makes sites like npm redirect properly instead of ending up at a non-existent path