### PR TITLE
docs(tutorial): fix local dev docs

### DIFF
--- a/website/src/content/docs/tutorial/part-4.mdx
+++ b/website/src/content/docs/tutorial/part-4.mdx
@@ -7,28 +7,28 @@ sidebar:
 
 In [Part 3](/tutorial/part-3) you wrote integration tests against
 your deployed stack. But deploying to Cloudflare on every code change
-is slow. In this part you'll use `alchemy dev` to run everything
+is slow. In this part you'll use `bun alchemy dev` to run everything
 locally with hot reloading.
 
 ## Start dev mode
 
 ```sh
-alchemy dev
+bun alchemy dev
 ```
 
 That's it. Alchemy deploys your stack to the cloud and proxies
 requests to Workers running locally in workerd. It watches for file
 changes and hot reloads your Worker automatically.
 
-Your Worker is available at `http://localhost:1337` by default:
+Your Worker is available at `http://worker.localhost:1337` by default:
 
 ```sh
-curl http://localhost:1337/hello.txt
+curl http://worker.localhost:1337/hello.txt
 ```
 
 ## How it works
 
-`alchemy dev` does three things:
+`bun alchemy dev` does three things:
 
 1. **Deploys to the cloud** — resources like R2 Buckets are created
    on Cloudflare, while Workers run locally in workerd
@@ -60,10 +60,10 @@ export default Cloudflare.Worker(
 
 ## Run tests in dev mode
 
-You don't need to run `alchemy dev` in a separate terminal to test
+You don't need to run `bun alchemy dev` in a separate terminal to test
 against locally-emulated resources. The test harness has its own
 `dev` flag that flips every Worker over to workerd inside the test
-process — same wiring as `alchemy dev`, no extra terminal.
+process — same wiring as `bun alchemy dev`, no extra terminal.
 
 ```diff lang="typescript"
 // test/integ.test.ts
@@ -75,7 +75,7 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
 ```
 
 `beforeAll(deploy(Stack))` now boots the Workers locally; HTTP
-assertions hit `http://localhost:1337` and roundtrip into your code
+assertions hit `http://worker.localhost:1337` and roundtrip into your code
 with full stack traces.
 
 ## Toggle dev mode from CI
@@ -105,7 +105,7 @@ ALCHEMY_DEV=1 bun test test/integ.test.ts
 
 You now have:
 
-- Local development with `alchemy dev`
+- Local development with `bun alchemy dev`
 - Hot reloading on file changes
 - Local emulation of Cloudflare resources
 


### PR DESCRIPTION
Updates Part 4 of the tutorial to use `bun alchemy dev` instead of `alchemy dev`, avoiding an implied global `alchemy` install.

Also updates the default Worker URL examples to include the Worker subdomain: `http://worker.localhost:1337`.