### PR TITLE
docs(blog): release notes for beta.38 and beta.39

### DIFF
--- a/website/src/content/docs/blog/2026-05-13-beta-38.md
+++ b/website/src/content/docs/blog/2026-05-13-beta-38.md
@@ -1,0 +1,213 @@
+---
+title: What's new in beta.38
+date: 2026-05-13
+category: release
+excerpt: Cloudflare Email Routing and the `send_email` Worker binding, a new `Action` plan node for arbitrary Effects that run during apply, a leaner Neon provider on the typed `@distilled.cloud/neon` SDK, and a transport-error retry fix.
+---
+
+`v2.0.0-beta.38` adds two new building blocks — full
+**Cloudflare Email** (zone routing + the `send_email`
+Worker binding) and the **`Action`** plan node for
+arbitrary Effects that run during apply — plus a
+behind-the-scenes Neon refactor onto the typed
+`@distilled.cloud/neon` SDK and a fault-tolerance fix in
+the apply transport.
+
+## Cloudflare Email
+
+Four new resources and one binding cover the whole flow:
+turn on Email Routing for a zone, register verified
+destination addresses, forward inbound mail with routing
+rules, and send outbound mail from a Worker.
+
+```typescript
+// alchemy.run.ts — enable Email Routing on a zone you own
+const routing = yield* Cloudflare.EmailRouting("Routing", {
+  zone: "example.com",
+});
+
+// Register a verified destination
+const ops = yield* Cloudflare.EmailAddress("Ops", {
+  email: "ops@example.com",
+});
+
+// Forward inbound info@ → ops@
+const rule = yield* Cloudflare.EmailRule("InfoForward", {
+  zone: "example.com",
+  matchers: [{ type: "literal", field: "to", value: "info@example.com" }],
+  actions: [{ type: "forward", value: ["ops@example.com"] }],
+});
+
+// Declare a `send_email` binding (the id is the env key)
+export const Email = Cloudflare.SendEmail("EmailOps", {
+  destinationAddress: "ops@example.com",
+  allowedSenderAddresses: ["noreply@example.com"],
+});
+```
+
+Bind `SendEmail` on a Worker and the runtime client gives
+you `send` (parsed) and `sendRaw` (RFC 822 bytes) with the
+same Effect error channel as every other binding:
+
+```typescript
+export default Cloudflare.Worker("Notifier",
+  { main: import.meta.path },
+  Effect.gen(function* () {
+    const email = yield* Cloudflare.SendEmail.bind(Email);
+
+    return {
+      fetch: Effect.gen(function* () {
+        yield* email.send({
+          from: "noreply@example.com",
+          to: "ops@example.com",
+          subject: "Hello",
+          text: "Hi from the edge",
+        });
+        return HttpServerResponse.text("sent");
+      }),
+    };
+  }).pipe(Effect.provide(Cloudflare.SendEmailBindingLive)),
+);
+```
+
+[Providers › `EmailRouting`](/providers/Cloudflare/EmailRouting) ·
+[`EmailAddress`](/providers/Cloudflare/EmailAddress) ·
+[`EmailRule`](/providers/Cloudflare/EmailRule) ·
+[`SendEmail`](/providers/Cloudflare/SendEmail)
+
+## `Action` — Effects that run as part of apply
+
+An **Action** is a node in the stack DAG that runs an
+arbitrary Effect during apply when its resolved input
+changes — the missing primitive for things like database
+migrations, cache invalidation, deploy announcements, or
+anything else that isn't a cloud resource but needs to run
+in order alongside one.
+
+The shape is intentionally close to `Resource`: define
+once, instantiate in a stack, pass it inputs, get an
+`Output` back that downstream nodes can depend on.
+
+```typescript
+import * as Alchemy from "alchemy";
+import * as Effect from "effect/Effect";
+
+const Sync = Alchemy.Action("Sync",
+  Effect.fn(function* (input: { table: string }) {
+    return { rows: 42 };
+  }),
+);
+
+// In a stack:
+const rows = yield* Sync({ table: bucket.name });
+//          ^? Output<{ rows: number }>
+```
+
+Unlike a Resource, an Action has no
+create/update/replace/delete lifecycle — the engine just
+hashes the resolved input and runs the body when it
+drifts. Removing the Action from the stack drops its
+persisted state in the GC pass; the body is never
+re-invoked on delete.
+
+The plan reports actions on their own row:
+
+```
+Plan: 1 to create | 1 to update | 1 to run
+
+~ Api (Cloudflare.Worker)
++ BucketA (Cloudflare.R2Bucket)
+λ AnnounceDeploy (AnnounceDeploy) [action]
+· DbMigrate (DbMigrate) [action]
+```
+
+`λ` (cyan) means *will run this apply*; `·` (gray) means
+*input hash matches, skip*. `--force` flips skip→run for
+actions the same way it does for resources.
+
+Init-style construction works too, for the common case
+where the body needs Effect Services from the stack's
+layers:
+
+```typescript
+const Sync = Alchemy.Action("Sync",
+  Effect.gen(function* () {
+    const db = yield* Database;
+    const logger = yield* Logger;
+    return Effect.fn(function* (input: { table: string }) {
+      yield* logger.info(`syncing ${input.table}`);
+      return { rows: yield* db.count(input.table) };
+    });
+  }),
+);
+```
+
+The init Effect runs once per process (memoized), so the
+runner is shared across every instance and every re-run.
+
+Actions also participate in the dependency graph in both
+directions — they can take resource Outputs as input *and*
+their own output can be consumed by downstream resources
+or other actions. The scheduler waits on a separate
+"stable" signal so an action body never observes a
+resource's precreate stub; it only sees terminal cloud
+state.
+
+[Concepts › Actions](/concepts/action)
+
+## Neon on `@distilled.cloud/neon`
+
+`Neon.Project` and `Neon.Branch` no longer ship a
+hand-rolled HTTP wrapper — they route through the typed
+[`@distilled.cloud/neon`](https://www.npmjs.com/package/@distilled.cloud/neon)
+SDK. The user-facing API is unchanged; what's gone is the
+`api.ts` shim, the manual JSON shapes, and the per-call
+error mapping.
+
+```diff
+- import * as api from "./api.ts";
++ import { getProject, updateProject, deleteProject } from "@distilled.cloud/neon/Operations";
+```
+
+404 handling now uses the SDK's tagged error directly:
+
+```typescript
+getProject({ project_id }).pipe(
+  Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
+)
+```
+
+This is mostly an internal cleanup, but it pays off
+immediately: errors carry typed tags instead of opaque
+strings, retries hang off `Schedule` instead of
+hand-written `try/catch`, and the next time the upstream
+OpenAPI spec moves we regenerate one package instead of
+patching one file.
+
+## Fault tolerance in the apply transport
+
+The transport that streams resource lifecycle events
+between the apply worker and the renderer now treats
+transient send/receive errors as retryable instead of
+collapsing the whole run. A flaky connection that drops
+mid-apply no longer aborts the stack — the transport
+backs off, reconnects, and resumes.
+
+## Other changes worth knowing about
+
+- **`effect@4.0.0-beta.66`.** Tracks the latest Effect
+  release. No public Alchemy API change; downstream apps
+  pinning Effect themselves should bump in lockstep.
+- **`ignore` is now vendored.** The MIT-licensed
+  `ignore` package is inlined into the Alchemy build to
+  shrink the supply-chain surface (one less transitive
+  dependency for everyone running `alchemy deploy` in CI).
+- **OTLP dashboard refresh.** Self-hosted OTel dashboards
+  now have resource-usage ranking and error-rate charts
+  per Stack / Stage. No code change in user code — it's
+  all dashboard config.
+
+## Where to go next
+
+- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta38)
+- [Compare v2.0.0-beta.37 → v2.0.0-beta.38](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.37...v2.0.0-beta.38)

