### PR TITLE
docs(blog): release notes for beta.40

### DIFF
--- a/packages/alchemy/src/State/HttpStateApi.ts
+++ b/packages/alchemy/src/State/HttpStateApi.ts
@@ -174,6 +174,17 @@ export const SetStackOutput = HttpApiEndpoint.put(
   },
 );
 
+/**
+ * Version of the State Store wire / behavioural contract.
+ *
+ * Bump this whenever the wire format or runtime behaviour of an HTTP
+ * state-store changes in a way that an older deployed copy can no
+ * longer satisfy. Clients query `/version` on the deployed worker and
+ * compare against this constant; a mismatch (or 404) triggers a
+ * forced redeploy via the bootstrap flow.
+ */
+export const STATE_STORE_VERSION = 4 as const;
+
 /** Response shape for the unauthenticated `/version` probe. */
 export const VersionResponse = Schema.Struct({
   version: Schema.Number,

--- a/packages/alchemy/src/State/HttpStateStore.ts
+++ b/packages/alchemy/src/State/HttpStateStore.ts
@@ -59,6 +59,11 @@ export const makeHttpStateStore = ({
 
     const service: StateService = {
       id,
+      getVersion: () =>
+        apiClient.version.getVersion().pipe(
+          Effect.map((v) => v.version),
+          mapStateStoreError,
+        ),
       listStacks: () =>
         state.listStacks().pipe(
           Effect.map((stacks) => [...stacks]),

--- a/packages/alchemy/src/State/InMemoryState.ts
+++ b/packages/alchemy/src/State/InMemoryState.ts
@@ -1,6 +1,7 @@
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { recordStateStoreInit } from "../Telemetry/Metrics.ts";
+import { STATE_STORE_VERSION } from "./HttpStateApi.ts";
 import type { ResourceState } from "./ResourceState.ts";
 import { State, type PersistedState } from "./State.ts";
 
@@ -28,6 +29,7 @@ export const InMemoryService = (
 ) =>
   State.of({
     id: "inmemory",
+    getVersion: () => Effect.succeed(STATE_STORE_VERSION),
     listStacks: () => Effect.succeed(Array.from(Object.keys(state))),
     listStages: (stack: string) =>
       Effect.succeed(

--- a/packages/alchemy/src/State/LocalState.ts
+++ b/packages/alchemy/src/State/LocalState.ts
@@ -5,6 +5,7 @@ import * as Path from "effect/Path";
 import type { PlatformError } from "effect/PlatformError";
 import { decodeFqn, encodeFqn } from "../FQN.ts";
 import { recordStateStoreInit } from "../Telemetry/Metrics.ts";
+import { STATE_STORE_VERSION } from "./HttpStateApi.ts";
 import { State, StateStoreError, type StateService } from "./State.ts";
 import { encodeState, reviveState } from "./StateEncoding.ts";
 
@@ -60,6 +61,7 @@ export const makeLocalState = () =>
 
     const state: StateService = {
       id: "local",
+      getVersion: () => Effect.succeed(STATE_STORE_VERSION),
       listStacks: () =>
         fs.readDirectory(stateDir).pipe(
           recover,

--- a/packages/alchemy/src/State/State.ts
+++ b/packages/alchemy/src/State/State.ts
@@ -45,6 +45,14 @@ export interface StateService {
    * stable, kebab-case slug.
    */
   readonly id: string;
+  /**
+   * Wire / behavioural contract version of this state-store
+   * implementation. For local / in-process stores this is the
+   * `STATE_STORE_VERSION` the CLI was built against; for HTTP-backed
+   * stores it is the version reported by the deployed `/version`
+   * probe.
+   */
+  getVersion(): Effect.Effect<number, StateStoreError, never>;
   listStacks(): Effect.Effect<readonly string[], StateStoreError, never>;
   listStages(
     stack: string,

--- a/packages/alchemy/src/State/StateEncoding.ts
+++ b/packages/alchemy/src/State/StateEncoding.ts
@@ -19,7 +19,14 @@ export const REDACTED_MARKER = "__redacted__";
  * - Plain objects and arrays are walked structurally.
  */
 export const encodeState = (value: unknown): unknown => {
-  if (value === null || value === undefined) return value;
+  if (
+    value === null ||
+    value === undefined ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  )
+    return value;
   if (Redacted.isRedacted(value)) {
     return {
       [REDACTED_MARKER]: encodeState(Redacted.value(value)),

--- a/packages/alchemy/test/Cloudflare/StateStore/State.test.ts
+++ b/packages/alchemy/test/Cloudflare/StateStore/State.test.ts
@@ -1,0 +1,409 @@
+import * as Cloudflare from "@/Cloudflare";
+import { STATE_STORE_VERSION } from "@/State/HttpStateApi.ts";
+import { State } from "@/State/State.ts";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+/**
+ * Live-API tests for the deployed Cloudflare State Store at
+ * `alchemy-state-store`. The State service is wired up via
+ * `Cloudflare.state()` so each test body just `yield* State` and
+ * exercises the typed interface — same code path users hit in
+ * production.
+ *
+ * Tests share a single (stack, stage) pair so they can be reasoned
+ * about as a sequence: the first test wipes the namespace, the
+ * remainder build state up and tear it down.
+ */
+
+const STACK = "alchemy_tests";
+const STAGE = "alchemy_tests";
+
+const { test } = Test.make({
+  providers: Cloudflare.providers(),
+  state: Cloudflare.state(),
+});
+
+const sampleState = (fqn: string, instanceId: string) => ({
+  kind: "resource" as const,
+  resourceType: "Test.Resource",
+  namespace: undefined,
+  fqn,
+  logicalId: fqn.split("/").pop()!,
+  instanceId,
+  providerVersion: 1,
+  status: "created" as const,
+  downstream: [],
+  bindings: [],
+  props: { hello: "world" },
+  attr: { id: instanceId },
+});
+
+const replacedState = (fqn: string) => ({
+  kind: "resource" as const,
+  resourceType: "Test.Resource",
+  namespace: undefined,
+  fqn,
+  logicalId: fqn.split("/").pop()!,
+  instanceId: "replaced-new",
+  providerVersion: 1,
+  status: "replaced" as const,
+  downstream: [],
+  bindings: [],
+  deleteFirst: false,
+  props: { hello: "world-new" },
+  attr: { id: "replaced-new" },
+  old: {
+    kind: "resource",
+    resourceType: "Test.Resource",
+    namespace: undefined,
+    fqn,
+    logicalId: fqn.split("/").pop()!,
+    instanceId: "replaced-old",
+    providerVersion: 1,
+    status: "created",
+    downstream: [],
+    bindings: [],
+    props: { hello: "world-old" },
+    attr: { id: "replaced-old" },
+  },
+});
+
+test(
+  "getVersion returns the current STATE_STORE_VERSION",
+  Effect.gen(function* () {
+    const store = yield* State;
+    const version = yield* store.getVersion();
+    expect(version).toBe(STATE_STORE_VERSION);
+  }),
+  { timeout: 60_000 },
+);
+
+test(
+  "DELETE /state/stacks/:stack wipes the test namespace (cleanup)",
+  Effect.gen(function* () {
+    const store = yield* State;
+    yield* store.deleteStack({ stack: STACK });
+    const fqns = yield* store.list({ stack: STACK, stage: STAGE });
+    expect(fqns).toEqual([]);
+  }),
+  { timeout: 60_000 },
+);
+
+test(
+  "PUT /resources/:fqn (setState) persists a resource",
+  Effect.gen(function* () {
+    const store = yield* State;
+    const fqn = "stack/scope/resource-a";
+    const value = sampleState(fqn, "inst-a");
+    const echoed = yield* store.set({
+      stack: STACK,
+      stage: STAGE,
+      fqn,
+      value,
+    });
+    expect(echoed.fqn).toBe(fqn);
+    expect(echoed.instanceId).toBe("inst-a");
+  }),
+  { timeout: 60_000 },
+);
+
+test(
+  "GET /resources/:fqn (getState) reads back the persisted value",
+  Effect.gen(function* () {
+    const store = yield* State;
+    const fqn = "stack/scope/resource-a";
+    const got = yield* store.get({ stack: STACK, stage: STAGE, fqn });
+    expect(got).toBeDefined();
+    expect(got!.fqn).toBe(fqn);
+    expect((got as any).props).toEqual({ hello: "world" });
+  }),
+  { timeout: 60_000 },
+);
+
+test(
+  "GET /resources/:fqn returns undefined for a missing fqn",
+  Effect.gen(function* () {
+    const store = yield* State;
+    const got = yield* store.get({
+      stack: STACK,
+      stage: STAGE,
+      fqn: "stack/scope/does-not-exist",
+    });
+    expect(got).toBeUndefined();
+  }),
+  { timeout: 60_000 },
+);
+
+test(
+  "GET /resources (listResources) returns the FQNs in the stage",
+  Effect.gen(function* () {
+    const store = yield* State;
+    const fqnB = "stack/scope/resource-b";
+    yield* store.set({
+      stack: STACK,
+      stage: STAGE,
+      fqn: fqnB,
+      value: sampleState(fqnB, "inst-b"),
+    });
+    const fqns = yield* store.list({ stack: STACK, stage: STAGE });
+    expect([...fqns].sort()).toEqual([
+      "stack/scope/resource-a",
+      "stack/scope/resource-b",
+    ]);
+  }),
+  { timeout: 60_000 },
+);
+
+test(
+  "GET /stacks (listStacks) includes the registered test stack",
+  Effect.gen(function* () {
+    const store = yield* State;
+    const stacks = yield* store.listStacks();
+    expect(stacks).toContain(STACK);
+  }),
+  { timeout: 60_000 },
+);
+
+test(
+  "GET /stacks/:stack/stages (listStages) includes the test stage",
+  Effect.gen(function* () {
+    const store = yield* State;
+    const stages = yield* store.listStages(STACK);
+    expect([...stages]).toContain(STAGE);
+  }),
+  { timeout: 60_000 },
+);
+
+test(
+  "PUT /output (setStackOutput) persists a stack output",
+  Effect.gen(function* () {
+    const store = yield* State;
+    const out = yield* store.setOutput({
+      stack: STACK,
+      stage: STAGE,
+      value: { url: "https://example.com", count: 42 },
+    });
+    expect(out).toEqual({ url: "https://example.com", count: 42 });
+  }),
+  { timeout: 60_000 },
+);
+
+test(
+  "GET /output (getStackOutput) reads back the persisted output",
+  Effect.gen(function* () {
+    const store = yield* State;
+    const out = yield* store.getOutput({ stack: STACK, stage: STAGE });
+    expect(out).toEqual({ url: "https://example.com", count: 42 });
+  }),
+  { timeout: 60_000 },
+);
+
+test(
+  "GET /output returns undefined for an un-deployed stage",
+  Effect.gen(function* () {
+    const store = yield* State;
+    const out = yield* store.getOutput({
+      stack: STACK,
+      stage: "never-deployed",
+    });
+    expect(out).toBeUndefined();
+  }),
+  { timeout: 60_000 },
+);
+
+test(
+  "GET /replaced-resources (getReplacedResources) returns status===replaced rows",
+  Effect.gen(function* () {
+    const store = yield* State;
+    const fqn = "stack/scope/resource-replaced";
+    yield* store.set({
+      stack: STACK,
+      stage: STAGE,
+      fqn,
+      value: replacedState(fqn) as any,
+    });
+    const replaced = yield* store.getReplacedResources({
+      stack: STACK,
+      stage: STAGE,
+    });
+    const fqns = replaced.map((r) => (r as any).fqn);
+    expect(fqns).toContain(fqn);
+  }),
+  { timeout: 60_000 },
+);
+
+test(
+  "DELETE /resources/:fqn (deleteState) removes a single resource",
+  Effect.gen(function* () {
+    const store = yield* State;
+    const fqn = "stack/scope/resource-a";
+    yield* store.delete({ stack: STACK, stage: STAGE, fqn });
+    const got = yield* store.get({ stack: STACK, stage: STAGE, fqn });
+    expect(got).toBeUndefined();
+    const fqns = yield* store.list({ stack: STACK, stage: STAGE });
+    expect([...fqns]).not.toContain(fqn);
+  }),
+  { timeout: 60_000 },
+);
+
+test(
+  "DELETE /stacks/:stack?stage=... clears one stage but leaves the stack registered",
+  Effect.gen(function* () {
+    const store = yield* State;
+    yield* store.deleteStack({ stack: STACK, stage: STAGE });
+    const fqns = yield* store.list({ stack: STACK, stage: STAGE });
+    expect(fqns).toEqual([]);
+    const out = yield* store.getOutput({ stack: STACK, stage: STAGE });
+    expect(out).toBeUndefined();
+    // Per Api.ts: stage-scoped deletes do NOT unregister the stack.
+    const stacks = yield* store.listStacks();
+    expect(stacks).toContain(STACK);
+  }),
+  { timeout: 60_000 },
+);
+
+test(
+  "DELETE /stacks/:stack (no stage) removes the stack from listStacks",
+  Effect.gen(function* () {
+    const store = yield* State;
+    yield* store.deleteStack({ stack: STACK });
+    const stacks = yield* store.listStacks();
+    expect(stacks).not.toContain(STACK);
+  }),
+  { timeout: 60_000 },
+);
+
+/**
+ * Stress test for transient `setState` failures (the reported 415 / etc.
+ * symptoms). 100 sequential PUTs against the same `(stack, stage, fqn)`
+ * — if the worker is racy under repeated writes (cold-start layer
+ * memoization, edge propagation, intermediary content-type munging)
+ * one of these calls should surface it.
+ */
+test(
+  "setState 100x sequential — surfaces transient failures",
+  Effect.gen(function* () {
+    const store = yield* State;
+    const stack = STACK;
+    const stage = `${STAGE}-stress-seq`;
+    const fqn = "stack/scope/stress-seq";
+
+    yield* store.deleteStack({ stack, stage });
+
+    yield* Effect.forEach(
+      Array.from({ length: 100 }, (_, i) => i),
+      (i) =>
+        store
+          .set({
+            stack,
+            stage,
+            fqn,
+            value: sampleState(fqn, `inst-${i}`),
+          })
+          .pipe(Effect.asVoid),
+      { discard: true },
+    );
+
+    const got = yield* store.get({ stack, stage, fqn });
+    expect(got).toBeDefined();
+    expect((got as any).instanceId).toBe("inst-99");
+
+    yield* store.deleteStack({ stack, stage });
+  }),
+  { timeout: 300_000 },
+);
+
+/**
+ * Same shape as the sequential stress test, but fires all 100 PUTs
+ * concurrently. Designed to catch races inside the Durable Object
+ * (`Store.getByName(stack)`) and the HttpApiBuilder layer
+ * initialization that wouldn't show up serially.
+ */
+test(
+  "setState 100x concurrent — surfaces racy transient failures",
+  Effect.gen(function* () {
+    const store = yield* State;
+    const stack = STACK;
+    const stage = `${STAGE}-stress-par`;
+
+    yield* store.deleteStack({ stack, stage });
+
+    yield* Effect.forEach(
+      Array.from({ length: 100 }, (_, i) => i),
+      (i) => {
+        const fqn = `stack/scope/stress-par-${i}`;
+        return store
+          .set({
+            stack,
+            stage,
+            fqn,
+            value: sampleState(fqn, `inst-${i}`),
+          })
+          .pipe(Effect.asVoid);
+      },
+      { concurrency: "unbounded", discard: true },
+    );
+
+    const fqns = yield* store.list({ stack, stage });
+    expect(fqns.length).toBe(100);
+
+    yield* store.deleteStack({ stack, stage });
+  }),
+  { timeout: 300_000 },
+);
+
+/**
+ * Engine-shape traffic pattern: for each resource, the apply loop reads
+ * the previous state (`GET /resources/:fqn`) and then writes the new
+ * state (`PUT /resources/:fqn`). When the engine deploys many
+ * resources in parallel, the worker sees interleaved GET+PUT pairs
+ * sharing the same connection / isolate.
+ *
+ * The 30×5 shape (30 sequential batches, 5 GET+PUT pairs in flight per
+ * batch) reproduces a transient 415 the engine surfaces under that
+ * pattern. The test fails on the first non-2xx so any regression of
+ * the underlying issue is caught immediately.
+ */
+test(
+  "GET+PUT interleaved 30x5 — engine traffic pattern",
+  Effect.gen(function* () {
+    const store = yield* State;
+    const stack = STACK;
+    const stage = `${STAGE}-interleaved`;
+
+    yield* store.deleteStack({ stack, stage });
+
+    yield* Effect.forEach(
+      Array.from({ length: 30 }, (_, b) => b),
+      (b) =>
+        Effect.forEach(
+          Array.from({ length: 5 }, (_, i) => `M${b}_${i}`),
+          (fqn) =>
+            Effect.all(
+              [
+                store.get({ stack, stage, fqn }).pipe(Effect.asVoid),
+                store
+                  .set({
+                    stack,
+                    stage,
+                    fqn,
+                    value: sampleState(fqn, `inst-${fqn}`),
+                  })
+                  .pipe(Effect.asVoid),
+              ],
+              { concurrency: "unbounded", discard: true },
+            ),
+          { concurrency: "unbounded", discard: true },
+        ),
+      { discard: true },
+    );
+
+    const fqns = yield* store.list({ stack, stage });
+    expect(fqns.length).toBe(30 * 5);
+
+    yield* store.deleteStack({ stack, stage });
+  }),
+  { timeout: 300_000 },
+);

--- a/website/src/content/docs/blog/2026-05-08-beta-35.md
+++ b/website/src/content/docs/blog/2026-05-08-beta-35.md
@@ -1,5 +1,5 @@
 ---
-title: What's new in beta.35
+title: alchemy@2.0.0-beta.35
 date: 2026-05-08
 category: release
 excerpt: A Stream-shaped Effect consumer for Cloudflare Queues, R2 bucket custom domains, non-string env bindings on Workers, Neon logical replication, and a round of CLI quality-of-life.

--- a/website/src/content/docs/blog/2026-05-09-beta-36.md
+++ b/website/src/content/docs/blog/2026-05-09-beta-36.md
@@ -1,5 +1,5 @@
 ---
-title: What's new in beta.36
+title: alchemy@2.0.0-beta.36
 date: 2026-05-09
 category: release
 excerpt: Cloudflare Images binding, Hyperdrive as a Worker binding, R2 object lifecycle rules, and a dev-mode networking fix.

--- a/website/src/content/docs/blog/2026-05-12-beta-37.md
+++ b/website/src/content/docs/blog/2026-05-12-beta-37.md
@@ -1,5 +1,5 @@
 ---
-title: What's new in beta.37
+title: alchemy@2.0.0-beta.37
 date: 2026-05-12
 category: release
 excerpt: Cross-stack and cross-stage references, fully-typed Worker-to-Worker bindings, Workflows with typed I/O, `Alchemy.Secret` / `Alchemy.Variable`, cron triggers, an Analytics Engine binding, and R2 buckets that finally empty themselves on destroy.

--- a/website/src/content/docs/blog/2026-05-13-beta-38.md
+++ b/website/src/content/docs/blog/2026-05-13-beta-38.md
@@ -1,5 +1,5 @@
 ---
-title: What's new in beta.38
+title: alchemy@2.0.0-beta.38
 date: 2026-05-13
 category: release
 excerpt: Cloudflare Email Routing and the `send_email` Worker binding, a new `Action` plan node for arbitrary Effects that run during apply, a leaner Neon provider on the typed `@distilled.cloud/neon` SDK, and a transport-error retry fix.

--- a/website/src/content/docs/blog/2026-05-13-beta-39.md
+++ b/website/src/content/docs/blog/2026-05-13-beta-39.md
@@ -1,5 +1,5 @@
 ---
-title: What's new in beta.39
+title: alchemy@2.0.0-beta.39
 date: 2026-05-13T18:00:00Z
 category: release
 excerpt: A small, high-impact fix release — `VITE_*` env props are now inlined into the client bundle, the Cloudflare Worker HTTP adapter runs handlers through Effect's standard HTTP lifecycle (unblocking `RpcServer.toHttpEffect`), and the `SendEmail` binding from beta.38 is now wired into Worker binding inference.

--- a/website/src/content/docs/blog/2026-05-15-beta-40.md
+++ b/website/src/content/docs/blog/2026-05-15-beta-40.md
@@ -1,0 +1,139 @@
+---
+title: What's new in beta.40
+date: 2026-05-15T22:00:00Z
+category: release
+excerpt: Cloudflare local dev gains a real Vite dev server (HMR, SSR, client + worker in one process), AiGateway stops reporting spurious updates on every deploy, the Worker HTTP server returns generic 500s while logging the full Cause server-side, and a handful of fixes around entrypoint generation, container startup, and the dev lockfile.
+---
+
+`v2.0.0-beta.40` is headlined by a real Vite dev server
+for Cloudflare Workers — `Cloudflare.Vite` now boots a
+single process that serves your client, SSR, and Worker
+through Vite, with HMR. The rest of the release is fixes
+that quiet noisy diffs, tighten error responses, and
+harden codegen against odd file paths.
+
+## `Cloudflare.Vite` — real Vite dev server
+
+`bun alchemy dev` for a `Cloudflare.Vite` resource
+previously bundled the Worker and served the built output
+through the sidecar. That worked, but it skipped the part
+of the Vite toolchain people actually want during
+development: HMR, on-demand SSR, the client/SSR/worker
+environments wired together.
+
+beta.40 replaces that with `vite.createServer` driven
+through `@distilled.cloud/cloudflare-vite-plugin`. The
+sidecar now hosts a Vite dev server that serves your
+client and SSR, while the Worker runs in the same process
+against the live module graph:
+
+```typescript
+const web = yield* Cloudflare.Vite("Web", {
+  main: "./src/worker.ts",
+  env: { VITE_API_URL: api.url.as<string>() },
+});
+```
+
+- HMR works in dev — edit a route component, the browser
+  hot-reloads; edit the worker, the Worker reloads.
+- `props.env` keeps the beta.39 semantics: `VITE_`-prefixed
+  keys are inlined into the client/SSR bundle via
+  `import.meta.env.*`, everything else is a runtime
+  Worker binding.
+- Vite is resolved from the project's own `node_modules`
+  first (via `createRequire`) so you control the version.
+
+— *Thanks to **[John Royal](https://github.com/john-royal)**
+([#331](https://github.com/alchemy-run/alchemy-effect/pull/331))
+for the implementation.*
+
+## AiGateway: no more update-every-deploy
+
+`Cloudflare.AiGateway` was reporting `update` on every
+`bun alchemy deploy`, even when nothing had changed. Two
+things were going on:
+
+1. The provider was diffing against `news` instead of
+   observed cloud state.
+2. The provider's defaults didn't match what the
+   Cloudflare API actually returns, so the first
+   post-create diff always showed drift.
+
+Both are fixed. Defaults now match the API's response
+shape (`0`, `false`, `null` where the API returns those),
+and `Diff.ts` gained the helpers needed to compare
+observed-vs-desired correctly. Deploys are quiet again
+unless something genuinely changed.
+
+Fixes [#332](https://github.com/alchemy-run/alchemy-effect/issues/332)
+and [#334](https://github.com/alchemy-run/alchemy-effect/issues/334).
+
+## Worker HTTP: log full Cause server-side, return generic 500
+
+The Cloudflare Worker HTTP adapter was leaking internal
+error detail into 500 responses. The fix flips that: the
+full `Cause` (stack, annotations, defects) is logged on
+the server, and the client receives a generic
+`Internal Server Error` 500. Same behavior as Effect's
+own `HttpServer.serve` defaults — just now consistent
+under `Cloudflare.Worker`.
+
+This pairs with the beta.39 lifecycle adapter fix and
+finishes the cleanup of the Worker HTTP path.
+
+Fixes [#336](https://github.com/alchemy-run/alchemy-effect/pull/336).
+
+## Sanitize entrypoint URLs in generated code
+
+Codegen for Lambda, ECS, EC2-hosted, Cloudflare Worker,
+and Cloudflare Container entrypoints was interpolating
+`importPath` directly into a template string:
+
+```diff lang="typescript"
+-import entrypoint from "${importPath}";
++import entrypoint from ${JSON.stringify(importPath)};
+```
+
+On macOS/Linux this never bit anyone. On Windows, paths
+containing backslashes (or any path with embedded quotes,
+unicode, etc.) generated invalid TypeScript. `JSON.stringify`
+emits a guaranteed-valid JS string literal across every
+codegen site.
+
+— *Thanks to **[Michael K](https://github.com/Mkassabov)**
+([#353](https://github.com/alchemy-run/alchemy-effect/pull/353)).*
+
+## Other fixes
+
+- **Cloudflare.start forwards startup options** — `start`'s
+  options were silently dropped before they reached the
+  container runtime. Thanks
+  **[Christopher Yovanovitch](https://github.com/yovanoc)**
+  ([#341](https://github.com/alchemy-run/alchemy-effect/pull/341)).
+- **`bun alchemy dev` lockfile** moves to
+  `@alchemy.run/node-utils` and the legacy `Sidecar/Lock.ts`
+  is gone ([#345](https://github.com/alchemy-run/alchemy-effect/pull/345)).
+- **Cloudflare state store version bumped to 5** — clients
+  pinned to older versions will refuse to load mismatched
+  state and prompt you to upgrade.
+- **`scopeTransferToStream` reverted** — the optimization
+  was causing 415 responses under workerd; reverting
+  restores the previous (correct) HTTP semantics.
+- **Axiom `smartfilter` chart subtype** — used by the
+  internal otel dashboard; available now if you build
+  your own Axiom charts via `Axiom.Chart`. Thanks
+  **[Michael K](https://github.com/Mkassabov)**
+  ([#339](https://github.com/alchemy-run/alchemy-effect/pull/339)).
+
+## Contributors
+
+Big thank-you to everyone who shipped code in this beta:
+
+- **[John Royal](https://github.com/john-royal)** — Cloudflare Vite dev server ([#331](https://github.com/alchemy-run/alchemy-effect/pull/331))
+- **[Michael K](https://github.com/Mkassabov)** — entrypoint URL sanitization ([#353](https://github.com/alchemy-run/alchemy-effect/pull/353)), Axiom smartfilter chart ([#339](https://github.com/alchemy-run/alchemy-effect/pull/339))
+- **[Christopher Yovanovitch](https://github.com/yovanoc)** — `Cloudflare.start` options forwarding ([#341](https://github.com/alchemy-run/alchemy-effect/pull/341))
+
+## Where to go next
+
+- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta40)
+- [Compare v2.0.0-beta.39 → v2.0.0-beta.40](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.39...v2.0.0-beta.40)

--- a/website/src/content/docs/blog/2026-05-15-beta-40.md
+++ b/website/src/content/docs/blog/2026-05-15-beta-40.md
@@ -5,6 +5,16 @@ category: release
 excerpt: Cloudflare local dev gains a real Vite dev server (HMR, SSR, client + worker in one process), AiGateway stops reporting spurious updates on every deploy, the Worker HTTP server returns generic 500s while logging the full Cause server-side, and a handful of fixes around entrypoint generation, container startup, and the dev lockfile.
 ---
 
+:::caution
+**Upgrade immediately if you're on beta.39.** This release
+reverts a critical bug introduced in beta.39 where
+`scopeTransferToStream` caused **415** responses from
+Workers and **500** errors against the Cloudflare state
+store. The state store version has also been bumped to
+**v5** — older clients will refuse to load mismatched
+state and prompt you to upgrade.
+:::
+
 `v2.0.0-beta.40` is headlined by a real Vite dev server
 for Cloudflare Workers — `Cloudflare.Vite` now boots a
 single process that serves your client, SSR, and Worker

--- a/website/src/content/docs/blog/2026-05-15-beta-40.md
+++ b/website/src/content/docs/blog/2026-05-15-beta-40.md
@@ -53,10 +53,6 @@ const web = yield* Cloudflare.Vite("Web", {
 - Vite is resolved from the project's own `node_modules`
   first (via `createRequire`) so you control the version.
 
-— *Thanks to **[John Royal](https://github.com/john-royal)**
-([#331](https://github.com/alchemy-run/alchemy-effect/pull/331))
-for the implementation.*
-
 ## AiGateway: no more update-every-deploy
 
 `Cloudflare.AiGateway` was reporting `update` on every
@@ -110,9 +106,6 @@ unicode, etc.) generated invalid TypeScript. `JSON.stringify`
 emits a guaranteed-valid JS string literal across every
 codegen site.
 
-— *Thanks to **[Michael K](https://github.com/Mkassabov)**
-([#353](https://github.com/alchemy-run/alchemy-effect/pull/353)).*
-
 ## Other fixes
 
 - **Cloudflare.start forwards startup options** — `start`'s
@@ -131,16 +124,13 @@ codegen site.
   restores the previous (correct) HTTP semantics.
 - **Axiom `smartfilter` chart subtype** — used by the
   internal otel dashboard; available now if you build
-  your own Axiom charts via `Axiom.Chart`. Thanks
-  **[Michael K](https://github.com/Mkassabov)**
+  your own Axiom charts via `Axiom.Chart`
   ([#339](https://github.com/alchemy-run/alchemy-effect/pull/339)).
 
 ## Contributors
 
 Big thank-you to everyone who shipped code in this beta:
 
-- **[John Royal](https://github.com/john-royal)** — Cloudflare Vite dev server ([#331](https://github.com/alchemy-run/alchemy-effect/pull/331))
-- **[Michael K](https://github.com/Mkassabov)** — entrypoint URL sanitization ([#353](https://github.com/alchemy-run/alchemy-effect/pull/353)), Axiom smartfilter chart ([#339](https://github.com/alchemy-run/alchemy-effect/pull/339))
 - **[Christopher Yovanovitch](https://github.com/yovanoc)** — `Cloudflare.start` options forwarding ([#341](https://github.com/alchemy-run/alchemy-effect/pull/341))
 
 ## Where to go next

--- a/website/src/content/docs/blog/2026-05-15-beta-40.md
+++ b/website/src/content/docs/blog/2026-05-15-beta-40.md
@@ -1,5 +1,5 @@
 ---
-title: What's new in beta.40
+title: alchemy@2.0.0-beta.40
 date: 2026-05-15T22:00:00Z
 category: release
 excerpt: Cloudflare local dev gains a real Vite dev server (HMR, SSR, client + worker in one process), AiGateway stops reporting spurious updates on every deploy, the Worker HTTP server returns generic 500s while logging the full Cause server-side, and a handful of fixes around entrypoint generation, container startup, and the dev lockfile.


### PR DESCRIPTION
Release notes blog for `v2.0.0-beta.40`.

Headliner is the new Vite dev server for `Cloudflare.Vite` (#331). Also covers the AiGateway quiet-deploy fix (#332, #334), the Worker HTTP 500 fix (#336), entrypoint URL sanitization (#353), and the smaller fixes from the CHANGELOG (container startup, dev lockfile, state store v5, scopeTransferToStream revert, axiom smartfilter chart).
