### PR TITLE
fix(Cloudflare/Worker): defer Platform hook bindings to avoid TDZ from npm

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -681,7 +681,13 @@ export const Worker: Platform<
     Req | Providers
   >;
 } = Platform(WorkerTypeId, {
-  onCreate: bindWorkerAsyncBindings,
+  // Wrap in an arrow so the `bindWorkerAsyncBindings` reference is resolved
+  // at call time rather than at module-load time. Worker.ts <-> WorkerAsyncBindings.ts
+  // form an import cycle (the latter imports `isWorker` from this file), and
+  // reading the binding eagerly here hits TDZ when Bun loads the package from
+  // node_modules in a different module-init order than the local workspace.
+  onCreate: (resource, props) =>
+    bindWorkerAsyncBindings(resource as Worker, props),
   createRuntimeContext: makeWorkerRuntimeContext,
 });
 

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -681,14 +681,16 @@ export const Worker: Platform<
     Req | Providers
   >;
 } = Platform(WorkerTypeId, {
-  // Wrap in an arrow so the `bindWorkerAsyncBindings` reference is resolved
-  // at call time rather than at module-load time. Worker.ts <-> WorkerAsyncBindings.ts
-  // form an import cycle (the latter imports `isWorker` from this file), and
-  // reading the binding eagerly here hits TDZ when Bun loads the package from
-  // node_modules in a different module-init order than the local workspace.
+  // Both hooks are wrapped in arrows so the imported references are resolved
+  // at call time rather than at module-load time. Worker.ts forms import
+  // cycles with both WorkerAsyncBindings.ts (which imports `isWorker` here)
+  // and WorkerRuntimeContext.ts (which imports `WorkerTypeId`/`WorkerEnvironment`
+  // here). Reading either binding eagerly here hits TDZ when Bun loads the
+  // package from node_modules in a different module-init order than the local
+  // workspace.
   onCreate: (resource, props) =>
     bindWorkerAsyncBindings(resource as Worker, props),
-  createRuntimeContext: makeWorkerRuntimeContext,
+  createRuntimeContext: (id) => makeWorkerRuntimeContext(id),
 });
 
 class MissingDurableObjectNamespaces extends Data.TaggedError(


### PR DESCRIPTION
`Worker.ts` forms import cycles with `WorkerAsyncBindings.ts` (which imports `isWorker` from this file) and `WorkerRuntimeContext.ts` (which imports `WorkerTypeId`/`WorkerEnvironment`/`ExportedHandlerMethods` from this file). Passing the imported references directly into `Platform(...)` reads them at module-load time, which TDZs when Bun enters the cycle from the other side (e.g. via `SidecarHandlers.ts → WorkerAsyncBindings.ts → Worker.ts`). The local workspace happens to walk the graph the other way, so it only surfaced when installed from npm:

```
ReferenceError: Cannot access 'bindWorkerAsyncBindings' before initialization
  at node_modules/alchemy/src/Cloudflare/Workers/Worker.ts:684:13
```

Wrap both hook args in arrows so the references are resolved at call time, not at module-load time:

```diff lang="typescript"
  } = Platform(WorkerTypeId, {
-   onCreate: bindWorkerAsyncBindings,
-   createRuntimeContext: makeWorkerRuntimeContext,
+   onCreate: (resource, props) =>
+     bindWorkerAsyncBindings(resource as Worker, props),
+   createRuntimeContext: (id) => makeWorkerRuntimeContext(id),
  });
```