### PR TITLE
fix(sidecar): preserve Redacted values across RPC serialization

### DIFF
--- a/packages/alchemy/src/Sidecar/RpcHandler.ts
+++ b/packages/alchemy/src/Sidecar/RpcHandler.ts
@@ -129,6 +129,21 @@ export const serializeRpcHandlers = <T extends RpcHandlers>(
     ]),
   ) as SerializedRpcHandlers<T>;
 
+const encodeRedacted = (value: unknown): unknown => {
+  if (Redacted.isRedacted(value)) {
+    return { _tag: "Redacted", value: Redacted.value(value) };
+  }
+  if (Array.isArray(value)) {
+    return value.map(encodeRedacted);
+  }
+  if (value && typeof value === "object" && !("toJSON" in value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [key, encodeRedacted(child)]),
+    );
+  }
+  return value;
+};
+
 const deserializeRpcHandler =
   <Args extends Array<any>, Success, Error>(
     handler: SerializedRpcHandler<Args, Success, Error>,
@@ -137,15 +152,9 @@ const deserializeRpcHandler =
   (...args) =>
     Effect.promise(async () => {
       try {
-        const serializedArgs = JSON.stringify(args, (_, value) => {
-          if (Redacted.isRedacted(value)) {
-            return {
-              _tag: "Redacted",
-              value: Redacted.value(value),
-            };
-          }
-          return value;
-        }) as SerializedArgs<Args>;
+        const serializedArgs = JSON.stringify(
+          encodeRedacted(args),
+        ) as SerializedArgs<Args>;
         return await handler(serializedArgs);
       } catch (error) {
         console.error("Error calling handler", error);

--- a/packages/alchemy/test/Sidecar/RpcHandler.test.ts
+++ b/packages/alchemy/test/Sidecar/RpcHandler.test.ts
@@ -1,0 +1,56 @@
+import {
+  defineSchema,
+  deserializeRpcHandlers,
+  type RpcHandlers,
+  serializeRpcHandlers,
+} from "@/Sidecar/RpcHandler.ts";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import * as Schema from "effect/Schema";
+
+interface Handlers extends RpcHandlers {
+  echo: (s: Redacted.Redacted<string>) => Effect.Effect<string>;
+  password: (env: {
+    password: Redacted.Redacted<string>;
+  }) => Effect.Effect<string>;
+  withDate: (env: { when: Date }) => Effect.Effect<string>;
+}
+
+const schema = defineSchema<Handlers>({
+  echo: { success: Schema.String, error: Schema.Never },
+  password: { success: Schema.String, error: Schema.Never },
+  withDate: { success: Schema.String, error: Schema.Never },
+});
+
+const handlers: Handlers = {
+  echo: (s) => Effect.succeed(Redacted.value(s)),
+  password: (env) => Effect.succeed(Redacted.value(env.password)),
+  withDate: ((env: { when: unknown }) => Effect.succeed(String(env.when))) as Handlers["withDate"],
+};
+
+const client = () =>
+  deserializeRpcHandlers(serializeRpcHandlers(handlers, schema), schema);
+
+describe("Sidecar.RpcHandler", () => {
+  it.effect("round-trips a top-level Redacted argument", () =>
+    Effect.gen(function* () {
+      expect(yield* client().echo(Redacted.make("hush"))).toBe("hush");
+    }),
+  );
+
+  it.effect("round-trips a Redacted nested inside an object", () =>
+    Effect.gen(function* () {
+      expect(
+        yield* client().password({ password: Redacted.make("hush") }),
+      ).toBe("hush");
+    }),
+  );
+
+  it.effect("preserves objects with their own toJSON (Date)", () =>
+    Effect.gen(function* () {
+      const d = new Date("2026-05-16T12:00:00.000Z");
+      expect(yield* client().withDate({ when: d })).toBe(d.toISOString());
+    }),
+  );
+});


### PR DESCRIPTION
Ran into this while testing the Vite + Cloudflare Worker setup from #331 (`feat(cloudflare): vite dev`). On `alchemy dev`, `Redacted` values sent through the sidecar RPC arrive on the worker side as the literal string `"<redacted>"`.

Anything passing a `Redacted` through a binding hits this. In my case, Hyperdrive's `password`:

```ts
Cloudflare.Hyperdrive("db", {
  origin: { ..., password: secret /* Redacted<string> */ },
});
```

→ `password authentication failed`.

`JSON.stringify` calls `toJSON()` before the replacer, and `Redacted.toJSON()` returns `"<redacted>"`, so this replacer in [Sidecar/RpcHandler.ts](packages/alchemy/src/Sidecar/RpcHandler.ts) never fires:

```ts
JSON.stringify(args, (_, value) => {
  if (Redacted.isRedacted(value)) {
    return { _tag: "Redacted", value: Redacted.value(value) };
  }
  return value;
});
```

Deserialize side already handles the `{ _tag: "Redacted", value }` envelope.

### Fix

Pre-walk the args with `encodeRedacted` before `JSON.stringify`:

- recurses into arrays, plain objects, and the inner value of nested `Redacted`
- skips objects with their own `toJSON` (Date, URL, …) so `JSON.stringify` keeps using their custom shape

Covered by [packages/alchemy/test/Sidecar/RpcHandler.test.ts](packages/alchemy/test/Sidecar/RpcHandler.test.ts): top-level `Redacted`, `Redacted` nested in an object, and a `Date` arg (exercises the `toJSON` skip).
