### PR TITLE
fix(apply): eager terminal status events + pending while waiting on deps

### DIFF
--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -405,8 +405,19 @@ const executeNode = (
       });
 
     const markTerminal = (status: "created" | "updated") =>
-      Effect.sync(() => {
+      Effect.gen(function* () {
         terminalStatuses.set(fqn, {
+          id: logicalId,
+          type: node.resource.Type,
+          status,
+        });
+        // Emit immediately so the CLI surfaces the terminal status as soon
+        // as the resource is actually done — instead of batching every
+        // resource's "created"/"updated" event to the end of apply(), which
+        // makes long-running siblings appear stuck in "creating" until the
+        // entire deploy finishes.
+        yield* session.emit({
+          kind: "status-change",
           id: logicalId,
           type: node.resource.Type,
           status,
@@ -576,11 +587,16 @@ const executeNode = (
           });
         }
 
-        yield* report("creating");
+        // While we're waiting on upstream outputs the resource isn't actually
+        // creating anything yet — surface that as "pending" so the CLI doesn't
+        // look stuck in "creating" for slow-upstream deploys.
+        yield* report("pending");
 
         // Create runs against fully resolved upstream outputs and bindings, not the
         // raw Output expressions stored in the plan.
         yield* waitForDeps(allUpstreamFqns());
+
+        yield* report("creating");
         const outputs = getOutputs();
 
         const news = (yield* Output.evaluate(node.props, outputs)) as Record<
@@ -662,6 +678,9 @@ const executeNode = (
           });
         }
 
+        // See create-flow note: while we're waiting on upstream outputs
+        // this resource isn't actually updating yet.
+        yield* report("pending");
         yield* waitForDeps(allUpstreamFqns());
         const outputs = getOutputs();
 
@@ -867,11 +886,15 @@ const executeNode = (
           });
         }
 
-        yield* report("creating replacement");
+        // See create-flow note: while we're waiting on upstream outputs
+        // the replacement isn't actually being created yet.
+        yield* report("pending");
 
         // Replacement create is evaluated exactly like create, but against the new
         // generation's instance id and with the previous generations preserved in `old`.
         yield* waitForDeps(allUpstreamFqns());
+
+        yield* report("creating replacement");
         const outputs = getOutputs();
 
         const news = (yield* Output.evaluate(node.props, outputs)) as Record<
@@ -1052,13 +1075,16 @@ const executeActionNode = (
         type: task.Type,
         status: "skipped",
       });
+      yield* report("skipped");
       return;
     }
 
     // ── run ──
-    // Wait for stable (post-reconcile) upstream attrs — not precreate stubs.
-    // This is `waitForStableDeps` at the call site, passed in as the
-    // `waitForDeps` parameter here.
+    // Tasks wait on `waitForStableDeps` (post-reconcile attrs) for their
+    // upstreams, which is often the slowest dep chain in the deploy.
+    // Surface that as "pending" instead of having the task show no status
+    // until its run actually starts.
+    yield* report("pending");
     yield* waitForDeps(
       Object.keys(Output.resolveUpstream(node.input)).filter(
         (f) => f in readyStable,
@@ -1108,6 +1134,7 @@ const executeActionNode = (
       type: task.Type,
       status: "ran",
     });
+    yield* report("ran");
   }).pipe(
     Effect.catchCause((cause) =>
       Effect.gen(function* () {

--- a/packages/alchemy/test/Sidecar/RpcHandler.test.ts
+++ b/packages/alchemy/test/Sidecar/RpcHandler.test.ts
@@ -26,7 +26,8 @@ const schema = defineSchema<Handlers>({
 const handlers: Handlers = {
   echo: (s) => Effect.succeed(Redacted.value(s)),
   password: (env) => Effect.succeed(Redacted.value(env.password)),
-  withDate: ((env: { when: unknown }) => Effect.succeed(String(env.when))) as Handlers["withDate"],
+  withDate: ((env: { when: unknown }) =>
+    Effect.succeed(String(env.when))) as Handlers["withDate"],
 };
 
 const client = () =>


### PR DESCRIPTION
Two long-standing UX bugs in the apply loop, both visible in PR [#113](https://github.com/alchemy-run/alchemy-effect/pull/113) (PlanetScale) where databases take minutes to provision.

we already do the correct behavior for destroy

### 1. Terminal events were batched to end of `apply()`

`markTerminal("created" | "updated")` only stashed the status in a `terminalStatuses` map. The actual `status-change` event was emitted in a single batch at the very end of `apply()` ([Apply.ts:183-188](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Apply.ts#L183-L188)). A resource that finished in 30s would keep rendering `creating` in the TUI until every slow sibling also finished. Same for tasks (`ran` / `skipped`).

```diff
 const markTerminal = (status: "created" | "updated") =>
-  Effect.sync(() => {
+  Effect.gen(function* () {
     terminalStatuses.set(fqn, { ... });
+    yield* session.emit({ kind: "status-change", id: logicalId, type: node.resource.Type, status });
   });
```

The end-of-apply batch is kept as a redundant safety re-emit.

### 2. Resources blocked on `waitForDeps` rendered as `creating`

`report("creating")` (or `"updating"` / `"creating replacement"`) fired *before* `waitForDeps`, so a resource sitting idle for minutes waiting on a slow upstream looked like it was doing work the whole time.

```diff
+ // While we're waiting on upstream outputs the resource isn't actually
+ // creating anything yet — surface that as "pending".
+ yield* report("pending");
  yield* waitForDeps(allUpstreamFqns());
+ yield* report("creating");
- yield* report("creating");  // moved
```

Applied to all three lifecycles (create / update / replace) plus the task lifecycle (`pending` while waiting on `waitForStableDeps`).

`"pending"` was already in the [`ApplyStatus`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cli/Event.ts) union — this is just the engine starting to use it.

### Scope

Purely event-stream timing. No behavioural changes to state persistence, signaling, retries, or the end-of-apply batch.

### Before

https://github.com/user-attachments/assets/6e0bd9f2-00b3-4a21-8509-4b95ba5d74b1

### After

https://github.com/user-attachments/assets/5cce7793-a20a-4aa4-9e54-c8941675012d

