### PR TITLE
chore(cloudflare): add Effect HTTP API worker test fixture

### DIFF
--- a/packages/alchemy/test/Cloudflare/Workers/HttpApi.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/HttpApi.test.ts
@@ -116,6 +116,64 @@ test(
 );
 
 test(
+  "concurrent createTask + getTask survive scope-lifecycle pressure",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    const client = yield* HttpClient.HttpClient;
+
+    yield* client
+      .execute(
+        HttpClientRequest.post(`${url}/`).pipe(
+          HttpClientRequest.bodyJsonUnsafe({ title: "warmup" }),
+        ),
+      )
+      .pipe(
+        Effect.flatMap((res) =>
+          res.status === 200
+            ? Effect.succeed(res)
+            : Effect.fail(new Error(`warmup not ready: ${res.status}`)),
+        ),
+        Effect.retry({
+          schedule: Schedule.exponential("500 millis"),
+          times: 15,
+        }),
+      );
+
+    const N = 200;
+    const results = yield* Effect.forEach(
+      Array.from({ length: N }, (_, i) => i),
+      (i) =>
+        Effect.gen(function* () {
+          const created = yield* client
+            .execute(
+              HttpClientRequest.post(`${url}/`).pipe(
+                HttpClientRequest.bodyJsonUnsafe({ title: `task-${i}` }),
+              ),
+            )
+            .pipe(Effect.timeout("15 seconds"));
+          if (created.status !== 200) {
+            return yield* Effect.fail(
+              new Error(`create ${i} -> ${created.status}`),
+            );
+          }
+          const body = (yield* created.json) as { id: string; title: string };
+          if (body.title !== `task-${i}`) {
+            return yield* Effect.fail(
+              new Error(`create ${i} title mismatch: ${body.title}`),
+            );
+          }
+          return body.id;
+        }),
+      { concurrency: 64 },
+    );
+
+    expect(results).toHaveLength(N);
+    expect(new Set(results).size).toBe(N);
+  }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test(
   "deployed http-api worker is consumable via typed HttpApiClient",
   Effect.gen(function* () {
     const { url } = yield* stack;

--- a/packages/alchemy/test/Cloudflare/Workers/HttpApi.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/HttpApi.test.ts
@@ -1,0 +1,143 @@
+import * as Alchemy from "@/index.ts";
+import * as Cloudflare from "@/Cloudflare";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
+import { TaskApi } from "./fixtures/http-api/api.ts";
+import HttpApiTestWorker from "./fixtures/http-api/worker.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const Stack = Alchemy.Stack(
+  "HttpApiTestStack",
+  {
+    providers: Cloudflare.providers(),
+    state: Cloudflare.state(),
+  },
+  Effect.gen(function* () {
+    const worker = yield* HttpApiTestWorker;
+    return {
+      url: worker.url.as<string>(),
+    };
+  }),
+);
+
+const stack = beforeAll(deploy(Stack));
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
+
+test(
+  "deployed http-api worker handles createTask + getTask via HttpClient",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    expect(url).toBeTypeOf("string");
+    const client = yield* HttpClient.HttpClient;
+
+    const created = yield* client
+      .execute(
+        HttpClientRequest.post(`${url}/`).pipe(
+          HttpClientRequest.bodyJsonUnsafe({ title: "Write docs" }),
+        ),
+      )
+      .pipe(
+        Effect.flatMap((res) =>
+          res.status === 200
+            ? Effect.succeed(res)
+            : Effect.fail(new Error(`Worker not ready: ${res.status}`)),
+        ),
+        Effect.retry({
+          schedule: Schedule.exponential("500 millis"),
+          times: 15,
+        }),
+      );
+    const createdBody = (yield* created.json) as {
+      id: string;
+      title: string;
+      completed: boolean;
+    };
+    expect(createdBody.title).toBe("Write docs");
+    expect(createdBody.completed).toBe(false);
+    expect(createdBody.id).toBeTypeOf("string");
+
+    const fetched = yield* client.get(`${url}/${createdBody.id}`);
+    expect(fetched.status).toBe(200);
+    const fetchedBody = (yield* fetched.json) as { id: string; title: string };
+    expect(fetchedBody.id).toBe(createdBody.id);
+    expect(fetchedBody.title).toBe("Write docs");
+
+    const missing = yield* client.get(`${url}/does-not-exist`);
+    expect(missing.status).toBe(404);
+    const missingBody = (yield* missing.json) as {
+      _tag: string;
+      id: string;
+    };
+    expect(missingBody._tag).toBe("TaskNotFound");
+    expect(missingBody.id).toBe("does-not-exist");
+  }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test(
+  "cors middleware adds Access-Control-Allow-Origin header on preflight",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    const client = yield* HttpClient.HttpClient;
+
+    const res = yield* client
+      .execute(
+        HttpClientRequest.make("OPTIONS")(url).pipe(
+          HttpClientRequest.setHeaders({
+            Origin: "https://example.com",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "content-type",
+          }),
+        ),
+      )
+      .pipe(
+        Effect.retry({
+          schedule: Schedule.exponential("500 millis"),
+          times: 10,
+        }),
+      );
+    expect(res.headers["access-control-allow-origin"]).toBeDefined();
+  }).pipe(logLevel),
+  { timeout: 60_000 },
+);
+
+test(
+  "deployed http-api worker is consumable via typed HttpApiClient",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+
+    const client = yield* HttpApiClient.make(TaskApi, { baseUrl: url });
+
+    const created = yield* client.Tasks.createTask({
+      payload: { title: "Typed client task" },
+    }).pipe(
+      Effect.retry({
+        schedule: Schedule.exponential("500 millis"),
+        times: 15,
+      }),
+    );
+    expect(created.title).toBe("Typed client task");
+    expect(created.completed).toBe(false);
+
+    const fetched = yield* client.Tasks.getTask({
+      params: { id: created.id },
+    });
+    expect(fetched.id).toBe(created.id);
+    expect(fetched.title).toBe("Typed client task");
+  }).pipe(logLevel),
+  { timeout: 180_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/RpcHttp.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/RpcHttp.test.ts
@@ -1,0 +1,129 @@
+import * as Alchemy from "@/index.ts";
+import * as Cloudflare from "@/Cloudflare";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as RpcClient from "effect/unstable/rpc/RpcClient";
+import * as RpcSerialization from "effect/unstable/rpc/RpcSerialization";
+import { PingRpcs } from "./fixtures/rpc-http/group.ts";
+import RpcHttpTestWorker from "./fixtures/rpc-http/worker.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const Stack = Alchemy.Stack(
+  "RpcHttpTestStack",
+  {
+    providers: Cloudflare.providers(),
+    state: Cloudflare.state(),
+  },
+  Effect.gen(function* () {
+    const worker = yield* RpcHttpTestWorker;
+    return {
+      url: worker.url.as<string>(),
+    };
+  }),
+);
+
+const stack = beforeAll(deploy(Stack));
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
+
+// The Cloudflare Worker fetch adapter (`workersHttpHandler`) currently
+// short-circuits Effect's standard HTTP lifecycle (it manually
+// provides `HttpServerRequest` and converts the response to a web
+// `Response` outside of `HttpEffect.toHandled`). PR #328 reported that
+// this can deadlock `RpcServer.toHttpEffect` under workerd. This test
+// hammers a real deployed Worker exposing an Effect RPC group to
+// surface lifecycle / per-request scope regressions.
+const clientLayer = (url: string) =>
+  RpcClient.layerProtocolHttp({ url }).pipe(
+    Layer.provide(FetchHttpClient.layer),
+    Layer.provide(
+      Layer.succeed(RpcSerialization.RpcSerialization, RpcSerialization.ndjson),
+    ),
+  );
+
+test(
+  "RpcServer.toHttpEffect: warmup ping",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        const client = yield* RpcClient.make(PingRpcs);
+        const result = yield* client.Ping({ message: "hello" }).pipe(
+          Effect.retry({
+            schedule: Schedule.exponential("500 millis"),
+            times: 15,
+          }),
+        );
+        expect(result.echo).toBe("hello");
+        expect(result.n).toBeGreaterThan(0);
+      }),
+    ).pipe(Effect.provide(clientLayer(url)));
+  }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
+test(
+  "RpcServer.toHttpEffect: 200 concurrent calls do not hang",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        const client = yield* RpcClient.make(PingRpcs);
+
+        const N = 200;
+        const results = yield* Effect.forEach(
+          Array.from({ length: N }, (_, i) => i),
+          (i) =>
+            client
+              .Ping({ message: `m-${i}` })
+              .pipe(Effect.timeout("20 seconds")),
+          { concurrency: 64 },
+        );
+
+        expect(results).toHaveLength(N);
+        for (let i = 0; i < N; i++) {
+          expect(results[i].echo).toBe(`m-${i}`);
+        }
+      }),
+    ).pipe(Effect.provide(clientLayer(url)));
+  }).pipe(logLevel),
+  { timeout: 240_000 },
+);
+
+test(
+  "RpcServer.toHttpEffect: slow handler under concurrency does not leak request scope",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        const client = yield* RpcClient.make(PingRpcs);
+
+        const N = 64;
+        const results = yield* Effect.forEach(
+          Array.from({ length: N }, (_, i) => i),
+          () => client.Slow({ ms: 250 }).pipe(Effect.timeout("30 seconds")),
+          { concurrency: N },
+        );
+
+        expect(results).toHaveLength(N);
+        for (const r of results) expect(r.slept).toBe(250);
+      }),
+    ).pipe(Effect.provide(clientLayer(url)));
+  }).pipe(logLevel),
+  { timeout: 240_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/http-api/api.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/http-api/api.ts
@@ -1,0 +1,39 @@
+import * as Schema from "effect/Schema";
+import * as HttpApi from "effect/unstable/httpapi/HttpApi";
+import * as HttpApiEndpoint from "effect/unstable/httpapi/HttpApiEndpoint";
+import * as HttpApiGroup from "effect/unstable/httpapi/HttpApiGroup";
+
+export class Task extends Schema.Class<Task>("Task")({
+  id: Schema.String,
+  title: Schema.String,
+  completed: Schema.Boolean,
+}) {}
+
+export class TaskNotFound extends Schema.TaggedErrorClass<TaskNotFound>()(
+  "TaskNotFound",
+  { id: Schema.String },
+  { httpApiStatus: 404 },
+) {}
+
+const TaskParams = Schema.Struct({
+  id: Schema.String,
+});
+
+const getTask = HttpApiEndpoint.get("getTask", "/:id", {
+  params: TaskParams,
+  success: Task,
+  error: TaskNotFound,
+});
+
+const createTask = HttpApiEndpoint.post("createTask", "/", {
+  success: Task,
+  payload: Schema.Struct({
+    title: Schema.String,
+  }),
+});
+
+export class TasksGroup extends HttpApiGroup.make("Tasks")
+  .add(getTask)
+  .add(createTask) {}
+
+export class TaskApi extends HttpApi.make("TaskApi").add(TasksGroup) {}

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/http-api/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/http-api/worker.ts
@@ -1,0 +1,64 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Etag from "effect/unstable/http/Etag";
+import * as HttpPlatform from "effect/unstable/http/HttpPlatform";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
+import { Task, TaskApi, TaskNotFound } from "./api.ts";
+
+const HttpPlatformStub = Layer.succeed(HttpPlatform.HttpPlatform, {
+  fileResponse: () => Effect.die("HttpPlatform.fileResponse not supported"),
+  fileWebResponse: () =>
+    Effect.die("HttpPlatform.fileWebResponse not supported"),
+});
+
+const corsLayer = HttpRouter.cors({
+  allowedOrigins: ["*"],
+  allowedMethods: ["GET", "POST", "OPTIONS"],
+  allowedHeaders: ["Content-Type"],
+});
+
+export default class HttpApiTestWorker extends Cloudflare.Worker<HttpApiTestWorker>()(
+  "HttpApiTestWorker",
+  {
+    main: import.meta.filename,
+    subdomain: { enabled: true, previewsEnabled: false },
+    compatibility: { date: "2024-09-23", flags: ["nodejs_compat"] },
+  },
+  Effect.gen(function* () {
+    const tasks = new Map<string, Task>();
+
+    const tasksGroup = HttpApiBuilder.group(TaskApi, "Tasks", (handlers) =>
+      handlers
+        .handle("getTask", ({ params }) => {
+          const task = tasks.get(params.id);
+          if (!task) {
+            return Effect.fail(new TaskNotFound({ id: params.id }));
+          }
+          return Effect.succeed(task);
+        })
+        .handle("createTask", ({ payload }) =>
+          Effect.sync(() => {
+            const task = new Task({
+              id: crypto.randomUUID(),
+              title: payload.title,
+              completed: false,
+            });
+            tasks.set(task.id, task);
+            return task;
+          }),
+        ),
+    );
+
+    return {
+      fetch: HttpApiBuilder.layer(TaskApi).pipe(
+        Layer.provide(tasksGroup),
+        Layer.provide([Etag.layer, HttpPlatformStub, Path.layer]),
+        Layer.provide(corsLayer),
+        HttpRouter.toHttpEffect,
+      ),
+    };
+  }),
+) {}

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/rpc-http/group.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/rpc-http/group.ts
@@ -1,0 +1,14 @@
+import * as Schema from "effect/Schema";
+import * as Rpc from "effect/unstable/rpc/Rpc";
+import * as RpcGroup from "effect/unstable/rpc/RpcGroup";
+
+export const PingRpcs = RpcGroup.make(
+  Rpc.make("Ping", {
+    payload: { message: Schema.String },
+    success: Schema.Struct({ echo: Schema.String, n: Schema.Number }),
+  }),
+  Rpc.make("Slow", {
+    payload: { ms: Schema.Number },
+    success: Schema.Struct({ slept: Schema.Number }),
+  }),
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/rpc-http/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/rpc-http/worker.ts
@@ -1,0 +1,37 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as RpcSerialization from "effect/unstable/rpc/RpcSerialization";
+import * as RpcServer from "effect/unstable/rpc/RpcServer";
+import { PingRpcs } from "./group.ts";
+
+let counter = 0;
+
+const handlersLayer = PingRpcs.toLayer({
+  Ping: ({ message }) =>
+    Effect.sync(() => ({
+      echo: message,
+      n: ++counter,
+    })),
+  Slow: ({ ms }) => Effect.sleep(`${ms} millis`).pipe(Effect.as({ slept: ms })),
+});
+
+export default class RpcHttpTestWorker extends Cloudflare.Worker<RpcHttpTestWorker>()(
+  "RpcHttpTestWorker",
+  {
+    main: import.meta.filename,
+    subdomain: { enabled: true, previewsEnabled: false },
+    compatibility: { date: "2024-09-23", flags: ["nodejs_compat"] },
+  },
+  Effect.gen(function* () {
+    return {
+      fetch: RpcServer.toHttpEffect(PingRpcs).pipe(
+        Effect.provide(
+          Layer.mergeAll(handlersLayer, RpcSerialization.layerNdjson),
+          // ^ ndjson is the canonical RpcServer.toHttpEffect protocol;
+          //   it streams one message per line.
+        ),
+      ),
+    };
+  }),
+) {}

--- a/website/src/content/docs/guides/effect-http-api.mdx
+++ b/website/src/content/docs/guides/effect-http-api.mdx
@@ -231,6 +231,33 @@ We assemble it in three layers:
     };
 ```
 
+### 3d. Enable CORS
+
+`HttpRouter.cors(...)` returns a `Layer` that registers a global
+router middleware. Plug it in alongside the platform services with
+another `Layer.provide`.
+
+```diff lang="typescript"
+    return {
+      fetch: HttpApiBuilder.layer(TaskApi).pipe(
+        Layer.provide(tasksGroup),
+        Layer.provide([HttpPlatform.layer, Etag.layer]),
++       Layer.provide(HttpRouter.cors({
++         allowedOrigins: ["*"],
++         allowedMethods: ["GET", "POST", "OPTIONS"],
++         allowedHeaders: ["Content-Type"],
++       })),
+        HttpRouter.toHttpEffect,
+      ),
+    };
+```
+
+The middleware wraps every response — including the automatic
+`OPTIONS` preflight — with the configured `Access-Control-*` headers.
+Because it's a `Layer<never, never, HttpRouter>`, it composes the same
+way as the rest of the API stack: order doesn't matter, and there's
+no per-handler plumbing.
+
 ### Putting it together
 
 Here's the complete `src/worker.ts`:
@@ -285,6 +312,13 @@ export default Cloudflare.Worker(
       fetch: HttpApiBuilder.layer(TaskApi).pipe(
         Layer.provide(tasksGroup),
         Layer.provide([HttpPlatform.layer, Etag.layer]),
+        Layer.provide(
+          HttpRouter.cors({
+            allowedOrigins: ["*"],
+            allowedMethods: ["GET", "POST", "OPTIONS"],
+            allowedHeaders: ["Content-Type"],
+          }),
+        ),
         HttpRouter.toHttpEffect,
       ),
     };


### PR DESCRIPTION
Adds an Effect HTTP API fixture + integration test for `Cloudflare.Worker`. Deploys a real worker, drives it via raw `HttpClient` and a typed `HttpApiClient`, and verifies CORS preflight.

```ts
// fixtures/http-api/worker.ts
const corsLayer = HttpRouter.cors({
  allowedOrigins: ["*"],
  allowedMethods: ["GET", "POST", "OPTIONS"],
  allowedHeaders: ["Content-Type"],
});

return {
  fetch: HttpApiBuilder.layer(TaskApi).pipe(
    Layer.provide(tasksGroup),
    Layer.provide([Etag.layer, HttpPlatformStub, Path.layer]),
    Layer.provide(corsLayer),
    HttpRouter.toHttpEffect,
  ),
};
```

- `fixtures/http-api/api.ts` — `Task` / `TaskNotFound` schemas (`{ httpApiStatus: 404 }`) + `TaskApi` spec, importable by both server and typed client.
- `fixtures/http-api/worker.ts` — `Cloudflare.Worker` constructing handlers in Init, serving `HttpApiBuilder.layer(...)` with `Etag.layer`, an `HttpPlatform` stub, `Path.layer`, and `HttpRouter.cors(...)` as a global router middleware layer.
- `HttpApi.test.ts` — `beforeAll(deploy(Stack))` / `afterAll(destroy(Stack))`; tests `createTask` + `getTask` + 404 over `HttpClient`, OPTIONS preflight returns `Access-Control-Allow-Origin`, and round-trips via `HttpApiClient.make(TaskApi, { baseUrl })`.
