### PR TITLE
fix(cloudflare/vite): inline `env` props as `import.meta.env.*` in the bundle

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1607,6 +1607,22 @@ export const LiveWorkerProvider = () =>
           const builder = await vite.createBuilder(
             {
               root: props.vite?.rootDir,
+              // Emulate `vite build` env semantics for `props.env`: only
+              // keys with Vite's default `VITE_` prefix are inlined into
+              // the bundle as `import.meta.env.*`. `Redacted` values are
+              // unwrapped — by prefixing with `VITE_` the user is opting
+              // them into the public bundle.
+              define: Object.fromEntries(
+                Object.entries(props.env ?? {}).flatMap(([key, raw]) => {
+                  if (!key.startsWith("VITE_")) return [];
+                  const value = Redacted.isRedacted(raw)
+                    ? Redacted.value(raw)
+                    : raw;
+                  return [
+                    [`import.meta.env.${key}`, JSON.stringify(value)] as const,
+                  ];
+                }),
+              ),
               // Declare the ssr environment so Vite 8+ creates it.
               // The cloudflare-vite-plugin config hook merges its
               // SSR-specific settings on top of this stub.

--- a/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
@@ -6,6 +6,7 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import { MinimumLogLevel } from "effect/References";
+import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as pathe from "pathe";
 import { cloneFixture } from "../Utils/Fixture.ts";
 import { expectUrlContains } from "../Utils/Http.ts";
@@ -183,6 +184,64 @@ test.provider(
     }).pipe(logLevel),
   { timeout: 360_000 },
 );
