### PR TITLE
feat(cloudflare): expose bucket client service

### DIFF
--- a/packages/alchemy/src/Cloudflare/AiGateway/AiGatewayBinding.ts
+++ b/packages/alchemy/src/Cloudflare/AiGateway/AiGatewayBinding.ts
@@ -6,6 +6,7 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Binding from "../../Binding.ts";
 import type { ResourceLike } from "../../Resource.ts";
+import { makeBoundClientService } from "../BoundClient.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import type { AiGateway as AiGatewayResource } from "./AiGateway.ts";
 
@@ -98,6 +99,13 @@ export class AiGatewayBinding extends Binding.Service<
   AiGatewayBinding,
   (gateway: AiGatewayResource) => Effect.Effect<AiGatewayClient>
 >()("Cloudflare.AiGateway.Binding") {}
+
+export const AiGatewayClient = makeBoundClientService<
+  AiGatewayClient,
+  AiGatewayResource,
+  AiGatewayClient,
+  AiGatewayBinding
+>("Cloudflare.AiGateway.Client", AiGatewayBinding);
 
 /**
  * Runtime layer for {@link AiGatewayBinding}.

--- a/packages/alchemy/src/Cloudflare/AiGateway/AiGatewayBinding.ts
+++ b/packages/alchemy/src/Cloudflare/AiGateway/AiGatewayBinding.ts
@@ -29,8 +29,8 @@ export class AiGatewayError extends Data.TaggedError("AiGatewayError")<{
  *
  * Wraps the runtime {@link AiGateway} binding so each operation returns an
  * Effect tagged with {@link AiGatewayError}. Provide
- * `Cloudflare.AiGatewayClient.layer(gateway)` to services that need the
- * gateway client.
+ * `Cloudflare.AiGatewayClient.layer(boundGateway)` to services that need the
+ * gateway client after binding the gateway in Worker init.
  */
 export interface AiGatewayClient {
   /**
@@ -93,6 +93,8 @@ export interface AiGatewayClient {
  *
  * @example Providing an AI Gateway client to a service
  * ```typescript
+ * const boundGateway = yield* Cloudflare.AiGateway.bind(gateway);
+ *
  * class Ai extends Context.Service<Ai, {
  *   status: Effect.Effect<Response, Cloudflare.AiGatewayError>;
  * }>()("Ai") {}
@@ -111,8 +113,7 @@ export interface AiGatewayClient {
  *     };
  *   }),
  * ).pipe(
- *   Layer.provide(Cloudflare.AiGatewayClient.layer(gateway)),
- *   Layer.provide(Cloudflare.AiGatewayBindingLive),
+ *   Layer.provide(Cloudflare.AiGatewayClient.layer(boundGateway)),
  * );
  *
  * return {
@@ -133,10 +134,8 @@ export class AiGatewayBinding extends Binding.Service<
 
 export const AiGatewayClient = makeBoundClientService<
   AiGatewayClient,
-  AiGatewayResource,
-  AiGatewayClient,
-  AiGatewayBinding
->("Cloudflare.AiGateway.Client", AiGatewayBinding);
+  AiGatewayClient
+>("Cloudflare.AiGateway.Client");
 
 /**
  * Runtime layer for {@link AiGatewayBinding}.

--- a/packages/alchemy/src/Cloudflare/AiGateway/AiGatewayBinding.ts
+++ b/packages/alchemy/src/Cloudflare/AiGateway/AiGatewayBinding.ts
@@ -28,8 +28,9 @@ export class AiGatewayError extends Data.TaggedError("AiGatewayError")<{
  * Effect-native client for a Cloudflare AI Gateway Worker binding.
  *
  * Wraps the runtime {@link AiGateway} binding so each operation returns an
- * Effect tagged with {@link AiGatewayError}. Use
- * `Cloudflare.AiGatewayBinding.bind(gateway)` inside a Worker's init phase.
+ * Effect tagged with {@link AiGatewayError}. Provide
+ * `Cloudflare.AiGatewayClient.layer(gateway)` to services that need the
+ * gateway client.
  */
 export interface AiGatewayClient {
   /**
@@ -76,24 +77,54 @@ export interface AiGatewayClient {
  * Bind the gateway during the Worker's init phase, then use `run` or `getUrl`
  * from request handlers.
  *
- * @example Run through a gateway
+ * @example Direct binding inside a Worker
  * ```typescript
- * const aiGateway = yield* Cloudflare.AiGatewayBinding.bind(gateway);
+ * const aiGateway = yield* Cloudflare.AiGateway.bind(gateway);
  *
  * return {
- *   fetch: Effect.gen(function* () {
- *     return yield* aiGateway.run({
- *       provider: "workers-ai",
- *       endpoint: "@cf/meta/llama-3.1-8b-instruct",
- *       headers: { "content-type": "application/json" },
- *       query: { prompt: "Write a concise status update" },
- *     });
+ *   fetch: aiGateway.run({
+ *     provider: "workers-ai",
+ *     endpoint: "@cf/meta/llama-3.1-8b-instruct",
+ *     headers: { "content-type": "application/json" },
+ *     query: { prompt: "Write a concise status update" },
  *   }),
  * };
  * ```
  *
- * Provide {@link AiGatewayBindingLive} in the worker's runtime layer to
- * resolve the underlying Cloudflare AI binding at request time.
+ * @example Providing an AI Gateway client to a service
+ * ```typescript
+ * class Ai extends Context.Service<Ai, {
+ *   status: Effect.Effect<Response, Cloudflare.AiGatewayError>;
+ * }>()("Ai") {}
+ *
+ * const AiLive = Layer.effect(
+ *   Ai,
+ *   Effect.gen(function* () {
+ *     const aiGateway = yield* Cloudflare.AiGatewayClient;
+ *     return {
+ *       status: aiGateway.run({
+ *         provider: "workers-ai",
+ *         endpoint: "@cf/meta/llama-3.1-8b-instruct",
+ *         headers: { "content-type": "application/json" },
+ *         query: { prompt: "Write a concise status update" },
+ *       }),
+ *     };
+ *   }),
+ * ).pipe(
+ *   Layer.provide(Cloudflare.AiGatewayClient.layer(gateway)),
+ *   Layer.provide(Cloudflare.AiGatewayBindingLive),
+ * );
+ *
+ * return {
+ *   fetch: Effect.gen(function* () {
+ *     const ai = yield* Ai;
+ *     return yield* ai.status;
+ *   }).pipe(Effect.provide(AiLive)),
+ * };
+ * ```
+ *
+ * Provide {@link AiGatewayBindingLive} with the client layer so Alchemy can
+ * attach the underlying Cloudflare AI binding and resolve it at request time.
  */
 export class AiGatewayBinding extends Binding.Service<
   AiGatewayBinding,

--- a/packages/alchemy/src/Cloudflare/AnalyticsEngine/AnalyticsEngineDataset.ts
+++ b/packages/alchemy/src/Cloudflare/AnalyticsEngine/AnalyticsEngineDataset.ts
@@ -34,10 +34,31 @@ export type AnalyticsEngineDatasetProps = {
  * });
  * ```
  *
- * @example Effect-style worker
+ * @example Direct binding inside a Worker
  * ```typescript
  * const analytics = yield* Cloudflare.AnalyticsEngineDataset.bind(Analytics);
+ *
  * yield* analytics.writeDataPoint({ blobs: ["signup"] });
+ * ```
+ *
+ * @example Providing an Analytics client to a service
+ * ```typescript
+ * class Events extends Context.Service<Events, {
+ *   writeSignup: Effect.Effect<void, Cloudflare.AnalyticsEngineDatasetError>;
+ * }>()("Events") {}
+ *
+ * const EventsLive = Layer.effect(
+ *   Events,
+ *   Effect.gen(function* () {
+ *     const analytics = yield* Cloudflare.AnalyticsEngineDatasetClient;
+ *     return {
+ *       writeSignup: analytics.writeDataPoint({ blobs: ["signup"] }),
+ *     };
+ *   }),
+ * ).pipe(
+ *   Layer.provide(Cloudflare.AnalyticsEngineDatasetClient.layer(Analytics)),
+ *   Layer.provide(Cloudflare.AnalyticsEngineDatasetBindingLive),
+ * );
  * ```
  */
 export type AnalyticsEngineDataset = {

--- a/packages/alchemy/src/Cloudflare/AnalyticsEngine/AnalyticsEngineDataset.ts
+++ b/packages/alchemy/src/Cloudflare/AnalyticsEngine/AnalyticsEngineDataset.ts
@@ -43,6 +43,8 @@ export type AnalyticsEngineDatasetProps = {
  *
  * @example Providing an Analytics client to a service
  * ```typescript
+ * const boundAnalytics = yield* Cloudflare.AnalyticsEngineDataset.bind(Analytics);
+ *
  * class Events extends Context.Service<Events, {
  *   writeSignup: Effect.Effect<void, Cloudflare.AnalyticsEngineDatasetError>;
  * }>()("Events") {}
@@ -56,8 +58,7 @@ export type AnalyticsEngineDatasetProps = {
  *     };
  *   }),
  * ).pipe(
- *   Layer.provide(Cloudflare.AnalyticsEngineDatasetClient.layer(Analytics)),
- *   Layer.provide(Cloudflare.AnalyticsEngineDatasetBindingLive),
+ *   Layer.provide(Cloudflare.AnalyticsEngineDatasetClient.layer(boundAnalytics)),
  * );
  * ```
  */

--- a/packages/alchemy/src/Cloudflare/AnalyticsEngine/AnalyticsEngineDatasetBinding.ts
+++ b/packages/alchemy/src/Cloudflare/AnalyticsEngine/AnalyticsEngineDatasetBinding.ts
@@ -40,10 +40,8 @@ export class AnalyticsEngineDatasetBinding extends Binding.Service<
 
 export const AnalyticsEngineDatasetClient = makeBoundClientService<
   AnalyticsEngineDatasetClient,
-  AnalyticsEngineDatasetLike,
-  AnalyticsEngineDatasetClient,
-  AnalyticsEngineDatasetBinding
->("Cloudflare.AnalyticsEngineDataset.Client", AnalyticsEngineDatasetBinding);
+  AnalyticsEngineDatasetClient
+>("Cloudflare.AnalyticsEngineDataset.Client");
 
 export const AnalyticsEngineDatasetBindingLive = Layer.effect(
   AnalyticsEngineDatasetBinding,

--- a/packages/alchemy/src/Cloudflare/AnalyticsEngine/AnalyticsEngineDatasetBinding.ts
+++ b/packages/alchemy/src/Cloudflare/AnalyticsEngine/AnalyticsEngineDatasetBinding.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import type { ResourceLike } from "../../Resource.ts";
+import { makeBoundClientService } from "../BoundClient.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import type { AnalyticsEngineDataset as AnalyticsEngineDatasetLike } from "./AnalyticsEngineDataset.ts";
 
@@ -36,6 +37,13 @@ export class AnalyticsEngineDatasetBinding extends Binding.Service<
     dataset: AnalyticsEngineDatasetLike,
   ) => Effect.Effect<AnalyticsEngineDatasetClient>
 >()("Cloudflare.AnalyticsEngineDataset.Binding") {}
+
+export const AnalyticsEngineDatasetClient = makeBoundClientService<
+  AnalyticsEngineDatasetClient,
+  AnalyticsEngineDatasetLike,
+  AnalyticsEngineDatasetClient,
+  AnalyticsEngineDatasetBinding
+>("Cloudflare.AnalyticsEngineDataset.Client", AnalyticsEngineDatasetBinding);
 
 export const AnalyticsEngineDatasetBindingLive = Layer.effect(
   AnalyticsEngineDatasetBinding,

--- a/packages/alchemy/src/Cloudflare/Artifacts/Artifacts.ts
+++ b/packages/alchemy/src/Cloudflare/Artifacts/Artifacts.ts
@@ -111,6 +111,8 @@ export const isArtifacts = (value: unknown): value is Artifacts =>
  *
  * @example Providing an Artifacts client to a service
  * ```typescript
