### PR TITLE
fix(Cloudflare): Cloudflare Worker HTTP effect lifecycle

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/HttpServer.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/HttpServer.ts
@@ -1,9 +1,12 @@
 import type * as cf from "@cloudflare/workers-types";
 import * as Cause from "effect/Cause";
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import type { Scope } from "effect/Scope";
 import type { HttpBodyError } from "effect/unstable/http/HttpBody";
+import * as EffectHttp from "effect/unstable/http/HttpEffect";
+import { ClientAbort } from "effect/unstable/http/HttpServerError";
 import * as HttpServerError from "effect/unstable/http/HttpServerError";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
@@ -48,6 +51,10 @@ export const serveWebRequest = <Req = never>(
   Exclude<Req, HttpServerRequest.HttpServerRequest | Scope>
 > =>
   Effect.gen(function* () {
+    const context =
+      yield* Effect.context<
+        Exclude<Req, HttpServerRequest.HttpServerRequest | Scope>
+      >();
     const request = HttpServerRequest.fromWeb(
       webRequest as any as globalThis.Request,
     ).modify({
@@ -61,9 +68,7 @@ export const serveWebRequest = <Req = never>(
         }),
     });
 
-    const response = yield* handler.pipe(
-      Effect.provideService(HttpServerRequest.HttpServerRequest, request),
-      Effect.provideService(Request, webRequest as any),
+    const safeHandler = handler.pipe(
       Effect.catchCause((cause) => {
         const message = Option.match(Cause.findErrorOption(cause), {
           onNone: () => "Internal Server Error",
@@ -81,7 +86,34 @@ export const serveWebRequest = <Req = never>(
       }),
     );
 
-    return HttpServerResponse.toWeb(response, {
-      context: yield* Effect.context(),
+    const resolveSymbol = Symbol.for("@effect/platform/HttpApp/resolve");
+    const httpApp = EffectHttp.toHandled(safeHandler, (request, response) => {
+      response = EffectHttp.scopeTransferToStream(response);
+      (request as any)[resolveSymbol](
+        HttpServerResponse.toWeb(response, {
+          withoutBody: request.method === "HEAD",
+          context,
+        }),
+      );
+      return Effect.void;
+    });
+
+    return yield* Effect.promise(() => {
+      return new Promise<Response>((resolve) => {
+        const contextMap = new Map<string, any>(context.mapUnsafe);
+        contextMap.set(HttpServerRequest.HttpServerRequest.key, request);
+        contextMap.set(Request.key, webRequest);
+        (request as any)[resolveSymbol] = resolve;
+        const fiber = Effect.runForkWith(Context.makeUnsafe(contextMap))(
+          httpApp as any,
+        );
+        webRequest.signal?.addEventListener(
+          "abort",
+          () => {
+            fiber.interruptUnsafe(undefined, ClientAbort.annotation);
+          },
+          { once: true },
+        );
+      });
     });
   }) as any;

--- a/packages/alchemy/test/Cloudflare/Workers/HttpServer.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/HttpServer.test.ts
@@ -1,0 +1,79 @@
+import { serveWebRequest } from "@/Cloudflare/Workers/HttpServer";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import {
+  Rpc,
+  RpcGroup,
+  RpcSerialization,
+  RpcServer,
+} from "effect/unstable/rpc";
+
+class PingResult extends Schema.Class<PingResult>("PingResult")({
+  ok: Schema.Boolean,
+  message: Schema.String,
+}) {}
+
+const ping = Rpc.make("ping", {
+  payload: {
+    name: Schema.String,
+  },
+  success: PingResult,
+});
+
+const Rpcs = RpcGroup.make(ping);
+
+const RpcHandlers = Rpcs.toLayer({
+  ping: ({ name }) =>
+    Effect.succeed(
+      new PingResult({
+        ok: true,
+        message: `hello ${name}`,
+      }),
+    ),
+});
+
+describe("Cloudflare.Workers.HttpServer", () => {
+  it.effect("serves Effect RPC HTTP apps through the Worker adapter", () =>
+    Effect.gen(function* () {
+      const rpcApp = yield* RpcServer.toHttpEffect(Rpcs).pipe(
+        Effect.provide(
+          Layer.mergeAll(RpcHandlers, RpcSerialization.layerJsonRpc()),
+        ),
+      );
+
+      const response = yield* serveWebRequest(
+        new Request("https://worker.example/rpc", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 0,
+            method: "ping",
+            params: {
+              name: "workerd",
+            },
+            headers: [],
+          }),
+        }) as any,
+        rpcApp,
+      ).pipe(Effect.timeout("2 seconds"));
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain(
+        "application/json",
+      );
+      expect(JSON.parse(yield* Effect.promise(() => response.text()))).toEqual({
+        jsonrpc: "2.0",
+        id: 0,
+        result: {
+          ok: true,
+          message: "hello workerd",
+        },
+      });
+    }),
+  );
+});


### PR DESCRIPTION
## Summary

Fixes the Cloudflare Worker HTTP adapter so it runs handlers through Effect's standard HTTP lifecycle while preserving Alchemy's Worker-specific request context.

The previous adapter manually provided `HttpServerRequest` and converted `HttpServerResponse` to a web `Response`. That works for simple HTTP handlers, but it diverges from Effect's `HttpEffect.toHandled` / `toWebHandler` lifecycle in ways that can break scoped HTTP apps such as `RpcServer.toHttpEffect` under workerd. In the repro from #327, the same Effect RPC app succeeds under raw Wrangler but hangs when served through Alchemy.

This keeps Alchemy's existing behavior for:

- `cf-connecting-ip` -> `remoteAddress`
- the original Cloudflare `Request` service
- patched `request.raw` access
- existing 500 response mapping from `serveWebRequest`

while adding Effect's handled HTTP lifecycle, stream scope transfer, HEAD body suppression, and request abort interruption.

## Tests

- `bun tsc -b packages/alchemy`
- `bunx vitest run packages/alchemy/test/Cloudflare/Workers/HttpServer.test.ts --project alchemy`
- External repro: `effect-rpc-workerd-repro` with local Alchemy checkout, `alchemy dev alchemy.broken.ts`, then `RPC_URL=http://reproapi.localhost:1337/rpc pnpm request` returns `HTTP/1.1 200 OK` with the expected JSON-RPC result.

Fixes #327.
