### PR TITLE
docs(blog): announcement - Agents as Effects (vision draft)

### DIFF
--- a/website/src/content/docs/blog/2026-05-16-agents-as-effects.md
+++ b/website/src/content/docs/blog/2026-05-16-agents-as-effects.md
@@ -1,0 +1,327 @@
+---
+title: Agents as Effects — the third layer
+date: 2026-05-16
+draft: true
+excerpt: Infrastructure-as-Code converges state. Infrastructure-as-Effects unifies runtime and infra. Agents-as-Effects describes systems of agents in the same typed graph — and lets the agents modify themselves the only safe way: by editing code.
+---
+
+Alchemy is built in three layers, each one
+strictly above the last.
+
+The first is the IaC engine — a reconcile
+loop that converges cloud state to whatever
+your code says it should be. The second is
+Infrastructure-as-Effects: the same program
+that *describes* the Worker also *is* the
+Worker, so a bucket reference at deploy time
+and a bucket call at runtime come from the
+same `.bind(...)` ([why](/blog/2026-04-30-bindings)).
+
+The third is what this post is about. We
+think of it as Agents-as-Effects: agents and
+their prompts living inside the same typed
+graph as the resources they touch. And
+because the graph is just code, the agents
+modify themselves by editing it — not by
+issuing imperative API calls.
+
+That last sentence is the whole pitch. The
+rest of this post unpacks it.
+
+## What you can write today
+
+You can already build an agent in Alchemy.
+The shape, from
+[PR #293](https://github.com/alchemy-run/alchemy-effect/pull/293):
+
+```typescript
+export const Gateway = Cloudflare.AiGateway("Gateway", {
+  cacheTtl: 60,
+  collectLogs: true,
+});
+
+export default class ChatAgent extends Cloudflare.DurableObjectNamespace<ChatAgent>()(
+  "ChatAgent",
+  Effect.gen(function* () {
+    const ai = yield* Cloudflare.AiGateway.bind(Gateway);
+    const model = ai.model({
+      client: ai,
+      model: "@cf/moonshotai/kimi-k2.6",
+      parameters: { temperature: 0.3, maxTokens: 1024 },
+    });
+
+    return Effect.gen(function* () {
+      const persistence = yield* Chat.Persistence;
+      const chat = yield* persistence.getOrCreate("session");
+      return {
+        send: (prompt: string) =>
+          chat.generateText({ prompt }).pipe(Effect.orDie),
+      };
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          model,
+          Chat.layerPersisted({ storeId: "chat" }).pipe(
+            Layer.provideMerge(Cloudflare.DurableObjectChatPersistence),
+          ),
+        ),
+      ),
+    );
+  }),
+) {}
+```
+
+A Durable Object whose `state.storage` backs
+Effect's `Chat.Persistence`, a language
+model coming out of an AI Gateway resource,
+a `send` RPC method. One program. The
+gateway is a resource, the DO is a resource,
+the chat history lives in a resource, and
+the runtime code that talks to all of them
+sits in the same file as the declarations.
+
+## The next layer: prompts that reference resources
+
+The natural next step — what we mean by
+"Agents-as-Effects" — is to let the prompt
+itself participate in the graph. Alchemy
+already has a tagged-template form for
+splicing typed `Output<…>` values into
+strings:
+
+```typescript
+Resource: [Output.interpolate`${bucket.bucketArn}/*`]
+```
+
+Lift that into agent prompts and the system
+message becomes a node in the graph too:
+
+```typescript
+const system = Output.interpolate`
+  You are the on-call assistant for ${app.name}.
+  When a user asks about an order, look it up in
+  the table at ${OrdersTable.tableName}. The
+  customer search endpoint is ${SearchWorker.url}.
+  Persist conversation summaries to ${Memory.bucketArn}.
+`;
+```
+
+The interesting part isn't the prompt string —
+it's that *every reference inside the
+backticks is a typed `Output`*. If `OrdersTable`
+is renamed, the prompt's type breaks. If the
+table is removed from the stack, the agent
+node has no upstream and the planner refuses
+the deploy. The prompt is no longer a free-form
+string you keep in sync by hand; it's a value
+in the same graph as the IAM policies, the
+env vars, and the bindings.
+
+Same story for tools: a tool the agent can
+call is just a capability binding
+([`Binding.Service` + `Binding.Policy`](/blog/2026-04-30-bindings))
+that participates in the dependency graph
+exactly like `S3.GetObject` does.
+
+The whole thing — model, gateway, tools,
+prompt, history store, the Worker that fronts
+it — type-checks as a single Effect program.
+There is no "agent config" sitting in a YAML
+file pretending it doesn't depend on the
+infrastructure it actually depends on.
+
+## Code is the only state
+
+Here is the move that makes this more than
+just "nice infrastructure for agents."
+
+When agents are normally given the ability
+to "manage infrastructure," they get an
+imperative tool surface — `create_table`,
+`delete_worker`, `update_dns`. The agent
+holds a model of what's deployed, decides
+what to change, calls a tool, watches for
+errors, retries, polls for state, and tries
+to keep its mental picture in sync with the
+cloud's actual state. That picture drifts.
+Recovery is hard. Auditing is harder.
+
+Alchemy already solved that problem for
+humans. We don't ask you to call CRUD APIs
+in the right order — you declare the desired
+state, the reconciler converges to it
+([why](/blog/2026-05-04-reconcile)). The
+source code *is* the desired state. State
+management is the engine's job, not yours.
+
+Apply the same move to agents.
+
+An agent in this system has exactly one tool
+that touches infrastructure: **edit the
+code**. Compile it. Run the tests. If both
+pass, deploy it. If the deploy succeeds, the
+cloud now matches the new code.
+
+```text
+agent → edit *.ts → tsc → vitest → alchemy deploy → cloud
+```
+
+The agent does not track external state. It
+does not poll. It does not decide which API
+to call in which order to migrate from
+"current shape" to "desired shape." It edits
+the file, and the IaC engine does the rest.
+
+Three things drop out of this for free.
+
+**Type checking is the agent's first
+feedback signal.** `tsc -b` runs on every
+change. Half of the failure modes an
+imperative agent has to reason about
+post-hoc — wrong ARN shape, missing binding,
+stale env var — become compile errors before
+the agent ever calls a tool.
+
+**Tests run on the same program.** Because
+infra and runtime are the same Effect graph,
+the agent's vitest run exercises the actual
+handler against the actual bindings (in
+their `BackingMemory` form). "Did my change
+break the chat agent?" stops being a vibes
+question.
+
+**Preview environments are free.** Alchemy
+already supports per-stage deploys. The
+agent works on a branch, deploys to a fresh
+stage, you click a URL, you approve or
+reject. The graph that produces production
+is the same graph that produces the preview;
+the only thing that changes is the stage
+name.
+
+## The bootstrap
+
+Now compose these pieces into the actual
+product.
+
+`bun alchemy create chat-server` deploys a
+Slack-shaped service: a Worker fronting an
+HTTP and WebSocket API, a DO per channel
+holding message history, a DO per session
+holding chat state, an AI Gateway in front of
+the model, an R2 bucket for attachments.
+Standard Alchemy stack — every node visible
+in the plan, every binding type-checked.
+
+The first agent you add is a coding agent.
+Its prompt references the stack itself —
+the GitHub repo containing this `alchemy.run.ts`,
+the test command, the deploy command:
+
+```typescript
+const Coder = Cloudflare.DurableObjectNamespace<Coder>()(
+  "Coder",
+  Effect.gen(function* () {
+    const ai = yield* Cloudflare.AiGateway.bind(Gateway);
+    const repo = yield* GitHub.Repo.bind(SelfRepo);
+    // …
+    const system = Output.interpolate`
+      You are a coding agent working on ${SelfRepo.fullName}.
+      Source of truth is the repository — every change to
+      the running service is a code change you author and
+      land via a pull request.
+
+      Workflow:
+        1. Read the file you need with ${repo.getContents.name}.
+        2. Propose a diff via ${repo.createOrUpdateFile.name}.
+        3. Open a PR; CI runs tsc + vitest + a preview deploy.
+        4. Wait for the human in #${Channel.name} to merge.
+
+      Never call infrastructure APIs directly. You don't have any.
+    `;
+    // … bind the model, expose a `send` method, etc.
+  }),
+);
+```
+
+The Slack-shaped service has channels and
+people, and now it has agents. The agents
+have access to the same things people do —
+they post in channels, they get pinged, they
+read history. The coding agent's "tools" are
+GitHub bindings, not infrastructure
+bindings. The infrastructure changes
+*because the code changes*, not because the
+agent decided to call `CreateTable`.
+
+You can iterate from inside the product. Tell
+the coding agent in a channel: "add a
+moderation agent that watches #general and
+flags messages with PII." It opens a PR
+adding the new DO, the new prompt, the new
+toolkit, the new bindings. CI passes. A
+preview link appears in the channel. You
+open it, send a test message, see the
+moderation agent reply. Merge. Production
+deploys.
+
+The whole organization — channels, members,
+agents, the policies that govern them — is
+one Effect program. Adding an agent is
+adding a node. Removing one is deleting
+the file. Rerouting one is editing the
+prompt's tagged template. Reasoning about
+the system is reading the source.
+
+## Why this is the third layer, not the first
+
+You couldn't do this on top of plain
+Terraform. The infra would be there but the
+runtime wouldn't — the agent's prompt
+references resources, but those references
+would have to be smuggled in as env vars
+and rehydrated at runtime, and the type
+checker wouldn't connect the two halves. The
+prompt would drift from the schema. The
+tools would be defined twice.
+
+You couldn't do this on top of bare Effect
+either. Effect would give you the
+composition story but not the
+cloud-converging engine. You'd be back to
+"the agent edits code, then a human runs
+`terraform apply`."
+
+You need both: a reconciler underneath
+(so the agent doesn't have to manage state),
+plus a single typed program above (so the
+agent's prompts, tools, and runtime live in
+the same graph as the cloud). That's the
+shape Alchemy has been climbing toward —
+[bindings](/blog/2026-04-30-bindings),
+[the unified reconciler](/blog/2026-05-04-reconcile),
+[circular references](/blog/2026-04-25-circular-references),
+[actions](/blog/2026-05-13-actions) — every
+piece in service of being able to put this
+layer on top.
+
+That's the announcement. The first two
+floors are load-bearing. The third is what
+we're building on them, and the building is
+an autonomous organization that describes
+itself in a single program.
+
+## Where to go next
+
+- [What is Alchemy?](/what-is-alchemy) — the
+  framework in two minutes.
+- [Bindings — one line, two phases](/blog/2026-04-30-bindings) —
+  how the deploy/runtime split that agents
+  also use already works for IAM and SDK
+  clients.
+- [One reconcile, no create vs. update](/blog/2026-05-04-reconcile) —
+  why the engine converges state so the
+  agent doesn't have to.
+- [PR #293](https://github.com/alchemy-run/alchemy-effect/pull/293) —
+  the AI Gateway + DO-backed chat
+  persistence the first agent is built on.

--- a/website/src/content/docs/blog/2026-05-16-agents-as-effects.md
+++ b/website/src/content/docs/blog/2026-05-16-agents-as-effects.md
@@ -1,327 +1,341 @@
 ---
-title: Agents as Effects — the third layer
+title: Infrastructure-as-Code, Infrastructure-as-Effects, Agents-as-Effects
 date: 2026-05-16
 draft: true
-excerpt: Infrastructure-as-Code converges state. Infrastructure-as-Effects unifies runtime and infra. Agents-as-Effects describes systems of agents in the same typed graph — and lets the agents modify themselves the only safe way: by editing code.
+excerpt: Three floors stacked, each one load-bearing for the next. From the cloud resource to the runtime to the agent that lives inside it — one Effect program, type-safe, declarative, controlled end-to-end by versioned code.
 ---
 
-Alchemy is built in three layers, each one
-strictly above the last.
+Picture the whole thing in one place.
 
-The first is the IaC engine — a reconcile
-loop that converges cloud state to whatever
-your code says it should be. The second is
-Infrastructure-as-Effects: the same program
-that *describes* the Worker also *is* the
-Worker, so a bucket reference at deploy time
-and a bucket call at runtime come from the
-same `.bind(...)` ([why](/blog/2026-04-30-bindings)).
+Every cloud resource your product runs on.
+Every line of runtime code that touches
+those resources. Every agent that lives
+inside the product and helps shape it.
+Not three repositories with a wiki holding
+them together. Not a Terraform module here,
+a Worker over there, an agent configured
+in some console. **One source tree. One
+type checker. One reconciler. One deploy.**
 
-The third is what this post is about. We
-think of it as Agents-as-Effects: agents and
-their prompts living inside the same typed
-graph as the resources they touch. And
-because the graph is just code, the agents
-modify themselves by editing it — not by
-issuing imperative API calls.
+That picture is the destination. Alchemy is
+how we are trying to get there, and we are
+trying to get there by stacking three
+floors on top of each other:
 
-That last sentence is the whole pitch. The
-rest of this post unpacks it.
+- **Infrastructure-as-Code** — declare what
+  the cloud should look like; let an engine
+  converge it.
+- **Infrastructure-as-Effects** — fuse the
+  cloud and the runtime that uses it into
+  one typed program.
+- **Agents-as-Effects** — put the agents
+  inside that program too, and let them
+  modify the system the only safe way:
+  by editing the code.
 
-## What you can write today
+Each floor is load-bearing for the next.
+None of them would be enough on their own.
+This post is the story of those floors,
+and the building they make once they're
+all up.
 
-You can already build an agent in Alchemy.
-The shape, from
-[PR #293](https://github.com/alchemy-run/alchemy-effect/pull/293):
+## The first floor — Infrastructure-as-Code
 
-```typescript
-export const Gateway = Cloudflare.AiGateway("Gateway", {
-  cacheTtl: 60,
-  collectLogs: true,
-});
+There was a time before IaC. You logged
+into a cloud console and you clicked. You
+made a bucket. You wrote down its name on
+a sticky note. You created a Lambda by
+pasting some code into a textarea. You
+typed the bucket's name into an environment
+variable. You hoped you remembered which
+one was which. Two months later something
+broke, and "what is actually deployed in
+production" was a question only the senior
+engineer who had been there since the
+beginning could answer.
 
-export default class ChatAgent extends Cloudflare.DurableObjectNamespace<ChatAgent>()(
-  "ChatAgent",
-  Effect.gen(function* () {
-    const ai = yield* Cloudflare.AiGateway.bind(Gateway);
-    const model = ai.model({
-      client: ai,
-      model: "@cf/moonshotai/kimi-k2.6",
-      parameters: { temperature: 0.3, maxTokens: 1024 },
-    });
+IaC was the response. You write down what
+you want the cloud to look like. A tool
+converges the cloud to match. The source
+of truth lives in your repository instead
+of in someone's head. Diffs are reviewable.
+Rollbacks are real. The cloud stops being
+folklore.
 
-    return Effect.gen(function* () {
-      const persistence = yield* Chat.Persistence;
-      const chat = yield* persistence.getOrCreate("session");
-      return {
-        send: (prompt: string) =>
-          chat.generateText({ prompt }).pipe(Effect.orDie),
-      };
-    }).pipe(
-      Effect.provide(
-        Layer.mergeAll(
-          model,
-          Chat.layerPersisted({ storeId: "chat" }).pipe(
-            Layer.provideMerge(Cloudflare.DurableObjectChatPersistence),
-          ),
-        ),
-      ),
-    );
-  }),
-) {}
-```
+This was a real shift, and it is the floor
+everything else stands on. The author no
+longer manages state imperatively — no more
+"create the bucket, then the role, then
+attach the policy, then update the env
+var." They declare the desired state, and
+the engine reconciles. State management is
+the engine's job. The author's job is to
+say what should exist.
 
-A Durable Object whose `state.storage` backs
-Effect's `Chat.Persistence`, a language
-model coming out of an AI Gateway resource,
-a `send` RPC method. One program. The
-gateway is a resource, the DO is a resource,
-the chat history lives in a resource, and
-the runtime code that talks to all of them
-sits in the same file as the declarations.
+But there is still a seam, and the seam is
+the whole story of why we kept building.
 
-## The next layer: prompts that reference resources
+The seam is this. The infrastructure lives
+in one language. The runtime lives in
+another. Two worlds joined by ARNs smuggled
+through environment variables and IAM
+policies typed by hand. You rename a
+resource on the infra side and the handler
+on the runtime side hardcodes the old name
+and your test suite has no idea. The
+bridge is brittle because the type checker
+on either side cannot see across it.
 
-The natural next step — what we mean by
-"Agents-as-Effects" — is to let the prompt
-itself participate in the graph. Alchemy
-already has a tagged-template form for
-splicing typed `Output<…>` values into
-strings:
+## The second floor — Infrastructure-as-Effects
 
-```typescript
-Resource: [Output.interpolate`${bucket.bucketArn}/*`]
-```
+Now imagine the seam isn't there.
 
-Lift that into agent prompts and the system
-message becomes a node in the graph too:
+The bucket isn't a resource declared in
+Terraform and consumed in TypeScript. The
+bucket is a value in a TypeScript program.
+The Worker that uses the bucket is another
+value in the same program. A single line —
+`yield* bucket.bind(...)` — wires the IAM
+policy at deploy time and hands the runtime
+a typed client. Rename the bucket and the
+handler breaks at compile time, not in
+production. Add a method call the policy
+doesn't cover and the compiler will tell
+you, before you ever deploy.
 
-```typescript
-const system = Output.interpolate`
-  You are the on-call assistant for ${app.name}.
-  When a user asks about an order, look it up in
-  the table at ${OrdersTable.tableName}. The
-  customer search endpoint is ${SearchWorker.url}.
-  Persist conversation summaries to ${Memory.bucketArn}.
-`;
-```
+This is what we shipped as Alchemy.
 
-The interesting part isn't the prompt string —
-it's that *every reference inside the
-backticks is a typed `Output`*. If `OrdersTable`
-is renamed, the prompt's type breaks. If the
-table is removed from the stack, the agent
-node has no upstream and the planner refuses
-the deploy. The prompt is no longer a free-form
-string you keep in sync by hand; it's a value
-in the same graph as the IAM policies, the
-env vars, and the bindings.
+We call it Infrastructure-as-Effects because
+every node — the bucket, the policy, the
+Worker, the handler that runs inside it —
+is an Effect. Effects compose. Effects
+carry typed errors. Effects aggregate
+dependencies up the call tree. So the
+program that *describes* the cloud and the
+program that *runs on* the cloud become
+the same program, written in the same
+language, checked by the same type
+checker, deployed by the same command.
 
-Same story for tools: a tool the agent can
-call is just a capability binding
-([`Binding.Service` + `Binding.Policy`](/blog/2026-04-30-bindings))
-that participates in the dependency graph
-exactly like `S3.GetObject` does.
+Two worlds collapse into one. The bridge
+disappears, because there is nothing left
+on either side of it.
 
-The whole thing — model, gateway, tools,
-prompt, history store, the Worker that fronts
-it — type-checks as a single Effect program.
-There is no "agent config" sitting in a YAML
-file pretending it doesn't depend on the
-infrastructure it actually depends on.
+The author's life gets simpler again. They
+don't write IaC and runtime separately and
+keep them in sync. They write one thing. A
+declaration is a value, a runtime call is
+a value, a binding between them is a
+value, and the whole thing is reasoned
+about end to end by one program.
 
-## Code is the only state
+We've spent the last year-ish making this
+real. [Bindings.](/blog/2026-04-30-bindings)
+[Reconcilers.](/blog/2026-05-04-reconcile)
+[Circular references.](/blog/2026-04-25-circular-references)
+[Actions.](/blog/2026-05-13-actions) Every
+piece in service of the same simple
+principle: one program for everything that
+runs in the cloud.
 
-Here is the move that makes this more than
-just "nice infrastructure for agents."
+That principle is the second floor. And on
+top of it, you can finally put something
+that wouldn't have been safe to put on
+either of the first two alone.
 
-When agents are normally given the ability
-to "manage infrastructure," they get an
-imperative tool surface — `create_table`,
-`delete_worker`, `update_dns`. The agent
-holds a model of what's deployed, decides
-what to change, calls a tool, watches for
-errors, retries, polls for state, and tries
-to keep its mental picture in sync with the
-cloud's actual state. That picture drifts.
-Recovery is hard. Auditing is harder.
+## The third floor — Agents-as-Effects
 
-Alchemy already solved that problem for
-humans. We don't ask you to call CRUD APIs
-in the right order — you declare the desired
-state, the reconciler converges to it
-([why](/blog/2026-05-04-reconcile)). The
-source code *is* the desired state. State
-management is the engine's job, not yours.
+Once everything is one program, the agents
+can move in too.
 
-Apply the same move to agents.
+An agent in this picture is not a service
+living outside your infrastructure that
+has to be configured to know about it. It
+is a node in the same graph as the bucket
+and the Worker, sitting alongside them.
+Its prompt is not a string in a config
+file you keep in sync by hand; it is a
+value, with the same typed references to
+resources that the Worker uses. Its tools
+are not a separate registry to maintain;
+they are bindings, exactly the same shape
+as the bindings your handlers already use.
+Its dependencies bubble up the same `Req`
+channel that everything else's does.
+Remove the resource the agent depends on
+and the agent's type breaks. Provide the
+resource and the deploy goes through.
 
-An agent in this system has exactly one tool
-that touches infrastructure: **edit the
-code**. Compile it. Run the tests. If both
-pass, deploy it. If the deploy succeeds, the
-cloud now matches the new code.
+Stack. Worker. Agent. One program. One
+type checker. One reconciler. One deploy.
 
-```text
-agent → edit *.ts → tsc → vitest → alchemy deploy → cloud
-```
+That is the architectural picture. And it
+is already, on its own, a thing worth
+having. But the reason we are excited
+about this floor — the reason we built the
+first two — is what becomes possible once
+the agents are *inside* the program rather
+than outside it.
 
-The agent does not track external state. It
-does not poll. It does not decide which API
-to call in which order to migrate from
-"current shape" to "desired shape." It edits
-the file, and the IaC engine does the rest.
+## The move that ties it together
 
-Three things drop out of this for free.
+Here is the part that turns the three
+floors into a building.
 
-**Type checking is the agent's first
-feedback signal.** `tsc -b` runs on every
-change. Half of the failure modes an
-imperative agent has to reason about
-post-hoc — wrong ARN shape, missing binding,
-stale env var — become compile errors before
-the agent ever calls a tool.
+When agents are bolted onto an imperative
+tool surface — `create_table`, `update_dns`,
+`delete_worker`, `restart_service` — they
+have to manage state. They hold a mental
+picture of what is deployed. They issue
+calls to change it. They watch for errors.
+They retry. They poll. They drift. They
+guess. Every imperative tool you give them
+is a new way for their picture of the
+world to be wrong.
 
-**Tests run on the same program.** Because
-infra and runtime are the same Effect graph,
-the agent's vitest run exercises the actual
-handler against the actual bindings (in
-their `BackingMemory` form). "Did my change
-break the chat agent?" stops being a vibes
-question.
+We already solved that problem for the
+human. The human doesn't call CRUD APIs
+in the right order. The human declares
+the desired state and the engine
+converges to it. **Source code is the
+truth. State management is the engine's
+responsibility, not the author's.**
 
-**Preview environments are free.** Alchemy
-already supports per-stage deploys. The
-agent works on a branch, deploys to a fresh
-stage, you click a URL, you approve or
-reject. The graph that produces production
-is the same graph that produces the preview;
-the only thing that changes is the stage
-name.
+So we do exactly the same thing for the
+agent.
 
-## The bootstrap
+The agent has one tool that touches the
+system: **edit the code.** Open the file.
+Change the value. Run the type checker.
+Run the tests. Open a pull request. If
+everything passes, the deploy goes out,
+the cloud converges, the runtime updates,
+the agent's own prompt — if it referenced
+a renamed resource — comes back type-safe.
 
-Now compose these pieces into the actual
-product.
+The agent did not manage state. It did
+not call infrastructure APIs. It did not
+keep a picture of what's deployed. It
+modified a file in a git repository the
+same way a human teammate would, and the
+same machinery that handles the human's
+change handles the agent's. Type checks.
+Tests. Preview environment. Review.
+Merge. Deploy.
 
-`bun alchemy create chat-server` deploys a
-Slack-shaped service: a Worker fronting an
-HTTP and WebSocket API, a DO per channel
-holding message history, a DO per session
-holding chat state, an AI Gateway in front of
-the model, an R2 bucket for attachments.
-Standard Alchemy stack — every node visible
-in the plan, every binding type-checked.
+This is what we mean by **stateless from
+the author's perspective**. Neither the
+human nor the agent ever has to know what
+is actually deployed. They write code.
+The engine reconciles. The source is the
+desired state. Everything else is the
+engine's problem.
 
-The first agent you add is a coding agent.
-Its prompt references the stack itself —
-the GitHub repo containing this `alchemy.run.ts`,
-the test command, the deploy command:
+The same property that made IaC worth
+building in the first place — *the author
+declares; the engine reconciles* — now
+extends all the way up the stack. To the
+runtime. To the agents. To the
+organization the agents are members of.
 
-```typescript
-const Coder = Cloudflare.DurableObjectNamespace<Coder>()(
-  "Coder",
-  Effect.gen(function* () {
-    const ai = yield* Cloudflare.AiGateway.bind(Gateway);
-    const repo = yield* GitHub.Repo.bind(SelfRepo);
-    // …
-    const system = Output.interpolate`
-      You are a coding agent working on ${SelfRepo.fullName}.
-      Source of truth is the repository — every change to
-      the running service is a code change you author and
-      land via a pull request.
+## What the building looks like
 
-      Workflow:
-        1. Read the file you need with ${repo.getContents.name}.
-        2. Propose a diff via ${repo.createOrUpdateFile.name}.
-        3. Open a PR; CI runs tsc + vitest + a preview deploy.
-        4. Wait for the human in #${Channel.name} to merge.
+So what does an organization look like
+when it's described this way?
 
-      Never call infrastructure APIs directly. You don't have any.
-    `;
-    // … bind the model, expose a `send` method, etc.
-  }),
-);
-```
+A repository. One file at the top. Inside
+it: a chat-shaped service — channels,
+members, messages, an HTTP and WebSocket
+front door. Sitting alongside it in the
+same program: a handful of agents, each
+one a node in the graph, each one with a
+typed prompt that references the resources
+it uses and a typed toolkit of bindings.
+Among them, the first one we deploy: a
+coding agent, whose prompt references the
+repository itself.
 
-The Slack-shaped service has channels and
-people, and now it has agents. The agents
-have access to the same things people do —
-they post in channels, they get pinged, they
-read history. The coding agent's "tools" are
-GitHub bindings, not infrastructure
-bindings. The infrastructure changes
-*because the code changes*, not because the
-agent decided to call `CreateTable`.
+You talk to the coding agent in a channel.
+You say, "add a moderation agent that
+watches `#general`." The agent opens a
+pull request. CI runs the type checker.
+CI runs the tests. CI deploys a preview
+to a fresh stage. A link appears back in
+the channel. You click the link and you
+are talking to the proposed moderation
+agent in a parallel universe of the
+service. You verify it does what you
+wanted. You merge. Production deploys.
+The channel now has a new member.
 
-You can iterate from inside the product. Tell
-the coding agent in a channel: "add a
-moderation agent that watches #general and
-flags messages with PII." It opens a PR
-adding the new DO, the new prompt, the new
-toolkit, the new bindings. CI passes. A
-preview link appears in the channel. You
-open it, send a test message, see the
-moderation agent reply. Merge. Production
-deploys.
+No one ran a script. No one updated a
+wiki. No one logged into a console. The
+change went through the same path every
+other change goes through — code, review,
+type-checks, tests, preview, merge — and
+the cloud quietly converged at the end of
+it.
 
-The whole organization — channels, members,
-agents, the policies that govern them — is
-one Effect program. Adding an agent is
-adding a node. Removing one is deleting
-the file. Rerouting one is editing the
-prompt's tagged template. Reasoning about
-the system is reading the source.
+The system has rearranged itself, and
+every step of the rearrangement is in the
+git history.
 
-## Why this is the third layer, not the first
+## Why all three floors are needed
 
-You couldn't do this on top of plain
-Terraform. The infra would be there but the
-runtime wouldn't — the agent's prompt
-references resources, but those references
-would have to be smuggled in as env vars
-and rehydrated at runtime, and the type
-checker wouldn't connect the two halves. The
-prompt would drift from the schema. The
-tools would be defined twice.
+You could not build this on plain
+Terraform. The infrastructure would be
+there but the runtime would not, and the
+agent's prompt would reference resources
+that the type checker couldn't see, and
+the seam between infra and runtime that
+broke things for humans would break them
+for agents too — only faster.
 
-You couldn't do this on top of bare Effect
-either. Effect would give you the
-composition story but not the
-cloud-converging engine. You'd be back to
-"the agent edits code, then a human runs
-`terraform apply`."
+You could not build it on plain Effect
+either. The composition story would be
+there but the cloud-converging engine
+would not, and the agent's "edit the
+code" workflow would terminate at a
+commit that doesn't actually deploy
+itself.
 
-You need both: a reconciler underneath
-(so the agent doesn't have to manage state),
-plus a single typed program above (so the
-agent's prompts, tools, and runtime live in
-the same graph as the cloud). That's the
-shape Alchemy has been climbing toward —
-[bindings](/blog/2026-04-30-bindings),
-[the unified reconciler](/blog/2026-05-04-reconcile),
-[circular references](/blog/2026-04-25-circular-references),
-[actions](/blog/2026-05-13-actions) — every
-piece in service of being able to put this
-layer on top.
+You need both. A reconciler underneath,
+so neither human nor agent ever has to
+manage state. A single typed program
+above, so the agent's prompts and tools
+and runtime live in the same graph as
+the cloud they touch. The floors have to
+stack, in that order, each one strictly
+above the last.
 
-That's the announcement. The first two
-floors are load-bearing. The third is what
-we're building on them, and the building is
-an autonomous organization that describes
-itself in a single program.
+That stack is what Alchemy is.
 
-## Where to go next
+## What we mean by an organization in one program
 
-- [What is Alchemy?](/what-is-alchemy) — the
-  framework in two minutes.
-- [Bindings — one line, two phases](/blog/2026-04-30-bindings) —
-  how the deploy/runtime split that agents
-  also use already works for IAM and SDK
-  clients.
-- [One reconcile, no create vs. update](/blog/2026-05-04-reconcile) —
-  why the engine converges state so the
-  agent doesn't have to.
-- [PR #293](https://github.com/alchemy-run/alchemy-effect/pull/293) —
-  the AI Gateway + DO-backed chat
-  persistence the first agent is built on.
+An organization is not the boxes on the
+org chart. It is the work the people do
+and the systems they do it on. Most
+software companies today describe pieces
+of that — the infrastructure in one
+place, the application in another, the
+processes in a wiki, the agents in some
+third-party tool — and the rest is held
+together by tradition and Slack threads.
+
+We think it can all live in one program.
+Type-checked. Declarative. Versioned.
+The cloud the company runs on, the code
+that runs in that cloud, and the agents
+that work alongside the humans inside
+that code — all of it in a source tree
+you can clone, read, and reason about
+end to end.
+
+That is the announcement. The first two
+floors are built. The third is going up.
+The first thing we are putting on it is
+a chat-shaped service whose first member
+is a coding agent pointed at the repo
+that describes it.
+
+From there, the system writes itself.

--- a/website/src/content/docs/blog/2026-05-16-agents-as-effects.md
+++ b/website/src/content/docs/blog/2026-05-16-agents-as-effects.md
@@ -2,7 +2,7 @@
 title: Infrastructure-as-Code, Infrastructure-as-Effects, Agents-as-Effects
 date: 2026-05-16
 draft: true
-excerpt: Three floors stacked, each one load-bearing for the next. From the cloud resource to the runtime to the agent that lives inside it — one Effect program, type-safe, declarative, controlled end-to-end by versioned code.
+excerpt: Three floors stacked, each one load-bearing for the next. The "as Effects" thread is what merges them — one declarative, type-safe program that holds the cloud, the runtime that uses it, and the agents that live inside it.
 ---
 
 Picture the whole thing in one place.
@@ -14,328 +14,384 @@ inside the product and helps shape it.
 Not three repositories with a wiki holding
 them together. Not a Terraform module here,
 a Worker over there, an agent configured
-in some console. **One source tree. One
-type checker. One reconciler. One deploy.**
+in some console.
 
-That picture is the destination. Alchemy is
-how we are trying to get there, and we are
+**One source tree. One type checker.
+One reconciler. One deploy.**
+
+That picture is the destination. Alchemy
+is how we are trying to get there. We are
 trying to get there by stacking three
 floors on top of each other:
 
-- **Infrastructure-as-Code** — declare what
-  the cloud should look like; let an engine
-  converge it.
-- **Infrastructure-as-Effects** — fuse the
-  cloud and the runtime that uses it into
-  one typed program.
-- **Agents-as-Effects** — put the agents
-  inside that program too, and let them
-  modify the system the only safe way:
-  by editing the code.
+1. **Infrastructure-as-Code** — declare
+   what the cloud should look like; let
+   an engine converge it.
+2. **Infrastructure-as-Effects** — fuse
+   the cloud and the runtime that uses it
+   into one typed program.
+3. **Agents-as-Effects** — put the agents
+   inside that program too, and let them
+   modify the system the only safe way:
+   by editing the code.
 
 Each floor is load-bearing for the next.
-None of them would be enough on their own.
-This post is the story of those floors,
-and the building they make once they're
-all up.
+None of them would be enough on its own.
+And the part of each name that does the
+real work — the part that lets them stack
+at all — is the two words at the end.
 
-## The first floor — Infrastructure-as-Code
+*As Effects.*
+
+## What "as Effects" means
+
+Effect is a way of writing code where every
+computation is a value. Each value is typed.
+Each value carries its dependencies in its
+type. Each value carries its errors in its
+type. Two values compose by yielding one
+inside the other, and the result is itself
+a value of the same shape. Nothing leaks
+out the side. Nothing escapes the type
+system.
+
+Once you start writing this way, the
+boundaries between things you used to think
+of as different stop existing. A bucket is
+a value. A handler that reads from the
+bucket is a value. The IAM policy that
+makes the read possible is a value. The
+agent that helps shape the system is a
+value. They all live in the same tree.
+They speak the same language. They are
+checked by the same compiler. They are
+deployed by the same command.
+
+This is the unification that makes the
+three floors stack. Not a marketing word
+for the layers — *the actual common
+substrate.* The cloud is Effects. The
+runtime is Effects. The agents are
+Effects. The program you write is the
+graph that ties them together, and the
+graph is the source of truth from the
+console at the bottom of your stack to
+the LLM call at the top.
+
+That is the claim. The rest of this post
+is what it buys you, one floor at a time.
+
+## Floor one — Infrastructure-as-Code
 
 There was a time before IaC. You logged
-into a cloud console and you clicked. You
-made a bucket. You wrote down its name on
-a sticky note. You created a Lambda by
-pasting some code into a textarea. You
-typed the bucket's name into an environment
-variable. You hoped you remembered which
-one was which. Two months later something
-broke, and "what is actually deployed in
-production" was a question only the senior
-engineer who had been there since the
-beginning could answer.
+into a cloud console and clicked. You
+made a bucket, scribbled its name on a
+sticky note, pasted some code into a
+Lambda textarea, typed the bucket's name
+into an environment variable, and hoped
+to remember which was which. Two months
+later something broke, and the answer to
+"what is actually deployed in production"
+lived in someone's head.
 
 IaC was the response. You write down what
 you want the cloud to look like. A tool
 converges the cloud to match. The source
-of truth lives in your repository instead
-of in someone's head. Diffs are reviewable.
-Rollbacks are real. The cloud stops being
-folklore.
+of truth lives in your repository. Diffs
+are reviewable. Rollbacks are real. The
+cloud stops being folklore.
 
-This was a real shift, and it is the floor
-everything else stands on. The author no
-longer manages state imperatively — no more
-"create the bucket, then the role, then
-attach the policy, then update the env
-var." They declare the desired state, and
-the engine reconciles. State management is
-the engine's job. The author's job is to
-say what should exist.
+This was a real shift, and it is the
+floor everything else stands on. **The
+author no longer manages state. They
+declare it. The engine reconciles.** Hold
+on to that sentence; it is the entire
+product, said in seven words. It is going
+to get repeated.
 
-But there is still a seam, and the seam is
-the whole story of why we kept building.
+But there is still a seam, and the seam
+is the whole reason we kept building.
 
-The seam is this. The infrastructure lives
-in one language. The runtime lives in
-another. Two worlds joined by ARNs smuggled
-through environment variables and IAM
-policies typed by hand. You rename a
-resource on the infra side and the handler
-on the runtime side hardcodes the old name
-and your test suite has no idea. The
-bridge is brittle because the type checker
-on either side cannot see across it.
+The infrastructure lives in one tool, in
+one language. The runtime — the Lambda,
+the Worker, the handler — lives in
+another. The two sides talk through ARNs
+smuggled in environment variables and
+IAM policies typed by hand. You rename a
+resource on the infra side; the handler
+on the runtime side hardcodes the old
+name; nothing catches the mismatch until
+production does. The bridge is brittle
+because the type checker on either side
+cannot see across it.
 
-## The second floor — Infrastructure-as-Effects
+Two worlds. One narrow plank between them.
 
-Now imagine the seam isn't there.
+## Floor two — Infrastructure-as-Effects
 
-The bucket isn't a resource declared in
-Terraform and consumed in TypeScript. The
-bucket is a value in a TypeScript program.
-The Worker that uses the bucket is another
-value in the same program. A single line —
+Now imagine the plank isn't there.
+
+The bucket isn't declared on one side and
+consumed on the other. The bucket is a
+value in a TypeScript program. The Worker
+that uses the bucket is another value in
+the same program. A single line —
 `yield* bucket.bind(...)` — wires the IAM
 policy at deploy time and hands the runtime
 a typed client. Rename the bucket and the
-handler breaks at compile time, not in
-production. Add a method call the policy
-doesn't cover and the compiler will tell
-you, before you ever deploy.
+handler breaks at compile time, not at
+3 a.m. Add a method the policy doesn't
+cover and the compiler will tell you,
+before you ever ship.
 
-This is what we shipped as Alchemy.
+The reason this works is that the bucket,
+the policy, the binding, and the handler
+are *all Effects*. Effects compose. Effects
+carry their dependencies up the call tree.
+Effects carry their errors in the type
+system. So the program that *describes*
+the cloud and the program that *runs on*
+the cloud become the same program, written
+in the same language, checked by the same
+compiler, deployed by the same command.
 
-We call it Infrastructure-as-Effects because
-every node — the bucket, the policy, the
-Worker, the handler that runs inside it —
-is an Effect. Effects compose. Effects
-carry typed errors. Effects aggregate
-dependencies up the call tree. So the
-program that *describes* the cloud and the
-program that *runs on* the cloud become
-the same program, written in the same
-language, checked by the same type
-checker, deployed by the same command.
+The two worlds don't get bridged. They
+collapse. There is no bridge anymore
+because there is nothing on either side
+of it.
 
-Two worlds collapse into one. The bridge
-disappears, because there is nothing left
-on either side of it.
+This is what we shipped. We have spent
+the better part of a year making the
+abstractions earn their keep —
+[bindings](/blog/2026-04-30-bindings),
+[reconcilers](/blog/2026-05-04-reconcile),
+[circular references](/blog/2026-04-25-circular-references),
+[actions](/blog/2026-05-13-actions) —
+and every one of those pieces exists for
+the same reason: to keep the promise that
+your cloud and your code are one program.
 
-The author's life gets simpler again. They
-don't write IaC and runtime separately and
-keep them in sync. They write one thing. A
-declaration is a value, a runtime call is
-a value, a binding between them is a
-value, and the whole thing is reasoned
-about end to end by one program.
+The author's life gets simpler again.
+They don't write IaC and runtime
+separately and keep them in sync. They
+write one thing. One file, or one tree
+of files, with the cloud and the code
+that runs on it sitting side by side as
+peers — values of the same kind, composed
+the same way, type-checked together.
 
-We've spent the last year-ish making this
-real. [Bindings.](/blog/2026-04-30-bindings)
-[Reconcilers.](/blog/2026-05-04-reconcile)
-[Circular references.](/blog/2026-04-25-circular-references)
-[Actions.](/blog/2026-05-13-actions) Every
-piece in service of the same simple
-principle: one program for everything that
-runs in the cloud.
+And the same sentence as before still
+holds, just bigger this time. The author
+no longer manages state. They declare
+it — the cloud, *and* the runtime that
+uses it. The engine reconciles.
 
-That principle is the second floor. And on
-top of it, you can finally put something
-that wouldn't have been safe to put on
-either of the first two alone.
+That is floor two. On top of it, something
+becomes possible that wouldn't have been
+safe on either of the first two alone.
 
-## The third floor — Agents-as-Effects
+## Floor three — Agents-as-Effects
 
-Once everything is one program, the agents
-can move in too.
+Once everything is one program of Effects,
+the agents can move in.
 
 An agent in this picture is not a service
 living outside your infrastructure that
 has to be configured to know about it. It
 is a node in the same graph as the bucket
-and the Worker, sitting alongside them.
-Its prompt is not a string in a config
-file you keep in sync by hand; it is a
-value, with the same typed references to
-resources that the Worker uses. Its tools
-are not a separate registry to maintain;
-they are bindings, exactly the same shape
-as the bindings your handlers already use.
-Its dependencies bubble up the same `Req`
-channel that everything else's does.
-Remove the resource the agent depends on
-and the agent's type breaks. Provide the
-resource and the deploy goes through.
+and the Worker. Its prompt is not a free
+string in a config file you keep in sync
+by hand — it is a value, with the same
+typed references to resources that the
+Worker uses. Its tools are not a separate
+registry — they are bindings, the exact
+same shape as `S3.GetObject.bind(bucket)`.
+Its dependencies bubble up the `Req`
+channel the same way every other Effect's
+do. Remove the resource the agent depends
+on and the agent's type breaks. Provide
+it and the deploy goes through.
 
-Stack. Worker. Agent. One program. One
-type checker. One reconciler. One deploy.
+There is no new framework here. There is
+no agent runtime separate from the
+application runtime. There is no schema
+that has to be kept in sync with the
+infrastructure. The agent is an Effect.
+The bucket is an Effect. The binding
+between them is an Effect. The graph that
+holds them is a TypeScript program.
 
-That is the architectural picture. And it
-is already, on its own, a thing worth
-having. But the reason we are excited
-about this floor — the reason we built the
-first two — is what becomes possible once
-the agents are *inside* the program rather
-than outside it.
+Stack. Worker. Agent. **One program.**
+One type checker. One reconciler.
+One deploy.
 
-## The move that ties it together
+This is the architectural payoff of the
+floors stacking. But it is not yet the
+real prize. The real prize is what
+happens when you take the IaC principle
+seriously — the one we keep repeating —
+and let it climb all the way to the top.
 
-Here is the part that turns the three
-floors into a building.
+## The pattern, applied to the agent
 
 When agents are bolted onto an imperative
 tool surface — `create_table`, `update_dns`,
 `delete_worker`, `restart_service` — they
 have to manage state. They hold a mental
-picture of what is deployed. They issue
-calls to change it. They watch for errors.
-They retry. They poll. They drift. They
-guess. Every imperative tool you give them
-is a new way for their picture of the
-world to be wrong.
+model of what is deployed. They issue
+calls to change it. They watch for
+errors. They retry. They poll. They
+drift. They guess. Every imperative tool
+you give them is a new way for their
+picture of the world to be wrong.
 
-We already solved that problem for the
-human. The human doesn't call CRUD APIs
-in the right order. The human declares
-the desired state and the engine
-converges to it. **Source code is the
-truth. State management is the engine's
-responsibility, not the author's.**
+We already solved that problem. Not for
+the agent — for the human. **The human
+no longer manages state. They declare it.
+The engine reconciles.** It is the only
+sentence the framework has ever really
+said.
 
-So we do exactly the same thing for the
-agent.
+So we say it again. **The agent no
+longer manages state. It declares it.
+The engine reconciles.**
 
-The agent has one tool that touches the
-system: **edit the code.** Open the file.
-Change the value. Run the type checker.
-Run the tests. Open a pull request. If
-everything passes, the deploy goes out,
-the cloud converges, the runtime updates,
-the agent's own prompt — if it referenced
-a renamed resource — comes back type-safe.
+The agent has exactly one tool that
+touches the system: *edit the code.*
+Open the file. Change the value. Run the
+type checker. Run the tests. Open a pull
+request. If everything passes, the deploy
+goes out, the cloud converges, the
+runtime updates, the agent's own prompt —
+if it referenced a renamed resource —
+comes back type-safe in the next plan.
 
-The agent did not manage state. It did
-not call infrastructure APIs. It did not
-keep a picture of what's deployed. It
-modified a file in a git repository the
-same way a human teammate would, and the
-same machinery that handles the human's
-change handles the agent's. Type checks.
-Tests. Preview environment. Review.
-Merge. Deploy.
+The agent did not call infrastructure
+APIs. It did not keep a picture of what's
+deployed. It did not race with itself or
+with another agent. It edited a file in
+a git repository, the same way a human
+teammate would, and the same machinery
+that handles the human's change handles
+the agent's. Type checks. Tests. Preview
+environment. Review. Merge. Deploy.
 
 This is what we mean by **stateless from
 the author's perspective**. Neither the
 human nor the agent ever has to know what
 is actually deployed. They write code.
-The engine reconciles. The source is the
-desired state. Everything else is the
-engine's problem.
+The source is the desired state.
+Everything else is the engine's problem.
 
 The same property that made IaC worth
-building in the first place — *the author
-declares; the engine reconciles* — now
-extends all the way up the stack. To the
-runtime. To the agents. To the
+building in the first place now extends
+all the way up the stack — through the
+runtime, through the agents, into the
 organization the agents are members of.
 
-## What the building looks like
-
-So what does an organization look like
-when it's described this way?
+## What it looks like
 
 A repository. One file at the top. Inside
-it: a chat-shaped service — channels,
-members, messages, an HTTP and WebSocket
-front door. Sitting alongside it in the
-same program: a handful of agents, each
-one a node in the graph, each one with a
-typed prompt that references the resources
-it uses and a typed toolkit of bindings.
+it, a chat-shaped service: channels,
+members, message history, an HTTP and
+WebSocket front door. Sitting next to it
+in the same program, a handful of
+agents — each one a node in the graph,
+each one with a typed prompt that
+references the resources it uses, each
+one with a typed toolkit of bindings.
+
 Among them, the first one we deploy: a
 coding agent, whose prompt references the
 repository itself.
 
-You talk to the coding agent in a channel.
-You say, "add a moderation agent that
-watches `#general`." The agent opens a
-pull request. CI runs the type checker.
-CI runs the tests. CI deploys a preview
-to a fresh stage. A link appears back in
-the channel. You click the link and you
-are talking to the proposed moderation
-agent in a parallel universe of the
-service. You verify it does what you
-wanted. You merge. Production deploys.
-The channel now has a new member.
+You talk to the coding agent in a
+channel. You say, "add a moderation
+agent that watches `#general` and flags
+PII." The agent opens a pull request. CI
+runs the type checker. CI runs the tests.
+CI deploys a preview to a fresh stage. A
+link appears back in the channel. You
+click it. You are talking to the
+proposed moderation agent in a parallel
+universe of the service. You verify it
+does what you wanted. You merge.
+Production deploys. The channel has a
+new member.
 
 No one ran a script. No one updated a
 wiki. No one logged into a console. The
 change went through the same path every
 other change goes through — code, review,
-type-checks, tests, preview, merge — and
-the cloud quietly converged at the end of
-it.
+type checks, tests, preview, merge — and
+the cloud quietly converged at the end
+of it.
 
 The system has rearranged itself, and
-every step of the rearrangement is in the
-git history.
+every step of the rearrangement is in
+the git history.
 
-## Why all three floors are needed
+## Why each floor needs the others
 
 You could not build this on plain
 Terraform. The infrastructure would be
-there but the runtime would not, and the
+there but the runtime would not. The
 agent's prompt would reference resources
-that the type checker couldn't see, and
-the seam between infra and runtime that
-broke things for humans would break them
-for agents too — only faster.
+the type checker couldn't see. The seam
+that broke things for humans would break
+them faster for agents.
 
-You could not build it on plain Effect
-either. The composition story would be
-there but the cloud-converging engine
-would not, and the agent's "edit the
-code" workflow would terminate at a
-commit that doesn't actually deploy
-itself.
+You could not build it on plain Effect.
+The composition story would be there but
+the cloud-converging engine would not.
+The agent's "edit the code" workflow
+would terminate at a commit that doesn't
+deploy itself.
 
-You need both. A reconciler underneath,
-so neither human nor agent ever has to
-manage state. A single typed program
-above, so the agent's prompts and tools
-and runtime live in the same graph as
-the cloud they touch. The floors have to
-stack, in that order, each one strictly
-above the last.
+You need both, in that order. A reconciler
+underneath, so neither human nor agent
+ever has to manage state. A graph of
+Effects above it, so the agent's prompts
+and tools and runtime are first-class
+nodes in the same program as the cloud.
+Each floor exists to make the next one
+possible.
 
-That stack is what Alchemy is.
-
-## What we mean by an organization in one program
+## The vision, said straight
 
 An organization is not the boxes on the
 org chart. It is the work the people do
 and the systems they do it on. Most
-software companies today describe pieces
-of that — the infrastructure in one
-place, the application in another, the
+software companies describe pieces of
+that — the infrastructure in one place,
+the application in another, the
 processes in a wiki, the agents in some
-third-party tool — and the rest is held
-together by tradition and Slack threads.
+third-party console — and the rest is
+held together by tradition and Slack
+threads.
 
-We think it can all live in one program.
+We think the whole thing can live in one
+program.
+
 Type-checked. Declarative. Versioned.
-The cloud the company runs on, the code
-that runs in that cloud, and the agents
-that work alongside the humans inside
-that code — all of it in a source tree
-you can clone, read, and reason about
-end to end.
+The cloud the company runs on. The code
+that runs in that cloud. The agents that
+work alongside the humans inside that
+code. All of it visible in one source
+tree, reasoned about by one type checker,
+deployed by one reconciler, modified by
+one workflow: write code, run tests,
+ship.
 
-That is the announcement. The first two
-floors are built. The third is going up.
-The first thing we are putting on it is
-a chat-shaped service whose first member
-is a coding agent pointed at the repo
-that describes it.
+Effects all the way down — from the
+console at the bottom of the stack to
+the LLM call at the top.
+
+The first two floors are built. The
+third is going up. The first thing we
+are putting on it is a chat-shaped
+service whose first member is a coding
+agent pointed at the repository that
+describes it.
 
 From there, the system writes itself.


### PR DESCRIPTION
Draft post that frames Alchemy as three layers (IaC, IaE, Agents as
Effects) and lays out the autonomous-organization vision: agents whose
prompts splice typed Output references via Output.interpolate, that
modify themselves by editing code rather than calling imperative infra
APIs. Grounds the shape in PR #293's ChatAgent DO and shows the
bootstrap (coding agent pointed at Alchemy itself, Slack-shaped service
of channels + people + agents).