### PR TITLE
fix(Cloudflare/Worker): log full Cause server-side, return generic 500 to client

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/HttpServer.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/HttpServer.ts
@@ -1,13 +1,10 @@
 import type * as cf from "@cloudflare/workers-types";
-import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import type { Scope } from "effect/Scope";
-import type { HttpBodyError } from "effect/unstable/http/HttpBody";
 import * as EffectHttp from "effect/unstable/http/HttpEffect";
 import { ClientAbort } from "effect/unstable/http/HttpServerError";
-import * as HttpServerError from "effect/unstable/http/HttpServerError";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import * as Http from "../../Http.ts";
@@ -19,11 +16,10 @@ export type HttpEffect = Http.HttpEffect<WorkerServices>;
 export const workersHttpHandler = <Req = never>(
   handler: Http.HttpEffect<Req> | Effect.Effect<Http.HttpEffect<Req>>,
 ) => {
-  const safeHandler = Http.safeHttpEffect(handler);
   return (event: any) => {
     if (isWorkerEvent(event) && event.type === "fetch") {
       const webRequest = event.input;
-      return serveWebRequest(webRequest, safeHandler, {
+      return serveWebRequest(webRequest, handler, {
         remoteAddress: webRequest.headers.get("cf-connecting-ip") ?? undefined,
       });
     }
@@ -32,11 +28,7 @@ export const workersHttpHandler = <Req = never>(
 
 export const serveWebRequest = <Req = never>(
   webRequest: cf.Request,
-  handler: Effect.Effect<
-    HttpServerResponse.HttpServerResponse,
-    HttpServerError.HttpServerError | HttpBodyError,
-    Req
-  >,
+  handler: Http.HttpEffect<Req> | Effect.Effect<Http.HttpEffect<Req>>,
   options: {
     // Preserve transport metadata when this helper is adapting a request
     // that originated from another runtime surface.
@@ -68,23 +60,12 @@ export const serveWebRequest = <Req = never>(
         }),
     });
 
-    const safeHandler = handler.pipe(
-      Effect.catchCause((cause) => {
-        const message = Option.match(Cause.findErrorOption(cause), {
-          onNone: () => "Internal Server Error",
-          onSome: (error) =>
-            error instanceof Error && error.message
-              ? error.message
-              : "Internal Server Error",
-        });
-        return Effect.succeed(
-          HttpServerResponse.text(message, {
-            status: 500,
-            statusText: message,
-          }),
-        );
-      }),
-    );
+    // Centralized error handling: every cause is caught, logged, and
+    // rendered as a structured 500. Every entry into this function — the
+    // Worker fetch path, the Durable Object fetch path in `Rpc.ts`, etc —
+    // gets identical failure semantics, regardless of how the caller
+    // produced `handler`.
+    const safeHandler = Http.safeHttpEffect(handler);
 
     const resolveSymbol = Symbol.for("@effect/platform/HttpApp/resolve");
     const httpApp = EffectHttp.toHandled(safeHandler, (request, response) => {

--- a/packages/alchemy/src/Http.ts
+++ b/packages/alchemy/src/Http.ts
@@ -61,18 +61,22 @@ export const safeHttpEffect = <Req = never>(
       ),
     ) as any as HttpEffect<Req>,
     (cause) => {
-      const message = Option.match(Cause.findErrorOption(cause), {
-        onNone: () => "Internal Server Error",
-        onSome: (error) => error.message ?? "Internal Server Error",
-      });
-
-      return Effect.map(
-        Effect.all([Effect.logError(message), Effect.logError(cause)]),
-        () =>
-          HttpServerResponse.text(message, {
+      // ClientAbort interrupts are not real failures — the client closed
+      // the connection. Skip logging and respond with 499 if applicable.
+      if (Cause.hasInterruptsOnly(cause)) {
+        return Effect.succeed(HttpServerResponse.empty({ status: 499 }));
+      }
+      // Log the full cause server-side so operators can debug, but return
+      // a generic 500 to the client. Causes can contain sensitive data
+      // (prompt contents, API keys baked into error messages, internal
+      // file paths) and should never be echoed back to the network.
+      return Effect.logError("HTTP handler failed", cause).pipe(
+        Effect.as(
+          HttpServerResponse.text("Internal Server Error", {
             status: 500,
-            statusText: message,
+            statusText: "Internal Server Error",
           }),
+        ),
       );
     },
   );


### PR DESCRIPTION
When a fetch handler failed, the response body was `Error.message` (or `"Internal Server Error"` for tagged errors with no message) and the structured `Cause` was logged opaquely. Tagged errors like `AiError` whose surface message is empty disappeared into a blank 500 with no information in either the response or `bun alchemy logs`.

### Log the full cause server-side, return a generic 500 to the client

Causes commonly contain sensitive data — prompt contents, internal file paths, error messages that leak credentials — so they should never be echoed back over the network. Log them through the structured logger and keep the response generic:

```diff
- const message = Option.match(Cause.findErrorOption(cause), {
-   onNone: () => "Internal Server Error",
-   onSome: (error) => error.message ?? "Internal Server Error",
- });
- return Effect.map(
-   Effect.all([Effect.logError(message), Effect.logError(cause)]),
-   () => HttpServerResponse.text(message, { status: 500, statusText: message }),
- );
+ return Effect.logError("HTTP handler failed", cause).pipe(
+   Effect.as(
+     HttpServerResponse.text("Internal Server Error", {
+       status: 500,
+       statusText: "Internal Server Error",
+     }),
+   ),
+ );
```

A single structured `logError("HTTP handler failed", cause)` lands in the logger so observability pipelines see one event per failure with the full `Cause` tree attached. Operators debug from logs; clients only ever see a plain 500.

`ClientAbort` interrupts now respond `499` and skip logging — they're client disconnects, not handler failures.

### Centralize the wrap in `serveWebRequest`

`serveWebRequest` is called from two places: the Worker fetch path (via `workersHttpHandler`) and the Durable Object fetch path in `Rpc.ts`. Only the first one was wrapping with `safeHttpEffect`, so DO fetch handlers had no protection.

```diff
 export const serveWebRequest = <Req = never>(
   webRequest: cf.Request,
-  handler: Effect.Effect<HttpServerResponse, HttpServerError | HttpBodyError, Req>,
+  handler: Http.HttpEffect<Req> | Effect.Effect<Http.HttpEffect<Req>>,
   options = {},
 ) =>
   Effect.gen(function* () {
     ...
+    const safeHandler = Http.safeHttpEffect(handler);
     const httpApp = EffectHttp.toHandled(safeHandler, ...);
   });
```

Every entry into `serveWebRequest` now gets identical failure semantics regardless of caller. The `HttpEffect` type stays unchanged — handlers still have to discharge `HttpServerError | HttpBodyError` themselves; `safeHttpEffect` is purely the runtime safety net for unexpected defects.
