### PR TITLE
feat(state): RPC-based state store for Cloudflare worker

### DIFF
--- a/packages/alchemy/src/Cloudflare/StateStore/Api.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Api.ts
@@ -1,17 +1,10 @@
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import * as Path from "effect/Path";
-import * as Etag from "effect/unstable/http/Etag";
-import * as HttpPlatform from "effect/unstable/http/HttpPlatform";
-import * as HttpRouter from "effect/unstable/http/HttpRouter";
-import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
-import * as HttpApiError from "effect/unstable/httpapi/HttpApiError";
+import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
 import crypto from "node:crypto";
-import {
-  BearerTokenValidator,
-  StateApi,
-  StateAuthLive,
-} from "../../State/HttpStateApi.ts";
+import { RPC_PATH, StateRpcs } from "../../State/RpcStateApi.ts";
 import * as Secret from "../SecretsStore/Secret.ts";
 import { SecretBindingLive } from "../SecretsStore/SecretBinding.ts";
 import { Worker } from "../Workers/Worker.ts";
@@ -29,73 +22,8 @@ export const STATE_STORE_SCRIPT_NAME = "alchemy-state-store" as const;
  * compare against this constant; a mismatch (or 404) triggers a
  * forced redeploy via the bootstrap flow.
  */
-export const STATE_STORE_VERSION = 4 as const;
+export const STATE_STORE_VERSION = 5 as const;
 
