### PR TITLE
fix(cloudflare): provide worker env to do methods

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectNamespace.ts
@@ -607,6 +607,14 @@ export const DurableObjectNamespace: DurableObjectNamespaceClass =
                 kind: "durableObject",
                 make: (state: cf.DurableObjectState, env: any) => {
                   const doState = fromDurableObjectState(state);
+                  const provideRuntimeServices = (
+                    effect: Effect.Effect<any, any, any>,
+                  ) =>
+                    effect.pipe(
+                      Effect.provideService(DurableObjectState, doState),
+                      Effect.provideService(WorkerEnvironment, env),
+                    );
+
                   return constructor.pipe(
                     Effect.provideContext(services),
                     Effect.provideService(DurableObjectState, doState),
@@ -616,22 +624,15 @@ export const DurableObjectNamespace: DurableObjectNamespaceClass =
                       for (const key of Object.getOwnPropertyNames(methods)) {
                         const value = methods[key];
                         if (Effect.isEffect(value)) {
-                          wrapped[key] = (
-                            value as Effect.Effect<any, any, any>
-                          ).pipe(
-                            Effect.provideService(DurableObjectState, doState),
+                          wrapped[key] = provideRuntimeServices(
+                            value as Effect.Effect<any, any, any>,
                           );
                         } else if (typeof value === "function") {
                           wrapped[key] = (...args: unknown[]) => {
                             const result = (value as Function)(...args);
                             if (Effect.isEffect(result)) {
-                              return (
-                                result as Effect.Effect<any, any, any>
-                              ).pipe(
-                                Effect.provideService(
-                                  DurableObjectState,
-                                  doState,
-                                ),
+                              return provideRuntimeServices(
+                                result as Effect.Effect<any, any, any>,
                               );
                             }
                             return result;

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
@@ -1,0 +1,60 @@
+import * as Alchemy from "@/index.ts";
+import * as Cloudflare from "@/Cloudflare";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import DurableObjectWorkerEnvironmentWorker from "./fixtures/durable-object-worker-environment-worker.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const Stack = Alchemy.Stack(
+  "DurableObjectWorkerEnvironmentStack",
+  {
+    providers: Cloudflare.providers(),
+    state: Cloudflare.state(),
+  },
+  Effect.gen(function* () {
+    const worker = yield* DurableObjectWorkerEnvironmentWorker;
+    return {
+      url: worker.url.as<string>(),
+    };
+  }),
+);
+
+const stack = beforeAll(deploy(Stack));
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
+
+test(
+  "durable object methods can use binding clients",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    const client = yield* HttpClient.HttpClient;
+
+    const res = yield* client.post(`${url}/roundtrip`).pipe(
+      Effect.flatMap((res) =>
+        res.status === 200
+          ? Effect.succeed(res)
+          : Effect.fail(new Error(`Worker not ready: ${res.status}`)),
+      ),
+      Effect.retry({
+        schedule: Schedule.exponential("500 millis"),
+        times: 15,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (yield* res.json) as { value: string };
+    expect(body.value).toBe("ok");
+  }).pipe(logLevel),
+  { timeout: 180_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/durable-object-worker-environment-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/durable-object-worker-environment-worker.ts
@@ -1,0 +1,56 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+const DurableObjectWorkerEnvironmentKV = Cloudflare.KVNamespace(
+  "DurableObjectWorkerEnvironmentKV",
+  {
+    title: "durable-object-worker-environment-kv",
+  },
+);
+
+export class WorkerEnvironmentKVObject extends Cloudflare.DurableObjectNamespace<WorkerEnvironmentKVObject>()(
+  "WorkerEnvironmentKVObject",
+  Effect.gen(function* () {
+    const kv = yield* Cloudflare.KVNamespace.bind(
+      DurableObjectWorkerEnvironmentKV,
+    );
+
+    return Effect.gen(function* () {
+      return {
+        put: (key: string, value: string) => kv.put(key, value),
+        get: (key: string) => kv.get(key),
+      };
+    });
+  }).pipe(Effect.provide(Cloudflare.KVNamespaceBindingLive)),
+) {}
+
+export default class DurableObjectWorkerEnvironmentWorker extends Cloudflare.Worker<DurableObjectWorkerEnvironmentWorker>()(
+  "DurableObjectWorkerEnvironmentWorker",
+  {
+    main: import.meta.filename,
+    subdomain: { enabled: true, previewsEnabled: false },
+    compatibility: { date: "2024-09-23", flags: ["nodejs_compat"] },
+  },
+  Effect.gen(function* () {
+    const objects = yield* WorkerEnvironmentKVObject;
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://x");
+
+        if (request.method === "POST" && url.pathname === "/roundtrip") {
+          const object = objects.getByName("default");
+          const key = "durable-object-worker-environment";
+          yield* object.put(key, "ok").pipe(Effect.orDie);
+          const value = yield* object.get(key).pipe(Effect.orDie);
+          return yield* HttpServerResponse.json({ value });
+        }
+
+        return HttpServerResponse.text("Not Found", { status: 404 });
+      }),
+    };
+  }),
+) {}


### PR DESCRIPTION
Provide `WorkerEnvironment` when `DurableObjectNamespace` wraps returned method Effects.

```ts
const provideRuntimeServices = (effect) =>
  effect.pipe(
    Effect.provideService(DurableObjectState, doState),
    Effect.provideService(WorkerEnvironment, env),
  );
```

Adds a regression fixture where a Durable Object method calls `KVNamespaceClient` directly.

Fixes #368.

Attribution: Pi GPT5.5 on high, guided by Dillon Mulroy <dillon@cloudflare.com>.
