### PR TITLE
fix(cloudflare): normalize durable object fetch http effects

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectNamespace.ts
@@ -80,7 +80,9 @@ export interface DurableObjectNamespace<
 }
 
 export interface DurableObjectShape {
-  fetch?: HttpEffect<DurableObjectState>;
+  fetch?:
+    | HttpEffect<DurableObjectState>
+    | Effect.Effect<HttpEffect<DurableObjectState>>;
   alarm?: (
     alarmInfo?: AlarmInvocationInfo,
   ) => Effect.Effect<void, never, never>;

--- a/packages/alchemy/src/Cloudflare/Workers/Rpc.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Rpc.ts
@@ -7,6 +7,7 @@ import * as Option from "effect/Option";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import * as Socket from "effect/unstable/socket/Socket";
+import * as Http from "../../Http.ts";
 import type { HttpEffect } from "../../Http.ts";
 import { isYieldableEffect } from "../../Util/effect.ts";
 import { fromCloudflareFetcher } from "../Fetcher.ts";
@@ -332,8 +333,13 @@ export const makeDurableObjectBridge =
       async fetch(request: cf.Request): Promise<cf.Response> {
         const methods = await this.object;
         if (methods.fetch) {
-          const fetch = methods.fetch as HttpEffect<never>;
+          const fetch = Http.safeHttpEffect(
+            methods.fetch as
+              | HttpEffect<never>
+              | Effect.Effect<HttpEffect<never>>,
+          );
           const response = await serveWebRequest(request, fetch).pipe(
+            Effect.scoped,
             Effect.runPromise,
           );
           return response as any;

--- a/packages/alchemy/test/Cloudflare/Workers/Rpc.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Rpc.test.ts
@@ -13,6 +13,7 @@ import {
   fromRpcReadableStream,
   fromRpcStreamEnvelope,
   toRpcStream,
+  makeDurableObjectBridge,
   makeRpcStub,
   type RpcErrorEnvelope,
   type RpcStreamEnvelope,
@@ -22,7 +23,13 @@ import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
+import * as Rpc from "effect/unstable/rpc/Rpc";
+import * as RpcGroup from "effect/unstable/rpc/RpcGroup";
+import * as RpcSerialization from "effect/unstable/rpc/RpcSerialization";
+import * as RpcServer from "effect/unstable/rpc/RpcServer";
 
 class MyError extends Data.TaggedError("MyError")<{
   readonly message: string;
@@ -446,6 +453,85 @@ describe("toRpcStream", () => {
       const chunks = yield* Stream.runCollect(decoded);
       expect(chunks).toEqual([]);
     }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// makeDurableObjectBridge
+// ---------------------------------------------------------------------------
+
+describe("makeDurableObjectBridge", () => {
+  it.effect(
+    "serves Durable Object fetch declared as RpcServer.toHttpEffect",
+    () =>
+      Effect.gen(function* () {
+        class Message extends Schema.Class<Message>("Message")({
+          message: Schema.String,
+        }) {}
+
+        const Rpcs = RpcGroup.make(
+          Rpc.make("Echo", {
+            payload: { input: Message },
+            success: Schema.Struct({
+              echo: Schema.String,
+              typed: Schema.Boolean,
+            }),
+          }),
+        );
+
+        const handlers = Rpcs.toLayer({
+          Echo: ({ input }) =>
+            Effect.succeed({
+              echo: input.message,
+              typed: input instanceof Message,
+            }),
+        });
+
+        const fetch = RpcServer.toHttpEffect(Rpcs).pipe(
+          Effect.provide(
+            Layer.mergeAll(handlers, RpcSerialization.layerJsonRpc()),
+          ),
+        );
+
+        class TestDurableObject {
+          constructor(_state: unknown, _env: unknown) {}
+        }
+
+        const Bridge = makeDurableObjectBridge(
+          TestDurableObject as any,
+          async () => () => Effect.succeed({ fetch }),
+        )("TestDurableObject");
+
+        const object = new Bridge(
+          {
+            blockConcurrencyWhile: (fn: () => Promise<unknown>) => fn(),
+          } as any,
+          {},
+        );
+
+        const response = yield* Effect.promise(
+          () =>
+            object.fetch(
+              new Request("https://example.test/rpc", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({
+                  jsonrpc: "2.0",
+                  id: 1,
+                  method: "Echo",
+                  params: { input: { message: "hello" } },
+                  headers: [],
+                }),
+              }) as any,
+            ) as unknown as Promise<Response>,
+        );
+
+        expect(response.status).toBe(200);
+        const body = (yield* Effect.promise(() => response.json())) as {
+          result: { echo: string; typed: boolean };
+        };
+        expect(body.result).toEqual({ echo: "hello", typed: true });
+      }),
   );
 });
 


### PR DESCRIPTION
Durable Object fetch now accepts the same nested HTTP-effect constructor shape that Worker fetch accepts.

```ts
fetch: RpcServer.toHttpEffect(Rpcs).pipe(
  Effect.provide(RpcHandlers),
  Effect.provide(RpcSerialization.layerJsonRpc()),
)
```

Fixes #366.
