### PR TITLE
docs(concepts/secrets): simplify structure and recommend Alchemy.Secret

### DIFF
--- a/website/src/content/docs/concepts/secrets.mdx
+++ b/website/src/content/docs/concepts/secrets.mdx
@@ -5,35 +5,37 @@ sidebar:
   order: 8
 ---
 
-`Alchemy.Secret` and `Alchemy.Variable` bind a value into the
-active deploy target's environment (a Cloudflare Worker's `env`,
-a Lambda function's env vars, …) and hand you back an **accessor**
-for reading that value at runtime. `Secret` carries a
-`Redacted<string>` so each platform's provider routes it through
-its secure binding (Cloudflare → `secret_text`, Lambda →
-encrypted env var, etc.); `Variable` is the same shape without
-redaction.
+A **secret** is any sensitive value your Worker or Function needs
+at runtime — an API key, a database password, a signing key, an
+OAuth client secret. You don't want it in source code, you don't
+want it in plain-text env vars on disk, and you don't want it
+echoed in logs.
 
-## Yield twice — "bind" and "use"
+`Alchemy.Secret` binds a secret value directly to the active
+deploy target (a Cloudflare Worker, a Lambda function, …) through
+that platform's secure binding — Cloudflare's `secret_text`,
+Lambda's encrypted environment variable, etc. — and hands you back
+an **accessor** that reads it at runtime as a `Redacted<string>`.
 
-Like any [binding](/concepts/binding), `yield*`-ing in **Init**
-records the binding and returns an accessor; `yield*`-ing the
-accessor in **Exec** resolves the value per request.
+`Alchemy.Variable` is the same shape for non-sensitive config
+(ports, log levels, feature flags). The value rides as plain text
+(or JSON for non-strings) and the accessor preserves the original
+type.
 
-`Alchemy.Secret` returns a `Redacted<string>` accessor — the
-provider deploys it through its secure binding (Cloudflare →
-`secret_text`, Lambda → encrypted env var):
+## Bind a secret to your Worker
+
+`yield*`-ing `Alchemy.Secret` in the Worker's **Init** phase
+registers the binding and returns an accessor. `yield*`-ing the
+accessor inside `fetch` (the **Exec** phase) resolves the value:
 
 ```typescript
 export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.path },
   Effect.gen(function* () {
-    // ─── Init phase ───
     const apiKey = yield* Alchemy.Secret("API_KEY");
 
     return {
-      // ─── Exec phase ───
       fetch: Effect.gen(function* () {
         const value = yield* apiKey;
         // Redacted<string> — Redacted.value(value) to unwrap
@@ -43,26 +45,78 @@ export default Cloudflare.Worker(
 );
 ```
 
