### PR TITLE
docs(blog): rewrite beta.35/36/37 release notes

### DIFF
--- a/website/src/content/docs/blog/2026-05-08-beta-35.md
+++ b/website/src/content/docs/blog/2026-05-08-beta-35.md
@@ -1,44 +1,126 @@
 ---
 title: What's new in beta.35
 date: 2026-05-08
-excerpt: A new Effect-native queue consumer API, R2 custom domains, Neon logical replication, non-string env bindings, and CLI quality-of-life.
+excerpt: A Stream-shaped Effect consumer for Cloudflare Queues, R2 bucket custom domains, non-string env bindings on Workers, Neon logical replication, and a round of CLI quality-of-life.
 ---
 
-`v2.0.0-beta.35` is out. The headline addition is a
-Stream-shaped consumer API for Cloudflare Queues, plus a
-handful of new resource options and CLI polish.
+`v2.0.0-beta.35` is out. The headline addition is an
+Effect-native, `Stream`-shaped consumer API for Cloudflare
+Queues — write a queue handler the same way you'd write
+any other Effect pipeline. Plus R2 bucket custom domains,
+non-string Worker env bindings, Neon logical replication,
+and a handful of CLI polish. Community contributors get
+inline shoutouts; full credits in the
+[Contributors section](#contributors).
 
-## `Cloudflare.messages(queue).subscribe(...)` — Effect consumer API
+## `Cloudflare.messages(queue).subscribe(...)` — Effect-native queue consumer
 
 Process Cloudflare Queue batches as a typed Effect `Stream`,
 with `ack`/`retry` exposed per message. The handler returns
 when the batch is done; failed messages get retried up to
-`maxRetries`.
+`maxRetries`. Same Worker, same Effect runtime, same
+bindings — the queue consumer is just another `yield*` in
+the init phase.
+
+A real producer-and-consumer pair: a Worker accepts POSTs
+to `/queue/send`, the consumer writes each message to R2
+as JSON so the result is observable. Bindings already on
+the Worker (`bucket`, `queue`) are in scope inside the
+stream handler — the consumer is a peer to the Worker's
+init phase, not a separate file.
 
 ```typescript
-yield* Cloudflare.messages<MyEvent>(queueResource, {
-  batchSize: 25,
-  maxRetries: 3,
-}).subscribe((stream) =>
-  Stream.runForEach(stream, (msg) =>
-    Effect.log(`event ${msg.body.id}`),
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import { Bucket } from "./Bucket.ts";
+import { Queue } from "./Queue.ts";
+
+interface QueueMessageBody {
+  id: string;
+  text: string;
+  sentAt: number;
+}
+
+export default class Api extends Cloudflare.Worker<Api>()(
+  "Api",
+  { main: import.meta.filename },
+  Effect.gen(function* () {
+    const bucket = yield* Cloudflare.R2Bucket.bind(Bucket);
+    const queueResource = yield* Queue;
+    const queue = yield* Cloudflare.QueueBinding.bind(queueResource);
+
+    // Consumer side. Each batch arrives as a Stream of QueueMessage<Body>;
+    // success ack()s every message, failure retry()s. Crash mid-batch and
+    // unprocessed messages are redelivered.
+    yield* Cloudflare.messages<QueueMessageBody>(queueResource, {
+      batchSize: 25,
+      maxRetries: 3,
+    }).subscribe((stream) =>
+      Stream.runForEach(stream, (msg) =>
+        bucket
+          .put(`/queue/${msg.body.id}`, JSON.stringify(msg.body), {
+            httpMetadata: { contentType: "application/json" },
+          })
+          .pipe(Effect.asVoid),
+      ),
+    );
+
+    return {
+      // Producer side: POST /queue/send adds a message.
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        if (request.url === "/queue/send" && request.method === "POST") {
+          const text = yield* request.text;
+          const msg: QueueMessageBody = {
+            id: crypto.randomUUID(),
+            text,
+            sentAt: Date.now(),
+          };
+          yield* queue.send(msg);
+          return yield* HttpServerResponse.json({ sent: msg }, { status: 202 });
+        }
+        return HttpServerResponse.text("ok");
+      }),
+    };
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        Cloudflare.R2BucketBindingLive,
+        Cloudflare.QueueBindingLive,
+        Cloudflare.QueueEventSourceLive, // required for `messages(...)` to dispatch
+      ),
+    ),
   ),
-);
+) {}
 ```
 
+The full round-trip lives in
+[`examples/cloudflare-worker/src/Api.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/examples/cloudflare-worker/src/Api.ts).
 [Tutorial › Queue consumer](/tutorial/cloudflare/queue-consumer)
 
 ## R2 bucket custom domains
 
 Attach custom hostnames to an R2 bucket directly from the
 resource declaration. Add or remove entries by editing the
-array — Alchemy reconciles the live attachments.
+array — Alchemy reconciles the live attachments on the
+next deploy.
 
 ```typescript
-const Bucket = yield* Cloudflare.R2Bucket("Assets", {
-  customDomains: ["assets.example.com"],
+const Assets = yield* Cloudflare.R2Bucket("Assets", {
+  customDomains: [
+    "assets.example.com",
+    "cdn.example.com",
+  ],
 });
 ```
+
+Each domain points at the bucket's public origin; pair
+with a Cloudflare `Zone` if you want the DNS record
+provisioned in the same stack.
+
+— *Thanks to **Alex** ([#241](https://github.com/alchemy-run/alchemy-effect/pull/241))
+for the contribution.*
 
 ## Non-string env bindings on Workers
 
@@ -48,26 +130,48 @@ on either side. Alchemy serializes at deploy and the typed
 runtime binding gives you the original shape back.
 
 ```typescript
-const Worker = yield* Cloudflare.Worker("Api", {
+const Api = yield* Cloudflare.Worker("Api", {
   main: "./src/worker.ts",
   bindings: {
-    MAX_ITEMS: 100,
-    FEATURES: { beta: true, experimental: false },
+    MAX_ITEMS: 100,                         // number
+    DEBUG: true,                            // boolean
+    FEATURES: { beta: true, alpha: false }, // object
   },
 });
+
+// inside the Worker
+const limit    = env.MAX_ITEMS;   // ^? number — 100
+const debug    = env.DEBUG;       // ^? boolean — true
+const features = env.FEATURES;    // ^? { beta: boolean; alpha: boolean }
 ```
+
+Previously you'd round-trip through `JSON.stringify` at
+the binding site and `JSON.parse` on the runtime side
+with an `as` cast for typing. Now it's just `env.MAX_ITEMS`.
+
+— *Thanks to **Michael K**
+([#269](https://github.com/alchemy-run/alchemy-effect/pull/269))
+for the contribution.*
 
 ## Neon logical replication
 
 Opt-in flag on `Neon.Project` for enabling logical
 replication — needed for downstream CDC tools, change-data
-pipelines, and some replicas.
+pipelines, and some replicas. Defaults to off.
 
 ```typescript
 const Project = yield* Neon.Project("App", {
+  region: "aws-us-east-1",
   enableLogicalReplication: true,
 });
 ```
+
+Toggling the flag on an existing project applies in place —
+no replacement needed.
+
+— *Thanks to **Baptiste Arnaud**
+([#268](https://github.com/alchemy-run/alchemy-effect/pull/268))
+for the contribution.*
 
 ## CLI: version-on-npm warning
 
@@ -95,18 +199,20 @@ the Cloudflare-backed state store. Top-level commands
 (`deploy`, `destroy`, `plan`, `dev`, `test`) are unchanged.
 
 ```sh
-alchemy cloudflare state ls       # list state entries
+alchemy cloudflare state ls     # list state entries
+alchemy aws state get <key>     # read a state entry
 ```
 
 ## Fixes worth knowing about
 
 - **Auth providers moved into layers.** The `R` requirement
-  on stack effects is now `never` again — credential
-  resolution is internal to the provider layer.
+  on stack effects is `never` again — credential resolution
+  is internal to the provider layer instead of leaking into
+  the user-facing stack type.
 - **Dev mode Node compatibility & profiles.** Several
   Node-specific runtime issues in `alchemy dev` fixed,
   including profile handling for AWS/Cloudflare credentials.
-- **`QueueConsumer.listConsumers` pagination.** Previously
+- **`QueueConsumer.listConsumers` paginates.** Previously
   truncated at the API's default page size when a Worker
   was listed as a consumer on many queues. Now paginates
   and surfaces conflicting consumer registrations with a
@@ -120,6 +226,14 @@ alchemy cloudflare state ls       # list state entries
   class of build failures when bundling Workers via the
   Vite plugin.
 - **Distilled Cloudflare runtime bumped to 0.3.1.**
+
+## Contributors
+
+Big thank-you to everyone who shipped code in this beta:
+
+- **Alex** — R2 bucket custom domains ([#241](https://github.com/alchemy-run/alchemy-effect/pull/241))
+- **Michael K** — non-string env bindings on Workers ([#269](https://github.com/alchemy-run/alchemy-effect/pull/269))
+- **Baptiste Arnaud** — Neon `enableLogicalReplication` ([#268](https://github.com/alchemy-run/alchemy-effect/pull/268))
 
 ## Where to go next
 

--- a/website/src/content/docs/blog/2026-05-09-beta-36.md
+++ b/website/src/content/docs/blog/2026-05-09-beta-36.md
@@ -1,63 +1,143 @@
 ---
 title: What's new in beta.36
 date: 2026-05-09
-excerpt: Cloudflare Images binding, Hyperdrive as a Worker binding, R2 lifecycle rules, and a few sharp-edge fixes.
+excerpt: Cloudflare Images binding, Hyperdrive as a Worker binding, R2 object lifecycle rules, and a dev-mode networking fix.
 ---
 
-`v2.0.0-beta.36` is out. Three new Cloudflare features and
-a dev-mode networking fix.
+`v2.0.0-beta.36` is mostly a Cloudflare-themed release —
+three new Worker bindings (Images, Hyperdrive,
+R2 lifecycle policies), all from outside the core team.
+Props to the contributors throughout, and full credits in
+the [Contributors section](#contributors).
 
 ## Cloudflare Images binding
 
 Cloudflare's image transformation runtime, exposed as a
-Worker binding. The Effect-native client takes Effect
-`Stream<Uint8Array>` inputs and chains transforms before
-emitting a `Response`.
+Worker binding. The Effect-native client takes an Effect
+`Stream<Uint8Array>` input — typically the request body —
+and either streams a transformed image back out or returns
+typed metadata.
 
 ```typescript
-const Pipeline = yield* Cloudflare.Images({ name: "PIPELINE" });
+// alchemy.run.ts — declare the pipeline resource
+export const Pipeline = yield* Cloudflare.Images({ name: "PIPELINE" });
 
-Cloudflare.Worker("ImageWorker", { main: import.meta.filename },
+// in your Worker
+export default class ImageWorker extends Cloudflare.Worker<ImageWorker>()(
+  "ImageWorker",
+  { main: import.meta.filename },
   Effect.gen(function* () {
     const images = yield* Cloudflare.Images.bind(Pipeline);
+
     return {
       fetch: Effect.gen(function* () {
         const request = yield* HttpServerRequest;
-        const info = yield* images.info(request.stream);
-        return yield* HttpServerResponse.json(info);
+
+        // Probe the upload — returns format, width, height, etc.
+        if (request.url.endsWith("/info")) {
+          const info = yield* images.info(request.stream);
+          return yield* HttpServerResponse.json(info);
+        }
+
+        // Transform: resize to 512×512 WebP, stream the result back.
+        const transformed = yield* images
+          .input(request.stream)
+          .transform({ width: 512, height: 512 })
+          .output({ format: "image/webp" });
+        return HttpServerResponse.stream(transformed.body);
       }),
     };
   }).pipe(Effect.provide(Cloudflare.ImagesBindingLive)),
-);
+) {}
 ```
 
+— *Thanks to **Alex** ([#237](https://github.com/alchemy-run/alchemy-effect/pull/237))
+for the contribution.*
 [`Images.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cloudflare/Images/Images.ts)
 
 ## Hyperdrive in Worker bindings
 
-`Hyperdrive` resources can now be attached as Worker
-bindings the same way as R2, KV, D1. Connect through the
-binding's pooled connection string instead of going direct
-to the origin database.
+`Hyperdrive` resources are bindable on Workers the same way
+as R2, KV, D1. Two flavors to know:
+
+**Declare a Hyperdrive over an existing origin string.**
+Useful when the database lives outside of Alchemy (existing
+RDS, Supabase, etc.):
 
 ```typescript
 const Hyperdrive = yield* Cloudflare.Hyperdrive("DbPool", {
   origin: { connectionString: process.env.POSTGRES_URL! },
 });
+```
 
-export const Worker = Cloudflare.Worker("Api", {
-  main: "./src/worker.ts",
-  bindings: { DB: Hyperdrive },
+**Wire it onto a Neon branch you already deployed.**
+`Neon.Branch` exposes a pre-parsed `origin` output that
+`Cloudflare.Hyperdrive` takes directly — Alchemy orders the
+deploy graph correctly:
+
+```typescript
+// src/Db.ts
+export const NeonDb = Effect.gen(function* () {
+  const project = yield* Neon.Project("app-db", { region: "aws-us-east-1" });
+  const branch  = yield* Neon.Branch("app-branch", { project });
+  return { project, branch };
+});
+
+export const Hyperdrive = Effect.gen(function* () {
+  const { branch } = yield* NeonDb;
+  return yield* Cloudflare.Hyperdrive("app-hyperdrive", {
+    origin: branch.origin,            // direct (non-pooled) Neon endpoint
+  });
 });
 ```
 
+Bind it on the Worker and read the pooled connection
+string at runtime — Hyperdrive does the connection pooling
+so the Worker can spin up a fresh `pg` client per request
+without exhausting the database:
+
+```typescript
+export default class Api extends Cloudflare.Worker<Api>()(
+  "Api",
+  {
+    main: import.meta.path,
+    compatibility: { flags: ["nodejs_compat"] },
+  },
+  Effect.gen(function* () {
+    const hd = yield* Cloudflare.Hyperdrive.bind(Hyperdrive);
+
+    return {
+      fetch: Effect.gen(function* () {
+        const connectionString = yield* hd.connectionString;
+        const rows = yield* Effect.promise(async () => {
+          const client = new Client({ connectionString });
+          await client.connect();
+          try {
+            const r = await client.query("SELECT now() as now");
+            return r.rows;
+          } finally {
+            await client.end().catch(() => {});
+          }
+        });
+        return yield* HttpServerResponse.json({ rows });
+      }),
+    };
+  }).pipe(Effect.provide(Cloudflare.HyperdriveConnectionLive)),
+) {}
+```
+
+— *Thanks to **Baptiste Arnaud**
+([#282](https://github.com/alchemy-run/alchemy-effect/pull/282))
+for the contribution.*
 [Tutorial › Neon + Hyperdrive](/tutorial/cloudflare/neon-hyperdrive)
 
 ## R2 lifecycle rules
 
 Object lifecycle policies on `R2Bucket` — age-based
 deletion, storage-class transitions, multipart-upload
-abort — declared inline.
+abort — declared inline alongside the rest of the bucket
+config. Max 1000 rules per bucket; pass an empty array (or
+omit) to clear all rules.
 
 ```typescript
 const Logs = yield* Cloudflare.R2Bucket("Logs", {
@@ -65,37 +145,56 @@ const Logs = yield* Cloudflare.R2Bucket("Logs", {
     {
       id: "archive-then-delete",
       prefix: "logs/",
+      // After 60 days: move to Infrequent Access.
       storageClassTransitions: [
         {
           condition: { type: "Age", maxAge: 60 * 60 * 24 * 60 },
           storageClass: "InfrequentAccess",
         },
       ],
+      // After 365 days: delete entirely.
       deleteObjectsTransition: {
         condition: { type: "Age", maxAge: 60 * 60 * 24 * 365 },
+      },
+      // Stale multipart uploads — drop after 7 days.
+      abortMultipartUploadsTransition: {
+        condition: { type: "Age", maxAge: 60 * 60 * 24 * 7 },
       },
     },
   ],
 });
 ```
 
-Max 1000 rules per bucket. Pass an empty array (or omit)
-to clear all rules.
-[Cloudflare R2 docs › Object lifecycles](https://developers.cloudflare.com/r2/buckets/object-lifecycles/).
+Each entry is reconciled in place — edit the array and the
+next deploy applies the delta against R2's live policy.
+
+— *Thanks to **Baptiste Arnaud**
+([#284](https://github.com/alchemy-run/alchemy-effect/pull/284))
+for the contribution.* See [Cloudflare R2 docs › Object
+lifecycles](https://developers.cloudflare.com/r2/buckets/object-lifecycles/)
+for the underlying behavior.
 
 ## Fixes worth knowing about
 
 - **`*.localhost` resolution in dev mode.** `bun alchemy
-  dev` now routes `*.localhost` hostnames through a custom
-  undici dispatcher, so cross-Worker `fetch` calls to e.g.
-  `https://backend.localhost` resolve to the local sidecar
-  instead of failing DNS.
+  dev` now routes `*.localhost` hostnames through a
+  custom undici dispatcher, so cross-Worker `fetch` calls
+  to e.g. `https://backend.localhost` resolve to the local
+  sidecar instead of failing DNS.
 
 ## Performance
 
 - **Smoke tests install canaries at the workspace root**
   rather than per-fixture. Batched smoke runs are
   noticeably faster on cold caches.
+
+## Contributors
+
+Big thank-you to everyone who shipped code in this beta:
+
+- **Alex** — Cloudflare Images binding ([#237](https://github.com/alchemy-run/alchemy-effect/pull/237))
+- **Baptiste Arnaud** — Hyperdrive in Worker bindings ([#282](https://github.com/alchemy-run/alchemy-effect/pull/282))
+- **Baptiste Arnaud** — R2 lifecycle rules ([#284](https://github.com/alchemy-run/alchemy-effect/pull/284))
 
 ## Where to go next
 

--- a/website/src/content/docs/blog/2026-05-12-beta-37.md
+++ b/website/src/content/docs/blog/2026-05-12-beta-37.md
@@ -1,81 +1,399 @@
 ---
 title: What's new in beta.37
 date: 2026-05-12
-excerpt: Cross-stack references, Worker-to-Worker bindings, Workflows with typed I/O, cron triggers, Analytics Engine, R2 empty-on-destroy, and a few sharp-edge fixes.
+excerpt: Cross-stack and cross-stage references, fully-typed Worker-to-Worker bindings, Workflows with typed I/O, `Alchemy.Secret` / `Alchemy.Variable`, cron triggers, an Analytics Engine binding, and R2 buckets that finally empty themselves on destroy.
 ---
 
-`v2.0.0-beta.37` is out. A handful of new resources and
-bindings, one substantial new core feature (cross-stack /
-cross-stage references), and some quality-of-life fixes.
+`v2.0.0-beta.37` is the biggest beta in a while. The
+headline addition is **cross-stack and cross-stage
+references** — the missing piece that lets PR-preview
+stages share a database with `staging` instead of
+re-provisioning a whole Postgres cluster every time someone
+opens a draft PR. On top of that: fully-typed
+Worker-to-Worker bindings, typed Workflow I/O, the new
+`Alchemy.Secret` / `Alchemy.Variable` one-liners, cron
+triggers, and an Analytics Engine binding.
+
+A bunch of this came from outside the core team — props
+to the contributors throughout, and full credits at the
+[bottom of the post](#contributors).
 
 ## Cross-stack and cross-stage references
 
 Lazy, typed references to resources deployed by a
-*different* stack or stage. Useful for long-lived `staging`
-/ `prod` infra that ephemeral PR previews point at, or for
-sharing one team's `Database` across many app stacks.
+*different* stack or stage. The use case it was built for:
+ephemeral PR-preview stages that need a Neon project,
+shouldn't pay for their own, and should instead share one
+that's owned by `staging`.
+
+### Pointing a PR stage at `staging`'s database
+
+Same `alchemy.run.ts`, conditional on the stage. If the
+stage looks like a PR preview (`pr-147`, `pr-148`, …),
+`Neon.Project.ref` reaches into the `staging` stage's state
+file and pulls out the already-deployed project. Otherwise
+the stage creates its own.
 
 ```typescript
-const project = yield* Neon.Project.ref("app-db", {
-  stage: "staging",
+// src/Db.ts
+import * as Alchemy from "alchemy";
+import * as Drizzle from "alchemy/Drizzle";
+import * as Neon from "alchemy/Neon";
+import * as Effect from "effect/Effect";
+
+export const NeonDb = Effect.gen(function* () {
+  const { stage } = yield* Alchemy.Stack;
+
+  const schema = yield* Drizzle.Schema("app-schema", {
+    schema: "./src/schema.ts",
+    out: "./migrations",
+  });
+
+  // PR previews share the long-lived staging project.
+  // Every other stage gets its own.
+  const project = stage.startsWith("pr-")
+    ? yield* Neon.Project.ref("app-db", { stage: "staging" })
+    : yield* Neon.Project("app-db", { region: "aws-us-east-1" });
+
+  // Branches are cheap and per-stage either way.
+  const branch = yield* Neon.Branch("app-branch", {
+    project,
+    migrationsDir: schema.out,
+  });
+
+  return { project, branch, schema };
 });
-// project: Neon.Project — same shape as `yield* Neon.Project(...)`
 ```
 
-Resolved at plan time from the persisted [state
-store](/concepts/state-store) — fails loudly with
-`InvalidReferenceError` if the upstream hasn't been
-deployed.
+Three things to note:
 
-[Concepts › References](/concepts/references) ·
-[Guides › Shared database](/guides/shared-database) ·
-[Tutorial › Branch from a shared database](/tutorial/cloudflare/branch-from-shared-database)
+- **Same logical id, same type.** `"app-db"` matches the
+  id `staging` uses to create the project; `project` is
+  `Neon.Project` either way, so downstream
+  (`Neon.Branch({ project })`) doesn't know or care
+  whether it's real or referenced.
+- **Resolved at plan time.** Alchemy reads the project's
+  attributes (id, host, etc.) out of `staging`'s persisted
+  [state store](/concepts/state-store). If `staging`
+  hasn't been deployed yet, plan fails loudly with
+  `InvalidReferenceError`.
+- **PR teardown stays scoped.** `alchemy destroy --stage
+  pr-147` deletes the per-PR `Neon.Branch` but doesn't
+  touch the shared project — this stage doesn't own it.
 
-## Worker-to-Worker bindings, fully typed
+Deploy `staging` once, then PR stages can point at it:
 
-A Worker can now be bound as a binding on another Worker,
-and the caller gets full RPC types on the other side — no
-codegen, no manual interfaces. Three call shapes are
-supported: the async binding (`env.BACKEND.fetch`), the
-typed RPC client (`Cloudflare.toPromiseApi<Backend>`), and
-the Effect-native `Backend.bind(...)`.
-
-```typescript
-// alchemy.run.ts
-export const Website = Cloudflare.Vite("Website", {
-  bindings: { BACKEND: Backend },
-});
-
-// inside the caller
-const backend = Cloudflare.toPromiseApi<Backend>(env.BACKEND);
-const value = await backend.hello(key);  // typed, throws on Effect.fail
+```sh
+alchemy deploy --stage staging        # creates the project once
+alchemy deploy --stage pr-147         # references it, creates only the branch
 ```
 
-[Tutorial › Vite SPA + Worker bridge](/tutorial/cloudflare/vite-spa)
+The full file lives in
+[`examples/cloudflare-neon-drizzle/src/Db.ts`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-neon-drizzle/src/Db.ts);
+the guide is at
+[Guides › Shared database across stages](/guides/shared-database).
 
-## Workflows with typed input and output
+### Referencing an entire stack's outputs
 
-`Cloudflare.Workflow` is now generic over input and output
-types. The workflow body is just an `Effect.fn` taking the
-typed input; `workflow.create(input)` is type-checked end
-to end, and `instance.status().output` carries the workflow
-return type through.
+The example above pulls one **resource** across stages.
+The other shape — pulling a **whole stack's outputs** —
+is what you reach for in a monorepo where the frontend
+package wants to read the backend stack's deployed URL.
+
+Declare a typed stack handle once:
 
 ```typescript
-const NotifyWorkflow = Cloudflare.Workflow(
-  "Notify",
-  { main: "./src/NotifyWorkflow.ts" },
+// backend/src/Stack.ts
+import * as Alchemy from "alchemy";
+
+export class Backend extends Alchemy.Stack<
+  Backend,
+  { url: string }
+>()("Backend") {}
+```
+
+Deploy the backend with `Backend.make(...)` (the typed
+shorthand for `Alchemy.Stack`), then `yield* Backend` from
+the frontend's stack to get its outputs back, type-checked:
+
+```typescript
+// frontend/alchemy.run.ts
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import { Backend } from "backend";
+import * as Effect from "effect/Effect";
+
+export default Alchemy.Stack(
+  "Frontend",
+  { providers: Cloudflare.providers(), state: Cloudflare.state() },
   Effect.gen(function* () {
-    const room = yield* Room;
-    return Effect.fn(function* (input: { orderId: string }) {
-      const result = yield* Cloudflare.task("process", doWork(input.orderId));
-      return result;
+    // Resolves Backend's outputs from the same stage of the same
+    // stack name. `pr-42` frontend reads `pr-42` backend.
+    const backend = yield* Backend;
+    //    ^? { url: string }
+
+    return yield* Cloudflare.Vite("Website", {
+      env: { VITE_API_URL: backend.url },
     });
   }),
 );
+```
 
-// later, from a Worker:
-const instance = yield* workflow.create({ orderId: "abc" });
+`yield* Backend` defaults to "same stage as the consumer".
+When you need to pin — say, the prod frontend always reads
+the prod backend regardless of which branch deploys it —
+use `Backend.stage.<name>`:
+
+```typescript
+const backend = yield* Backend.stage.prod;        // always pin to prod
+const backend = yield* Backend.stage["pr-42"];    // arbitrary stage name
+```
+
+Under the hood, both shapes are
+[`Output.stackRef`](/concepts/outputs#ref) /
+[`Resource.ref`](/concepts/resource#ref) reading the
+state store. The new APIs just make them ergonomic.
+
+[Concepts › References](/concepts/references) ·
+[Guides › Shared database](/guides/shared-database) ·
+[Guides › Monorepos](/guides/monorepo) ·
+[Tutorial › Branch from a shared database](/tutorial/cloudflare/branch-from-shared-database)
+
+## `Alchemy.Secret` and `Alchemy.Variable`
+
+The boring part of a stack — wiring an env var into a
+deploy target — used to leak across three files. One yield
+now collapses it into a line that's also a typed runtime
+accessor.
+
+```typescript
+// alchemy.run.ts — declare once on the Worker
+export default Cloudflare.Worker("Api",
+  { main: import.meta.path },
+  Effect.gen(function* () {
+    const apiKey = yield* Alchemy.Secret("OPENAI_API_KEY");
+    //    ^? Output<Redacted<string>>
+
+    return {
+      fetch: Effect.gen(function* () {
+        // …and read the bound value inside the handler.
+        const key = yield* apiKey; // Redacted<string>
+        return HttpServerResponse.text(
+          `key has ${Redacted.value(key).length} chars`,
+        );
+      }),
+    };
+  }),
+);
+```
+
+`Alchemy.Variable` is the same shape without `Redacted`:
+
+```typescript
+const port  = yield* Alchemy.Variable("PORT", 3000);
+const flags = yield* Alchemy.Variable("FLAGS", { beta: true });
+
+// inside fetch
+const p = yield* port;   // number — 3000
+const f = yield* flags;  // { beta: true }
+```
+
+Both accept a literal, an `Effect`, a `Config`, or default
+to reading the value from the active `ConfigProvider` under
+the same name. The same call routes to the platform's
+native secret/variable binding — Cloudflare `secret_text`
+for `Secret`, Lambda encrypted env vars on AWS — and the
+runtime accessor decodes back to the original type.
+
+The deeper write-up is at
+[Secrets and Variables](/blog/2026-05-11-secrets-and-variables);
+docs at
+[Concepts › Secrets](/concepts/secrets) ·
+[Guides › Secrets and env vars](/guides/secrets).
+
+## Worker-to-Worker bindings, fully typed
+
+A Worker is now bindable as a binding on another Worker,
+and the caller gets full RPC types on the other side — no
+codegen, no manual interfaces, no `as` casts on `env`.
+Three call shapes are supported, all on the same
+deployment.
+
+The example: a `Backend` Worker exposing both an RPC method
+and an HTTP route, plus a TanStack Start frontend calling
+it three different ways. (This is the
+[`examples/cloudflare-tanstack`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-tanstack)
+project — cut down to the relevant pieces.)
+
+The backend Worker:
+
+```typescript
+// src/backend.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+export const Bucket = Cloudflare.R2Bucket("Bucket");
+
+export default class Backend extends Cloudflare.Worker<Backend>()(
+  "Backend",
+  { main: import.meta.path },
+  Effect.gen(function* () {
+    const bucket = yield* Cloudflare.R2Bucket.bind(Bucket);
+
+    return {
+      // RPC method — callable via `backend.hello(key)` on the other side.
+      hello: Effect.fn("Backend.hello")(function* (key: string) {
+        const object = yield* bucket.get(key);
+        return object === null ? null : yield* object.text();
+      }),
+
+      // HTTP handler — callable via `env.BACKEND.fetch(...)`.
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const key = new URL(request.url, "http://backend").searchParams.get("key");
+        if (!key) return HttpServerResponse.text("missing key", { status: 400 });
+
+        if (request.method === "GET") {
+          const object = yield* bucket.get(key);
+          return object === null
+            ? HttpServerResponse.text("not found", { status: 404 })
+            : HttpServerResponse.stream(object.body);
+        }
+        return HttpServerResponse.text("method not allowed", { status: 405 });
+      }),
+    };
+  }).pipe(Effect.provide(Cloudflare.R2BucketBindingLive)),
+) {}
+```
+
+Wire it into another Worker as a binding:
+
+```typescript
+// alchemy.run.ts
+import Backend, { Bucket } from "./src/backend.ts";
+
+export const Website = Cloudflare.Vite("Website", {
+  bindings: {
+    BUCKET: Bucket,       // R2 binding
+    BACKEND: Backend,     // Worker-to-Worker binding
+  },
+});
+```
+
+Now the caller has three ways to talk to the backend. All
+three are real, all three are typed, all three work in the
+same handler — pick whichever fits the call site.
+
+```typescript
+// frontend route handler
+import * as Cloudflare from "alchemy/Cloudflare";
+import type Backend from "../backend.ts";
+import { env } from "../env.ts";
+
+// Option 1 — async binding (just call the platform API directly).
+const object = await env.BUCKET.get(key);
+
+// Option 2 — Worker-to-Worker fetch over the service binding.
+const res = await env.BACKEND.fetch(`https://backend/?key=${encodeURIComponent(key)}`);
+
+// Option 3 — typed RPC. `toPromiseApi<Backend>` wraps the wire-shape
+// binding into a Promise<T> view that throws on `Effect.fail` and
+// unwraps stream envelopes — full method signatures from `Backend`.
+const backend = Cloudflare.toPromiseApi<Backend>(env.BACKEND);
+const value = await backend.hello(key);
+//    ^? string | null  (typed end-to-end)
+```
+
+Effect-native callers also get a fourth path — `yield*
+Backend.bind(env.BACKEND)` returns the same RPC surface
+without the Promise envelope. The HTTP option (#2) is the
+right one when you need request/response semantics with
+streaming bodies; the RPC option (#3) is the right one
+when you want typed method calls.
+
+[Tutorial › Vite SPA + Worker bridge](/tutorial/cloudflare/vite-spa) ·
+[Example › `cloudflare-tanstack`](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-tanstack)
+
+## Workflows with typed input and output
+
+`Cloudflare.Workflow` is now generic over input *and*
+output types. The body is an `Effect.fn` that takes the
+typed input directly; `workflow.create(input)` is
+type-checked end to end; the returned value flows through
+to `instance.status().output`.
+
+A realistic example — a notifier workflow that touches KV,
+reads an `Alchemy.Secret`, broadcasts through a Durable
+Object, sleeps, and finalizes — with each side effect
+wrapped in a `task` so a crash + replay returns the
+persisted result instead of re-running:
+
+```typescript
+// src/NotifyWorkflow.ts
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import { KV } from "./KV.ts";
+import Room from "./Room.ts";
+
+export default class NotifyWorkflow extends Cloudflare.Workflow<NotifyWorkflow>()(
+  "Notifier",
+  Effect.gen(function* () {
+    // Outer init phase: resolve shared dependencies once.
+    const rooms = yield* Room;
+    const kv = yield* Cloudflare.KVNamespace.bind(KV);
+    const secret = yield* Alchemy.Secret("WORKFLOW_SECRET");
+
+    return Effect.fn(function* (input: { roomId: string; message: string }) {
+      const { roomId, message } = input;
+
+      // Each `task` is a checkpoint — replay-safe.
+      const stored = yield* Cloudflare.task("kv-roundtrip",
+        Effect.gen(function* () {
+          const key = `notify:${roomId}`;
+          yield* kv.put(key, message);
+          return (yield* kv.get(key)) ?? message;
+        }).pipe(Effect.orDie),
+      );
+
+      const value = Redacted.value(yield* secret);
+      const processed = yield* Cloudflare.task("process",
+        Effect.succeed({ text: `Processed: ${stored}`, secret: value }),
+      );
+
+      yield* Cloudflare.task("broadcast",
+        rooms.getByName(roomId).broadcast(`[workflow] ${processed.text}`),
+      );
+
+      yield* Cloudflare.sleep("cooldown", "2 seconds");
+      yield* Cloudflare.task("finalize",
+        rooms.getByName(roomId).broadcast(`[workflow] complete for ${roomId}`),
+      );
+
+      return processed;
+    });
+  }),
+) {}
+```
+
+Start it from a Worker — `create` is typed against the
+input shape, `instance.status()` reports the typed output:
+
+```typescript
+// inside a Worker's fetch handler
+const notifier = yield* NotifyWorkflow;
+
+const instance = yield* notifier.create({
+  roomId: "room-42",
+  message: "hello",
+});
+// instance.id: string
+
+const status = yield* (yield* notifier.get(instance.id)).status();
+// status.output: { text: string; secret: string } | undefined
 ```
 
 [Tutorial › Workflows](/tutorial/cloudflare/workflows)
@@ -85,78 +403,128 @@ const instance = yield* workflow.create({ orderId: "abc" });
 Subscribe to a Cloudflare Cron Trigger with an Effect
 handler. The deploy-time half attaches the cron expression
 to the host Worker; the runtime half registers a
-`scheduled` listener.
+`scheduled` listener. Use it alongside any other binding
+you've already wired up — the handler runs inside the same
+Worker context.
 
 ```typescript
-yield* Cloudflare.cron("0 12 * * *").subscribe((controller) =>
-  Effect.log(`scheduled at ${controller.scheduledTime}`),
+export default Cloudflare.Worker("Reporter",
+  { main: import.meta.path },
+  Effect.gen(function* () {
+    const kv = yield* Cloudflare.KVNamespace.bind(Counters);
+
+    // Fires once at the top of every hour.
+    yield* Cloudflare.cron("0 * * * *").subscribe((controller) =>
+      Effect.gen(function* () {
+        yield* kv.put(`tick:${controller.scheduledTime}`, "ok");
+        yield* Effect.log(`tick at ${new Date(controller.scheduledTime).toISOString()}`);
+      }),
+    );
+
+    return { fetch: Effect.succeed(HttpServerResponse.text("ok")) };
+  }),
 );
 ```
 
-[`CronEventSource.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cloudflare/Workers/CronEventSource.ts)
+Multiple `cron("…")` calls register multiple schedules on
+the same Worker; the cheapest cron granularity Cloudflare
+offers is one minute (`* * * * *`).
+
+— *Thanks to **Dawson** ([#288](https://github.com/alchemy-run/alchemy-effect/pull/288))
+for the contribution.*
 
 ## Analytics Engine binding
 
 Cloudflare Workers Analytics Engine, exposed as a
-zero-provisioning binding. Bind it on a Worker and call
-`writeDataPoint(...)` from your handler.
+zero-provisioning Worker binding. Declare a dataset
+resource, bind it on a Worker, and call `writeDataPoint`
+from the handler — same Effect-error channel as every
+other Alchemy binding.
 
 ```typescript
-const Analytics = yield* Cloudflare.AnalyticsEngineDataset("Analytics", {
+// alchemy.run.ts
+export const Events = Cloudflare.AnalyticsEngineDataset("Events", {
   dataset: "app-events",
 });
 
 // inside the Worker
-const analytics = yield* Cloudflare.AnalyticsEngineDataset.bind(Analytics);
-yield* analytics.writeDataPoint({ blobs: ["signup"] });
+export default Cloudflare.Worker("Api",
+  { main: import.meta.path },
+  Effect.gen(function* () {
+    const analytics = yield* Cloudflare.AnalyticsEngineDataset.bind(Events);
+
+    return {
+      fetch: Effect.gen(function* () {
+        yield* analytics.writeDataPoint({
+          indexes: ["account-1"],   // queryable, low-cardinality
+          blobs: ["signup"],        // arbitrary string columns
+          doubles: [1],             // numeric metrics
+        });
+        return HttpServerResponse.text("recorded");
+      }),
+    };
+  }).pipe(Effect.provide(Cloudflare.AnalyticsEngineDatasetBindingLive)),
+);
 ```
 
-[`AnalyticsEngineDataset.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cloudflare/AnalyticsEngine/AnalyticsEngineDataset.ts)
+— *Thanks to **Dawson** ([#286](https://github.com/alchemy-run/alchemy-effect/pull/286))
+for the contribution.*
 
-## R2 buckets empty on destroy
+## R2 buckets empty themselves on destroy
 
 `destroy` on an `R2Bucket` now drains the contents before
-deleting the bucket. No more "BucketNotEmpty" failures
-during teardown; ephemeral PR previews and integration
-tests tear cleanly.
+deleting the bucket. No more `BucketNotEmpty` failures
+during teardown — ephemeral PR previews and integration
+tests tear down cleanly with a single `alchemy destroy`.
 
 ```typescript
 const Photos = Cloudflare.R2Bucket("Photos");
-// `bun alchemy destroy` now empties and deletes Photos in one go
+// `alchemy destroy` empties Photos and deletes it in one go
 ```
 
-## `Alchemy.Secret` and `Alchemy.Variable`
-
-Already covered in [its own
-post](/blog/2026-05-11-secrets-and-variables), but worth
-calling out here: one yield binds a value into the active
-deploy target's env and returns a typed runtime accessor.
+If you want the old behavior (fail if non-empty) for
+production guards, opt out per-bucket:
 
 ```typescript
-const apiKey = yield* Alchemy.Secret("OPENAI_API_KEY");
-//    ^? Output<Redacted<string>>
+const Photos = Cloudflare.R2Bucket("Photos", { emptyOnDestroy: false });
 ```
 
-[Concepts › Secrets](/concepts/secrets) ·
-[Guides › Secrets and env vars](/guides/secrets)
+— *Thanks to **Michael K** ([#276](https://github.com/alchemy-run/alchemy-effect/pull/276))
+for the contribution.*
 
 ## Fixes worth knowing about
 
-- **D1 `prepare()` / `bind()` are now synchronous.** Matches
-  the upstream Cloudflare Workers API — no more `yield*` on
-  trivial statement construction.
-- **WASM modules in local sidecar bundles.** `bun alchemy
+- **D1 `prepare()` / `bind()` are synchronous now.** Matches
+  the upstream Cloudflare Workers API — no more `yield*`
+  on trivial statement construction.
+- **WASM modules in the local sidecar bundle.** `bun alchemy
   dev` now correctly bundles `.wasm` modules into the local
-  sidecar, fixing a class of "module not found" errors when
-  running Workers that depend on WASM.
+  sidecar, fixing a class of "module not found" errors for
+  Workers that depend on WASM. *Thanks to **Baptiste
+  Arnaud**
+  ([#305](https://github.com/alchemy-run/alchemy-effect/pull/305)).*
 - **Unresolved `Output` JS-coercion throws.** Accidentally
-  using an unresolved `Output<string>` in a template literal
-  (e.g. `\`${bucket.bucketName}\`` outside an Effect)
-  previously coerced to `"[object Output]"` and shipped
-  garbage to the cloud. It now throws.
+  using an unresolved `Output<string>` in a template
+  literal (e.g. `` `${bucket.bucketName}` `` outside an
+  Effect) previously coerced to `"[object Output]"` and
+  shipped garbage to the cloud. It now throws. *Thanks to
+  **Zé Yuri**
+  ([#306](https://github.com/alchemy-run/alchemy-effect/pull/306)).*
 - **Deprecated libsodium wrapper types removed.** No public
   API impact; if you were importing internal types they're
-  gone.
+  gone. *Thanks to **齐天大圣**
+  ([#311](https://github.com/alchemy-run/alchemy-effect/pull/311)).*
+
+## Contributors
+
+Big thank-you to everyone who shipped code in this beta:
+
+- **Michael K** — R2 empty-on-destroy ([#276](https://github.com/alchemy-run/alchemy-effect/pull/276))
+- **Dawson** — Worker cron triggers ([#288](https://github.com/alchemy-run/alchemy-effect/pull/288))
+- **Dawson** — Analytics Engine binding ([#286](https://github.com/alchemy-run/alchemy-effect/pull/286))
+- **Baptiste Arnaud** — WASM in local sidecar bundle ([#305](https://github.com/alchemy-run/alchemy-effect/pull/305))
+- **Zé Yuri** — throw on unresolved `Output` JS-coercion ([#306](https://github.com/alchemy-run/alchemy-effect/pull/306))
+- **齐天大圣** — remove deprecated libsodium wrapper types ([#311](https://github.com/alchemy-run/alchemy-effect/pull/311))
 
 ## Where to go next
 

--- a/website/src/content/docs/concepts/action.mdx
+++ b/website/src/content/docs/concepts/action.mdx
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 An **Action** is a node in the stack's dependency graph that runs an
-arbitrary Effect during `apply`. Unlike a [Resource](./resource), it has
+arbitrary Effect during `apply`. Unlike a [Resource](/concepts/resource), it has
 no provider lifecycle — no replace, no read, no delete. The engine just
 diffs the resolved input against the last persisted hash and either runs
 the body or skips it.
@@ -35,7 +35,7 @@ rows.rows // Output<number>
 ```
 
 The body Effect receives the **resolved** input — any
-[Output](./outputs) references in the input are evaluated against the
+[Output](/concepts/outputs) references in the input are evaluated against the
 current tracker before the body runs.
 
 ### Init constructor (pulling in dependencies)
@@ -74,7 +74,7 @@ const hourly  = yield* Sync("hourly",  { table: eventsBucket.name });
 
 When you want to split the contract from the implementation — e.g. for
 testing or to keep stack code declarative — use the class form. It
-mirrors [Platform](./platform):
+mirrors [Platform](/concepts/platform):
 
 ```typescript
 export class Sync extends Action<Sync, { table: string }, { rows: number }>()("Sync") {}
@@ -138,7 +138,7 @@ Cycles are rejected at plan time just like resource cycles.
 - **Not a Resource.** No `diff`/`read`/`reconcile`/`delete`. If you
   need lifecycle management of a cloud entity, model it as a Resource.
 - **Not a runtime function.** An Action runs at deploy time. To call code
-  from a deployed Worker/Lambda, use a [Platform](./platform).
+  from a deployed Worker/Lambda, use a [Platform](/concepts/platform).
 - **Not idempotent for free.** The engine guarantees the body runs
   only when inputs change, but the body itself must tolerate retries
   on apply restart (its `running` state is persisted but not its


### PR DESCRIPTION
Rewrite the three most recent release-note blogs (beta.35 / .36 / .37) so they show real code from `examples/cloudflare-tanstack` and `examples/cloudflare-worker`, reorder features by impact, and credit community contributors.

### What changed per post

**beta.37**

- Reordered: cross-stack/stage refs → secrets/variables → Worker↔Worker → workflows → cron → analytics engine → R2 empty-on-destroy → fixes. (`Alchemy.Secret` / `Alchemy.Variable` now come before Analytics Engine.)
- New `pr-*` shared-database example:

  ```ts
  const project = stage.startsWith("pr-")
    ? yield* Neon.Project.ref("app-db", { stage: "staging" })
    : yield* Neon.Project("app-db", { region: "aws-us-east-1" });
  ```

- New stack-outputs example using `Backend.stage.<name>`.
- Worker-to-Worker section now shows all three call shapes (async binding / service-fetch / `toPromiseApi<Backend>` RPC) plus the real `Backend` worker source from `examples/cloudflare-tanstack`.
- Workflow section replaces the toy `doWork` body with the actual `NotifyWorkflow` body — KV bind, `Alchemy.Secret`, DO broadcast, `Cloudflare.task` checkpoints, `Cloudflare.sleep`.
- Inline contributor credits on R2 empty-on-destroy, cron, Analytics Engine, and three of the fixes; Contributors footer.

**beta.36**

- Expanded Images snippet to show the real `input(...).transform(...).output(...)` pipeline.
- Hyperdrive section now shows both the direct-origin shape and the `Neon.Branch.origin` shape, plus the runtime `pg` client pattern.
- R2 lifecycle rules snippet now demonstrates all three transition shapes (storage class, delete, multipart abort).
- All three features are community-contributed — inline shoutouts + Contributors footer.

**beta.35**

- Replaced the queue-consumer snippet with the full producer-and-consumer pair from `examples/cloudflare-worker/src/Api.ts` (R2 write inside `Stream.runForEach`, layered bindings, `QueueEventSourceLive`).
- Expanded the non-string env bindings snippet to show number/boolean/object plus typed runtime access.
- Inline credits for Alex (R2 custom domains), Michael K (non-string env), Baptiste Arnaud (Neon logical replication) + footer.

### Credit policy

Community contributors get two mentions per post:

- Inline italic line right under the relevant feature (`— *Thanks to **Name** (#PR) for the contribution.*`)
- A grouped Contributors section at the bottom

Display names match the CHANGELOG exactly (`Michael K`, `Baptiste Arnaud`, `Dawson`, `Alex`, `Zé Yuri`, `齐天大圣`); no GitHub handles fabricated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFhbEaQtRgmRNEpcx7HDyE)_