### PR TITLE
fix(cloudflare/worker): force delete scripts on teardown

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -2517,6 +2517,12 @@ export const LiveWorkerProvider = () =>
           yield* deleteScript({
             accountId: output.accountId,
             scriptName: output.workerName,
+            // Force teardown of queue consumers, durable object classes, and
+            // service bindings hanging off this worker. Without `force`, those
+            // conditions raise QueueConsumerConflict / ServiceBindingConflict
+            // and leave the script in CF. Alchemy is the source of truth for
+            // the worker, so we want a hard delete on teardown.
+            force: true,
           }).pipe(Effect.catchTag("WorkerNotFound", () => Effect.void));
         }),
         tail: ({ output }) =>


### PR DESCRIPTION
Pass `force: true` when deleting a Worker script. Without it, the call raises `QueueConsumerConflict` / `ServiceBindingConflict` and the script stays in Cloudflare whenever the worker still owns queue consumers, durable object classes that haven't been migrated away, or service bindings.

```diff
 yield* deleteScript({
   accountId: output.accountId,
   scriptName: output.workerName,
+  force: true,
 }).pipe(Effect.catchTag("WorkerNotFound", () => Effect.void));
```

Alchemy is the source of truth for the worker on teardown, so a hard delete is the intended behavior — same flag our [`scripts/cleanup-cloudflare-workers.ts`](scripts/cleanup-cloudflare-workers.ts) already uses for the same reason.

### Related

Paired with [alchemy-run/distilled#296](https://github.com/alchemy-run/distilled/pull/296), which removes a stale `{ code: 10013 }` matcher from `WorkerNotFound` in the distilled cloudflare SDK. That matcher was causing `Effect.catchTag("WorkerNotFound", ...)` in this provider to swallow unrelated errors (auth, KV namespace collisions). Once distilled publishes, bump `@distilled.cloud/cloudflare` to pick up the fix.