+ * const boundArtifacts = yield* Cloudflare.Artifacts.bind(Repos);
+ *
  * class Repositories extends Context.Service<Repositories, {
  *   createStarter: Effect.Effect<ArtifactsCreateRepoResult, Cloudflare.ArtifactsError>;
  * }>()("Repositories") {}
@@ -126,8 +128,7 @@ export const isArtifacts = (value: unknown): value is Artifacts =>
  *     };
  *   }),
  * ).pipe(
- *   Layer.provide(Cloudflare.ArtifactsClient.layer(Repos)),
- *   Layer.provide(Cloudflare.ArtifactsBindingLive),
+ *   Layer.provide(Cloudflare.ArtifactsClient.layer(boundArtifacts)),
  * );
  * ```
  */

--- a/packages/alchemy/src/Cloudflare/Artifacts/Artifacts.ts
+++ b/packages/alchemy/src/Cloudflare/Artifacts/Artifacts.ts
@@ -100,12 +100,35 @@ export const isArtifacts = (value: unknown): value is Artifacts =>
  * };
  * ```
  *
- * @example Effect-style worker
+ * @example Direct binding inside a Worker
  * ```typescript
  * const artifacts = yield* Cloudflare.Artifacts.bind(Repos);
+ *
  * const repo = yield* artifacts.create("starter-repo", {
  *   setDefaultBranch: "main",
  * });
+ * ```
+ *
+ * @example Providing an Artifacts client to a service
+ * ```typescript
+ * class Repositories extends Context.Service<Repositories, {
+ *   createStarter: Effect.Effect<ArtifactsCreateRepoResult, Cloudflare.ArtifactsError>;
+ * }>()("Repositories") {}
+ *
+ * const RepositoriesLive = Layer.effect(
+ *   Repositories,
+ *   Effect.gen(function* () {
+ *     const artifacts = yield* Cloudflare.ArtifactsClient;
+ *     return {
+ *       createStarter: artifacts.create("starter-repo", {
+ *         setDefaultBranch: "main",
+ *       }),
+ *     };
+ *   }),
+ * ).pipe(
+ *   Layer.provide(Cloudflare.ArtifactsClient.layer(Repos)),
+ *   Layer.provide(Cloudflare.ArtifactsBindingLive),
+ * );
  * ```
  */
 export const Artifacts: {

--- a/packages/alchemy/src/Cloudflare/Artifacts/ArtifactsBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Artifacts/ArtifactsBinding.ts
@@ -63,8 +63,8 @@ export interface ArtifactsRepoClient {
  *
  * Wraps the runtime {@link Artifacts} binding so each method returns an
  * Effect tagged with {@link ArtifactsError}. Provide
- * `Cloudflare.ArtifactsClient.layer(Repos)` to services that need the
- * namespace client.
+ * `Cloudflare.ArtifactsClient.layer(boundArtifacts)` to services that need the
+ * namespace client after binding Artifacts in Worker init.
  */
 export interface ArtifactsClient {
   /** Effect resolving to the raw Cloudflare runtime binding. */
@@ -103,10 +103,8 @@ export class ArtifactsBinding extends Binding.Service<
 
 export const ArtifactsClient = makeBoundClientService<
   ArtifactsClient,
-  ArtifactsLike,
-  ArtifactsClient,
-  ArtifactsBinding
->("Cloudflare.Artifacts.Client", ArtifactsBinding);
+  ArtifactsClient
+>("Cloudflare.Artifacts.Client");
 
 export const ArtifactsBindingLive = Layer.effect(
   ArtifactsBinding,

--- a/packages/alchemy/src/Cloudflare/Artifacts/ArtifactsBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Artifacts/ArtifactsBinding.ts
@@ -62,8 +62,9 @@ export interface ArtifactsRepoClient {
  * Effect-native client for a Cloudflare Artifacts namespace binding.
  *
  * Wraps the runtime {@link Artifacts} binding so each method returns an
- * Effect tagged with {@link ArtifactsError}. Use
- * `Cloudflare.ArtifactsBinding.bind(Repos)` inside a Worker's init phase.
+ * Effect tagged with {@link ArtifactsError}. Provide
+ * `Cloudflare.ArtifactsClient.layer(Repos)` to services that need the
+ * namespace client.
  */
 export interface ArtifactsClient {
   /** Effect resolving to the raw Cloudflare runtime binding. */

--- a/packages/alchemy/src/Cloudflare/Artifacts/ArtifactsBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Artifacts/ArtifactsBinding.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import type { ResourceLike } from "../../Resource.ts";
+import { makeBoundClientService } from "../BoundClient.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import { type Artifacts as ArtifactsLike } from "./Artifacts.ts";
 
@@ -98,6 +99,13 @@ export class ArtifactsBinding extends Binding.Service<
   ArtifactsBinding,
   (artifacts: ArtifactsLike) => Effect.Effect<ArtifactsClient>
 >()("Cloudflare.Artifacts.Binding") {}
+
+export const ArtifactsClient = makeBoundClientService<
+  ArtifactsClient,
+  ArtifactsLike,
+  ArtifactsClient,
+  ArtifactsBinding
+>("Cloudflare.Artifacts.Client", ArtifactsBinding);
 
 export const ArtifactsBindingLive = Layer.effect(
   ArtifactsBinding,

--- a/packages/alchemy/src/Cloudflare/BoundClient.ts
+++ b/packages/alchemy/src/Cloudflare/BoundClient.ts
@@ -1,0 +1,31 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+/**
+ * Creates a yieldable client service for a Cloudflare runtime object binding.
+ *
+ * The binding remains the source of truth for deploy-time attachment; the
+ * client service is only the app-facing Effect service produced by binding a
+ * specific resource.
+ */
+export const makeBoundClientService = <Self, Resource, Client, BindingReq>(
+  id: string,
+  binding: {
+    bind: <Req = never>(
+      resource: Resource | Effect.Effect<Resource, never, Req>,
+    ) => Effect.Effect<Client, never, BindingReq | Req>;
+  },
+): Context.Service<Self, Client> & {
+  layer: <Req = never>(
+    resource: Resource | Effect.Effect<Resource, never, Req>,
+  ) => Layer.Layer<Self, never, BindingReq | Req>;
+} => {
+  const tag = Context.Service<Self, Client>(id);
+
+  return Object.assign(tag, {
+    layer: <Req = never>(
+      resource: Resource | Effect.Effect<Resource, never, Req>,
+    ) => Layer.effect(tag, binding.bind(resource)),
+  });
+};

--- a/packages/alchemy/src/Cloudflare/BoundClient.ts
+++ b/packages/alchemy/src/Cloudflare/BoundClient.ts
@@ -1,31 +1,22 @@
 import * as Context from "effect/Context";
-import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
 /**
  * Creates a yieldable client service for a Cloudflare runtime object binding.
  *
- * The binding remains the source of truth for deploy-time attachment; the
- * client service is only the app-facing Effect service produced by binding a
- * specific resource.
+ * The binding remains the source of truth for deploy-time attachment. The
+ * layer requires an already-bound client value so callers must run
+ * `yield* Resource.bind(resource)` in the Worker's init effect, where Alchemy
+ * can discover the deploy-time binding.
  */
-export const makeBoundClientService = <Self, Resource, Client, BindingReq>(
+export const makeBoundClientService = <Self, Client>(
   id: string,
-  binding: {
-    bind: <Req = never>(
-      resource: Resource | Effect.Effect<Resource, never, Req>,
-    ) => Effect.Effect<Client, never, BindingReq | Req>;
-  },
 ): Context.Service<Self, Client> & {
-  layer: <Req = never>(
-    resource: Resource | Effect.Effect<Resource, never, Req>,
-  ) => Layer.Layer<Self, never, BindingReq | Req>;
+  layer: (client: Client) => Layer.Layer<Self>;
 } => {
   const tag = Context.Service<Self, Client>(id);
 
   return Object.assign(tag, {
-    layer: <Req = never>(
-      resource: Resource | Effect.Effect<Resource, never, Req>,
-    ) => Layer.effect(tag, binding.bind(resource)),
+    layer: (client: Client) => Layer.succeed(tag, client),
   });
 };

--- a/packages/alchemy/src/Cloudflare/D1/D1Connection.ts
+++ b/packages/alchemy/src/Cloudflare/D1/D1Connection.ts
@@ -120,10 +120,8 @@ export class D1Connection extends Binding.Service<
 
 export const D1ConnectionClient = makeBoundClientService<
   D1ConnectionClient,
-  D1Database,
-  D1ConnectionClient,
-  D1Connection
->("Cloudflare.D1.Connection.Client", D1Connection);
+  D1ConnectionClient
+>("Cloudflare.D1.Connection.Client");
 
 export const D1ConnectionLive = Layer.effect(
   D1Connection,

--- a/packages/alchemy/src/Cloudflare/D1/D1Connection.ts
+++ b/packages/alchemy/src/Cloudflare/D1/D1Connection.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Binding from "../../Binding.ts";
+import { makeBoundClientService } from "../BoundClient.ts";
 import { WorkerEnvironment } from "../Workers/Worker.ts";
 import type { D1Database } from "./D1Database.ts";
 import { DatabaseBinding } from "./D1DatabaseBinding.ts";
@@ -116,6 +117,13 @@ export class D1Connection extends Binding.Service<
   D1Connection,
   (database: D1Database) => Effect.Effect<D1ConnectionClient>
 >()("Cloudflare.D1.Connection") {}
+
+export const D1ConnectionClient = makeBoundClientService<
+  D1ConnectionClient,
+  D1Database,
+  D1ConnectionClient,
+  D1Connection
+>("Cloudflare.D1.Connection.Client", D1Connection);
 
 export const D1ConnectionLive = Layer.effect(
   D1Connection,

--- a/packages/alchemy/src/Cloudflare/D1/D1Database.ts
+++ b/packages/alchemy/src/Cloudflare/D1/D1Database.ts
@@ -224,19 +224,50 @@ export type D1Database = Resource<
  * ```
  *
  * @section Binding to a Worker
- * @example Using D1 inside a Worker
+ * @example Direct binding inside a Worker
  * ```typescript
  * const db = yield* Cloudflare.D1Connection.bind(MyDB);
  *
- * // Run a query
  * const results = yield* db.prepare("SELECT * FROM users WHERE id = ?")
  *   .bind(userId)
  *   .all();
  *
- * // Execute a mutation
  * yield* db.prepare("INSERT INTO users (id, name) VALUES (?, ?)")
  *   .bind(newId, name)
  *   .run();
+ * ```
+ *
+ * @example Providing a D1 client to a service
+ * ```typescript
+ * class Users extends Context.Service<Users, {
+ *   findById(userId: number): Effect.Effect<D1Result<User>>;
+ *   insert(newId: number, name: string): Effect.Effect<D1Result>;
+ * }>()("Users") {}
+ *
+ * const UsersLive = Layer.effect(
+ *   Users,
+ *   Effect.gen(function* () {
+ *     const db = yield* Cloudflare.D1ConnectionClient;
+ *     return {
+ *       findById: (userId: number) =>
+ *         db.prepare("SELECT * FROM users WHERE id = ?")
+ *           .bind(userId)
+ *           .all(),
+ *       insert: (newId: number, name: string) =>
+ *         db.prepare("INSERT INTO users (id, name) VALUES (?, ?)")
+ *           .bind(newId, name)
+ *           .run(),
+ *     };
+ *   }),
+ * ).pipe(
+ *   Layer.provide(Cloudflare.D1ConnectionClient.layer(MyDB)),
+ *   Layer.provide(Cloudflare.D1ConnectionLive),
+ * );
+ *
+ * const users = yield* Users;
+ * const results = yield* users.findById(userId);
+ *
+ * yield* users.insert(newId, name);
  * ```
  *
  * @see https://developers.cloudflare.com/d1/

--- a/packages/alchemy/src/Cloudflare/D1/D1Database.ts
+++ b/packages/alchemy/src/Cloudflare/D1/D1Database.ts
@@ -239,6 +239,8 @@ export type D1Database = Resource<
  *
  * @example Providing a D1 client to a service
  * ```typescript
+ * const boundDB = yield* Cloudflare.D1Connection.bind(MyDB);
+ *
  * class Users extends Context.Service<Users, {
  *   findById(userId: number): Effect.Effect<D1Result<User>>;
  *   insert(newId: number, name: string): Effect.Effect<D1Result>;
@@ -260,8 +262,7 @@ export type D1Database = Resource<
  *     };
  *   }),
  * ).pipe(
- *   Layer.provide(Cloudflare.D1ConnectionClient.layer(MyDB)),
- *   Layer.provide(Cloudflare.D1ConnectionLive),
+ *   Layer.provide(Cloudflare.D1ConnectionClient.layer(boundDB)),
  * );
  *
  * const users = yield* Users;

--- a/packages/alchemy/src/Cloudflare/Email/SendEmail.ts
+++ b/packages/alchemy/src/Cloudflare/Email/SendEmail.ts
@@ -41,15 +41,39 @@ export type SendEmailProps = {
  * @example Send to any verified destination
  * ```typescript
  * const Email = Cloudflare.SendEmail("Email");
- *
- * // in the Worker effect:
  * const email = yield* Cloudflare.SendEmail.bind(Email);
+ *
  * yield* email.send({
  *   from: "noreply@example.com",
  *   to: "user@example.com",
  *   subject: "Hello",
  *   text: "Hi from Alchemy",
  * });
+ * ```
+ *
+ * @example Providing an Email client to a service
+ * ```typescript
+ * class Mailer extends Context.Service<Mailer, {
+ *   hello: Effect.Effect<EmailSendResult, Cloudflare.SendEmailError>;
+ * }>()("Mailer") {}
+ *
+ * const MailerLive = Layer.effect(
+ *   Mailer,
+ *   Effect.gen(function* () {
+ *     const email = yield* Cloudflare.SendEmailClient;
+ *     return {
+ *       hello: email.send({
+ *         from: "noreply@example.com",
+ *         to: "user@example.com",
+ *         subject: "Hello",
+ *         text: "Hi from Alchemy",
+ *       }),
+ *     };
+ *   }),
+ * ).pipe(
+ *   Layer.provide(Cloudflare.SendEmailClient.layer(Email)),
+ *   Layer.provide(Cloudflare.SendEmailBindingLive),
+ * );
  * ```
  *
  * @example Restrict the sender address

--- a/packages/alchemy/src/Cloudflare/Email/SendEmail.ts
+++ b/packages/alchemy/src/Cloudflare/Email/SendEmail.ts
@@ -53,6 +53,8 @@ export type SendEmailProps = {
  *
  * @example Providing an Email client to a service
  * ```typescript
+ * const boundEmail = yield* Cloudflare.SendEmail.bind(Email);
+ *
  * class Mailer extends Context.Service<Mailer, {
  *   hello: Effect.Effect<EmailSendResult, Cloudflare.SendEmailError>;
  * }>()("Mailer") {}
@@ -71,8 +73,7 @@ export type SendEmailProps = {
  *     };
  *   }),
  * ).pipe(
- *   Layer.provide(Cloudflare.SendEmailClient.layer(Email)),
- *   Layer.provide(Cloudflare.SendEmailBindingLive),
+ *   Layer.provide(Cloudflare.SendEmailClient.layer(boundEmail)),
  * );
  * ```
  *

--- a/packages/alchemy/src/Cloudflare/Email/SendEmailBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Email/SendEmailBinding.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import type { ResourceLike } from "../../Resource.ts";
+import { makeBoundClientService } from "../BoundClient.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import type { SendEmail } from "./SendEmail.ts";
 
@@ -60,6 +61,13 @@ export class SendEmailBinding extends Binding.Service<
   SendEmailBinding,
   (sender: SendEmail) => Effect.Effect<SendEmailClient>
 >()("Cloudflare.SendEmail.Binding") {}
+
+export const SendEmailClient = makeBoundClientService<
+  SendEmailClient,
+  SendEmail,
+  SendEmailClient,
+  SendEmailBinding
+>("Cloudflare.SendEmail.Client", SendEmailBinding);
 
 export const SendEmailBindingLive = Layer.effect(
   SendEmailBinding,

--- a/packages/alchemy/src/Cloudflare/Email/SendEmailBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Email/SendEmailBinding.ts
@@ -64,10 +64,8 @@ export class SendEmailBinding extends Binding.Service<
 
 export const SendEmailClient = makeBoundClientService<
   SendEmailClient,
-  SendEmail,
-  SendEmailClient,
-  SendEmailBinding
->("Cloudflare.SendEmail.Client", SendEmailBinding);
+  SendEmailClient
+>("Cloudflare.SendEmail.Client");
 
 export const SendEmailBindingLive = Layer.effect(
   SendEmailBinding,

--- a/packages/alchemy/src/Cloudflare/Hyperdrive/Hyperdrive.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/Hyperdrive.ts
@@ -147,10 +147,34 @@ export type Hyperdrive = Resource<
  * ```
  *
  * @section Binding to a Worker
- * @example Using Hyperdrive inside a Worker
+ * @example Direct binding inside a Worker
  * ```typescript
  * const hd = yield* Cloudflare.Hyperdrive.bind(MyDB);
+ *
  * const url = yield* hd.connectionString;
+ * ```
+ *
+ * @example Providing a Hyperdrive client to a service
+ * ```typescript
+ * class Database extends Context.Service<Database, {
+ *   connectionString: Effect.Effect<Redacted.Redacted<string>>;
+ * }>()("Database") {}
+ *
+ * const DatabaseLive = Layer.effect(
+ *   Database,
+ *   Effect.gen(function* () {
+ *     const hd = yield* Cloudflare.HyperdriveBindingClient;
+ *     return {
+ *       connectionString: hd.connectionString,
+ *     };
+ *   }),
+ * ).pipe(
+ *   Layer.provide(Cloudflare.HyperdriveBindingClient.layer(MyDB)),
+ *   Layer.provide(Cloudflare.HyperdriveBindingLive),
+ * );
+ *
+ * const database = yield* Database;
+ * const url = yield* database.connectionString;
  * ```
  */
 export const Hyperdrive = Resource<Hyperdrive>("Cloudflare.Hyperdrive")({

--- a/packages/alchemy/src/Cloudflare/Hyperdrive/Hyperdrive.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/Hyperdrive.ts
@@ -156,6 +156,8 @@ export type Hyperdrive = Resource<
  *
  * @example Providing a Hyperdrive client to a service
  * ```typescript
+ * const boundHyperdrive = yield* Cloudflare.Hyperdrive.bind(MyDB);
+ *
  * class Database extends Context.Service<Database, {
  *   connectionString: Effect.Effect<Redacted.Redacted<string>>;
  * }>()("Database") {}
@@ -169,8 +171,7 @@ export type Hyperdrive = Resource<
  *     };
  *   }),
  * ).pipe(
- *   Layer.provide(Cloudflare.HyperdriveBindingClient.layer(MyDB)),
- *   Layer.provide(Cloudflare.HyperdriveBindingLive),
+ *   Layer.provide(Cloudflare.HyperdriveBindingClient.layer(boundHyperdrive)),
  * );
  *
  * const database = yield* Database;

--- a/packages/alchemy/src/Cloudflare/Hyperdrive/HyperdriveBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/HyperdriveBinding.ts
@@ -60,6 +60,8 @@ export interface HyperdriveBindingClient {
  *
  * @example Providing a Hyperdrive client to a service
  * ```typescript
+ * const boundHyperdrive = yield* Cloudflare.Hyperdrive.bind(MyHyperdrive);
+ *
  * class Database extends Context.Service<Database, {
  *   connectionString: Effect.Effect<Redacted.Redacted<string>>;
  * }>()("Database") {}
@@ -73,8 +75,7 @@ export interface HyperdriveBindingClient {
  *     };
  *   }),
  * ).pipe(
- *   Layer.provide(Cloudflare.HyperdriveBindingClient.layer(MyHyperdrive)),
- *   Layer.provide(Cloudflare.HyperdriveBindingLive),
+ *   Layer.provide(Cloudflare.HyperdriveBindingClient.layer(boundHyperdrive)),
  * );
  *
  * const database = yield* Database;
@@ -90,10 +91,8 @@ export class HyperdriveBinding extends Binding.Service<
 
 export const HyperdriveBindingClient = makeBoundClientService<
   HyperdriveBindingClient,
-  Hyperdrive,
-  HyperdriveBindingClient,
-  HyperdriveBinding
->("Cloudflare.Hyperdrive.Client", HyperdriveBinding);
+  HyperdriveBindingClient
+>("Cloudflare.Hyperdrive.Client");
 
 export const HyperdriveBindingLive = Layer.effect(
   HyperdriveBinding,

--- a/packages/alchemy/src/Cloudflare/Hyperdrive/HyperdriveBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/HyperdriveBinding.ts
@@ -7,6 +7,7 @@ import { AlchemyContext } from "../../AlchemyContext.ts";
 import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import type { ResourceLike } from "../../Resource.ts";
+import { makeBoundClientService } from "../BoundClient.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import type { Hyperdrive } from "./Hyperdrive.ts";
 import { defaultPort, type HyperdriveDevOrigin } from "./Hyperdrive.ts";
@@ -62,6 +63,13 @@ export class HyperdriveBinding extends Binding.Service<
   HyperdriveBinding,
   (hyperdrive: Hyperdrive) => Effect.Effect<HyperdriveBindingClient>
 >()("Cloudflare.Hyperdrive.Binding") {}
+
+export const HyperdriveBindingClient = makeBoundClientService<
+  HyperdriveBindingClient,
+  Hyperdrive,
+  HyperdriveBindingClient,
+  HyperdriveBinding
+>("Cloudflare.Hyperdrive.Client", HyperdriveBinding);
 
 export const HyperdriveBindingLive = Layer.effect(
   HyperdriveBinding,

--- a/packages/alchemy/src/Cloudflare/Hyperdrive/HyperdriveBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/HyperdriveBinding.ts
@@ -51,10 +51,34 @@ export interface HyperdriveBindingClient {
  * (connection string, host, port, user, password, database) plus a `raw`
  * escape hatch for libraries that want direct access.
  *
- * @example Bind Hyperdrive in a Worker
+ * @example Direct binding inside a Worker
  * ```typescript
  * const hd = yield* Cloudflare.Hyperdrive.bind(MyHyperdrive);
+ *
  * const url = yield* hd.connectionString;
+ * ```
+ *
+ * @example Providing a Hyperdrive client to a service
+ * ```typescript
+ * class Database extends Context.Service<Database, {
+ *   connectionString: Effect.Effect<Redacted.Redacted<string>>;
+ * }>()("Database") {}
+ *
+ * const DatabaseLive = Layer.effect(
+ *   Database,
+ *   Effect.gen(function* () {
+ *     const hd = yield* Cloudflare.HyperdriveBindingClient;
+ *     return {
+ *       connectionString: hd.connectionString,
+ *     };
+ *   }),
+ * ).pipe(
+ *   Layer.provide(Cloudflare.HyperdriveBindingClient.layer(MyHyperdrive)),
+ *   Layer.provide(Cloudflare.HyperdriveBindingLive),
+ * );
+ *
+ * const database = yield* Database;
+ * const url = yield* database.connectionString;
  * ```
  *
  * @binding

--- a/packages/alchemy/src/Cloudflare/Images/Images.ts
+++ b/packages/alchemy/src/Cloudflare/Images/Images.ts
@@ -6,8 +6,8 @@ const ImagesTypeId = "Cloudflare.Images" as const;
 
 export type ImagesProps = {
   /**
-   * Binding name used when `Cloudflare.Images.bind(images)` attaches Images
-   * from inside a Worker init phase. When Images is passed through
+   * Binding name used when `Cloudflare.ImagesClient.layer(images)` attaches
+   * Images from inside a Worker init phase. When Images is passed through
    * `Worker({ bindings: { ... } })`, the object key remains the binding name.
    *
    * @default "IMAGES"
@@ -38,11 +38,10 @@ export const isImages = (value: unknown): value is Images =>
  * A Cloudflare Images binding for image transformation and manipulation inside
  * Workers.
  *
- * The Effect-native interface (`Cloudflare.Images.bind(...)`) returns an
- * `ImagesClient` whose methods take Effect `Stream.Stream<Uint8Array>`
- * inputs and return `Effect`s — `info`, `input(...).transform(...)
- * .draw(...).output(...)`. The runtime conversion to Cloudflare's
- * `ReadableStream` is handled internally.
+ * The Effect-native interface (`Cloudflare.ImagesClient`) takes Effect
+ * `Stream.Stream<Uint8Array>` inputs and returns `Effect`s — `info`,
+ * `input(...).transform(...).draw(...).output(...)`. The runtime conversion
+ * to Cloudflare's `ReadableStream` is handled internally.
  *
  * @section Declaring Images
  * @example
@@ -51,23 +50,47 @@ export const isImages = (value: unknown): value is Images =>
  * ```
  *
  * @section Effect-style Worker (recommended)
- * @example Read image format and dimensions from the request body
+ * @example Direct binding inside a Worker
+ * ```typescript
+ * const images = yield* Cloudflare.Images.bind(pipeline);
+ *
+ * const info = yield* images.info(request.stream);
+ * ```
+ *
+ * @example Providing an Images client to a service
  * ```typescript
  * import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
  *
  * Cloudflare.Worker("ImageWorker", { main: import.meta.filename },
  *   Effect.gen(function* () {
  *     const pipeline = yield* Pipeline;
- *     const images = yield* Cloudflare.Images.bind(pipeline);
+ *     class ImageInfo extends Context.Service<ImageInfo, {
+ *       read(stream: Stream.Stream<Uint8Array>): Effect.Effect<ImageInfoResponse, Cloudflare.ImagesError>;
+ *     }>()("ImageInfo") {}
+ *
+ *     const ImageInfoLive = Layer.effect(
+ *       ImageInfo,
+ *       Effect.gen(function* () {
+ *         const images = yield* Cloudflare.ImagesClient;
+ *         return {
+ *           read: (stream) => images.info(stream),
+ *         };
+ *       }),
+ *     ).pipe(
+ *       Layer.provide(Cloudflare.ImagesClient.layer(pipeline)),
+ *       Layer.provide(Cloudflare.ImagesBindingLive),
+ *     );
+ *
  *     return {
  *       fetch: Effect.gen(function* () {
  *         const request = yield* HttpServerRequest;
+ *         const imageInfo = yield* ImageInfo;
  *         // request.stream is Stream.Stream<Uint8Array>
- *         const info = yield* images.info(request.stream);
+ *         const info = yield* imageInfo.read(request.stream);
  *         return yield* HttpServerResponse.json(info);
- *       }),
+ *       }).pipe(Effect.provide(ImageInfoLive)),
  *     };
- *   }).pipe(Effect.provide(Cloudflare.ImagesBindingLive)),
+ *   }),
  * );
  * ```
  *
@@ -95,8 +118,8 @@ export const isImages = (value: unknown): value is Images =>
  * Inside the Worker, the raw Cloudflare runtime binding is reachable via
  * `client.raw` if you need to call `info()` / `input()` directly with
  * `async`/`await`. The Effect-native interface is preferred — it returns
- * tagged `ImagesError`s, threads `WorkerEnvironment`, and lets you stream
- * Effect `Stream<Uint8Array>` sources without manual conversion.
+ * tagged `ImagesError`s and lets you stream Effect `Stream<Uint8Array>`
+ * sources without manual conversion.
  *
  * @see https://developers.cloudflare.com/images/transform-images/bindings/
  */

--- a/packages/alchemy/src/Cloudflare/Images/Images.ts
+++ b/packages/alchemy/src/Cloudflare/Images/Images.ts
@@ -6,8 +6,8 @@ const ImagesTypeId = "Cloudflare.Images" as const;
 
 export type ImagesProps = {
   /**
-   * Binding name used when `Cloudflare.ImagesClient.layer(images)` attaches
-   * Images from inside a Worker init phase. When Images is passed through
+   * Binding name used when `Cloudflare.Images.bind(images)` attaches Images
+   * from inside a Worker init phase. When Images is passed through
    * `Worker({ bindings: { ... } })`, the object key remains the binding name.
    *
    * @default "IMAGES"
@@ -64,6 +64,8 @@ export const isImages = (value: unknown): value is Images =>
  * Cloudflare.Worker("ImageWorker", { main: import.meta.filename },
  *   Effect.gen(function* () {
  *     const pipeline = yield* Pipeline;
+ *     const boundImages = yield* Cloudflare.Images.bind(pipeline);
+ *
  *     class ImageInfo extends Context.Service<ImageInfo, {
  *       read(stream: Stream.Stream<Uint8Array>): Effect.Effect<ImageInfoResponse, Cloudflare.ImagesError>;
  *     }>()("ImageInfo") {}
@@ -77,8 +79,7 @@ export const isImages = (value: unknown): value is Images =>
  *         };
  *       }),
  *     ).pipe(
- *       Layer.provide(Cloudflare.ImagesClient.layer(pipeline)),
- *       Layer.provide(Cloudflare.ImagesBindingLive),
+ *       Layer.provide(Cloudflare.ImagesClient.layer(boundImages)),
  *     );
  *
  *     return {

--- a/packages/alchemy/src/Cloudflare/Images/ImagesBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Images/ImagesBinding.ts
@@ -51,8 +51,9 @@ export interface ImageTransformerClient {
  * Effect-native client for a Cloudflare Images binding.
  *
  * Wraps the runtime {@link cf.ImagesBinding} so each method returns
- * an Effect tagged with {@link ImagesError}. Use
- * `Cloudflare.Images.bind(images)` inside a Worker's init phase.
+ * an Effect tagged with {@link ImagesError}. Provide
+ * `Cloudflare.ImagesClient.layer(images)` to services that need the Images
+ * client.
  */
 export interface ImagesClient {
   /** Effect resolving to the raw Cloudflare runtime binding. */

--- a/packages/alchemy/src/Cloudflare/Images/ImagesBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Images/ImagesBinding.ts
@@ -5,6 +5,7 @@ import * as Layer from "effect/Layer";
 import * as Stream from "effect/Stream";
 import * as Binding from "../../Binding.ts";
 import type { ResourceLike } from "../../Resource.ts";
+import { makeBoundClientService } from "../BoundClient.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import { type Images as ImagesLike } from "./Images.ts";
 
@@ -79,6 +80,13 @@ export class ImagesBinding extends Binding.Service<
   ImagesBinding,
   (images: ImagesLike) => Effect.Effect<ImagesClient>
 >()("Cloudflare.Images.Binding") {}
+
+export const ImagesClient = makeBoundClientService<
+  ImagesClient,
+  ImagesLike,
+  ImagesClient,
+  ImagesBinding
+>("Cloudflare.Images.Client", ImagesBinding);
 
 export const ImagesBindingLive = Layer.effect(
   ImagesBinding,

--- a/packages/alchemy/src/Cloudflare/Images/ImagesBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Images/ImagesBinding.ts
@@ -52,8 +52,8 @@ export interface ImageTransformerClient {
  *
  * Wraps the runtime {@link cf.ImagesBinding} so each method returns
  * an Effect tagged with {@link ImagesError}. Provide
- * `Cloudflare.ImagesClient.layer(images)` to services that need the Images
- * client.
+ * `Cloudflare.ImagesClient.layer(boundImages)` to services that need the
+ * Images client after binding Images in Worker init.
  */
 export interface ImagesClient {
   /** Effect resolving to the raw Cloudflare runtime binding. */
@@ -82,12 +82,9 @@ export class ImagesBinding extends Binding.Service<
   (images: ImagesLike) => Effect.Effect<ImagesClient>
 >()("Cloudflare.Images.Binding") {}
 
-export const ImagesClient = makeBoundClientService<
-  ImagesClient,
-  ImagesLike,
-  ImagesClient,
-  ImagesBinding
->("Cloudflare.Images.Client", ImagesBinding);
+export const ImagesClient = makeBoundClientService<ImagesClient, ImagesClient>(
+  "Cloudflare.Images.Client",
+);
 
 export const ImagesBindingLive = Layer.effect(
   ImagesBinding,

--- a/packages/alchemy/src/Cloudflare/KV/KVNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/KV/KVNamespace.ts
@@ -56,6 +56,8 @@ export type KVNamespace = Resource<
  *
  * @example Providing a KV client to a service
  * ```typescript
+ * const boundKV = yield* Cloudflare.KVNamespace.bind(MyKV);
+ *
  * class Cache extends Context.Service<Cache, {
  *   get(key: string): Effect.Effect<string | null, Cloudflare.KVNamespaceError>;
  *   put(key: string, value: string): Effect.Effect<void, Cloudflare.KVNamespaceError>;
@@ -71,8 +73,7 @@ export type KVNamespace = Resource<
  *     };
  *   }),
  * ).pipe(
- *   Layer.provide(Cloudflare.KVNamespaceClient.layer(MyKV)),
- *   Layer.provide(Cloudflare.KVNamespaceBindingLive),
+ *   Layer.provide(Cloudflare.KVNamespaceClient.layer(boundKV)),
  * );
  *
  * const cache = yield* Cache;

--- a/packages/alchemy/src/Cloudflare/KV/KVNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/KV/KVNamespace.ts
@@ -46,15 +46,39 @@ export type KVNamespace = Resource<
  * ```
  *
  * @section Binding to a Worker
- * @example Using KV inside a Worker
+ * @example Direct binding inside a Worker
  * ```typescript
  * const kv = yield* Cloudflare.KVNamespace.bind(MyKV);
  *
- * // Read a value
  * const value = yield* kv.get("my-key");
- *
- * // Write a value
  * yield* kv.put("my-key", "hello world");
+ * ```
+ *
+ * @example Providing a KV client to a service
+ * ```typescript
+ * class Cache extends Context.Service<Cache, {
+ *   get(key: string): Effect.Effect<string | null, Cloudflare.KVNamespaceError>;
+ *   put(key: string, value: string): Effect.Effect<void, Cloudflare.KVNamespaceError>;
+ * }>()("Cache") {}
+ *
+ * const CacheLive = Layer.effect(
+ *   Cache,
+ *   Effect.gen(function* () {
+ *     const kv = yield* Cloudflare.KVNamespaceClient;
+ *     return {
+ *       get: (key: string) => kv.get(key),
+ *       put: (key: string, value: string) => kv.put(key, value),
+ *     };
+ *   }),
+ * ).pipe(
+ *   Layer.provide(Cloudflare.KVNamespaceClient.layer(MyKV)),
+ *   Layer.provide(Cloudflare.KVNamespaceBindingLive),
+ * );
+ *
+ * const cache = yield* Cache;
+ * const value = yield* cache.get("my-key");
+ *
+ * yield* cache.put("my-key", "hello world");
  * ```
  */
 export const KVNamespace = Resource<KVNamespace>("Cloudflare.KVNamespace")({

--- a/packages/alchemy/src/Cloudflare/KV/KVNamespaceBinding.ts
+++ b/packages/alchemy/src/Cloudflare/KV/KVNamespaceBinding.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import type { ResourceLike } from "../../Resource.ts";
+import { makeBoundClientService } from "../BoundClient.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import type { KVNamespace } from "./KVNamespace.ts";
 
@@ -221,6 +222,13 @@ export class KVNamespaceBinding extends Binding.Service<
   KVNamespaceBinding,
   (bucket: KVNamespace) => Effect.Effect<KVNamespaceClient>
 >()("Cloudflare.KVNamespace") {}
+
+export const KVNamespaceClient = makeBoundClientService<
+  KVNamespaceClient,
+  KVNamespace,
+  KVNamespaceClient,
+  KVNamespaceBinding
+>("Cloudflare.KVNamespace.Client", KVNamespaceBinding);
 
 export const KVNamespaceBindingLive = Layer.effect(
   KVNamespaceBinding,

--- a/packages/alchemy/src/Cloudflare/KV/KVNamespaceBinding.ts
+++ b/packages/alchemy/src/Cloudflare/KV/KVNamespaceBinding.ts
@@ -225,10 +225,8 @@ export class KVNamespaceBinding extends Binding.Service<
 
 export const KVNamespaceClient = makeBoundClientService<
   KVNamespaceClient,
-  KVNamespace,
-  KVNamespaceClient,
-  KVNamespaceBinding
->("Cloudflare.KVNamespace.Client", KVNamespaceBinding);
+  KVNamespaceClient
+>("Cloudflare.KVNamespace.Client");
 
 export const KVNamespaceBindingLive = Layer.effect(
   KVNamespaceBinding,

--- a/packages/alchemy/src/Cloudflare/Queue/Queue.ts
+++ b/packages/alchemy/src/Cloudflare/Queue/Queue.ts
@@ -52,8 +52,8 @@ export type Queue = Resource<
  *
  * @section Binding to a Worker
  * In an Effect-style Worker, bind the queue directly when the Worker owns the
- * use site. Provide `Cloudflare.QueueSender.layer(queue)` when another
- * service should receive the queue client.
+ * use site. Provide `Cloudflare.QueueSender.layer(boundQueue)` when another
+ * service should receive the already-bound queue client.
  *
  * @example Direct binding inside a Worker
  * ```typescript
@@ -72,6 +72,8 @@ export type Queue = Resource<
  * import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
  *
  * export const Queue = Cloudflare.Queue("Queue");
+ * const boundQueue = yield* Cloudflare.QueueBinding.bind(Queue);
+ *
  * class Producer extends Context.Service<Producer, {
  *   send(text: string): Effect.Effect<void, Cloudflare.QueueSendError>;
  * }>()("Producer") {}
@@ -86,8 +88,7 @@ export type Queue = Resource<
  *     };
  *   }),
  * ).pipe(
- *   Layer.provide(Cloudflare.QueueSender.layer(Queue)),
- *   Layer.provide(Cloudflare.QueueBindingLive),
+ *   Layer.provide(Cloudflare.QueueSender.layer(boundQueue)),
  * );
  *
  * export default Cloudflare.Worker(

--- a/packages/alchemy/src/Cloudflare/Queue/Queue.ts
+++ b/packages/alchemy/src/Cloudflare/Queue/Queue.ts
@@ -51,32 +51,57 @@ export type Queue = Resource<
  * ```
  *
  * @section Binding to a Worker
- * In an Effect-style Worker, use `Cloudflare.QueueBinding.bind` in
- * the init phase and provide `Cloudflare.QueueBindingLive` in the
- * runtime layer. The returned `QueueSender` exposes `send` and
- * `sendBatch`.
+ * In an Effect-style Worker, bind the queue directly when the Worker owns the
+ * use site. Provide `Cloudflare.QueueSender.layer(queue)` when another
+ * service should receive the queue client.
  *
- * @example Sending messages from a Worker
+ * @example Direct binding inside a Worker
+ * ```typescript
+ * const queue = yield* Cloudflare.QueueBinding.bind(Queue);
+ *
+ * yield* queue.send({ text: "hi", sentAt: Date.now() });
+ * ```
+ *
+ * @example Providing a Queue client to a service
  * ```typescript
  * import * as Cloudflare from "alchemy/Cloudflare";
+ * import * as Context from "effect/Context";
  * import * as Effect from "effect/Effect";
+ * import * as Layer from "effect/Layer";
  * import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
  * import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
  *
  * export const Queue = Cloudflare.Queue("Queue");
+ * class Producer extends Context.Service<Producer, {
+ *   send(text: string): Effect.Effect<void, Cloudflare.QueueSendError>;
+ * }>()("Producer") {}
+ *
+ * const ProducerLive = Layer.effect(
+ *   Producer,
+ *   Effect.gen(function* () {
+ *     const queue = yield* Cloudflare.QueueSender;
+ *     return {
+ *       send: (text: string) =>
+ *         queue.send({ text, sentAt: Date.now() }),
+ *     };
+ *   }),
+ * ).pipe(
+ *   Layer.provide(Cloudflare.QueueSender.layer(Queue)),
+ *   Layer.provide(Cloudflare.QueueBindingLive),
+ * );
  *
  * export default Cloudflare.Worker(
  *   "Worker",
  *   { main: import.meta.filename },
  *   Effect.gen(function* () {
- *     const queue = yield* Cloudflare.QueueBinding.bind(Queue);
+ *     const producer = yield* Producer;
  *
  *     return {
  *       fetch: Effect.gen(function* () {
  *         const request = yield* HttpServerRequest;
  *         if (request.url === "/queue/send" && request.method === "POST") {
  *           const text = yield* request.text;
- *           yield* queue.send({ text, sentAt: Date.now() }).pipe(Effect.orDie);
+ *           yield* producer.send(text).pipe(Effect.orDie);
  *           return yield* HttpServerResponse.json(
  *             { sent: { text } },
  *             { status: 202 },
@@ -85,7 +110,7 @@ export type Queue = Resource<
  *         return HttpServerResponse.text("Not Found", { status: 404 });
  *       }),
  *     };
- *   }).pipe(Effect.provide(Cloudflare.QueueBindingLive)),
+ *   }).pipe(Effect.provide(ProducerLive)),
  * );
  * ```
  */

--- a/packages/alchemy/src/Cloudflare/Queue/QueueBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Queue/QueueBinding.ts
@@ -32,17 +32,42 @@ export class QueueSendError extends Data.TaggedError("QueueSendError")<{
  * {@link QueueSender} you can call from a Worker's runtime Effect.
  *
  * @section Sending Messages
- * Bind the queue in the Worker's init phase, then use `send` for
- * single messages or `sendBatch` for many messages in one call.
+ * Bind a queue directly inside a Worker, or provide
+ * `Cloudflare.QueueSender.layer(queue)` to services that need to send
+ * messages. Use `send` for single messages or `sendBatch` for many messages
+ * in one call.
  * Messages can be any JSON-serializable value.
  *
- * @example Producer route
+ * @example Direct binding inside a Worker
  * ```typescript
  * const queue = yield* Cloudflare.QueueBinding.bind(Queue);
  *
+ * yield* queue.send({ text: "hi", sentAt: Date.now() });
+ * ```
+ *
+ * @example Providing a Queue client to a service
+ * ```typescript
+ * class Producer extends Context.Service<Producer, {
+ *   sendGreeting: Effect.Effect<void, Cloudflare.QueueSendError>;
+ * }>()("Producer") {}
+ *
+ * const ProducerLive = Layer.effect(
+ *   Producer,
+ *   Effect.gen(function* () {
+ *     const queue = yield* Cloudflare.QueueSender;
+ *     return {
+ *       sendGreeting: queue.send({ text: "hi", sentAt: Date.now() }),
+ *     };
+ *   }),
+ * ).pipe(
+ *   Layer.provide(Cloudflare.QueueSender.layer(Queue)),
+ *   Layer.provide(Cloudflare.QueueBindingLive),
+ * );
+ *
  * return {
  *   fetch: Effect.gen(function* () {
- *     yield* queue.send({ text: "hi", sentAt: Date.now() });
+ *     const producer = yield* Producer;
+ *     yield* producer.sendGreeting;
  *     return HttpServerResponse.empty({ status: 202 });
  *   }),
  * };
@@ -57,8 +82,8 @@ export class QueueSendError extends Data.TaggedError("QueueSendError")<{
  * ]);
  * ```
  *
- * Provide {@link QueueBindingLive} in the worker's runtime layer to
- * resolve the underlying Cloudflare queue at request time.
+ * Provide {@link QueueBindingLive} with the sender layer so Alchemy can attach
+ * the underlying Cloudflare queue binding and resolve it at request time.
  */
 export class QueueBinding extends Binding.Service<
   QueueBinding,

--- a/packages/alchemy/src/Cloudflare/Queue/QueueBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Queue/QueueBinding.ts
@@ -2,6 +2,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import type { ResourceLike } from "../../Resource.ts";
+import { makeBoundClientService } from "../BoundClient.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import type { Queue } from "./Queue.ts";
 
@@ -63,6 +64,13 @@ export class QueueBinding extends Binding.Service<
   QueueBinding,
   (queue: Queue) => Effect.Effect<QueueSender>
 >()("Cloudflare.Queue") {}
+
+export const QueueSender = makeBoundClientService<
+  QueueSender,
+  Queue,
+  QueueSender,
+  QueueBinding
+>("Cloudflare.Queue.Sender", QueueBinding);
 
 export const QueueBindingLive = Layer.effect(
   QueueBinding,

--- a/packages/alchemy/src/Cloudflare/Queue/QueueBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Queue/QueueBinding.ts
@@ -33,9 +33,9 @@ export class QueueSendError extends Data.TaggedError("QueueSendError")<{
  *
  * @section Sending Messages
  * Bind a queue directly inside a Worker, or provide
- * `Cloudflare.QueueSender.layer(queue)` to services that need to send
- * messages. Use `send` for single messages or `sendBatch` for many messages
- * in one call.
+ * `Cloudflare.QueueSender.layer(boundQueue)` to services that need to send
+ * messages after binding the queue in Worker init. Use `send` for single
+ * messages or `sendBatch` for many messages in one call.
  * Messages can be any JSON-serializable value.
  *
  * @example Direct binding inside a Worker
@@ -47,6 +47,8 @@ export class QueueSendError extends Data.TaggedError("QueueSendError")<{
  *
  * @example Providing a Queue client to a service
  * ```typescript
+ * const boundQueue = yield* Cloudflare.QueueBinding.bind(Queue);
+ *
  * class Producer extends Context.Service<Producer, {
  *   sendGreeting: Effect.Effect<void, Cloudflare.QueueSendError>;
  * }>()("Producer") {}
@@ -60,8 +62,7 @@ export class QueueSendError extends Data.TaggedError("QueueSendError")<{
  *     };
  *   }),
  * ).pipe(
- *   Layer.provide(Cloudflare.QueueSender.layer(Queue)),
- *   Layer.provide(Cloudflare.QueueBindingLive),
+ *   Layer.provide(Cloudflare.QueueSender.layer(boundQueue)),
  * );
  *
  * return {
@@ -90,12 +91,9 @@ export class QueueBinding extends Binding.Service<
   (queue: Queue) => Effect.Effect<QueueSender>
 >()("Cloudflare.Queue") {}
 
-export const QueueSender = makeBoundClientService<
-  QueueSender,
-  Queue,
-  QueueSender,
-  QueueBinding
->("Cloudflare.Queue.Sender", QueueBinding);
+export const QueueSender = makeBoundClientService<QueueSender, QueueSender>(
+  "Cloudflare.Queue.Sender",
+);
 
 export const QueueBindingLive = Layer.effect(
   QueueBinding,

--- a/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
@@ -180,6 +180,31 @@ export type R2Bucket = Resource<
  * }
  * ```
  *
+ * @example Providing an R2 client to another service
+ * ```typescript
+ * const Images = Context.Service<{
+ *   get(key: string): Effect.Effect<Uint8Array | undefined, Cloudflare.R2Error>;
+ * }>("Images");
+ *
+ * const ImagesLive = Layer.effect(
+ *   Images,
+ *   Effect.gen(function* () {
+ *     const bucket = yield* Cloudflare.R2BucketClient;
+ *
+ *     return {
+ *       get: (key: string) =>
+ *         Effect.gen(function* () {
+ *           const object = yield* bucket.get(key);
+ *           return object ? yield* object.bytes() : undefined;
+ *         }),
+ *     };
+ *   }),
+ * ).pipe(
+ *   Layer.provide(Cloudflare.R2BucketClient.layer(MyBucket)),
+ *   Layer.provide(Cloudflare.R2BucketBindingLive),
+ * );
+ * ```
+ *
  * @example Streaming upload with content length
  * ```typescript
  * const bucket = yield* Cloudflare.R2Bucket.bind(MyBucket);

--- a/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
@@ -178,6 +178,8 @@ export type R2Bucket = Resource<
  *
  * @example Providing an R2 client to a service
  * ```typescript
+ * const boundBucket = yield* Cloudflare.R2Bucket.bind(MyBucket);
+ *
  * class Store extends Context.Service<Store, {
  *   put(key: string, value: string): Effect.Effect<Cloudflare.R2Object, Cloudflare.R2Error>;
  *   get(key: string): Effect.Effect<string | undefined, Cloudflare.R2Error>;
@@ -197,8 +199,7 @@ export type R2Bucket = Resource<
  *     };
  *   }),
  * ).pipe(
- *   Layer.provide(Cloudflare.R2BucketClient.layer(MyBucket)),
- *   Layer.provide(Cloudflare.R2BucketBindingLive),
+ *   Layer.provide(Cloudflare.R2BucketClient.layer(boundBucket)),
  * );
  *
  * const store = yield* Store;
@@ -208,6 +209,8 @@ export type R2Bucket = Resource<
  *
  * @example Reusing the R2 client from another service
  * ```typescript
+ * const boundBucket = yield* Cloudflare.R2Bucket.bind(MyBucket);
+ *
  * class Images extends Context.Service<Images, {
  *   get(key: string): Effect.Effect<Uint8Array | undefined, Cloudflare.R2Error>;
  * }>()("Images") {}
@@ -226,8 +229,7 @@ export type R2Bucket = Resource<
  *     };
  *   }),
  * ).pipe(
- *   Layer.provide(Cloudflare.R2BucketClient.layer(MyBucket)),
- *   Layer.provide(Cloudflare.R2BucketBindingLive),
+ *   Layer.provide(Cloudflare.R2BucketClient.layer(boundBucket)),
  * );
  * ```
  *

--- a/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
+++ b/packages/alchemy/src/Cloudflare/R2/R2Bucket.ts
@@ -166,25 +166,51 @@ export type R2Bucket = Resource<
  * ```
  *
  * @section Binding to a Worker
- * @example Reading and writing objects
+ * @example Direct binding inside a Worker
  * ```typescript
  * const bucket = yield* Cloudflare.R2Bucket.bind(MyBucket);
  *
- * // Write an object
  * yield* bucket.put("hello.txt", "Hello, World!");
  *
- * // Read an object
  * const object = yield* bucket.get("hello.txt");
- * if (object) {
- *   const text = yield* object.text();
- * }
+ * const text = object ? yield* object.text() : undefined;
  * ```
  *
- * @example Providing an R2 client to another service
+ * @example Providing an R2 client to a service
  * ```typescript
- * const Images = Context.Service<{
+ * class Store extends Context.Service<Store, {
+ *   put(key: string, value: string): Effect.Effect<Cloudflare.R2Object, Cloudflare.R2Error>;
+ *   get(key: string): Effect.Effect<string | undefined, Cloudflare.R2Error>;
+ * }>()("Store") {}
+ *
+ * const StoreLive = Layer.effect(
+ *   Store,
+ *   Effect.gen(function* () {
+ *     const bucket = yield* Cloudflare.R2BucketClient;
+ *     return {
+ *       put: (key: string, value: string) => bucket.put(key, value),
+ *       get: (key: string) =>
+ *         Effect.gen(function* () {
+ *           const object = yield* bucket.get(key);
+ *           return object ? yield* object.text() : undefined;
+ *         }),
+ *     };
+ *   }),
+ * ).pipe(
+ *   Layer.provide(Cloudflare.R2BucketClient.layer(MyBucket)),
+ *   Layer.provide(Cloudflare.R2BucketBindingLive),
+ * );
+ *
+ * const store = yield* Store;
+ * yield* store.put("hello.txt", "Hello, World!");
+ * const text = yield* store.get("hello.txt");
+ * ```
+ *
+ * @example Reusing the R2 client from another service
+ * ```typescript
+ * class Images extends Context.Service<Images, {
  *   get(key: string): Effect.Effect<Uint8Array | undefined, Cloudflare.R2Error>;
- * }>("Images");
+ * }>()("Images") {}
  *
  * const ImagesLive = Layer.effect(
  *   Images,

--- a/packages/alchemy/src/Cloudflare/R2/R2BucketBinding.ts
+++ b/packages/alchemy/src/Cloudflare/R2/R2BucketBinding.ts
@@ -2,11 +2,13 @@ import type * as runtime from "@cloudflare/workers-types";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import type { ResourceLike } from "../../Resource.ts";
 import { getRawStream } from "../../Util/Stream.ts";
+import { makeBoundClientService } from "../BoundClient.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import type { R2Bucket } from "./R2Bucket.ts";
 
@@ -66,18 +68,18 @@ export type R2UploadedPart = runtime.R2UploadedPart;
 export interface R2UploadPartOptions extends runtime.R2UploadPartOptions {}
 
 export interface R2BucketClient {
-  raw: Effect.Effect<runtime.R2Bucket, never, WorkerEnvironment>;
-  head(key: string): Effect.Effect<R2Object | null, R2Error, WorkerEnvironment>;
+  raw: Effect.Effect<runtime.R2Bucket>;
+  head(key: string): Effect.Effect<R2Object | null, R2Error>;
   get(
     key: string,
     options: R2GetOptions & {
       onlyIf: runtime.R2Conditional | Headers;
     },
-  ): Effect.Effect<R2ObjectBody | R2Object | null, R2Error, WorkerEnvironment>;
+  ): Effect.Effect<R2ObjectBody | R2Object | null, R2Error>;
   get(
     key: string,
     options?: R2GetOptions,
-  ): Effect.Effect<R2ObjectBody | null, R2Error, WorkerEnvironment>;
+  ): Effect.Effect<R2ObjectBody | null, R2Error>;
   put<Err = never>(
     key: string,
     value:
@@ -92,7 +94,7 @@ export interface R2BucketClient {
       onlyIf: R2Conditional | Headers;
       contentLength?: number;
     },
-  ): Effect.Effect<R2Object | null, R2Error | Err, WorkerEnvironment>;
+  ): Effect.Effect<R2Object | null, R2Error | Err>;
   put<Err = never>(
     key: string,
     value:
@@ -103,7 +105,7 @@ export interface R2BucketClient {
       | null
       | Blob,
     options?: R2PutOptions,
-  ): Effect.Effect<R2Object, R2Error | Err, WorkerEnvironment>;
+  ): Effect.Effect<R2Object, R2Error | Err>;
   put<Err = never>(
     key: string,
     value:
@@ -117,27 +119,35 @@ export interface R2BucketClient {
     options: R2PutOptions & {
       contentLength: number;
     },
-  ): Effect.Effect<R2Object, R2Error | Err, WorkerEnvironment>;
-  delete(
-    keys: string | string[],
-  ): Effect.Effect<void, R2Error, WorkerEnvironment>;
-  list(
-    options?: R2ListOptions,
-  ): Effect.Effect<R2Objects, R2Error, WorkerEnvironment>;
+  ): Effect.Effect<R2Object, R2Error | Err>;
+  delete(keys: string | string[]): Effect.Effect<void, R2Error>;
+  list(options?: R2ListOptions): Effect.Effect<R2Objects, R2Error>;
   createMultipartUpload(
     key: string,
     options?: R2MultipartOptions,
-  ): Effect.Effect<R2MultipartUpload, R2Error, WorkerEnvironment>;
+  ): Effect.Effect<R2MultipartUpload, R2Error>;
   resumeMultipartUpload(
     key: string,
     uploadId: string,
-  ): Effect.Effect<R2MultipartUpload, R2Error, WorkerEnvironment>;
+  ): Effect.Effect<R2MultipartUpload, R2Error>;
+}
+
+export declare const R2BucketClientIdentifierTypeId: unique symbol;
+export interface R2BucketClientIdentifier {
+  readonly [R2BucketClientIdentifierTypeId]: typeof R2BucketClientIdentifierTypeId;
 }
 
 export class R2BucketBinding extends Binding.Service<
   R2BucketBinding,
   (bucket: R2Bucket) => Effect.Effect<R2BucketClient>
 >()("Cloudflare.R2Bucket") {}
+
+export const R2BucketClient = makeBoundClientService<
+  R2BucketClientIdentifier,
+  R2Bucket,
+  R2BucketClient,
+  R2BucketBinding
+>("Cloudflare.R2Bucket.Client", R2BucketBinding);
 
 export const R2BucketBindingLive = Layer.effect(
   R2BucketBinding,
@@ -146,11 +156,10 @@ export const R2BucketBindingLive = Layer.effect(
 
     return Effect.fn(function* (bucket: R2Bucket) {
       yield* bind(bucket);
-      const env = WorkerEnvironment;
-      const raw = env.pipe(
-        Effect.map(
-          (env) => (env as Record<string, runtime.R2Bucket>)[bucket.LogicalId],
-        ),
+      const raw = yield* Effect.serviceOption(WorkerEnvironment).pipe(
+        Effect.map(Option.getOrUndefined),
+        Effect.map((env) => env?.[bucket.LogicalId]! as runtime.R2Bucket),
+        Effect.cached,
       );
       const tryPromise = <T>(fn: () => Promise<T>): Effect.Effect<T, R2Error> =>
         Effect.tryPromise({
@@ -164,7 +173,7 @@ export const R2BucketBindingLive = Layer.effect(
 
       const use = <T>(
         fn: (raw: runtime.R2Bucket) => Promise<T>,
-      ): Effect.Effect<T, R2Error, WorkerEnvironment> =>
+      ): Effect.Effect<T, R2Error> =>
         raw.pipe(Effect.flatMap((raw) => tryPromise(() => fn(raw))));
 
       const wrapR2Object = (object: runtime.R2Object): R2Object => ({

--- a/packages/alchemy/src/Cloudflare/R2/R2BucketBinding.ts
+++ b/packages/alchemy/src/Cloudflare/R2/R2BucketBinding.ts
@@ -144,10 +144,8 @@ export class R2BucketBinding extends Binding.Service<
 
 export const R2BucketClient = makeBoundClientService<
   R2BucketClientIdentifier,
-  R2Bucket,
-  R2BucketClient,
-  R2BucketBinding
->("Cloudflare.R2Bucket.Client", R2BucketBinding);
+  R2BucketClient
+>("Cloudflare.R2Bucket.Client");
 
 export const R2BucketBindingLive = Layer.effect(
   R2BucketBinding,

--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectNamespace.ts
@@ -189,6 +189,8 @@ export class DurableObjectNamespaceScope extends Context.Service<
  * service instead:
  *
  * ```typescript
+ * const boundDB = yield* Cloudflare.D1Connection.bind(MyDB);
+ *
  * class Persistence extends Context.Service<Persistence, {
  *   save(data: string): Effect.Effect<D1Result>;
  * }>()("Persistence") {}
@@ -200,8 +202,7 @@ export class DurableObjectNamespaceScope extends Context.Service<
  *     return { save: (data: string) => db.exec("INSERT ...") };
  *   }),
  * ).pipe(
- *   Layer.provide(Cloudflare.D1ConnectionClient.layer(MyDB)),
- *   Layer.provide(Cloudflare.D1ConnectionLive),
+ *   Layer.provide(Cloudflare.D1ConnectionClient.layer(boundDB)),
  * );
  * ```
  *
@@ -268,9 +269,10 @@ export class DurableObjectNamespaceScope extends Context.Service<
  * export default Counter.make(
  *   Effect.gen(function* () {
  *     // init: use the client layer when a service owns database access
- *     const db = yield* Cloudflare.D1ConnectionClient;
+ *     const boundDB = yield* Cloudflare.D1Connection.bind(MyDB);
  *
  *     return Effect.gen(function* () {
+ *       const db = yield* Cloudflare.D1ConnectionClient;
  *       const state = yield* Cloudflare.DurableObjectState;
  *       const count = (yield* state.storage.get<number>("count")) ?? 0;
  *
@@ -287,8 +289,7 @@ export class DurableObjectNamespaceScope extends Context.Service<
  *       };
  *     });
  *   }).pipe(
- *     Effect.provide(Cloudflare.D1ConnectionClient.layer(MyDB)),
- *     Effect.provide(Cloudflare.D1ConnectionLive),
+ *     Effect.provide(Cloudflare.D1ConnectionClient.layer(boundDB)),
  *   ),
  * );
  * ```

--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectNamespace.ts
@@ -169,7 +169,7 @@ export class DurableObjectNamespaceScope extends Context.Service<
  *
  * ```typescript
  * Effect.gen(function* () {
- *   // Phase 1: resolve shared dependencies
+ *   // Phase 1: bind resources directly when the DO owns the use site
  *   const db = yield* Cloudflare.D1Connection.bind(MyDB);
  *
  *   return Effect.gen(function* () {
@@ -183,6 +183,26 @@ export class DurableObjectNamespaceScope extends Context.Service<
  *     };
  *   });
  * })
+ * ```
+ *
+ * If another service needs the database, provide the client layer to that
+ * service instead:
+ *
+ * ```typescript
+ * class Persistence extends Context.Service<Persistence, {
+ *   save(data: string): Effect.Effect<D1Result>;
+ * }>()("Persistence") {}
+ *
+ * const PersistenceLive = Layer.effect(
+ *   Persistence,
+ *   Effect.gen(function* () {
+ *     const db = yield* Cloudflare.D1ConnectionClient;
+ *     return { save: (data: string) => db.exec("INSERT ...") };
+ *   }),
+ * ).pipe(
+ *   Layer.provide(Cloudflare.D1ConnectionClient.layer(MyDB)),
+ *   Layer.provide(Cloudflare.D1ConnectionLive),
+ * );
  * ```
  *
  * There are two ways to define a Durable Object. See the
@@ -247,8 +267,8 @@ export class DurableObjectNamespaceScope extends Context.Service<
  *
  * export default Counter.make(
  *   Effect.gen(function* () {
- *     // init: bind resources
- *     const db = yield* Cloudflare.D1Connection.bind(MyDB);
+ *     // init: use the client layer when a service owns database access
+ *     const db = yield* Cloudflare.D1ConnectionClient;
  *
  *     return Effect.gen(function* () {
  *       const state = yield* Cloudflare.DurableObjectState;
@@ -266,7 +286,10 @@ export class DurableObjectNamespaceScope extends Context.Service<
  *         get: () => Effect.succeed(count),
  *       };
  *     });
- *   }),
+ *   }).pipe(
+ *     Effect.provide(Cloudflare.D1ConnectionClient.layer(MyDB)),
+ *     Effect.provide(Cloudflare.D1ConnectionLive),
+ *   ),
  * );
  * ```
  *

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -369,7 +369,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * ```typescript
  * Effect.gen(function* () {
  *   // Phase 1: bind resources (runs at deploy time)
- *   const kv = yield* Cloudflare.KVNamespace.bind(MyKV);
+ *   const kv = yield* Cloudflare.KVNamespaceClient;
  *
  *   return {
  *     // Phase 2: runtime handlers (runs on each request)
@@ -378,7 +378,10 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *       return HttpServerResponse.text(value ?? "not found");
  *     }),
  *   };
- * })
+ * }).pipe(
+ *   Effect.provide(Cloudflare.KVNamespaceClient.layer(MyKV)),
+ *   Effect.provide(Cloudflare.KVNamespaceBindingLive),
+ * )
  * ```
  *
  * There are three ways to define a Worker, from simplest to most
@@ -447,7 +450,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *   { main: import.meta.filename },
  *   Effect.gen(function* () {
  *     // init: bind resources
- *     const kv = yield* Cloudflare.KVNamespace.bind(MyKV);
+ *     const kv = yield* Cloudflare.KVNamespaceClient;
  *
  *     return {
  *       // runtime: use them
@@ -456,7 +459,10 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *         return HttpServerResponse.text(value ?? "not found");
  *       }),
  *     };
- *   }),
+ *   }).pipe(
+ *     Effect.provide(Cloudflare.KVNamespaceClient.layer(MyKV)),
+ *     Effect.provide(Cloudflare.KVNamespaceBindingLive),
+ *   ),
  * ) {}
  * ```
  *
@@ -485,7 +491,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * export default WorkerB.make(
  *   Effect.gen(function* () {
  *     // init: bind resources
- *     const kv = yield* Cloudflare.KVNamespace.bind(MyKV);
+ *     const kv = yield* Cloudflare.KVNamespaceClient;
  *
  *     return {
  *       // runtime: use them
@@ -495,7 +501,10 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *           return `Hello ${name}`;
  *         }),
  *     };
- *   }),
+ *   }).pipe(
+ *     Effect.provide(Cloudflare.KVNamespaceClient.layer(MyKV)),
+ *     Effect.provide(Cloudflare.KVNamespaceBindingLive),
+ *   ),
  * );
  * ```
  *
@@ -574,11 +583,11 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * ```
  *
  * @section R2 Bucket
- * Bind an R2 bucket in the init phase with `Cloudflare.R2Bucket.bind`.
- * The returned handle exposes `get`, `put`, `delete`, and `list`
- * methods you can call in your runtime handlers.
+ * Bind an R2 bucket directly inside a Worker when the handler owns the use
+ * site. Provide `Cloudflare.R2BucketClient.layer` when another service should
+ * receive the bucket client.
  *
- * @example Binding and using R2
+ * @example Direct binding and using R2
  * ```typescript
  * // init
  * const bucket = yield* Cloudflare.R2Bucket.bind(MyBucket);
@@ -601,12 +610,36 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * };
  * ```
  *
- * @section KV Namespace
- * Bind a KV namespace with `Cloudflare.KVNamespace.bind`. KV provides
- * eventually-consistent, low-latency key-value reads replicated
- * globally across Cloudflare's edge.
+ * @example Providing R2 to a service
  *
- * @example Binding and using KV
+ * ```typescript
+ * class Store extends Context.Service<Store, {
+ *   put(key: string, value: string): Effect.Effect<Cloudflare.R2Object, Cloudflare.R2Error>;
+ *   get(key: string): Effect.Effect<Cloudflare.R2Object | undefined, Cloudflare.R2Error>;
+ * }>()("Store") {}
+ *
+ * const StoreLive = Layer.effect(
+ *   Store,
+ *   Effect.gen(function* () {
+ *     const bucket = yield* Cloudflare.R2BucketClient;
+ *     return {
+ *       put: (key: string, value: string) => bucket.put(key, value),
+ *       get: (key: string) => bucket.get(key),
+ *     };
+ *   }),
+ * ).pipe(
+ *   Layer.provide(Cloudflare.R2BucketClient.layer(MyBucket)),
+ *   Layer.provide(Cloudflare.R2BucketBindingLive),
+ * );
+ * ```
+ *
+ * @section KV Namespace
+ * Bind a KV namespace directly inside a Worker, or provide
+ * `Cloudflare.KVNamespaceClient.layer` to a service. KV provides
+ * eventually-consistent, low-latency key-value reads replicated globally
+ * across Cloudflare's edge.
+ *
+ * @example Direct binding and using KV
  * ```typescript
  * // init
  * const kv = yield* Cloudflare.KVNamespace.bind(MyKV);
@@ -619,12 +652,36 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * };
  * ```
  *
- * @section D1 Database
- * Bind a D1 database with `Cloudflare.D1Connection.bind`. D1 is a
- * serverless SQLite database — use `prepare` to build parameterized
- * queries and `all`, `first`, or `run` to execute them.
+ * @example Providing KV to a service
  *
- * @example Binding and querying D1
+ * ```typescript
+ * class Cache extends Context.Service<Cache, {
+ *   get(key: string): Effect.Effect<string | null, Cloudflare.KVNamespaceError>;
+ *   put(key: string, value: string): Effect.Effect<void, Cloudflare.KVNamespaceError>;
+ * }>()("Cache") {}
+ *
+ * const CacheLive = Layer.effect(
+ *   Cache,
+ *   Effect.gen(function* () {
+ *     const kv = yield* Cloudflare.KVNamespaceClient;
+ *     return {
+ *       get: (key: string) => kv.get(key),
+ *       put: (key: string, value: string) => kv.put(key, value),
+ *     };
+ *   }),
+ * ).pipe(
+ *   Layer.provide(Cloudflare.KVNamespaceClient.layer(MyKV)),
+ *   Layer.provide(Cloudflare.KVNamespaceBindingLive),
+ * );
+ * ```
+ *
+ * @section D1 Database
+ * Bind a D1 database directly inside a Worker, or provide
+ * `Cloudflare.D1ConnectionClient.layer` to a service. D1 is a serverless
+ * SQLite database — use `prepare` to build parameterized queries and `all`,
+ * `first`, or `run` to execute them.
+ *
+ * @example Direct binding and querying D1
  * ```typescript
  * // init
  * const db = yield* Cloudflare.D1Connection.bind(MyDB);
@@ -638,6 +695,28 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *     return yield* HttpServerResponse.json(results);
  *   }),
  * };
+ * ```
+ *
+ * @example Providing D1 to a service
+ *
+ * ```typescript
+ * class Users extends Context.Service<Users, {
+ *   findById(userId: number): Effect.Effect<D1Result<User>>;
+ * }>()("Users") {}
+ *
+ * const UsersLive = Layer.effect(
+ *   Users,
+ *   Effect.gen(function* () {
+ *     const db = yield* Cloudflare.D1ConnectionClient;
+ *     return {
+ *       findById: (userId: number) =>
+ *         db.prepare("SELECT * FROM users WHERE id = ?").bind(userId).all(),
+ *     };
+ *   }),
+ * ).pipe(
+ *   Layer.provide(Cloudflare.D1ConnectionClient.layer(MyDB)),
+ *   Layer.provide(Cloudflare.D1ConnectionLive),
+ * );
  * ```
  *
  * @section Durable Objects

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -369,7 +369,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * ```typescript
  * Effect.gen(function* () {
  *   // Phase 1: bind resources (runs at deploy time)
- *   const kv = yield* Cloudflare.KVNamespaceClient;
+ *   const kv = yield* Cloudflare.KVNamespace.bind(MyKV);
  *
  *   return {
  *     // Phase 2: runtime handlers (runs on each request)
@@ -379,7 +379,6 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *     }),
  *   };
  * }).pipe(
- *   Effect.provide(Cloudflare.KVNamespaceClient.layer(MyKV)),
  *   Effect.provide(Cloudflare.KVNamespaceBindingLive),
  * )
  * ```
@@ -450,7 +449,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *   { main: import.meta.filename },
  *   Effect.gen(function* () {
  *     // init: bind resources
- *     const kv = yield* Cloudflare.KVNamespaceClient;
+ *     const kv = yield* Cloudflare.KVNamespace.bind(MyKV);
  *
  *     return {
  *       // runtime: use them
@@ -460,7 +459,6 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *       }),
  *     };
  *   }).pipe(
- *     Effect.provide(Cloudflare.KVNamespaceClient.layer(MyKV)),
  *     Effect.provide(Cloudflare.KVNamespaceBindingLive),
  *   ),
  * ) {}
@@ -491,7 +489,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * export default WorkerB.make(
  *   Effect.gen(function* () {
  *     // init: bind resources
- *     const kv = yield* Cloudflare.KVNamespaceClient;
+ *     const kv = yield* Cloudflare.KVNamespace.bind(MyKV);
  *
  *     return {
  *       // runtime: use them
@@ -502,7 +500,6 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *         }),
  *     };
  *   }).pipe(
- *     Effect.provide(Cloudflare.KVNamespaceClient.layer(MyKV)),
  *     Effect.provide(Cloudflare.KVNamespaceBindingLive),
  *   ),
  * );
@@ -613,6 +610,8 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * @example Providing R2 to a service
  *
  * ```typescript
+ * const boundBucket = yield* Cloudflare.R2Bucket.bind(MyBucket);
+ *
  * class Store extends Context.Service<Store, {
  *   put(key: string, value: string): Effect.Effect<Cloudflare.R2Object, Cloudflare.R2Error>;
  *   get(key: string): Effect.Effect<Cloudflare.R2Object | undefined, Cloudflare.R2Error>;
@@ -628,8 +627,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *     };
  *   }),
  * ).pipe(
- *   Layer.provide(Cloudflare.R2BucketClient.layer(MyBucket)),
- *   Layer.provide(Cloudflare.R2BucketBindingLive),
+ *   Layer.provide(Cloudflare.R2BucketClient.layer(boundBucket)),
  * );
  * ```
  *
@@ -655,6 +653,8 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * @example Providing KV to a service
  *
  * ```typescript
+ * const boundKV = yield* Cloudflare.KVNamespace.bind(MyKV);
+ *
  * class Cache extends Context.Service<Cache, {
  *   get(key: string): Effect.Effect<string | null, Cloudflare.KVNamespaceError>;
  *   put(key: string, value: string): Effect.Effect<void, Cloudflare.KVNamespaceError>;
@@ -670,8 +670,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *     };
  *   }),
  * ).pipe(
- *   Layer.provide(Cloudflare.KVNamespaceClient.layer(MyKV)),
- *   Layer.provide(Cloudflare.KVNamespaceBindingLive),
+ *   Layer.provide(Cloudflare.KVNamespaceClient.layer(boundKV)),
  * );
  * ```
  *
@@ -700,6 +699,8 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * @example Providing D1 to a service
  *
  * ```typescript
+ * const boundDB = yield* Cloudflare.D1Connection.bind(MyDB);
+ *
  * class Users extends Context.Service<Users, {
  *   findById(userId: number): Effect.Effect<D1Result<User>>;
  * }>()("Users") {}
@@ -714,8 +715,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *     };
  *   }),
  * ).pipe(
- *   Layer.provide(Cloudflare.D1ConnectionClient.layer(MyDB)),
- *   Layer.provide(Cloudflare.D1ConnectionLive),
+ *   Layer.provide(Cloudflare.D1ConnectionClient.layer(boundDB)),
  * );
  * ```
  *

--- a/packages/alchemy/src/Cloudflare/Workers/Workflow.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Workflow.ts
@@ -283,6 +283,8 @@ export class WorkflowScope extends Context.Service<
  * another service should own the resource access.
  *
  * ```typescript
+ * const boundKV = yield* Cloudflare.KVNamespace.bind(KV);
+ *
  * class Messages extends Context.Service<Messages, {
  *   roundtrip(roomId: string, message: string): Effect.Effect<string | null, Cloudflare.KVNamespaceError>;
  * }>()("Messages") {}
@@ -301,8 +303,7 @@ export class WorkflowScope extends Context.Service<
  *     };
  *   }),
  * ).pipe(
- *   Layer.provide(Cloudflare.KVNamespaceClient.layer(KV)),
- *   Layer.provide(Cloudflare.KVNamespaceBindingLive),
+ *   Layer.provide(Cloudflare.KVNamespaceClient.layer(boundKV)),
  * );
  *
  * Effect.gen(function* () {

--- a/packages/alchemy/src/Cloudflare/Workers/Workflow.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Workflow.ts
@@ -253,12 +253,11 @@ export class WorkflowScope extends Context.Service<
  * yield* Cloudflare.sleep("cooldown", "30 seconds");
  * ```
  *
- * @example Accessing env bindings inside a task
- * Bind a resource (e.g. `KVNamespace`, `R2Bucket`) in the workflow's
- * outer init phase to get a typed Effect-native client, then use it
- * directly inside `task`. `task` threads the binding's service
- * requirement (`WorkerEnvironment`) through automatically so the inner
- * Effect needs no extra plumbing.
+ * @example Direct binding inside a workflow
+ * Bind a resource in the workflow's outer init phase, then use it directly
+ * inside `task`. `task` threads the binding's service requirement
+ * (`WorkerEnvironment`) through automatically so the inner Effect needs no
+ * extra plumbing.
  *
  * ```typescript
  * Effect.gen(function* () {
@@ -267,7 +266,7 @@ export class WorkflowScope extends Context.Service<
  *   return Effect.fn(function* (input: { roomId: string; message: string }) {
  *     const { roomId, message } = input;
  *
- *     const stored = yield* Cloudflare.task(
+ *     return yield* Cloudflare.task(
  *       "kv-roundtrip",
  *       Effect.gen(function* () {
  *         const key = `workflow:${roomId}`;
@@ -275,10 +274,47 @@ export class WorkflowScope extends Context.Service<
  *         return yield* kv.get(key);
  *       }).pipe(Effect.orDie),
  *     );
- *
- *     return stored;
  *   });
  * });
+ * ```
+ *
+ * @example Providing a resource client to a service
+ * Provide a resource client (e.g. `KVNamespaceClient`, `R2BucketClient`) when
+ * another service should own the resource access.
+ *
+ * ```typescript
+ * class Messages extends Context.Service<Messages, {
+ *   roundtrip(roomId: string, message: string): Effect.Effect<string | null, Cloudflare.KVNamespaceError>;
+ * }>()("Messages") {}
+ *
+ * const MessagesLive = Layer.effect(
+ *   Messages,
+ *   Effect.gen(function* () {
+ *     const kv = yield* Cloudflare.KVNamespaceClient;
+ *     return {
+ *       roundtrip: (roomId: string, message: string) =>
+ *         Effect.gen(function* () {
+ *           const key = `workflow:${roomId}`;
+ *           yield* kv.put(key, message);
+ *           return yield* kv.get(key);
+ *         }),
+ *     };
+ *   }),
+ * ).pipe(
+ *   Layer.provide(Cloudflare.KVNamespaceClient.layer(KV)),
+ *   Layer.provide(Cloudflare.KVNamespaceBindingLive),
+ * );
+ *
+ * Effect.gen(function* () {
+ *   const messages = yield* Messages;
+ *
+ *   return Effect.fn(function* (input: { roomId: string; message: string }) {
+ *     return yield* Cloudflare.task(
+ *       "kv-roundtrip",
+ *       messages.roundtrip(input.roomId, input.message).pipe(Effect.orDie),
+ *     );
+ *   });
+ * }).pipe(Effect.provide(MessagesLive));
  * ```
  *
  * @section Starting and Monitoring Instances

--- a/packages/alchemy/src/Cloudflare/index.ts
+++ b/packages/alchemy/src/Cloudflare/index.ts
@@ -2,6 +2,7 @@ export * from "./ApiToken/index.ts";
 export * from "./Artifacts/index.ts";
 export * from "./AiGateway/index.ts";
 export * from "./AnalyticsEngine/index.ts";
+export * from "./BoundClient.ts";
 export * from "./CloudflareEnvironment.ts";
 export * from "./Container/index.ts";
 export * from "./D1/index.ts";


### PR DESCRIPTION
## Summary
- add yieldable Cloudflare bound-client service tags for Cloudflare object bindings
- add `.layer(boundClient)` helpers so application/service layers can receive an already-bound runtime client at the boundary
- require callers to run `.bind(resource)` first, in Worker init, so deploy-time binding discovery cannot be hidden inside an unbuilt service layer
- update source JSDoc examples to show both patterns: direct binding inside a Worker and providing a bound client to another Effect service

## Context
I was making an app service (`ImageStorage`) that wanted to use R2 without depending on `Cloudflare.R2Bucket.bind(Bucket)` directly. The old pattern made downstream services either bind the resource themselves or accept a binder-shaped dependency, which is awkward for idiomatic Effect services.

The first version of this PR let `R2BucketClient.layer(bucket)` call `.bind(...)` internally. That was too easy to misuse: if the layer is only provided around request/RPC handlers, Alchemy may never build that layer during deploy, so the Worker binding would not be discovered. This version makes the dependency explicit: bind in Worker init, then pass the already-bound client into the client layer.

This PR applies that client-service pattern across the scoped Cloudflare object bindings and documents both usage styles.

Example service: https://github.com/wking-io/creative-agent/blob/5d0506b861120e4c6d404b9db72d777afee96261/apps/api/src/infra/ImageStorage.ts#L90

Example worker: https://github.com/wking-io/creative-agent/blob/main/apps/api/src/worker.ts

## Usage Examples

### Direct binding inside a Worker

Use the existing `.bind(...)` API when the Worker owns the use site directly. This keeps the shortest path for simple runtime handlers and records the deploy-time Cloudflare binding during Worker init.

```ts
export const MyBucket = Cloudflare.R2Bucket("MyBucket");

export default Cloudflare.Worker(
  "ImageWorker",
  { main: import.meta.filename },
  Effect.gen(function* () {
    const bucket = yield* Cloudflare.R2Bucket.bind(MyBucket);

    return {
      fetch: Effect.gen(function* () {
        const request = yield* HttpServerRequest;
        const key = request.url.split("/").pop()!;

        if (request.method === "GET") {
          const object = yield* bucket.get(key);
          return object
            ? HttpServerResponse.text(yield* object.text())
            : HttpServerResponse.empty({ status: 404 });
        }

        yield* bucket.put(key, request.stream);
        return HttpServerResponse.empty({ status: 201 });
      }),
    };
  }).pipe(Effect.provide(Cloudflare.R2BucketBindingLive)),
);
```

### Providing a bound client to an Effect service

Use the new client service when another service should depend on an already-bound Cloudflare runtime client. The Worker init effect performs the deploy-discoverable bind first; the application service depends on `Cloudflare.R2BucketClient` and receives that concrete client from a layer.

```ts
export const MyBucket = Cloudflare.R2Bucket("MyBucket");

class Store extends Context.Service<Store, {
  put(key: string, value: string): Effect.Effect<Cloudflare.R2Object, Cloudflare.R2Error>;
  get(key: string): Effect.Effect<Cloudflare.R2Object | undefined, Cloudflare.R2Error>;
}>()("Store") {}

const StoreLive = Layer.effect(
  Store,
  Effect.gen(function* () {
    const bucket = yield* Cloudflare.R2BucketClient;
    return {
      put: (key: string, value: string) => bucket.put(key, value),
      get: (key: string) => bucket.get(key),
    };
  }),
);

export default Cloudflare.Worker(
  "ImageWorker",
  { main: import.meta.filename },
  Effect.gen(function* () {
    // This bind runs during Worker init, so Alchemy can discover and attach
    // the deploy-time R2 Worker binding.
    const bucket = yield* Cloudflare.R2Bucket.bind(MyBucket);

    const AppLayer = StoreLive.pipe(
      Layer.provide(Cloudflare.R2BucketClient.layer(bucket)),
    );

    return {
      fetch: Effect.gen(function* () {
        const store = yield* Store;
        const object = yield* store.get("hello.txt");
        return object
          ? HttpServerResponse.text(yield* object.text())
          : HttpServerResponse.empty({ status: 404 });
      }).pipe(Effect.provide(AppLayer)),
    };
  }).pipe(Effect.provide(Cloudflare.R2BucketBindingLive)),
);
```

### Same shape for other Cloudflare object clients

The same pattern is available for the other scoped Cloudflare bindings in this PR:

```ts
const kv = yield* Cloudflare.KVNamespace.bind(MyKV);
const db = yield* Cloudflare.D1Connection.bind(MyDB);
const queue = yield* Cloudflare.QueueBinding.bind(MyQueue);
const images = yield* Cloudflare.Images.bind(MyImages);
const artifacts = yield* Cloudflare.Artifacts.bind(Repos);
const analytics = yield* Cloudflare.AnalyticsEngineDataset.bind(Analytics);
const gateway = yield* Cloudflare.AiGateway.bind(Gateway);
const hyperdrive = yield* Cloudflare.Hyperdrive.bind(MyHyperdrive);
const email = yield* Cloudflare.SendEmail.bind(Email);

Layer.provide(Cloudflare.KVNamespaceClient.layer(kv));
Layer.provide(Cloudflare.D1ConnectionClient.layer(db));
Layer.provide(Cloudflare.QueueSender.layer(queue));
Layer.provide(Cloudflare.ImagesClient.layer(images));
Layer.provide(Cloudflare.ArtifactsClient.layer(artifacts));
Layer.provide(Cloudflare.AnalyticsEngineDatasetClient.layer(analytics));
Layer.provide(Cloudflare.AiGatewayClient.layer(gateway));
Layer.provide(Cloudflare.HyperdriveBindingClient.layer(hyperdrive));
Layer.provide(Cloudflare.SendEmailClient.layer(email));
```

## Validation
- `bun generate:api-reference`
- `git diff --check`
- `bun run build:packages`
- focused non-provider vitest suite: 13 files / 742 tests passed
- tested locally through `creative-agent` with `bun run infra:typecheck` and `bun test:e2e:api` against the linked local package