-/**
- * Hard-coded OTLP/HTTP endpoints. Point at the public ingest relay
- * defined in `stacks/otel.ts` (bound to `otel.alchemy.run`), which
- * forwards to Axiom with the bearer token attached server-side. Hard-
- * coded on purpose: the worker has no env-var plumbing and the relay
- * is account-level infra that lives outside any single deploy.
- */
-// const OTEL_TRACES_URL = "https://otel.alchemy.run/v1/traces";
-// const OTEL_METRICS_URL = "https://otel.alchemy.run/v1/metrics";
-// const OTEL_LOGS_URL = "https://otel.alchemy.run/v1/logs";
-
-/**
- * OTLP traces + metrics + logs Layer for the state-store worker.
- * Mirrors the CLI's `TelemetryLive` so every signal the worker emits
- * (`Effect.withSpan`, runtime metrics, `Effect.log*`) ships to the
- * same Axiom datasets as deploy-time CLI signals. Resource attributes
- * brand each signal with the worker's service name + contract version
- * so they're easy to slice in Axiom.
- */
-// const otelResource = {
-//   serviceName: STATE_STORE_SCRIPT_NAME,
-//   serviceVersion: String(STATE_STORE_VERSION),
-//   attributes: {
-//     "alchemy.state_store.script_name": STATE_STORE_SCRIPT_NAME,
-//     "alchemy.state_store.version": STATE_STORE_VERSION,
-//   },
-// } as const;
-
-// const TelemetryLive = Layer.mergeAll(
-//   OtlpTracer.layer({
-//     url: OTEL_TRACES_URL,
-//     resource: otelResource,
-//     exportInterval: "1 second",
-//   }),
-//   OtlpMetrics.layer({
-//     url: OTEL_METRICS_URL,
-//     resource: otelResource,
-//     exportInterval: "1 second",
-//   }),
-//   // Replace (don't merge with) the default stdout logger so worker logs
-//   // ship to Axiom instead of just `wrangler tail`.
-//   OtlpLogger.layer({
-//     url: OTEL_LOGS_URL,
-//     resource: otelResource,
-//     exportInterval: "1 second",
-//     mergeWithExisting: false,
-//   }),
-// ).pipe(
-//   Layer.provide(OtlpSerialization.layerJson),
-//   Layer.provide(FetchHttpClient.layer),
-// );
-
-/**
- * Path on disk to *this* file, used as the worker's bundling entry.
- *
- * When running from source (e.g. dev / monorepo), `import.meta.url` points
- * at `Api.ts` and we can use it directly. When the alchemy CLI is run from
- * its published `bin/alchemy.js` bundle, this module is inlined into the
- * CLI bundle and `import.meta.url` resolves to `bin/alchemy.js` — which
- * has no `default` export and breaks the worker bundler with
- * `[MISSING_EXPORT] "default" is not exported by "bin/alchemy.js"`.
- *
- * In the bundled case, fall back to the published source file shipped
- * alongside the CLI under `../src/Cloudflare/StateStore/Api.ts`.
- */
 export default Worker(
   "Api",
   {
@@ -111,34 +39,9 @@ export default Worker(
     const secret = yield* Secret.Secret.bind(AuthToken);
     const store = yield* Store;
 
-    const bearerTokenValidator = Layer.effect(
-      BearerTokenValidator,
-      secret.get().pipe(
-        Effect.map((expected) =>
-          BearerTokenValidator.of({
-            validate: (token) =>
-              !!expected && timingSafeEqual(token, expected)
-                ? Effect.void
-                : Effect.fail(new HttpApiError.Unauthorized()),
-          }),
-        ),
-        Effect.orDie,
-      ),
-    );
-
-    const versionApi = HttpApiBuilder.group(StateApi, "version", (handlers) =>
-      handlers.handle("getVersion", () =>
-        Effect.succeed({ version: STATE_STORE_VERSION }).pipe(
-          Effect.withSpan("state_store.getVersion", {
-            attributes: { "alchemy.state_store.op": "getVersion" },
-          }),
-        ),
-      ),
-    );
-
-    const stateApi = HttpApiBuilder.group(StateApi, "state", (handlers) =>
-      handlers
-        .handle("listStacks", () =>
+    const StateRpcsLive = StateRpcs.toLayer(
+      Effect.succeed({
+        listStacks: () =>
           store
             .getByName(Store.ROOT_DO_NAME)
             .listStacks()
@@ -147,192 +50,193 @@ export default Worker(
                 attributes: { "alchemy.state_store.op": "listStacks" },
               }),
             ),
-        )
-        .handle("listStages", ({ params }) =>
+        listStages: ({ stack }) =>
           store
-            .getByName(params.stack)
+            .getByName(stack)
             .listStages()
             .pipe(
               Effect.withSpan("state_store.listStages", {
                 attributes: {
                   "alchemy.state_store.op": "listStages",
-                  "alchemy.state_store.stack": params.stack,
+                  "alchemy.state_store.stack": stack,
                 },
               }),
             ),
-        )
-        .handle("listResources", ({ params }) =>
+        listResources: ({ stack, stage }) =>
           store
-            .getByName(params.stack)
-            .listResources({ stage: params.stage })
+            .getByName(stack)
+            .listResources({ stage })
             .pipe(
               Effect.withSpan("state_store.listResources", {
                 attributes: {
                   "alchemy.state_store.op": "listResources",
-                  "alchemy.state_store.stack": params.stack,
-                  "alchemy.state_store.stage": params.stage,
+                  "alchemy.state_store.stack": stack,
+                  "alchemy.state_store.stage": stage,
                 },
               }),
             ),
-        )
-        .handle("getState", ({ params }) => {
-          const fqn = decodeURIComponent(params.fqn);
-          return store
-            .getByName(params.stack)
-            .get({ stage: params.stage, fqn })
+        getState: ({ stack, stage, fqn }) =>
+          store
+            .getByName(stack)
+            .get({ stage, fqn })
             .pipe(
               Effect.withSpan("state_store.getState", {
                 attributes: {
                   "alchemy.state_store.op": "getState",
-                  "alchemy.state_store.stack": params.stack,
-                  "alchemy.state_store.stage": params.stage,
+                  "alchemy.state_store.stack": stack,
+                  "alchemy.state_store.stage": stage,
                   "alchemy.state_store.fqn": fqn,
                 },
               }),
-            );
-        })
-        .handle("setState", ({ params, payload }) => {
-          const fqn = decodeURIComponent(params.fqn);
-          return store
-            .getByName(params.stack)
-            .set({ stage: params.stage, fqn, value: payload as any })
+            ),
+        setState: ({ stack, stage, fqn, value }) =>
+          store
+            .getByName(stack)
+            .set({ stage, fqn, value: value as any })
             .pipe(
               Effect.tap(() =>
-                store
-                  .getByName(Store.ROOT_DO_NAME)
-                  .registerStack({ stack: params.stack }),
+                store.getByName(Store.ROOT_DO_NAME).registerStack({ stack }),
               ),
               Effect.withSpan("state_store.setState", {
                 attributes: {
                   "alchemy.state_store.op": "setState",
-                  "alchemy.state_store.stack": params.stack,
-                  "alchemy.state_store.stage": params.stage,
+                  "alchemy.state_store.stack": stack,
+                  "alchemy.state_store.stage": stage,
                   "alchemy.state_store.fqn": fqn,
                 },
               }),
-            );
-        })
-        .handle("deleteState", ({ params }) => {
-          const fqn = decodeURIComponent(params.fqn);
+            ),
+        deleteState: ({ stack, stage, fqn }) =>
           // The DO method is `remove`, not `delete` — `delete` is
           // reserved by Cloudflare's RPC stub proxy.
-          return store
-            .getByName(params.stack)
-            .remove({ stage: params.stage, fqn })
+          store
+            .getByName(stack)
+            .remove({ stage, fqn })
             .pipe(
               Effect.asVoid,
               Effect.withSpan("state_store.deleteState", {
                 attributes: {
                   "alchemy.state_store.op": "deleteState",
-                  "alchemy.state_store.stack": params.stack,
-                  "alchemy.state_store.stage": params.stage,
+                  "alchemy.state_store.stack": stack,
+                  "alchemy.state_store.stage": stage,
                   "alchemy.state_store.fqn": fqn,
                 },
               }),
-            );
-        })
-        .handle("getReplacedResources", ({ params }) =>
-          store
-            .getByName(params.stack)
-            .getReplacedResources({ stage: params.stage })
-            .pipe(
-              Effect.withSpan("state_store.getReplacedResources", {
-                attributes: {
-                  "alchemy.state_store.op": "getReplacedResources",
-                  "alchemy.state_store.stack": params.stack,
-                  "alchemy.state_store.stage": params.stage,
-                },
-              }),
             ),
-        )
-        .handle("getStackOutput", ({ params }) =>
+        deleteStack: ({ stack, stage }) =>
           store
-            .getByName(params.stack)
-            .getOutput({ stage: params.stage })
-            .pipe(
-              Effect.withSpan("state_store.getStackOutput", {
-                attributes: {
-                  "alchemy.state_store.op": "getStackOutput",
-                  "alchemy.state_store.stack": params.stack,
-                  "alchemy.state_store.stage": params.stage,
-                },
-              }),
-            ),
-        )
-        .handle("setStackOutput", ({ params, payload }) =>
-          store
-            .getByName(params.stack)
-            .setOutput({ stage: params.stage, value: payload as any })
-            .pipe(
-              Effect.tap(() =>
-                store
-                  .getByName(Store.ROOT_DO_NAME)
-                  .registerStack({ stack: params.stack }),
-              ),
-              Effect.withSpan("state_store.setStackOutput", {
-                attributes: {
-                  "alchemy.state_store.op": "setStackOutput",
-                  "alchemy.state_store.stack": params.stack,
-                  "alchemy.state_store.stage": params.stage,
-                },
-              }),
-            ),
-        )
-        .handle("deleteStack", ({ params, query }) =>
-          store
-            .getByName(params.stack)
-            .deleteStack(
-              query.stage === undefined ? {} : { stage: query.stage },
-            )
+            .getByName(stack)
+            .deleteStack(stage === undefined ? {} : { stage })
             .pipe(
               Effect.flatMap(() =>
-                query.stage === undefined
+                stage === undefined
                   ? store
                       .getByName(Store.ROOT_DO_NAME)
-                      .unregisterStack({ stack: params.stack })
+                      .unregisterStack({ stack })
                   : Effect.void,
               ),
               Effect.asVoid,
               Effect.withSpan("state_store.deleteStack", {
                 attributes: {
                   "alchemy.state_store.op": "deleteStack",
-                  "alchemy.state_store.stack": params.stack,
-                  "alchemy.state_store.stage": query.stage ?? "",
+                  "alchemy.state_store.stack": stack,
+                  "alchemy.state_store.stage": stage ?? "",
                   "alchemy.state_store.scope":
-                    query.stage === undefined ? "stack" : "stage",
+                    stage === undefined ? "stack" : "stage",
                 },
               }),
             ),
-        ),
+        getReplacedResources: ({ stack, stage }) =>
+          store
+            .getByName(stack)
+            .getReplacedResources({ stage })
+            .pipe(
+              Effect.withSpan("state_store.getReplacedResources", {
+                attributes: {
+                  "alchemy.state_store.op": "getReplacedResources",
+                  "alchemy.state_store.stack": stack,
+                  "alchemy.state_store.stage": stage,
+                },
+              }),
+            ),
+        getStackOutput: ({ stack, stage }) =>
+          store
+            .getByName(stack)
+            .getOutput({ stage })
+            .pipe(
+              Effect.withSpan("state_store.getStackOutput", {
+                attributes: {
+                  "alchemy.state_store.op": "getStackOutput",
+                  "alchemy.state_store.stack": stack,
+                  "alchemy.state_store.stage": stage,
+                },
+              }),
+            ),
+        setStackOutput: ({ stack, stage, value }) =>
+          store
+            .getByName(stack)
+            .setOutput({ stage, value: value as any })
+            .pipe(
+              Effect.tap(() =>
+                store.getByName(Store.ROOT_DO_NAME).registerStack({ stack }),
+              ),
+              Effect.withSpan("state_store.setStackOutput", {
+                attributes: {
+                  "alchemy.state_store.op": "setStackOutput",
+                  "alchemy.state_store.stack": stack,
+                  "alchemy.state_store.stage": stage,
+                },
+              }),
+            ),
+      }),
+    );
+
+    const rpcHandler = yield* RpcServer.toHttpEffect(StateRpcs).pipe(
+      Effect.provide(StateRpcsLive),
+      Effect.provide(RpcSerialization.layerJson),
     );
 
     return {
-      fetch: HttpApiBuilder.layer(StateApi).pipe(
-        Layer.provide(stateApi),
-        Layer.provide(versionApi),
-        Layer.provide(StateAuthLive),
-        Layer.provide(bearerTokenValidator),
-        // The state-store worker never serves files, so HttpPlatform's
-        // file-response surface is stubbed.
-        Layer.provide([Etag.layer, HttpPlatformStub, Path.layer]),
-        HttpRouter.toHttpEffect,
-        // Effect.provide(TelemetryLive),
-      ),
+      fetch: Effect.gen(function* () {
+        const req = yield* HttpServerRequest.HttpServerRequest;
+        const path = pathnameOf(req.url);
+
+        // Unauthenticated version probe.
+        if (path === "/version") {
+          return yield* HttpServerResponse.json({
+            version: STATE_STORE_VERSION,
+          });
+        }
+
+        // Bearer-token gate on every other route.
+        const expected = yield* secret.get().pipe(Effect.orDie);
+        const authHeader = req.headers.authorization ?? "";
+        const provided = authHeader.toLowerCase().startsWith("bearer ")
+          ? authHeader.slice(7).trim()
+          : "";
+        if (!expected || !timingSafeEqual(provided, expected)) {
+          return HttpServerResponse.empty({ status: 401 });
+        }
+
+        if (path === RPC_PATH) {
+          return yield* rpcHandler;
+        }
+
+        return HttpServerResponse.empty({ status: 404 });
+      }),
     };
   }).pipe(Effect.provide(Layer.mergeAll(SecretBindingLive))),
 );
 