+
+test.provider(
+  "Vite: `env` props are inlined as `import.meta.env.*` into the bundle",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+
+      yield* stack.destroy();
+
+      const rootDir = yield* cloneFixture(fixtureDir, {
+        prefix: "alchemy-vite-env-",
+        tempRoot,
+        entries: ["index.html", "package.json", "vite.config.ts", "src"],
+      });
+      const memoInclude = ["index.html", "src/**", "package.json"];
+      const marker = `vite-env-${Date.now()}`;
+
+      const site = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Vite("FixViteEnv", {
+            ...viteProps(rootDir, memoInclude),
+            env: { VITE_TEST_MARKER: marker },
+          });
+        }),
+      );
+
+      expect(site.url).toBeDefined();
+      // Resolve the hashed bundle URL by reading the deployed HTML, then
+      // assert the marker that `main.ts` references via
+      // `import.meta.env.VITE_TEST_MARKER` was actually inlined into the
+      // served JS asset by `Cloudflare.Vite`'s `env`-→-`define` plumbing.
+      const bundleUrl = yield* discoverBundleUrl(site.url!);
+      yield* expectUrlContains(bundleUrl, marker, {
+        timeout: "60 seconds",
+        label: "VITE_TEST_MARKER inlined into client bundle",
+      });
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(site.workerName, accountId);
+    }).pipe(logLevel),
+  { timeout: 360_000 },
+);
+
+const discoverBundleUrl = (siteUrl: string) =>
+  Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient;
+    const res = yield* client.get(`${siteUrl}/`);
+    const html = yield* res.text;
+    const match = html.match(/<script[^>]+src="(\/assets\/[^"]+\.js)"[^>]*>/i);
+    if (!match) {
+      return yield* Effect.die(
+        new Error(
+          `Could not find /assets/*.js script tag in HTML: ${html.slice(0, 200)}`,
+        ),
+      );
+    }
+    return `${siteUrl}${match[1]}`;
+  });
 
 const viteProps = (rootDir: string, memoInclude: string[]) => ({
   rootDir,

--- a/packages/alchemy/test/Cloudflare/Website/vite-fixture/src/main.ts
+++ b/packages/alchemy/test/Cloudflare/Website/vite-fixture/src/main.ts
@@ -1,7 +1,15 @@
 // Minimal client entry. The cloudflare-vite-plugin handles the worker
 // runtime separately; this file just satisfies the `index.html` script tag
 // reference so Vite emits a real client bundle.
+//
+// `import.meta.env.VITE_TEST_MARKER` is referenced here so the
+// "Vite: env props" test can verify `Cloudflare.Vite({ env })` actually
+// reaches the client bundle. Vite inlines the value via the `define`
+// hook at build time; the integration test fetches the deployed JS
+// asset and asserts the value is present.
+const marker = (import.meta.env as { VITE_TEST_MARKER?: string })
+  .VITE_TEST_MARKER;
 const el = document.getElementById("app");
 if (el) {
-  el.textContent = `${el.textContent} (hydrated)`;
+  el.textContent = `${el.textContent} (hydrated, marker=${marker ?? ""})`;
 }

--- a/website/src/content/docs/tutorial/cloudflare/vite-spa.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/vite-spa.mdx
@@ -130,6 +130,45 @@ Any framework Vite supports works the same way — vanilla TS,
 Vue, Solid, Svelte — bring whatever `src/` layout the framework
 wants.
 
+### Inject the Worker URL at build time
+
+A pure SPA needs the backend's URL baked into the JS bundle at
+build time — there's no server to resolve it on each request. Pass
+`env` to `Cloudflare.Vite` and any `VITE_`-prefixed entry is
+inlined as `import.meta.env.<KEY>` during the Vite build, the same
+as if you'd run `VITE_API_URL=https://… vite build`:
+
+```diff lang="typescript"
+// alchemy.run.ts
+ const worker = yield* Worker;
+ const web = yield* Cloudflare.Vite("Website", {
++  env: {
++    VITE_API_URL: worker.url.as<string>(),
++  },
+ });
+```
+
+Then read it from the SPA:
+
+```tsx
+// src/main.tsx
+const apiUrl = import.meta.env.VITE_API_URL;
+
+await fetch(`${apiUrl}/api/hello`);
+```
+
+A few notes:
+
+- **Only `VITE_`-prefixed keys are inlined into the bundle**, matching
+  Vite's default `envPrefix`. Other keys are still attached to the
+  deployed Worker as runtime bindings but stay out of the SPA's JS.
+- **`Redacted` values are unwrapped** when they're `VITE_`-prefixed —
+  prefixing means "this is public", so the redaction is taken as a
+  marker for log scrubbing, not for hiding the value from the bundle.
+  Don't prefix secrets with `VITE_`.
+- **`Output` values resolve at deploy time** before the build runs,
+  so `worker.url.as<string>()` works as shown.
+
 ## Use the create-vite template
 
 If you'd rather start from a real framework scaffold (React + TS


### PR DESCRIPTION
`Cloudflare.Vite("Site", { env: { VITE_API_URL: worker.url } })` was forwarding `env` only as runtime worker bindings; the values never made it into the client (or SSR) bundle. SPAs reading `import.meta.env.VITE_*` fell back to whatever default the code hardcoded, breaking dynamic backend URLs at build time.

`viteBuild` now passes `props.env` through Vite's `define` hook, emulating `vite build`'s env semantics:

- Only `VITE_`-prefixed keys are inlined into the bundle as `import.meta.env.<key>` (matches Vite's default `envPrefix`).
- Non-`VITE_` entries stay out of the bundle — still attached to the deployed Worker as runtime bindings.
- `Redacted` values are unwrapped when they're `VITE_`-prefixed (the user is opting them into the public bundle).

```ts
const web = yield* Cloudflare.Vite("Web", {
  env: { VITE_API_URL: worker.url.as<string>() },
});
// SPA: `import.meta.env.VITE_API_URL` now contains the deployed worker URL.
```

```diff
// packages/alchemy/src/Cloudflare/Workers/Worker.ts
  const builder = await vite.createBuilder({
    root: props.vite?.rootDir,
+   define: Object.fromEntries(
+     Object.entries(props.env ?? {}).flatMap(([key, raw]) => {
+       if (!key.startsWith("VITE_")) return [];
+       const value = Redacted.isRedacted(raw) ? Redacted.value(raw) : raw;
+       return [[`import.meta.env.${key}`, JSON.stringify(value)] as const];
+     }),
+   ),
```

Behavior is asserted in `packages/alchemy/test/Cloudflare/Website/Vite.test.ts` — the fixture's `main.ts` reads `import.meta.env.VITE_TEST_MARKER`, the test deploys with that env, fetches the served `/assets/*.js` bundle, and asserts the marker is inlined.

Tutorial doc (`website/src/content/docs/tutorial/cloudflare/vite-spa.mdx`) gains an "Inject the Worker URL at build time" section covering the pattern, the `VITE_` prefix rule, and the `Redacted` unwrap behavior.