--- a/website/src/content/docs/blog/2026-05-13-beta-39.md
+++ b/website/src/content/docs/blog/2026-05-13-beta-39.md
@@ -1,0 +1,108 @@
+---
+title: What's new in beta.39
+date: 2026-05-13
+category: release
+excerpt: A small, high-impact fix release — `VITE_*` env props are now inlined into the client bundle, the Cloudflare Worker HTTP adapter runs handlers through Effect's standard HTTP lifecycle (unblocking `RpcServer.toHttpEffect`), and the `SendEmail` binding from beta.38 is now wired into Worker binding inference.
+---
+
+`v2.0.0-beta.39` is a fix-only release that lands three
+things people hit immediately after beta.38: SPAs reading
+`import.meta.env.VITE_*`, Effect RPC servers running under
+the Cloudflare Worker adapter, and the brand-new
+`SendEmail` binding showing up in Worker binding types.
+
+## `Cloudflare.Vite` inlines `VITE_*` env into the bundle
+
+`Cloudflare.Vite("Site", { env: { ... } })` was forwarding
+`env` only as runtime Worker bindings — the values never
+made it into the client (or SSR) bundle. SPAs reading
+`import.meta.env.VITE_API_URL` fell back to whatever
+default the code hardcoded, breaking dynamic backend URLs
+at build time.
+
+The build step now passes `props.env` through Vite's
+`define` hook, emulating `vite build`'s env semantics:
+
+```typescript
+const web = yield* Cloudflare.Vite("Web", {
+  env: { VITE_API_URL: worker.url.as<string>() },
+});
+// SPA: `import.meta.env.VITE_API_URL` now contains the deployed worker URL.
+```
+
+The rules match Vite itself:
+
+- Only `VITE_`-prefixed keys are inlined into the bundle
+  as `import.meta.env.<key>` (matches Vite's default
+  `envPrefix`).
+- Non-`VITE_` entries stay out of the bundle but are still
+  attached to the deployed Worker as runtime bindings.
+- `Redacted` values are unwrapped when they're
+  `VITE_`-prefixed — opting them into the public bundle
+  is an explicit choice you make by naming them that way.
+
+The tutorial gains an [Inject the Worker URL at build
+time](/tutorial/cloudflare/vite-spa) section covering the
+pattern end-to-end.
+
+## Cloudflare Worker HTTP adapter — Effect's handled lifecycle
+
+The Worker HTTP adapter previously hand-rolled the
+`HttpServerRequest` / `HttpServerResponse` bridge. That
+worked for simple handlers but diverged from Effect's
+`HttpEffect.toHandled` / `toWebHandler` lifecycle in ways
+that broke scoped HTTP apps under workerd — most visibly,
+`RpcServer.toHttpEffect` hung when served through Alchemy
+even though the same app worked under raw Wrangler.
+
+The adapter now runs handlers through Effect's standard
+HTTP lifecycle while preserving every Worker-specific
+behavior:
+
+- `cf-connecting-ip` → `remoteAddress`
+- the original Cloudflare `Request` service
+- patched `request.raw` access
+- existing 500 response mapping from `serveWebRequest`
+
+…plus the parts that were missing: stream-scope transfer,
+HEAD body suppression, and request-abort interruption.
+
+The net effect: anything that worked under
+`@effect/platform`'s standard HTTP lifecycle now works
+under `Cloudflare.Worker` too. `RpcServer.toHttpEffect`,
+in particular, is unblocked.
+
+— *Thanks to **Will King**
+([#328](https://github.com/alchemy-run/alchemy-effect/pull/328))
+for the fix.* Fixes
+[#327](https://github.com/alchemy-run/alchemy-effect/issues/327).
+
+## `SendEmail` binding type inference
+
+beta.38 added `Cloudflare.SendEmail` but two wiring sites
+in `Worker.ts` were missed — the binding type inference
+didn't know about it, and the deploy-time binding
+metadata didn't emit a `send_email` entry. The result:
+typing `bindings: { EMAIL: Email }` on a Worker errored,
+and deploys silently dropped the binding.
+
+Both are wired up now — `SendEmail` is a first-class
+member of the Worker binding union, the env key carries
+the right runtime type, and Cloudflare receives the
+expected `send_email` binding metadata at deploy time.
+
+— *Thanks to **Gerben Mulder**
+([#326](https://github.com/alchemy-run/alchemy-effect/pull/326))
+for catching this.*
+
+## Contributors
+
+Big thank-you to everyone who shipped code in this beta:
+
+- **Will King** — Cloudflare Worker HTTP effect lifecycle ([#328](https://github.com/alchemy-run/alchemy-effect/pull/328))
+- **Gerben Mulder** — `SendEmail` Worker binding type and meta ([#326](https://github.com/alchemy-run/alchemy-effect/pull/326))
+
+## Where to go next
+
+- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta39)
+- [Compare v2.0.0-beta.38 → v2.0.0-beta.39](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.38...v2.0.0-beta.39)

--- a/website/src/content/docs/blog/2026-05-13-beta-39.md
+++ b/website/src/content/docs/blog/2026-05-13-beta-39.md
@@ -72,7 +72,7 @@ The net effect: anything that worked under
 under `Cloudflare.Worker` too. `RpcServer.toHttpEffect`,
 in particular, is unblocked.
 
-— *Thanks to **Will King**
+— *Thanks to **[Will King](https://github.com/wking-io)**
 ([#328](https://github.com/alchemy-run/alchemy-effect/pull/328))
 for the fix.* Fixes
 [#327](https://github.com/alchemy-run/alchemy-effect/issues/327).
@@ -91,7 +91,7 @@ member of the Worker binding union, the env key carries
 the right runtime type, and Cloudflare receives the
 expected `send_email` binding metadata at deploy time.
 
-— *Thanks to **Gerben Mulder**
+— *Thanks to **[Gerben Mulder](https://github.com/Gerbuuun)**
 ([#326](https://github.com/alchemy-run/alchemy-effect/pull/326))
 for catching this.*
 
@@ -99,8 +99,8 @@ for catching this.*
 
 Big thank-you to everyone who shipped code in this beta:
 
-- **Will King** — Cloudflare Worker HTTP effect lifecycle ([#328](https://github.com/alchemy-run/alchemy-effect/pull/328))
-- **Gerben Mulder** — `SendEmail` Worker binding type and meta ([#326](https://github.com/alchemy-run/alchemy-effect/pull/326))
+- **[Will King](https://github.com/wking-io)** — Cloudflare Worker HTTP effect lifecycle ([#328](https://github.com/alchemy-run/alchemy-effect/pull/328))
+- **[Gerben Mulder](https://github.com/Gerbuuun)** — `SendEmail` Worker binding type and meta ([#326](https://github.com/alchemy-run/alchemy-effect/pull/326))
 
 ## Where to go next
 


### PR DESCRIPTION
Release notes for the two betas cut since `.37`.

- [`2026-05-13-beta-38.md`](website/src/content/docs/blog/2026-05-13-beta-38.md) — Cloudflare Email Routing + `SendEmail`, the new `Action` plan node, Neon on `@distilled.cloud/neon`, transport-error fault tolerance.
- [`2026-05-13-beta-39.md`](website/src/content/docs/blog/2026-05-13-beta-39.md) — `Cloudflare.Vite` inlines `VITE_*` env into the bundle, Worker HTTP adapter runs through Effect's handled lifecycle, `SendEmail` wired into Worker binding inference.

Style follows `beta.37` (bigger feature post) and `beta.36` (small fix-driven post) respectively.
