### PR TITLE
fix(Cloudflare/AiGateway): stop reporting update on every deploy

### DIFF
--- a/packages/alchemy/src/Cloudflare/AiGateway/AiGateway.ts
+++ b/packages/alchemy/src/Cloudflare/AiGateway/AiGateway.ts
@@ -201,15 +201,15 @@ export type AiGateway = Resource<
     rateLimitingLimit: number | null;
     rateLimitingTechnique: AiGatewayRateLimitingTechnique;
     authentication: boolean | undefined;
-    dlp: AiGatewayDlp | null | undefined;
+    dlp: AiGatewayDlp | undefined;
     isDefault: boolean | undefined;
-    logManagement: number | null | undefined;
-    logManagementStrategy: AiGatewayLogManagementStrategy | null | undefined;
+    logManagement: number | undefined;
+    logManagementStrategy: AiGatewayLogManagementStrategy | undefined;
     logpush: boolean | undefined;
-    logpushPublicKey: string | null | undefined;
-    otel: AiGatewayOtel[] | null | undefined;
-    storeId: string | null | undefined;
-    stripe: AiGatewayStripe | null | undefined;
+    logpushPublicKey: string | undefined;
+    otel: AiGatewayOtel[] | undefined;
+    storeId: string | undefined;
+    stripe: AiGatewayStripe | undefined;
     zdr: boolean | undefined;
   },
   never,
@@ -302,15 +302,15 @@ export const AiGatewayProvider = () =>
             rateLimitingLimit: props?.rateLimitingLimit ?? null,
             rateLimitingTechnique: props?.rateLimitingTechnique ?? "fixed",
             authentication: props?.authentication,
-            dlp: props?.dlp,
+            dlp: props?.dlp ?? undefined,
             isDefault: props?.isDefault,
-            logManagement: props?.logManagement,
-            logManagementStrategy: props?.logManagementStrategy,
+            logManagement: props?.logManagement ?? undefined,
+            logManagementStrategy: props?.logManagementStrategy ?? undefined,
             logpush: props?.logpush,
-            logpushPublicKey: props?.logpushPublicKey,
-            otel: props?.otel,
-            storeId: props?.storeId,
-            stripe: props?.stripe,
+            logpushPublicKey: props?.logpushPublicKey ?? undefined,
+            otel: props?.otel ?? undefined,
+            storeId: props?.storeId ?? undefined,
+            stripe: props?.stripe ?? undefined,
             zdr: props?.zdr,
           };
         });
@@ -335,15 +335,15 @@ export const AiGatewayProvider = () =>
         rateLimitingLimit: nullIfZero(gateway.rateLimitingLimit),
         rateLimitingTechnique: gateway.rateLimitingTechnique ?? "fixed",
         authentication: gateway.authentication ?? undefined,
-        dlp: gateway.dlp,
+        dlp: gateway.dlp ?? undefined,
         isDefault: gateway.isDefault ?? undefined,
-        logManagement: gateway.logManagement,
-        logManagementStrategy: gateway.logManagementStrategy,
+        logManagement: gateway.logManagement ?? undefined,
+        logManagementStrategy: gateway.logManagementStrategy ?? undefined,
         logpush: gateway.logpush ?? undefined,
-        logpushPublicKey: gateway.logpushPublicKey,
-        otel: gateway.otel,
-        storeId: gateway.storeId,
-        stripe: gateway.stripe,
+        logpushPublicKey: gateway.logpushPublicKey ?? undefined,
+        otel: gateway.otel ?? undefined,
+        storeId: gateway.storeId ?? undefined,
+        stripe: gateway.stripe ?? undefined,
         zdr: gateway.zdr ?? undefined,
       });
 
@@ -355,7 +355,7 @@ export const AiGatewayProvider = () =>
         rateLimitingLimit: gateway.rateLimitingLimit,
         rateLimitingTechnique: gateway.rateLimitingTechnique,
         authentication: gateway.authentication,
-        dlp: gateway.dlp ?? undefined,
+        dlp: gateway.dlp,
         isDefault: gateway.isDefault,
         logManagement: gateway.logManagement,
         logManagementStrategy: gateway.logManagementStrategy,
@@ -434,48 +434,10 @@ export const AiGatewayProvider = () =>
             return { action: "replace" } as const;
           }
 
