### PR TITLE
fix(Cloudflare/AiGateway): align desired-state defaults with API defaults

### DIFF
--- a/packages/alchemy/src/Cloudflare/AiGateway/AiGateway.ts
+++ b/packages/alchemy/src/Cloudflare/AiGateway/AiGateway.ts
@@ -200,17 +200,17 @@ export type AiGateway = Resource<
     rateLimitingInterval: number | null;
     rateLimitingLimit: number | null;
     rateLimitingTechnique: AiGatewayRateLimitingTechnique;
-    authentication: boolean | undefined;
+    authentication: boolean;
     dlp: AiGatewayDlp | undefined;
-    isDefault: boolean | undefined;
-    logManagement: number | undefined;
-    logManagementStrategy: AiGatewayLogManagementStrategy | undefined;
-    logpush: boolean | undefined;
+    isDefault: boolean;
+    logManagement: number;
+    logManagementStrategy: AiGatewayLogManagementStrategy;
+    logpush: boolean;
     logpushPublicKey: string | undefined;
     otel: AiGatewayOtel[] | undefined;
-    storeId: string | undefined;
+    storeId: string;
     stripe: AiGatewayStripe | undefined;
-    zdr: boolean | undefined;
+    zdr: boolean;
   },
   never,
   Providers
@@ -301,17 +301,21 @@ export const AiGatewayProvider = () =>
             rateLimitingInterval: props?.rateLimitingInterval ?? null,
             rateLimitingLimit: props?.rateLimitingLimit ?? null,
             rateLimitingTechnique: props?.rateLimitingTechnique ?? "fixed",
-            authentication: props?.authentication,
+            // Defaults align with what Cloudflare's API returns for an
+            // unconfigured gateway, so the reconciler converges to noop
+            // when the user didn't explicitly set the field.
+            authentication: props?.authentication ?? false,
             dlp: props?.dlp ?? undefined,
-            isDefault: props?.isDefault,
-            logManagement: props?.logManagement ?? undefined,
-            logManagementStrategy: props?.logManagementStrategy ?? undefined,
-            logpush: props?.logpush,
+            isDefault: props?.isDefault ?? false,
+            logManagement: props?.logManagement ?? 100_000,
+            logManagementStrategy:
+              props?.logManagementStrategy ?? "STOP_INSERTING",
+            logpush: props?.logpush ?? false,
             logpushPublicKey: props?.logpushPublicKey ?? undefined,
             otel: props?.otel ?? undefined,
-            storeId: props?.storeId ?? undefined,
+            storeId: props?.storeId ?? "",
             stripe: props?.stripe ?? undefined,
-            zdr: props?.zdr,
+            zdr: props?.zdr ?? false,
           };
         });
 
@@ -334,17 +338,18 @@ export const AiGatewayProvider = () =>
         rateLimitingInterval: nullIfZero(gateway.rateLimitingInterval),
         rateLimitingLimit: nullIfZero(gateway.rateLimitingLimit),
         rateLimitingTechnique: gateway.rateLimitingTechnique ?? "fixed",
-        authentication: gateway.authentication ?? undefined,
+        authentication: gateway.authentication ?? false,
         dlp: gateway.dlp ?? undefined,
-        isDefault: gateway.isDefault ?? undefined,
-        logManagement: gateway.logManagement ?? undefined,
-        logManagementStrategy: gateway.logManagementStrategy ?? undefined,
-        logpush: gateway.logpush ?? undefined,
+        isDefault: gateway.isDefault ?? false,
+        logManagement: gateway.logManagement ?? 100_000,
+        logManagementStrategy:
+          gateway.logManagementStrategy ?? "STOP_INSERTING",
+        logpush: gateway.logpush ?? false,
         logpushPublicKey: gateway.logpushPublicKey ?? undefined,
         otel: gateway.otel ?? undefined,
-        storeId: gateway.storeId ?? undefined,
+        storeId: gateway.storeId ?? "",
         stripe: gateway.stripe ?? undefined,
-        zdr: gateway.zdr ?? undefined,
+        zdr: gateway.zdr ?? false,
       });
 
       const mutable = (gateway: AiGateway["Attributes"]) => ({


### PR DESCRIPTION
Follow-up to #332. After fixing the `null` vs `undefined` mismatch, `AiGateway` deploys still reported `update` on every run because Cloudflare's API returns concrete defaults for several optional fields, while our `desired()` left them `undefined`:

```
authentication        cloud: false              ours: undefined
isDefault             cloud: false              ours: undefined
logManagement         cloud: 100000             ours: undefined
logManagementStrategy cloud: "STOP_INSERTING"   ours: undefined
logpush               cloud: false              ours: undefined
storeId               cloud: ""                 ours: undefined
zdr                   cloud: false              ours: undefined
```

Align `desired()` defaults and `mapGateway` fallbacks with Cloudflare's API defaults, and tighten Attributes accordingly (these fields are always present in the response):

```diff
-    authentication: boolean | undefined;
-    isDefault: boolean | undefined;
-    logManagement: number | undefined;
-    logManagementStrategy: AiGatewayLogManagementStrategy | undefined;
-    logpush: boolean | undefined;
-    storeId: string | undefined;
-    zdr: boolean | undefined;
+    authentication: boolean;
+    isDefault: boolean;
+    logManagement: number;
+    logManagementStrategy: AiGatewayLogManagementStrategy;
+    logpush: boolean;
+    storeId: string;
+    zdr: boolean;
```

Verified locally: two consecutive `bun alchemy deploy --yes` runs now report `[Gateway] noop` on the second run instead of `updated`.
