### PR TITLE
docs(blog): release notes for beta.41 + retro touch-ups for beta.35-40

### DIFF
--- a/website/src/content/docs/blog/2026-05-08-beta-35.md
+++ b/website/src/content/docs/blog/2026-05-08-beta-35.md
@@ -2,16 +2,30 @@
 title: alchemy@2.0.0-beta.35
 date: 2026-05-08
 category: release
-excerpt: A Stream-shaped Effect consumer for Cloudflare Queues, R2 bucket custom domains, non-string env bindings on Workers, Neon logical replication, and a round of CLI quality-of-life.
+excerpt: Cloudflare Queue consumers as Effect `Stream`s with `ack`/`retry` per message, non-string env bindings on Workers (numbers, booleans, objects without manual JSON), R2 bucket custom domains inline on the resource, Neon logical replication, and CLI quality-of-life including a `*.localhost` dev-mode fix and a plain-text renderer for non-TTY terminals.
 ---
 
-`v2.0.0-beta.35` is out. The headline addition is an
-Effect-native, `Stream`-shaped consumer API for Cloudflare
-Queues — write a queue handler the same way you'd write
-any other Effect pipeline. Plus R2 bucket custom domains,
-non-string Worker env bindings, Neon logical replication,
-and a handful of CLI polish. Community contributors get
-inline shoutouts; full credits in the
+`v2.0.0-beta.35` makes Cloudflare Queues a first-class
+member of the Effect runtime. The headline is
+`Cloudflare.messages(queue).subscribe(...)` — process a
+batch as a typed `Stream`, with `ack`/`retry` per message,
+sitting next to the rest of the Worker's bindings instead
+of in a separate file. Queue consumers finally feel like
+any other Effect pipeline.
+
+Two devex unlocks land alongside it. **Non-string env
+bindings** on Workers — numbers, booleans, and objects go
+into `bindings: { ... }` directly, with no manual JSON on
+either side and the typed shape preserved at runtime. And
+**R2 bucket custom domains** attached inline on the
+resource declaration — edit the array and the next deploy
+reconciles the live attachments.
+
+The rest is fill-in: Neon logical replication (opt-in for
+CDC tools), CLI quality-of-life including a `*.localhost`
+DNS fix in dev mode and a non-TTY plain-text renderer for
+cleaner CI logs, and the usual round of fixes. Community
+contributors get inline shoutouts; full credits in the
 [Contributors section](#contributors).
 
 ## `Cloudflare.messages(queue).subscribe(...)` — Effect-native queue consumer

--- a/website/src/content/docs/blog/2026-05-09-beta-36.md
+++ b/website/src/content/docs/blog/2026-05-09-beta-36.md
@@ -2,14 +2,34 @@
 title: alchemy@2.0.0-beta.36
 date: 2026-05-09
 category: release
-excerpt: Cloudflare Images binding, Hyperdrive as a Worker binding, R2 object lifecycle rules, and a dev-mode networking fix.
+excerpt: Three new Cloudflare Worker bindings shipped by community contributors — image transformation as an Effect `Stream<Uint8Array>` pipeline, Hyperdrive pooled-connection bindings that wire directly onto a `Neon.Branch.origin`, and R2 object lifecycle rules declared inline on the bucket resource. Plus a `*.localhost` dev-mode networking fix that unblocks cross-Worker `fetch`.
 ---
 
-`v2.0.0-beta.36` is mostly a Cloudflare-themed release —
-three new Worker bindings (Images, Hyperdrive,
-R2 lifecycle policies), all from outside the core team.
-Props to the contributors throughout, and full credits in
-the [Contributors section](#contributors).
+`v2.0.0-beta.36` is three new Cloudflare Worker bindings
+from outside the core team — image transformation,
+Hyperdrive connection pooling, and R2 object lifecycle
+policies. None of them require a separate provisioning
+step; each is declared inline alongside the rest of the
+Worker config and binds into the runtime through the same
+Effect-native pattern.
+
+**Cloudflare Images** is the new transform/probe
+pipeline — pass in an Effect `Stream<Uint8Array>`
+(typically the request body), get a transformed stream
+back or typed metadata via `.info()`. **Hyperdrive** is
+the pooled-connection layer in front of Postgres —
+declare it over an existing connection string, or wire it
+directly onto a `Neon.Branch.origin` and the deploy graph
+orders the resources for you. **R2 lifecycle rules**
+collapse age-based deletion, storage-class transitions,
+and stale-multipart cleanup into an inline array — edit
+it and the next deploy applies the delta against the
+live policy.
+
+Plus a `*.localhost` dev-mode networking fix that
+unblocks cross-Worker `fetch` between sidecar instances.
+Community contributors get inline shoutouts; full credits
+in the [Contributors section](#contributors).
 
 ## Cloudflare Images binding
 

--- a/website/src/content/docs/blog/2026-05-12-beta-37.md
+++ b/website/src/content/docs/blog/2026-05-12-beta-37.md
@@ -2,7 +2,7 @@
 title: alchemy@2.0.0-beta.37
 date: 2026-05-12
 category: release
-excerpt: Cross-stack and cross-stage references, fully-typed Worker-to-Worker bindings, Workflows with typed I/O, `Alchemy.Secret` / `Alchemy.Variable`, cron triggers, an Analytics Engine binding, and R2 buckets that finally empty themselves on destroy.
+excerpt: The biggest beta in a while. Cross-stack and cross-stage references unblock PR-preview stages sharing a long-lived `staging` database, Worker-to-Worker bindings get fully typed RPC, Workflows gain typed input/output, and the `Alchemy.Secret` / `Alchemy.Variable` one-liners collapse secret wiring to a single yield. Plus cron triggers, an Analytics Engine binding, and R2 buckets that finally empty themselves on destroy.
 ---
 
 `v2.0.0-beta.37` is the biggest beta in a while. The

--- a/website/src/content/docs/blog/2026-05-13-beta-38.md
+++ b/website/src/content/docs/blog/2026-05-13-beta-38.md
@@ -2,16 +2,30 @@
 title: alchemy@2.0.0-beta.38
 date: 2026-05-13
 category: release
-excerpt: Cloudflare Email Routing and the `send_email` Worker binding, a new `Action` plan node for arbitrary Effects that run during apply, a leaner Neon provider on the typed `@distilled.cloud/neon` SDK, and a transport-error retry fix.
+excerpt: Cloudflare Email Routing and the `send_email` Worker binding close the loop on inbound/outbound email from the edge, a new `Action` plan node integrates arbitrary apply-time Effects into the dependency graph alongside `Resource`, the Neon provider moves onto the typed `@distilled.cloud/neon` SDK, and the apply transport becomes resilient to flaky connections mid-run.
 ---
 
-`v2.0.0-beta.38` adds two new building blocks — full
-**Cloudflare Email** (zone routing + the `send_email`
-Worker binding) and the **`Action`** plan node for
-arbitrary Effects that run during apply — plus a
-behind-the-scenes Neon refactor onto the typed
-`@distilled.cloud/neon` SDK and a fault-tolerance fix in
-the apply transport.
+`v2.0.0-beta.38` adds two new building blocks. **Cloudflare
+Email** — full zone routing (turn on the feature,
+register destinations, forward inbound mail with rules)
+plus the `send_email` Worker binding for outbound — closes
+the loop on email from the edge. **`Action`** is a new
+plan node alongside `Resource`: an arbitrary Effect that
+runs during apply when its resolved input changes, with
+real dependency-graph integration in both directions, so
+database migrations and deploy announcements stop living
+in shell scripts next to the stack.
+
+Underneath, the **Neon provider** moved off its
+hand-rolled HTTP wrapper onto the typed
+`@distilled.cloud/neon` SDK. No user-facing API change;
+the payoff is typed errors (`Effect.catchTag("NotFound",
+...)` works directly), declarative retry via `Schedule`,
+and one fewer surface area to babysit when the upstream
+OpenAPI spec moves. The **apply transport** also got a
+small but load-bearing fix: transient send/receive errors
+are now retryable, so a flaky connection mid-apply backs
+off and reconnects instead of aborting the whole run.
 
 ## Cloudflare Email
 

--- a/website/src/content/docs/blog/2026-05-13-beta-39.md
+++ b/website/src/content/docs/blog/2026-05-13-beta-39.md
@@ -2,14 +2,33 @@
 title: alchemy@2.0.0-beta.39
 date: 2026-05-13T18:00:00Z
 category: release
-excerpt: A small, high-impact fix release — `VITE_*` env props are now inlined into the client bundle, the Cloudflare Worker HTTP adapter runs handlers through Effect's standard HTTP lifecycle (unblocking `RpcServer.toHttpEffect`), and the `SendEmail` binding from beta.38 is now wired into Worker binding inference.
+excerpt: A small, high-impact fix release. The Cloudflare Worker HTTP adapter now runs handlers through Effect's standard `HttpEffect.toHandled` / `toWebHandler` lifecycle, unblocking `RpcServer.toHttpEffect` under workerd. `Cloudflare.Vite` inlines `VITE_*` env into the client bundle via Vite's `define` hook, and the `SendEmail` binding from beta.38 is now wired into Worker binding inference and deploy-time metadata.
 ---
 
-`v2.0.0-beta.39` is a fix-only release that lands three
-things people hit immediately after beta.38: SPAs reading
-`import.meta.env.VITE_*`, Effect RPC servers running under
-the Cloudflare Worker adapter, and the brand-new
-`SendEmail` binding showing up in Worker binding types.
+`v2.0.0-beta.39` is a fix-only release for three classes
+of breakage that hit users in the days after beta.38.
+
+The biggest of the three: the **Cloudflare Worker HTTP
+adapter** was hand-rolling the `HttpServerRequest` /
+`HttpServerResponse` bridge in ways that diverged from
+Effect's standard HTTP lifecycle. Most visibly, that
+broke `RpcServer.toHttpEffect` — the same app worked
+under raw Wrangler but hung under Alchemy. The adapter
+now runs handlers through Effect's
+`HttpEffect.toHandled` / `toWebHandler` lifecycle while
+preserving every Worker-specific behavior, so anything
+that works under `@effect/platform`'s standard HTTP
+lifecycle works under `Cloudflare.Worker` too.
+
+Two more, smaller in scope but immediately blocking.
+**`Cloudflare.Vite`** now passes `VITE_`-prefixed `env`
+props through Vite's `define` hook, so SPAs reading
+`import.meta.env.VITE_API_URL` actually get the deployed
+value instead of falling back to a hardcoded default. And
+the **`SendEmail` binding** from beta.38 is now wired into
+Worker binding inference — typing it on a Worker no
+longer errors, and Cloudflare actually receives the
+`send_email` binding metadata at deploy time.
 
 ## `Cloudflare.Vite` inlines `VITE_*` env into the bundle
 

--- a/website/src/content/docs/blog/2026-05-15-beta-40.md
+++ b/website/src/content/docs/blog/2026-05-15-beta-40.md
@@ -2,7 +2,7 @@
 title: alchemy@2.0.0-beta.40
 date: 2026-05-15T22:00:00Z
 category: release
-excerpt: Cloudflare local dev gains a real Vite dev server (HMR, SSR, client + worker in one process), AiGateway stops reporting spurious updates on every deploy, the Worker HTTP server returns generic 500s while logging the full Cause server-side, and a handful of fixes around entrypoint generation, container startup, and the dev lockfile.
+excerpt: A real Vite dev server for Cloudflare Workers — `Cloudflare.Vite` boots a single process that serves client, SSR, and Worker through `vite.createServer` with HMR on both sides. Plus `AiGateway` stops reporting spurious updates on every deploy, the Worker HTTP server returns generic 500s while logging the full `Cause` server-side, and a critical revert of beta.39's `scopeTransferToStream`.
 ---
 
 :::caution
@@ -18,9 +18,22 @@ state and prompt you to upgrade.
 `v2.0.0-beta.40` is headlined by a real Vite dev server
 for Cloudflare Workers — `Cloudflare.Vite` now boots a
 single process that serves your client, SSR, and Worker
-through Vite, with HMR. The rest of the release is fixes
-that quiet noisy diffs, tighten error responses, and
-harden codegen against odd file paths.
+through `vite.createServer`, with HMR on both the
+frontend and the Worker. The old "bundle the Worker and
+serve the built output through the sidecar" path is gone.
+
+The rest of the release is correctness fixes that pay off
+on every deploy. **`Cloudflare.AiGateway`** stops
+reporting `update` on every `bun alchemy deploy` — the
+diff was running against `news` instead of observed cloud
+state, so every first post-create deploy showed phantom
+drift. The **Cloudflare Worker HTTP adapter** stops
+leaking internal error detail into 500 responses — full
+`Cause` is now server-side-only, matching Effect's own
+`HttpServer.serve` defaults. And **entrypoint codegen**
+no longer breaks on Windows paths (backslashes, embedded
+quotes, unicode) thanks to a `JSON.stringify` of the
+import path across every codegen site.
 
 ## `Cloudflare.Vite` — real Vite dev server
 

--- a/website/src/content/docs/blog/2026-05-20-beta-41.md
+++ b/website/src/content/docs/blog/2026-05-20-beta-41.md
@@ -1,0 +1,276 @@
+---
+title: alchemy@2.0.0-beta.41
+date: 2026-05-20T22:00:00Z
+category: release
+excerpt: A big internal rewrite of the Cloudflare Worker runtime fixes hung requests and dropped responses from RPC and HTTP API workers. The Worker entrypoint is now a thin shell over `WorkerBridge.ts`, scopes are linearized per request, and the same schema-driven pattern (HTTP API, RPC, and Durable Object proxies) is now stable end-to-end.
+---
+
+:::caution
+**Upgrade if you're using `Cloudflare.Worker` with `HttpApi` or
+`RpcServer`.** beta.40 and earlier shared a Worker-level Effect
+runtime across requests, which caused intermittent 500s, hung
+`fetch` calls under load, and "promise resolved on the wrong I/O
+context" errors from workerd. beta.41 scopes everything per
+request — the failure modes documented in
+[#374](https://github.com/alchemy-run/alchemy-effect/pull/374)
+no longer reproduce.
+:::
+
+`v2.0.0-beta.41` is mostly the bridge rewrite. The Worker
+entrypoint is now a thin generated shell that calls into a
+type-checked `WorkerBridge.ts`; scope construction is linear,
+per-request, and no longer mixes promises across the workerd I/O
+boundary. The same fix lands across `Cloudflare.Worker`,
+`Cloudflare.DurableObjectNamespace`, and `Cloudflare.Workflow`,
+so the schema-driven pattern in the [HTTP API](/guides/effect-http-api)
+and [RPC](/guides/effect-rpc) guides now holds together under
+real traffic.
+
+## RPC and HTTP API — per-request scopes, no more cross-context promises
+
+The Worker runtime had been caching the user's Worker Effect once
+as a module-scope `Promise`, then mixing and matching scopes
+between `WorkerBundle`, `WorkerRuntime`, and `HttpServer` on each
+request. Three things went wrong in production:
+
+1. **Too many scopes.** Every layer in the stack created its own
+   `Scope`, and the close order between them wasn't well-defined.
+   Finalizers ran against scopes that had already been torn down,
+   or never ran at all.
+2. **Promises crossed the workerd I/O boundary.** A single cached
+   promise was awaited from multiple requests. workerd treats
+   that as "promise resolved on the wrong I/O context" and aborts
+   the request — manifesting as hung `fetch`es and dropped
+   responses.
+3. **Global vs request-level scope confusion.** Construction-time
+   layers (provided once) and per-request layers (provided per
+   `fetch`) were being merged in the wrong order, so request-level
+   services occasionally got resolved from the global scope and
+   then captured stale state from a previous request.
+
+beta.41 refactors the entrypoint into
+[`WorkerBridge.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts).
+The generated entrypoint is now thin — it just instantiates the
+bridge class. Everything else is type-checked TypeScript in the
+package. Scoping is linear: one `Scope.makeUnsafe()` per request,
+provided into the user's Effect, and closed via `ctx.waitUntil`
+when the response finishes streaming. Nothing is cached as a
+promise; the user's Worker Effect is re-evaluated per request
+against the request's own scope.
+
+> Performance note: the rewrite trades a small amount of
+> per-request setup for correctness. The previous "cache the
+> Worker once" path was the source of the bugs, so we've left it
+> off by default. There's a follow-up to identify what's actually
+> safe to cache (anything that doesn't capture a promise) — for
+> now, correctness first.
+
+[#374](https://github.com/alchemy-run/alchemy-effect/pull/374)
+
+### The schema-driven pattern, end to end
+
+The pattern the [HTTP API guide](/guides/effect-http-api) and
+[RPC guide](/guides/effect-rpc) describe — define a schema, build
+a server, wrap it as `{ fetch }`, and optionally proxy through a
+Durable Object — is the same shape regardless of which transport
+you pick. beta.41 is the release where it actually works for all
+three combinations.
+
+**1. Define the schema once.** Same `Task` schema feeds the HTTP
+API endpoint declarations and the RPC procedure declarations:
+
+```typescript
+// src/task.ts
+import * as Schema from "effect/Schema";
+
+export class Task extends Schema.Class<Task>("Task")({
+  id: Schema.String,
+  title: Schema.String,
+  completed: Schema.Boolean,
+}) {}
+
+export class TaskNotFound extends Schema.TaggedClass<TaskNotFound>()(
+  "TaskNotFound",
+  { id: Schema.String },
+) {}
+```
+
+**2a. HTTP API — declare endpoints, return `{ fetch }`.**
+`HttpApiBuilder.layer(TaskApi).pipe(..., HttpRouter.toHttpEffect)`
+is exactly the `HttpEffect` Workers expect:
+
+```typescript
+// src/worker.ts
+export default Cloudflare.Worker(
+  "Worker",
+  { main: import.meta.path },
+  Effect.gen(function* () {
+    const tasks = yield* Cloudflare.R2Bucket.bind(Bucket);
+
+    const tasksGroup = HttpApiBuilder.group(TaskApi, "Tasks", (h) =>
+      h.handle("getTask", ({ params }) =>
+        tasks.get(params.id).pipe(
+          Effect.flatMap((o) =>
+            o ? decodeTask(o) : Effect.fail(new TaskNotFound({ id: params.id })),
+          ),
+        ),
+      ),
+    );
+
+    return {
+      fetch: HttpApiBuilder.layer(TaskApi).pipe(
+        Layer.provide(tasksGroup),
+        HttpRouter.toHttpEffect,
+      ),
+    };
+  }).pipe(Effect.provide(Cloudflare.R2BucketBindingLive)),
+);
+```
+
+**2b. RPC — declare procedures, return `{ fetch }`.** Same
+schemas, same Worker shape, different transport. The RPC server
+also produces an `HttpEffect`:
+
+```typescript
+// src/rpcs.ts
+export class TaskRpcs extends RpcGroup.make(
+  Rpc.make("getTask", {
+    payload: { id: Schema.String },
+    success: Task,
+    error: TaskNotFound,
+  }),
+  Rpc.make("createTask", {
+    payload: { title: Schema.String },
+    success: Task,
+  }),
+) {}
+```
+
+```typescript
+// src/worker.ts
+export default Cloudflare.Worker(
+  "Worker",
+  { main: import.meta.path },
+  Effect.gen(function* () {
+    const tasks = yield* Cloudflare.R2Bucket.bind(Bucket);
+
+    const handlersLayer = TaskRpcs.toLayer({
+      getTask: ({ id }) => /* ... */,
+      createTask: ({ title }) => /* ... */,
+    });
+
+    return {
+      fetch: RpcServer.toHttpEffect(TaskRpcs).pipe(
+        Effect.provide(handlersLayer),
+        Effect.provide(RpcSerialization.layerJson),
+      ),
+    };
+  }).pipe(Effect.provide(Cloudflare.R2BucketBindingLive)),
+);
+```
+
+**3. Bind a Durable Object, get a typed fetcher per instance.**
+The DO's Init returns the same `{ fetch }` shape — an
+`HttpEffect` from either `HttpApiBuilder` or
+`RpcServer.toHttpEffect`. Inside the Worker, bind the DO and use
+`Cloudflare.toHttpClient(stub)` to turn each instance into a
+typed client:
+
+```typescript
+const tasksDO = yield* TasksObject;
+
+const getDOClient = (id: string = "default") =>
+  HttpApiClient.makeWith(TaskDOApi, {
+    baseUrl: "http://localhost",
+    httpClient: Cloudflare.toHttpClient(tasksDO.getByName(id)),
+  });
+```
+
+The `baseUrl` is a placeholder — `toHttpClient` short-circuits
+straight to `tasksDO.getByName(id).fetch`, so the call never
+leaves the isolate. The same wrapper plugs into
+`RpcClient.layerProtocolHttp` if the DO speaks RPC instead:
+
+```typescript
+const makeDOClient = (id: string = "default") =>
+  RpcClient.make(DoRpcs).pipe(
+    Effect.provide(
+      RpcClient.layerProtocolHttp({ url: "http://localhost" }).pipe(
+        Layer.provide(
+          Layer.succeed(
+            HttpClient.HttpClient,
+            Cloudflare.toHttpClient(tasksDO.getByName(id)),
+          ),
+        ),
+        Layer.provide(RpcSerialization.layerNdjson),
+      ),
+    ),
+  );
+```
+
+One `Task` schema. Worker exposes HTTP API or RPC. DO speaks the
+same protocol back to the Worker. Per-DO-instance fetchers via
+`getByName(id)`. With beta.41's per-request scoping, the whole
+chain runs without scope leaks or cross-context promise errors.
+
+The guides walk through the full thing:
+
+- [Effect HTTP API](/guides/effect-http-api) — schema → endpoints
+  → Worker → typed client, plus the DO-backed variant.
+- [Effect RPC](/guides/effect-rpc) — schema → procedures →
+  Worker → typed client, plus streaming and DO-backed RPCs.
+
+## Other fixes
+
+- **`WorkerProps.env` flows into `InferEnv`** — typing
+  `worker.env.MY_VAR` now picks up keys you declared in
+  `env: { ... }` on the Worker, not just bindings
+  ([#351](https://github.com/alchemy-run/alchemy-effect/pull/351)).
+- **`WorkerExecutionContext` + `ExecutionContext` in fetch types** —
+  the Worker fetch handler now exposes both the Effect-side
+  `ExecutionContext` (with the request scope) and the raw
+  workerd `WorkerExecutionContext`, so `ctx.waitUntil(...)` and
+  friends are reachable from inside the handler without an
+  extra cast. Thanks
+  **[Michael K](https://github.com/michaelkleene)**
+  ([#358](https://github.com/alchemy-run/alchemy-effect/pull/358)).
+- **DO methods receive the Worker env** — previously, RPC methods
+  on a `DurableObjectNamespace` were running with an empty `env`
+  context, breaking any binding the DO needed to call into. Thanks
+  **[Dillon Mulroy](https://github.com/dmmulroy)**
+  ([#369](https://github.com/alchemy-run/alchemy-effect/pull/369)).
+- **`Redacted` survives sidecar RPC serialization** — sidecar
+  was unwrapping `Redacted` values during JSON round-trips,
+  leaking secrets in dev logs. They're now preserved end to end.
+  Thanks **[Juliaan](https://github.com/Juliaan)**
+  ([#356](https://github.com/alchemy-run/alchemy-effect/pull/356)).
+- **`lightningcss` + `fsevents` externalized in the Worker
+  bundler** — both are platform-specific native deps that don't
+  belong in the Worker bundle. Thanks
+  **[Michael K](https://github.com/michaelkleene)**
+  ([#363](https://github.com/alchemy-run/alchemy-effect/pull/363)).
+- **Worker teardown force-deletes scripts** — if a Worker had
+  stuck Durable Object migrations from a previous failed deploy,
+  `destroy` would hang. It now force-deletes the script and
+  proceeds ([#348](https://github.com/alchemy-run/alchemy-effect/pull/348)).
+- **Eager terminal status events while waiting on deps** — the
+  CLI now shows `pending` for resources blocked on dependencies
+  and emits terminal status (created/updated/failed) as soon as
+  the resource's own reconcile finishes, rather than batching at
+  the end. Thanks **[Michael K](https://github.com/michaelkleene)**
+  ([#376](https://github.com/alchemy-run/alchemy-effect/pull/376)).
+
+## Contributors
+
+Big thank-you to everyone who shipped code in this beta:
+
+- **[Michael K](https://github.com/michaelkleene)** — Worker fetch type fix ([#358](https://github.com/alchemy-run/alchemy-effect/pull/358)), `lightningcss`/`fsevents` externalization ([#363](https://github.com/alchemy-run/alchemy-effect/pull/363)), eager terminal status events ([#376](https://github.com/alchemy-run/alchemy-effect/pull/376))
+- **[Dillon Mulroy](https://github.com/dmmulroy)** — DO methods receive Worker env ([#369](https://github.com/alchemy-run/alchemy-effect/pull/369))
+- **[Juliaan](https://github.com/Juliaan)** — `Redacted` across sidecar RPC ([#356](https://github.com/alchemy-run/alchemy-effect/pull/356))
+
+## Where to go next
+
+- [Effect HTTP API guide](/guides/effect-http-api)
+- [Effect RPC guide](/guides/effect-rpc)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta41)
+- [Compare v2.0.0-beta.40 → v2.0.0-beta.41](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.40...v2.0.0-beta.41)


### PR DESCRIPTION
Adds the beta.41 release blog (the `Cloudflare.Worker` RPC/HTTP per-request scoping rewrite from #374, plus the rest of the v2.0.0-beta.41 changelog) and retroactively polishes the openings of the beta.35–40 release blogs to match the same narrative style — substantive excerpts and 2–3 paragraph framings that call out the most important changes upfront before the body sections.

Bodies of the older posts are unchanged; only the frontmatter `excerpt` and the opening intro paragraph(s) above the first `##` heading.

### Files

- `website/src/content/docs/blog/2026-05-20-beta-41.md` — new (beta.41 release notes; covers the `WorkerBridge.ts` rewrite, the end-to-end schema-driven `HTTP API + RPC + DO` pattern, and the rest of the changelog)
- `website/src/content/docs/blog/2026-05-08-beta-35.md` — opening rewritten to lead with the `Cloudflare.messages(queue).subscribe(...)` queue consumer + two devex unlocks (non-string env, R2 custom domains)
- `website/src/content/docs/blog/2026-05-09-beta-36.md` — opening rewritten to frame the three new Worker bindings (Images, Hyperdrive, R2 lifecycle) with one paragraph per binding
- `website/src/content/docs/blog/2026-05-12-beta-37.md` — excerpt tightened; intro left mostly intact (already had narrative form)
- `website/src/content/docs/blog/2026-05-13-beta-38.md` — opening expanded to give Email and `Action` a paragraph each, then the Neon SDK + apply-transport fixes in a second paragraph
- `website/src/content/docs/blog/2026-05-13-beta-39.md` — opening reframed around the Worker HTTP adapter fix (the biggest of the three) with the other two in a follow-up paragraph
- `website/src/content/docs/blog/2026-05-15-beta-40.md` — caution box preserved; intro expanded to call out AiGateway, Worker HTTP 500-leak, and Windows entrypoint codegen as a second paragraph

---
_Generated by [Claude Code](https://claude.ai/code/session_015qmfxuMPHUmBGEh1PSWo2R)_