-/**
- * Stub `HttpPlatform` for the worker. The state-store API never
- * issues file responses, so both surface methods die if invoked. Lets
- * us avoid pulling in a `FileSystem` dependency that workers don't
- * have.
- */
-const HttpPlatformStub = Layer.succeed(HttpPlatform.HttpPlatform, {
-  fileResponse: () => Effect.die("HttpPlatform.fileResponse not supported"),
-  fileWebResponse: () =>
-    Effect.die("HttpPlatform.fileWebResponse not supported"),
-});
+/** Extract the pathname from a request URL that may be relative or absolute. */
+const pathnameOf = (url: string): string => {
+  try {
+    return new URL(url, "http://localhost").pathname;
+  } catch {
+    const q = url.indexOf("?");
+    return q >= 0 ? url.slice(0, q) : url;
+  }
+};
 
 /**
  * Timing-safe string comparison using the Workers runtime's built-in

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -6,7 +6,6 @@ import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
-import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
 import crypto from "node:crypto";
 import * as Output from "../../Output.ts";
 
@@ -21,11 +20,10 @@ import { ALCHEMY_PROFILE, ProfileLive } from "../../Auth/Profile.ts";
 import * as Cloudflare from "../../Cloudflare/Providers.ts";
 import { deploy } from "../../Deploy.ts";
 import * as Alchemy from "../../Stack.ts";
-import { StateApi } from "../../State/HttpStateApi.ts";
 import {
-  makeHttpStateStore,
-  type HttpStateStoreCredentials,
-} from "../../State/HttpStateStore.ts";
+  makeRpcStateStore,
+  type RpcStateStoreCredentials,
+} from "../../State/RpcStateStore.ts";
 import * as CloudflareEnvironment from "../CloudflareEnvironment.ts";
 import * as Credentials from "../Credentials.ts";
 
@@ -166,7 +164,7 @@ export const bootstrap = (options: BootstrapOptions = {}) =>
       const credentials = yield* loginWithCloudflare();
       if (!isCI) {
         const store = yield* CredentialsStore;
-        yield* store.write<HttpStateStoreCredentials>(
+        yield* store.write<RpcStateStoreCredentials>(
           profileName,
           CREDENTIALS_FILE,
           credentials,
@@ -211,7 +209,7 @@ export const state = () =>
       const alchemyContext = yield* AlchemyContext;
       const profileName = yield* ALCHEMY_PROFILE;
       const store = yield* CredentialsStore;
-      const credentials = yield* store.read<HttpStateStoreCredentials>(
+      const credentials = yield* store.read<RpcStateStoreCredentials>(
         profileName,
         CREDENTIALS_FILE,
       );
@@ -298,7 +296,7 @@ export const state = () =>
         // it exists, so fetch the secret token
         const credentials = yield* loginWithCloudflare();
         if (!isCI) {
-          yield* store.write<HttpStateStoreCredentials>(
+          yield* store.write<RpcStateStoreCredentials>(
             profileName,
             CREDENTIALS_FILE,
             credentials,
@@ -367,7 +365,7 @@ const makeCloudflareStateStore = Effect.fnUntraced(function* ({
 }) {
   const access = yield* Access.Access;
   const accessHeaders = yield* access.getAccessHeaders(new URL(url).host);
-  return yield* makeHttpStateStore({
+  return yield* makeRpcStateStore({
     url,
     authToken,
     transformClient: HttpClientRequest.setHeaders(accessHeaders),
@@ -593,7 +591,7 @@ export const loginWithCloudflare = () =>
       //    `loadOrConfigure` when this is invoked through `configure`.
       const credStore = yield* CredentialsStore;
       yield* credStore
-        .write<HttpStateStoreCredentials>(profileName, CREDENTIALS_FILE, {
+        .write<RpcStateStoreCredentials>(profileName, CREDENTIALS_FILE, {
           url,
           authToken: authToken.trim(),
         })
@@ -743,14 +741,16 @@ const waitForStateStoreVersion = (url: string) =>
 
 const checkStateStoreVersion = (url: string) =>
   Effect.gen(function* () {
-    const client = yield* HttpApiClient.make(StateApi, { baseUrl: url });
+    const http = yield* HttpClient.HttpClient;
     // The /version route may 404 transiently after a fresh deploy
     // while Cloudflare propagates the new script to the edge, and may
     // also surface transport-level blips on cold workers.dev hosts.
     // Retry the probe itself for ~10s before giving up — only after
     // exhausting that budget do we collapse to `undefined` and let
     // the caller treat it as a version mismatch.
-    const result = yield* client.version.getVersion().pipe(
+    const result = yield* http.get(`${url}/version`).pipe(
+      Effect.flatMap((res) => res.json),
+      Effect.map((body) => body as { version: number }),
       Effect.retry({
         schedule: Schedule.spaced("250 millis").pipe(
           Schedule.both(Schedule.recurs(40)),

--- a/packages/alchemy/src/State/RpcStateApi.ts
+++ b/packages/alchemy/src/State/RpcStateApi.ts
@@ -1,0 +1,92 @@
+import * as Schema from "effect/Schema";
+import { Rpc, RpcGroup } from "effect/unstable/rpc";
+
+/**
+ * RPC counterpart to {@link HttpStateApi}.
+ *
+ * Same shape, same semantics, but the wire format is the Effect-RPC
+ * transport (one POST per call, JSON-serialised payload + envelope)
+ * instead of one REST route per operation. Persisted state values pass
+ * through opaquely as `Schema.Unknown` — both the client and the worker
+ * apply {@link encodeState} / {@link reviveStateRecursive} themselves.
+ */
+
+/** Path the RPC handler is mounted on inside the worker. */
+export const RPC_PATH = "/rpc" as const;
+
+const StackPayload = { stack: Schema.String };
+const StackStagePayload = { stack: Schema.String, stage: Schema.String };
+const ResourceKeyPayload = {
+  stack: Schema.String,
+  stage: Schema.String,
+  fqn: Schema.String,
+};
+
+const listStacks = Rpc.make("listStacks", {
+  success: Schema.Array(Schema.String),
+});
+
+const listStages = Rpc.make("listStages", {
+  payload: StackPayload,
+  success: Schema.Array(Schema.String),
+});
+
+const listResources = Rpc.make("listResources", {
+  payload: StackStagePayload,
+  success: Schema.Array(Schema.String),
+});
+
+const getState = Rpc.make("getState", {
+  payload: ResourceKeyPayload,
+  success: Schema.UndefinedOr(Schema.Unknown),
+});
+
+const setState = Rpc.make("setState", {
+  payload: {
+    ...ResourceKeyPayload,
+    value: Schema.Unknown,
+  },
+  success: Schema.Unknown,
+});
+
+const deleteState = Rpc.make("deleteState", {
+  payload: ResourceKeyPayload,
+});
+
+const deleteStack = Rpc.make("deleteStack", {
+  payload: {
+    stack: Schema.String,
+    stage: Schema.optional(Schema.String),
+  },
+});
+
+const getReplacedResources = Rpc.make("getReplacedResources", {
+  payload: StackStagePayload,
+  success: Schema.Array(Schema.Unknown),
+});
+
+const getStackOutput = Rpc.make("getStackOutput", {
+  payload: StackStagePayload,
+  success: Schema.UndefinedOr(Schema.Unknown),
+});
+
+const setStackOutput = Rpc.make("setStackOutput", {
+  payload: {
+    ...StackStagePayload,
+    value: Schema.Unknown,
+  },
+  success: Schema.Unknown,
+});
+
+export class StateRpcs extends RpcGroup.make(
+  listStacks,
+  listStages,
+  listResources,
+  getState,
+  setState,
+  deleteState,
+  deleteStack,
+  getReplacedResources,
+  getStackOutput,
+  setStackOutput,
+) {}

