### PR TITLE
docs(blog): order beta.39 after beta.38 in sidebar

### DIFF
--- a/website/src/content/docs/blog/2026-05-13-beta-39.md
+++ b/website/src/content/docs/blog/2026-05-13-beta-39.md
@@ -1,6 +1,6 @@
 ---
 title: What's new in beta.39
-date: 2026-05-13
+date: 2026-05-13T18:00:00Z
 category: release
 excerpt: A small, high-impact fix release — `VITE_*` env props are now inlined into the client bundle, the Cloudflare Worker HTTP adapter runs handlers through Effect's standard HTTP lifecycle (unblocking `RpcServer.toHttpEffect`), and the `SendEmail` binding from beta.38 is now wired into Worker binding inference.
 ---


### PR DESCRIPTION
Both beta.38 and beta.39 used `date: 2026-05-13`, leaving the sidebar order between them undefined — beta.38 was appearing above beta.39.

```diff
-date: 2026-05-13
+date: 2026-05-13T18:00:00Z
```
