### PR TITLE
fix(cloudflare/container): forward startup options through Cloudflare.start

### DIFF
--- a/packages/alchemy/src/Cloudflare/Container/StartContainer.ts
+++ b/packages/alchemy/src/Cloudflare/Container/StartContainer.ts
@@ -7,7 +7,11 @@ import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import { type Fetcher } from "../Fetcher.ts";
 import { DurableObjectState } from "../Workers/DurableObjectState.ts";
-import { type Container, ContainerError } from "./Container.ts";
+import {
+  type Container,
+  type ContainerStartupOptions,
+  ContainerError,
+} from "./Container.ts";
 
 /**
  * Runs the Container in a Durable Object and monitors it, providing a durable fetch and RPC interface to it.
@@ -15,13 +19,16 @@ import { type Container, ContainerError } from "./Container.ts";
 export const start = Effect.fnUntraced(function* <
   Shape extends Container,
   Req = never,
->(containerEff: Effect.Effect<Shape, never, Req | DurableObjectState>) {
+>(
+  containerEff: Effect.Effect<Shape, never, Req | DurableObjectState>,
+  options?: ContainerStartupOptions,
+) {
   const container = yield* containerEff;
 
   const ensureRunning = Effect.gen(function* () {
     if (yield* container.running) return;
     yield* Effect.logInfo("Container not running, starting...");
-    yield* container.start();
+    yield* container.start(options);
     yield* Effect.logInfo("Container started, launching monitor");
     yield* Effect.forkDetach(
       container.monitor().pipe(


### PR DESCRIPTION
## Summary

`Cloudflare.start` currently calls `container.start()` with no arguments, silently dropping any `ContainerStartupOptions` the caller wants to apply on each start (e.g. `enableInternet`, `entrypoint`, `envVars` overrides).

This is a 10-line change that adds an optional second parameter to `Cloudflare.start` and forwards it to `container.start`.

## Why

The underlying `Container` interface already accepts options:

```ts
start(options?: ContainerStartupOptions): Effect.Effect<void>;
```

And `bindContainer` in `ContainerBinding.ts` already wires the runtime side correctly:

```ts
start: (options?: ContainerStartupOptions) =>
  Effect.sync(() => state.container!.start(options)),
```

But the public-facing `Cloudflare.start` helper has no way to pass options through, so callers have no path to set per-instance startup overrides documented in the Cloudflare Containers API. The runtime is fully ready — only the call-site signature is missing.

## Repro

```ts
const container = yield* Cloudflare.start(sandbox, { enableInternet: true });
//                                                  ^^^^^^^^^^^^^^^^^^^^^^^
// Today: ignored. After this PR: forwarded to container.start.
```

## Diff

10 insertions, 3 deletions in `StartContainer.ts` only:

- import `ContainerStartupOptions` alongside the existing `Container` / `ContainerError` imports
- accept `options?: ContainerStartupOptions` as the second parameter
- pass `options` to `container.start(options)`

No behavior change for existing callers (the parameter is optional).