--- a/packages/alchemy/src/State/RpcStateStore.ts
+++ b/packages/alchemy/src/State/RpcStateStore.ts
@@ -1,0 +1,185 @@
+import * as Effect from "effect/Effect";
+import { identity } from "effect/Function";
+import * as Layer from "effect/Layer";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import { RpcClient, RpcSerialization } from "effect/unstable/rpc";
+import type { ReplacedResourceState, ResourceState } from "./ResourceState.ts";
+import { RPC_PATH, StateRpcs } from "./RpcStateApi.ts";
+import {
+  StateStoreError,
+  type PersistedState,
+  type StateService,
+} from "./State.ts";
+import { encodeState, reviveStateRecursive } from "./StateEncoding.ts";
+
+/**
+ * Credentials for the RPC-flavoured remote state store. Wire-compatible
+ * with the legacy HTTP store credentials so existing on-disk files can
+ * be reused as-is — the `url` always points at the worker's root and
+ * the RPC handler is mounted at {@link RPC_PATH} internally.
+ */
+export interface RpcStateStoreCredentials {
+  url: string;
+  /** Bearer token used to authenticate every request. */
+  authToken: string;
+}
+
+export interface RpcStateStoreProps extends RpcStateStoreCredentials {
+  /**
+   * `StateService.id` slug for telemetry. Mirrors the HTTP store's
+   * `id` prop so each concrete deployment shows up distinctly on the
+   * adoption dashboard.
+   */
+  id: string;
+  transformClient?: (
+    client: HttpClientRequest.HttpClientRequest,
+  ) => HttpClientRequest.HttpClientRequest;
+}
+
+export const makeRpcStateStore = ({
+  url,
+  authToken,
+  transformClient,
+  id,
+}: RpcStateStoreProps) =>
+  Effect.gen(function* () {
+    const protocol = RpcClient.layerProtocolHttp({
+      url: `${url}${RPC_PATH}`,
+      transformClient: (client) =>
+        HttpClient.mapRequest(client, (req) =>
+          req.pipe(
+            HttpClientRequest.bearerToken(authToken),
+            transformClient ?? identity,
+          ),
+        ),
+    }).pipe(Layer.provide(RpcSerialization.layerJson));
+
+    const client = yield* RpcClient.make(StateRpcs).pipe(
+      Effect.provide(protocol),
+    );
+
+    const service: StateService = {
+      id,
+      listStacks: () =>
+        client.listStacks().pipe(
+          Effect.map((stacks) => [...stacks]),
+          mapStateStoreError,
+        ),
+      listStages: (stack) =>
+        client.listStages({ stack }).pipe(
+          Effect.map((stages) => [...stages]),
+          mapStateStoreError,
+        ),
+      list: (request) =>
+        client.listResources(request).pipe(
+          Effect.map((fqns) => [...fqns]),
+          mapStateStoreError,
+        ),
+      get: (request) =>
+        client.getState(request).pipe(
+          Effect.map((s) =>
+            s == null ? undefined : (reviveStateRecursive(s) as ResourceState),
+          ),
+          mapStateStoreError,
+        ),
+      getReplacedResources: (request) =>
+        client.getReplacedResources(request).pipe(
+          Effect.map((resources) =>
+            resources.map(
+              (s) => reviveStateRecursive(s) as ReplacedResourceState,
+            ),
+          ),
+          mapStateStoreError,
+        ),
+      set: <V extends PersistedState>(request: {
+        stack: string;
+        stage: string;
+        fqn: string;
+        value: V;
+      }) =>
+        client
+          .setState({
+            stack: request.stack,
+            stage: request.stage,
+            fqn: request.fqn,
+            value: encodeState(request.value),
+          })
+          .pipe(
+            // Server echoes the stored value, but the client already
+            // has the canonical object (including any Redacted<T>
+            // instances); returning the input avoids a lossy round-trip.
+            Effect.map(() => request.value),
+            mapStateStoreError,
+          ),
+      delete: (request) =>
+        client.deleteState(request).pipe(Effect.asVoid, mapStateStoreError),
+      deleteStack: (request) =>
+        client
+          .deleteStack({ stack: request.stack, stage: request.stage })
+          .pipe(Effect.asVoid, mapStateStoreError),
+      getOutput: (request) =>
+        client.getStackOutput(request).pipe(
+          Effect.map((s) => (s == null ? undefined : reviveStateRecursive(s))),
+          mapStateStoreError,
+        ),
+      setOutput: (request) =>
+        client
+          .setStackOutput({
+            stack: request.stack,
+            stage: request.stage,
+            value: encodeState(request.value as any),
+          })
+          .pipe(
+            Effect.map(() => request.value),
+            mapStateStoreError,
+          ),
+    };
+    return service;
+  });
+
+/**
+ * Predicate over an `RpcClientError` (or underlying transport error)
+ * that returns `true` for failures we expect to clear up on their own.
+ * Mirrors {@link HttpStateStore.isTransient}: transport-level errors,
+ * 404 / 408 / 429, and every 5xx are retried; everything else surfaces.
+ */
+const isTransient = (e: any): boolean => {
+  const reason = e?.reason ?? e;
+  if (reason?._tag === "HttpClientError" || e?._tag === "HttpClientError") {
+    const status: number | undefined =
+      reason?.response?.status ?? e?.response?.status;
+    if (status == null) return true;
+    if (status === 404 || status === 408 || status === 429) return true;
+    return status >= 500 && status < 600;
+  }
+  // RpcClientError without an embedded HttpClientError is treated as
+  // transient too — the most common shape is a transport-level blip
+  // surfaced through the protocol layer.
+  if (e?._tag === "RpcClientError") return true;
+  return false;
+};
+
+const retryTransient = <A, Err, Req>(eff: Effect.Effect<A, Err, Req>) =>
+  Effect.retry(eff, {
+    while: isTransient,
+    schedule: Schedule.exponential(100).pipe(
+      Schedule.either(Schedule.spaced("2 seconds")),
+      Schedule.both(Schedule.recurs(5)),
+    ),
+  });
+
+const mapStateStoreError = <A, E, R>(eff: Effect.Effect<A, E, R>) =>
+  eff.pipe(
+    Effect.tapError(Effect.log),
+    retryTransient,
+    Effect.catch((e: E) =>
+      Effect.fail(
+        new StateStoreError({
+          message: e instanceof Error ? e.message : String(e),
+          cause: e instanceof Error ? e : undefined,
+        }),
+      ),
+    ),
+  ) as Effect.Effect<A, StateStoreError, R>;