-`Alchemy.Secret(name)` is sugar for
-`Alchemy.Secret(name, Config.redacted(name))` — the active
-[ConfigProvider](https://effect.website/docs/configuration)
-resolves the value at plantime.
+See [Phases](/concepts/phases) for why Init and Exec run separately.
 
-`Alchemy.Variable` is the same shape without redaction — strings
-ride as `plain_text`, anything else as JSON, and the accessor
-returns the original type:
+## Resolve from `.env`
+
+`Alchemy.Secret("API_KEY")` with no second argument is sugar for
+`Alchemy.Secret("API_KEY", Config.redacted("API_KEY"))`. The
+active [ConfigProvider](https://effect.website/docs/configuration)
+resolves the value at planning time — by default that reads
+`process.env.API_KEY`, which Alchemy populates from your `.env`
+file.
+
+So this:
+
+```typescript
+const apiKey = yield* Alchemy.Secret("API_KEY");
+```
+
+is all you need if `API_KEY=…` is in `.env`.
+
+To pull from a differently-named env var, pass an explicit
+`Config`:
+
+```typescript
+const apiKey = yield* Alchemy.Secret("API_KEY", Config.redacted("OPENAI_KEY"));
+```
+
+## Provide the value explicitly
+
+The second argument accepts a literal, a `Redacted<string>`, an
+`Effect`, a `Config`, or an `Output` from another resource.
+
+A common pattern: mint a stable random secret with
+`Alchemy.Random` and bind it as a secret on the Worker — no
+`.env` entry, no manual rotation, the value is generated once and
+persisted in state:
 
 ```typescript
 export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.path },
   Effect.gen(function* () {
-    // ─── Init phase ───
+    const random = yield* Alchemy.Random("SESSION_SECRET");
+    const sessionSecret = yield* Alchemy.Secret("SESSION_SECRET", random.text);
+
+    return {
+      fetch: Effect.gen(function* () {
+        const value = yield* sessionSecret; // Redacted<string>
+      }),
+    };
+  }),
+);
+```
+
+Any `Output<Redacted<string>>` works the same way — e.g. a
+database password emitted by another resource can be piped
+straight into the consuming Worker.
+
+## Variables
+
+`Alchemy.Variable` is the non-redacted variant. Strings ride as
+`plain_text`, anything else as JSON, and the accessor returns the
+original type:
+
+```typescript
+export default Cloudflare.Worker(
+  "Worker",
+  { main: import.meta.path },
+  Effect.gen(function* () {
     const port = yield* Alchemy.Variable("PORT", 3000);
     const flags = yield* Alchemy.Variable("FLAGS", { beta: true });
 
     return {
-      // ─── Exec phase ───
       fetch: Effect.gen(function* () {
         const p = yield* port; // number — 3000
         const f = yield* flags; // { beta: true }
@@ -73,12 +127,11 @@ export default Cloudflare.Worker(
 ```
 
 `Alchemy.Variable(name)` is sugar for
-`Alchemy.Variable(name, Config.string(name))`. See
-[Phases](/concepts/phases) for why Init and Exec run separately.
+`Alchemy.Variable(name, Config.string(name))`.
 
 ## Input shapes
 
-Both helpers accept the same four shapes; `Secret` coerces every
+Both helpers accept the same shapes; `Secret` coerces every
 resolved value to `Redacted<string>`, `Variable` keeps the value's
 original type:
 
@@ -98,17 +151,17 @@ Alchemy.Variable("LOG_LEVEL", Config.string("LEVEL"));  // Config<T>
 ```
 
 If you already have a raw `string` or `Redacted<string>` and don't
-need an accessor, you can drop it into `env` directly — providers
-route by value shape (`Redacted<string>` → secure binding,
-`string` → plain, anything else → JSON). `Alchemy.Secret` /
-`Alchemy.Variable` earn their keep when you want `Config`/`.env`
-resolution or a runtime accessor.
+need an accessor, drop it into `env` directly — providers route
+by value shape (`Redacted<string>` → secure binding, `string` →
+plain, anything else → JSON). `Alchemy.Secret` /
+`Alchemy.Variable` earn their keep when you want `.env`
+resolution or a typed runtime accessor.
 
-## Out-of-band secrets
+## Account-wide secrets with `Cloudflare.Secret`
 
-For shared, account-wide secrets managed independently of your
-stack, use the platform's secret-management resources. On
-Cloudflare:
+Cloudflare has an account-level Secrets Store. A
+`Cloudflare.Secret` lives there and can be referenced by any
+Worker in the account:
 
 ```typescript
 const store = yield* Cloudflare.SecretsStore("Store");
@@ -118,9 +171,18 @@ const apiKey = yield* Cloudflare.Secret("ApiKey", {
 });
 ```
 
-Both paths produce an `Output<Redacted<string>>` you can drop into
-a target's `env`; the difference is where the ciphertext lives and
-who manages its lifecycle.
+:::caution
+Prefer `Alchemy.Secret` over `Cloudflare.Secret`. A Cloudflare
+Secrets Store is capped at **100 secrets per account**, and every
+`Cloudflare.Secret` consumes one of those slots even when only
+one Worker uses it. `Alchemy.Secret` binds the ciphertext
+directly to the Worker as a `secret_text` binding, so it doesn't
+count against the quota.
+
+Reach for `Cloudflare.Secret` only when you genuinely need a
+secret shared across many Workers and managed out-of-band from
+your stack.
+:::
 
 For the step-by-step "wire up `OPENAI_API_KEY` from `.env`" walk,
 see [Guides › Secrets and env vars](/guides/secrets).


### PR DESCRIPTION
Restructure the Secrets and Variables concept page to lead with what a secret is, then build up usage step-by-step.

- Replace "Yield twice — bind and use" with a plain "Bind a secret to your Worker" section.
- Add a "Resolve from `.env`" section explaining the default `ConfigProvider` lookup.
- Add a "Provide the value explicitly" section with `Alchemy.Random` piped into `Alchemy.Secret` as the headline example.
- Rename "Out-of-band secrets" to "Account-wide secrets with `Cloudflare.Secret`" and add a `:::caution` recommending `Alchemy.Secret` instead — Cloudflare caps a Secrets Store at 100 secrets per account, and every `Cloudflare.Secret` consumes a slot, whereas `Alchemy.Secret` binds directly to the Worker as a `secret_text` binding.