-          const oldMutable = output
-            ? mutable(output)
-            : yield* desired(id, olds).pipe(
-                Effect.map((old) => ({
-                  cacheInvalidateOnUpdate: old.cacheInvalidateOnUpdate,
-                  cacheTtl: old.cacheTtl,
-                  collectLogs: old.collectLogs,
-                  rateLimitingInterval: old.rateLimitingInterval,
-                  rateLimitingLimit: old.rateLimitingLimit,
-                  rateLimitingTechnique: old.rateLimitingTechnique,
-                  authentication: old.authentication,
-                  dlp: old.dlp,
-                  isDefault: old.isDefault,
-                  logManagement: old.logManagement,
-                  logManagementStrategy: old.logManagementStrategy,
-                  logpush: old.logpush,
-                  logpushPublicKey: old.logpushPublicKey,
-                  otel: old.otel,
-                  storeId: old.storeId,
-                  stripe: old.stripe,
-                  zdr: old.zdr,
-                })),
-              );
-          const nextMutable = {
-            cacheInvalidateOnUpdate: next.cacheInvalidateOnUpdate,
-            cacheTtl: next.cacheTtl,
-            collectLogs: next.collectLogs,
-            rateLimitingInterval: next.rateLimitingInterval,
-            rateLimitingLimit: next.rateLimitingLimit,
-            rateLimitingTechnique: next.rateLimitingTechnique,
-            authentication: next.authentication,
-            dlp: next.dlp,
-            isDefault: next.isDefault,
-            logManagement: next.logManagement,
-            logManagementStrategy: next.logManagementStrategy,
-            logpush: next.logpush,
-            logpushPublicKey: next.logpushPublicKey,
-            otel: next.otel,
-            storeId: next.storeId,
-            stripe: next.stripe,
-            zdr: next.zdr,
-          };
+          const oldMutable = mutable(
+            output ?? ((yield* desired(id, olds)) as AiGateway["Attributes"]),
+          );
+          const nextMutable = mutable(next as AiGateway["Attributes"]);
           if (!deepEqual(oldMutable, nextMutable)) {
             return { action: "update" } as const;
           }

--- a/packages/alchemy/src/Diff.ts
+++ b/packages/alchemy/src/Diff.ts
@@ -87,26 +87,47 @@ export const havePropsChanged = <Props extends object>(
   newProps: Props,
 ) =>
   Output.hasOutputs(newProps) ||
-  JSON.stringify(canonicalize(oldProps ?? {})) !==
-    JSON.stringify(canonicalize(newProps ?? {}));
+  JSON.stringify(canonicalize(oldProps ?? {}, false)) !==
+    JSON.stringify(canonicalize(newProps ?? {}, false));
+
+export type DeepEqualOptions = {
+  /**
+   * When true, treat `null` and `undefined` as equivalent at any depth.
+   * Useful when comparing cloud-API responses (which often return `null`
+   * for unconfigured optional fields) against desired-state shapes built
+   * from `props?.x` (which leave the same fields `undefined`).
+   *
+   * @default false
+   */
+  stripNullish?: boolean;
+};
 
 /**
  * Sort-keys deep equality for plain data (objects, arrays, primitives).
  * Use in provider `diff` handlers instead of ad-hoc `JSON.stringify` comparisons.
+ *
+ * By default, `null` and `undefined` are treated as distinct. Pass
+ * `{ stripNullish: true }` to opt into treating them as equivalent.
  */
-export const deepEqual = (a: unknown, b: unknown): boolean =>
-  JSON.stringify(canonicalize(a ?? undefined)) ===
-  JSON.stringify(canonicalize(b ?? undefined));
+export const deepEqual = (
+  a: unknown,
+  b: unknown,
+  options?: DeepEqualOptions,
+): boolean =>
+  JSON.stringify(canonicalize(a, options?.stripNullish ?? false)) ===
+  JSON.stringify(canonicalize(b, options?.stripNullish ?? false));
 
-const canonicalize = (value: unknown): unknown => {
+const canonicalize = (value: unknown, stripNullish: boolean): unknown => {
+  if (stripNullish && value == null) return undefined;
   if (Array.isArray(value)) {
-    return value.map(canonicalize);
+    return value.map((v) => canonicalize(v, stripNullish));
   }
   if (value && typeof value === "object") {
     return Object.fromEntries(
       Object.entries(value)
+        .filter(([, nested]) => !stripNullish || nested != null)
         .sort(([a], [b]) => a.localeCompare(b))
-        .map(([key, nested]) => [key, canonicalize(nested)]),
+        .map(([key, nested]) => [key, canonicalize(nested, stripNullish)]),
     );
   }
   return value;


### PR DESCRIPTION
`AiGateway`'s `diff` reported `update` on every deploy because the comparison treated `null` and `undefined` as different values — `mutable(output)` read cloud state where Cloudflare returns `null` for unconfigured optional fields, while `nextMutable` was built from `desired()` where the same fields resolved to `undefined`.

Two fixes:

### Stop the `null` bleed at the AiGateway boundary

```diff
-    dlp: AiGatewayDlp | null | undefined;
-    logManagement: number | null | undefined;
-    otel: AiGatewayOtel[] | null | undefined;
-    storeId: string | null | undefined;
+    dlp: AiGatewayDlp | undefined;
+    logManagement: number | undefined;
+    otel: AiGatewayOtel[] | undefined;
+    storeId: string | undefined;
```

`mapGateway` and `desired` now coerce `null → undefined` for fields where `null` has no user-meaningful semantics. `cacheTtl` / `rateLimitingInterval` / `rateLimitingLimit` keep `number | null` because `null` is the "disabled" sentinel the user explicitly opts into.

### Collapse `mutable(...)` so both sides share one shape

```ts
const oldMutable = mutable(
  output ?? ((yield* desired(id, olds)) as AiGateway["Attributes"]),
);
const nextMutable = mutable(next as AiGateway["Attributes"]);
```

### Add opt-in `stripNullish` to `deepEqual`

```ts
deepEqual(a, b, { stripNullish: true })
```

Default behavior unchanged (`null` and `undefined` remain distinct). Available for providers that can't normalize at their type boundary.