--- a/packages/alchemy/src/State/index.ts
+++ b/packages/alchemy/src/State/index.ts
@@ -1,5 +1,7 @@
 export * from "./HttpStateApi.ts";
 export * from "./HttpStateStore.ts";
+export * from "./RpcStateApi.ts";
+export * from "./RpcStateStore.ts";
 export * from "./InMemoryState.ts";
 export * from "./LocalState.ts";
 export * from "./ResourceState.ts";


### PR DESCRIPTION
Switches the Cloudflare State Store from `HttpApi` to Effect's `RpcServer` / `RpcClient` (one POST per call, JSON envelope) while keeping the on-disk credential shape and the unauthenticated `/version` probe.

```ts
// before — one REST route per op
const apiClient = yield* HttpApiClient.make(StateApi, { baseUrl: url, ... });
yield* apiClient.state.getState({ params: { stack, stage, fqn } });

// after — one RPC group, one transport
const client = yield* RpcClient.make(StateRpcs).pipe(
  Effect.provide(RpcClient.layerProtocolHttp({ url: `${url}/rpc`, transformClient })),
);
yield* client.getState({ stack, stage, fqn });
```

### Added
- `State/RpcStateApi.ts` — `StateRpcs` `RpcGroup` mirroring every `StateService` op; state values pass through as `Schema.Unknown` (encoder/reviver applied by the client).
- `State/RpcStateStore.ts` — `makeRpcStateStore({ url, authToken, transformClient, id })`. Same transient-retry / `StateStoreError` mapping as the HTTP store.

### Changed
- `Cloudflare/StateStore/Api.ts` — worker now mounts `RpcServer.toHttpEffect(StateRpcs)` at `/rpc` and hand-routes `GET /version` (unauth) + bearer-token gate for everything else. `STATE_STORE_VERSION` bumped 4 → 5.
- `Cloudflare/StateStore/State.ts` — uses `makeRpcStateStore` / `RpcStateStoreCredentials` (same on-disk shape as the HTTP credentials). Version probe is now a plain `HttpClient.get(${url}/version)`.

The legacy `HttpStateApi` / `HttpStateStore` modules are still exported for callers that want the REST flavour.
