### PR TITLE
fix(Cloudflare): move WorkerEnvironment requirement to the Layer instead of the binding API call

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -395,6 +395,38 @@ export class PutRecordPolicy extends Binding.Policy<...>()("AWS.Kinesis.PutRecor
 export const PutRecordPolicyLive = Layer.effect(PutRecordPolicy, ...);
 ```
 
+### Runtime-only methods: color with `Alchemy.RuntimeContext`
+
+The runtime callable returned by a `Binding.Service` (the inner Effect inside `.bind(resource)`'s return) **must** declare `Alchemy.RuntimeContext` as a requirement. This is how Alchemy models "this code can only run inside a deployed Function/Worker" at the type level — analogous to a colored function.
+
+```ts
+import type { RuntimeContext } from "../../RuntimeContext.ts";
+
+export class GetItem extends Binding.Service<
+  GetItem,
+  <T extends Table>(
+    table: T,
+  ) => Effect.Effect<
+    (
+      request: GetItemRequest,
+    ) => Effect.Effect<
+      DynamoDB.GetItemOutput,
+      DynamoDB.GetItemError,
+      RuntimeContext // ← runtime-only
+    >
+  >
+>()("AWS.DynamoDB.GetItem") {}
+```
+
+Rules:
+
+- **Outer Effect** (the `bind(resource)` setup) runs at the Function's init phase. It does NOT require `RuntimeContext`.
+- **Inner Effect** (the actual SDK invocation) only makes sense inside a running Function. It MUST require `RuntimeContext`.
+- Resolve cloud-environment services (`WorkerEnvironment`, AWS SDK clients, etc.) once during Layer construction and close over them. Do NOT leak `WorkerEnvironment` / `Lambda.FunctionEnvironment` onto the runtime callable — that couples downstream service code to a specific cloud and breaks Layer encapsulation. The Function/Worker runtime satisfies `RuntimeContext` automatically.
+- The implementation can return `Effect.Effect<A, E>` without explicitly providing `RuntimeContext` (it's contravariant in `R`); just declare it on the interface.
+
+Why this matters: consumers can build cloud-agnostic services on top of bindings using `Layer.effect(Tag, ...)` without polluting their service interface with `WorkerEnvironment`. See [Layers concept](./website/src/content/docs/concepts/layers.mdx).
+
 After implementing, register the Policy in `AWS.providers()()`:
 
 - Add the `*PolicyLive` layer to `bindings()` in [Providers.ts](./packages/alchemy/src/AWS/Providers.ts)

--- a/packages/alchemy/src/Binding.ts
+++ b/packages/alchemy/src/Binding.ts
@@ -90,7 +90,7 @@ export interface Policy<
   in out Self,
   in out Identifier extends string,
   in out Shape extends (...args: any[]) => Effect.Effect<any, any, any>,
-> extends Effect.Effect<Shape, never, Self | RuntimeContext> {
+> extends Effect.Effect<Shape, never, Self> {
   readonly key: Identifier;
   new (_: never): PolicyShape<Identifier, Shape>;
   layer: {

--- a/packages/alchemy/src/Cloudflare/AiGateway/AiGatewayBinding.ts
+++ b/packages/alchemy/src/Cloudflare/AiGateway/AiGatewayBinding.ts
@@ -3,9 +3,9 @@
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 import * as Binding from "../../Binding.ts";
 import type { ResourceLike } from "../../Resource.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import type { AiGateway as AiGatewayResource } from "./AiGateway.ts";
 
@@ -34,37 +34,37 @@ export interface AiGatewayClient {
   /**
    * Effect resolving to the raw Workers AI binding.
    */
-  raw: Effect.Effect<Ai, never, WorkerEnvironment>;
+  raw: Effect.Effect<Ai, never, RuntimeContext>;
   /**
    * Effect resolving to the raw AI Gateway runtime binding.
    */
-  gateway: Effect.Effect<AiGateway, never, WorkerEnvironment>;
+  gateway: Effect.Effect<AiGateway, never, RuntimeContext>;
   /**
    * Update metadata on an existing AI Gateway log entry.
    */
   patchLog(
     logId: string,
     data: Parameters<AiGateway["patchLog"]>[1],
-  ): Effect.Effect<void, AiGatewayError, WorkerEnvironment>;
+  ): Effect.Effect<void, AiGatewayError, RuntimeContext>;
   /**
    * Read an AI Gateway log entry by ID.
    */
   getLog(
     logId: string,
-  ): Effect.Effect<AiGatewayLog, AiGatewayError, WorkerEnvironment>;
+  ): Effect.Effect<AiGatewayLog, AiGatewayError, RuntimeContext>;
   /**
    * Build a provider URL routed through this gateway.
    */
   getUrl(
     provider?: Parameters<AiGateway["getUrl"]>[0],
-  ): Effect.Effect<string, AiGatewayError, WorkerEnvironment>;
+  ): Effect.Effect<string, AiGatewayError, RuntimeContext>;
   /**
    * Run an AI Gateway request through the Cloudflare runtime binding.
    */
   run(
     data: Parameters<AiGateway["run"]>[0],
     options?: Parameters<AiGateway["run"]>[1],
-  ): Effect.Effect<Response, AiGatewayError, WorkerEnvironment>;
+  ): Effect.Effect<Response, AiGatewayError, RuntimeContext>;
 }
 
 /**
@@ -106,18 +106,13 @@ export const AiGatewayBindingLive = Layer.effect(
   AiGatewayBinding,
   Effect.gen(function* () {
     const Policy = yield* AiGatewayBindingPolicy;
+    const env = yield* WorkerEnvironment;
 
     return Effect.fn(function* (gateway: AiGatewayResource) {
       yield* Policy(gateway);
-      // Capture the gatewayId accessor (which requires WorkerEnvironment) but
-      // don't resolve it here — that happens lazily at runtime when each
-      // method is invoked. Resolving eagerly would require WorkerEnvironment
-      // at deploy time, where it's intentionally not provided.
       const gatewayIdAccessor = yield* gateway.gatewayId;
-      const ai = yield* Effect.serviceOption(WorkerEnvironment).pipe(
-        Effect.map(Option.getOrUndefined),
-        Effect.map((env) => env?.[gateway.LogicalId]! as Ai),
-        Effect.cached,
+      const ai = Effect.sync(
+        () => (env as Record<string, Ai>)[gateway.LogicalId]!,
       );
       const runtimeGateway = yield* Effect.zip(ai, gatewayIdAccessor).pipe(
         Effect.map(([ai, gatewayId]) => ai.gateway(gatewayId)),
@@ -126,7 +121,7 @@ export const AiGatewayBindingLive = Layer.effect(
 
       const use = <T>(
         fn: (gateway: AiGateway) => Promise<T>,
-      ): Effect.Effect<T, AiGatewayError, WorkerEnvironment> =>
+      ): Effect.Effect<T, AiGatewayError> =>
         runtimeGateway.pipe(
           Effect.flatMap((gateway) => tryPromise(() => fn(gateway))),
         );

--- a/packages/alchemy/src/Cloudflare/AnalyticsEngine/AnalyticsEngineDatasetBinding.ts
+++ b/packages/alchemy/src/Cloudflare/AnalyticsEngine/AnalyticsEngineDatasetBinding.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import type { ResourceLike } from "../../Resource.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import type { AnalyticsEngineDataset as AnalyticsEngineDatasetLike } from "./AnalyticsEngineDataset.ts";
 
@@ -24,10 +25,10 @@ export class AnalyticsEngineDatasetError extends Data.TaggedError(
 }> {}
 
 export interface AnalyticsEngineDatasetClient {
-  raw: Effect.Effect<RuntimeAnalyticsEngineDataset, never, WorkerEnvironment>;
+  raw: Effect.Effect<RuntimeAnalyticsEngineDataset, never, RuntimeContext>;
   writeDataPoint(
     dataPoint: AnalyticsEngineDataPoint,
-  ): Effect.Effect<void, AnalyticsEngineDatasetError, WorkerEnvironment>;
+  ): Effect.Effect<void, AnalyticsEngineDatasetError, RuntimeContext>;
 }
 
 export class AnalyticsEngineDatasetBinding extends Binding.Service<
@@ -41,17 +42,14 @@ export const AnalyticsEngineDatasetBindingLive = Layer.effect(
   AnalyticsEngineDatasetBinding,
   Effect.gen(function* () {
     const bind = yield* AnalyticsEngineDatasetBindingPolicy;
+    const env = yield* WorkerEnvironment;
 
     return Effect.fnUntraced(function* (dataset: AnalyticsEngineDatasetLike) {
       yield* bind(dataset);
 
-      const raw = WorkerEnvironment.pipe(
-        Effect.map(
-          (env) =>
-            (env as Record<string, RuntimeAnalyticsEngineDataset>)[
-              dataset.name
-            ]!,
-        ),
+      const raw = Effect.sync(
+        () =>
+          (env as Record<string, RuntimeAnalyticsEngineDataset>)[dataset.name]!,
       );
 
       return {

--- a/packages/alchemy/src/Cloudflare/Artifacts/ArtifactsBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Artifacts/ArtifactsBinding.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import type { ResourceLike } from "../../Resource.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import { type Artifacts as ArtifactsLike } from "./Artifacts.ts";
 
@@ -66,32 +67,22 @@ export interface ArtifactsRepoClient {
  */
 export interface ArtifactsClient {
   /** Effect resolving to the raw Cloudflare runtime binding. */
-  raw: Effect.Effect<Artifacts, never, WorkerEnvironment>;
+  raw: Effect.Effect<Artifacts, never, RuntimeContext>;
   create(
     name: string,
     opts?: ArtifactsCreateOptions,
-  ): Effect.Effect<
-    ArtifactsCreateRepoResult,
-    ArtifactsError,
-    WorkerEnvironment
-  >;
+  ): Effect.Effect<ArtifactsCreateRepoResult, ArtifactsError, RuntimeContext>;
   /** Look up an existing repo by name. Fails with `ArtifactsError` if missing. */
   get(
     name: string,
-  ): Effect.Effect<ArtifactsRepoClient, ArtifactsError, WorkerEnvironment>;
+  ): Effect.Effect<ArtifactsRepoClient, ArtifactsError, RuntimeContext>;
   list(
     opts?: ArtifactsListOptions,
-  ): Effect.Effect<ArtifactsRepoListResult, ArtifactsError, WorkerEnvironment>;
-  delete(
-    name: string,
-  ): Effect.Effect<boolean, ArtifactsError, WorkerEnvironment>;
+  ): Effect.Effect<ArtifactsRepoListResult, ArtifactsError, RuntimeContext>;
+  delete(name: string): Effect.Effect<boolean, ArtifactsError, RuntimeContext>;
   import(
     opts: ArtifactsImportOptions,
-  ): Effect.Effect<
-    ArtifactsCreateRepoResult,
-    ArtifactsError,
-    WorkerEnvironment
-  >;
+  ): Effect.Effect<ArtifactsCreateRepoResult, ArtifactsError, RuntimeContext>;
 }
 
 export class ArtifactsBinding extends Binding.Service<
@@ -103,19 +94,17 @@ export const ArtifactsBindingLive = Layer.effect(
   ArtifactsBinding,
   Effect.gen(function* () {
     const Policy = yield* ArtifactsBindingPolicy;
+    const env = yield* WorkerEnvironment;
 
     return Effect.fn(function* (artifacts: ArtifactsLike) {
       yield* Policy(artifacts);
-      const env = WorkerEnvironment;
-      const raw = env.pipe(
-        Effect.map(
-          (env) => (env as Record<string, Artifacts>)[artifacts.name]!,
-        ),
+      const raw = Effect.sync(
+        () => (env as Record<string, Artifacts>)[artifacts.name]!,
       );
 
       const use = <T>(
         fn: (raw: Artifacts) => Promise<T>,
-      ): Effect.Effect<T, ArtifactsError, WorkerEnvironment> =>
+      ): Effect.Effect<T, ArtifactsError> =>
         raw.pipe(Effect.flatMap((raw) => tryPromise(() => fn(raw))));
 
       return {

--- a/packages/alchemy/src/Cloudflare/D1/D1Connection.ts
+++ b/packages/alchemy/src/Cloudflare/D1/D1Connection.ts
@@ -2,6 +2,7 @@ import type * as runtime from "@cloudflare/workers-types";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 import { WorkerEnvironment } from "../Workers/Worker.ts";
 import type { D1Database } from "./D1Database.ts";
 import { DatabaseBinding } from "./D1DatabaseBinding.ts";
@@ -32,32 +33,44 @@ export class D1PreparedStatement {
   }
 
   /** Run the query and return all matching rows. */
-  all<T = unknown>(): Effect.Effect<runtime.D1Result<T>> {
+  all<T = unknown>(): Effect.Effect<
+    runtime.D1Result<T>,
+    never,
+    RuntimeContext
+  > {
     return this.withRuntime((stmt) => stmt.all<T>());
   }
 
   /** Run the query and return the first row, or `null` if no rows. */
-  first<T = unknown>(): Effect.Effect<T | null>;
-  first<T = unknown>(column: string): Effect.Effect<T | null>;
-  first<T = unknown>(column?: string): Effect.Effect<T | null> {
+  first<T = unknown>(): Effect.Effect<T | null, never, RuntimeContext>;
+  first<T = unknown>(
+    column: string,
+  ): Effect.Effect<T | null, never, RuntimeContext>;
+  first<T = unknown>(
+    column?: string,
+  ): Effect.Effect<T | null, never, RuntimeContext> {
     return this.withRuntime((stmt) =>
       column !== undefined ? stmt.first<T>(column) : stmt.first<T>(),
     );
   }
 
   /** Run the query as a mutation; returns row metadata. */
-  run<T = unknown>(): Effect.Effect<runtime.D1Result<T>> {
+  run<T = unknown>(): Effect.Effect<
+    runtime.D1Result<T>,
+    never,
+    RuntimeContext
+  > {
     return this.withRuntime((stmt) => stmt.run<T>());
   }
 
   /** Run the query and return rows as flat arrays. */
-  raw<T = unknown[]>(): Effect.Effect<T[]>;
+  raw<T = unknown[]>(): Effect.Effect<T[], never, RuntimeContext>;
   raw<T = unknown[]>(options: {
     columnNames: true;
-  }): Effect.Effect<[string[], ...T[]]>;
+  }): Effect.Effect<[string[], ...T[]], never, RuntimeContext>;
   raw<T = unknown[]>(options?: {
     columnNames: true;
-  }): Effect.Effect<T[] | [string[], ...T[]]> {
+  }): Effect.Effect<T[] | [string[], ...T[]], never, RuntimeContext> {
     return this.withRuntime((stmt) =>
       options
         ? stmt.raw<T>(options)
@@ -79,10 +92,10 @@ export class D1PreparedStatement {
 
   private withRuntime<A>(
     fn: (stmt: runtime.D1PreparedStatement) => Promise<A>,
-  ): Effect.Effect<A> {
+  ): Effect.Effect<A, never, RuntimeContext> {
     return Effect.flatMap(this.rawEff, (raw) =>
       Effect.promise(() => fn(this._build(raw))),
-    );
+    ) as Effect.Effect<A, never, RuntimeContext>;
   }
 }
 
@@ -91,7 +104,7 @@ export interface D1ConnectionClient {
    * An Effect that resolves to the raw underlying Cloudflare D1Database binding.
    * Use this when you need direct access for libraries like Better Auth.
    */
-  raw: Effect.Effect<runtime.D1Database>;
+  raw: Effect.Effect<runtime.D1Database, never, RuntimeContext>;
   /**
    * Prepare a SQL statement. Returns synchronously — the network
    * round-trip happens when you yield one of the statement's
@@ -101,14 +114,16 @@ export interface D1ConnectionClient {
   /**
    * Execute raw SQL without prepared statements.
    */
-  exec: (query: string) => Effect.Effect<runtime.D1ExecResult>;
+  exec: (
+    query: string,
+  ) => Effect.Effect<runtime.D1ExecResult, never, RuntimeContext>;
   /**
    * Send multiple prepared statements in a single call.
    * Statements execute sequentially and are rolled back on failure.
    */
   batch: <T = unknown>(
     statements: D1PreparedStatement[],
-  ) => Effect.Effect<runtime.D1Result<T>[]>;
+  ) => Effect.Effect<runtime.D1Result<T>[], never, RuntimeContext>;
 }
 
 export class D1Connection extends Binding.Service<

--- a/packages/alchemy/src/Cloudflare/D1/D1Connection.ts
+++ b/packages/alchemy/src/Cloudflare/D1/D1Connection.ts
@@ -1,7 +1,6 @@
 import type * as runtime from "@cloudflare/workers-types";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 import * as Binding from "../../Binding.ts";
 import { WorkerEnvironment } from "../Workers/Worker.ts";
 import type { D1Database } from "./D1Database.ts";
@@ -121,13 +120,12 @@ export const D1ConnectionLive = Layer.effect(
   D1Connection,
   Effect.gen(function* () {
     const Policy = yield* D1ConnectionPolicy;
+    const env = yield* WorkerEnvironment;
 
     return Effect.fn(function* (database: D1Database) {
       yield* Policy(database);
-      const rawEff = yield* Effect.serviceOption(WorkerEnvironment).pipe(
-        Effect.map(Option.getOrUndefined),
-        Effect.map((env) => env?.[database.LogicalId]! as runtime.D1Database),
-        Effect.cached,
+      const rawEff = Effect.sync(
+        () => (env as Record<string, runtime.D1Database>)[database.LogicalId]!,
       );
 
       return {

--- a/packages/alchemy/src/Cloudflare/Email/SendEmailBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Email/SendEmailBinding.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import type { ResourceLike } from "../../Resource.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import type { SendEmail } from "./SendEmail.ts";
 
@@ -35,20 +36,20 @@ export interface SendEmailClient {
    * access to the Cloudflare object (e.g. to send a pre-built
    * `EmailMessage` from `cloudflare:email`).
    */
-  raw: Effect.Effect<runtime.SendEmail, never, WorkerEnvironment>;
+  raw: Effect.Effect<runtime.SendEmail, never, RuntimeContext>;
   /**
    * Send an email using the builder form. Equivalent to calling
    * `env.<name>.send({ from, to, subject, text, html, ... })`.
    */
   send(
     message: SendEmailMessage,
-  ): Effect.Effect<runtime.EmailSendResult, SendEmailError, WorkerEnvironment>;
+  ): Effect.Effect<runtime.EmailSendResult, SendEmailError, RuntimeContext>;
   /**
    * Send a raw `EmailMessage` (constructed via `cloudflare:email`).
    */
   sendRaw(
     message: runtime.EmailMessage,
-  ): Effect.Effect<runtime.EmailSendResult, SendEmailError, WorkerEnvironment>;
+  ): Effect.Effect<runtime.EmailSendResult, SendEmailError, RuntimeContext>;
 }
 
 /**
@@ -65,12 +66,13 @@ export const SendEmailBindingLive = Layer.effect(
   SendEmailBinding,
   Effect.gen(function* () {
     const bind = yield* SendEmailBindingPolicy;
+    const env = yield* WorkerEnvironment;
 
     return Effect.fnUntraced(function* (sender: SendEmail) {
       yield* bind(sender);
 
-      const raw = WorkerEnvironment.useSync(
-        (env) => (env as Record<string, runtime.SendEmail>)[sender.name]!,
+      const raw = Effect.sync(
+        () => (env as Record<string, runtime.SendEmail>)[sender.name]!,
       );
 
       const tryPromise = <T>(

--- a/packages/alchemy/src/Cloudflare/Hyperdrive/HyperdriveBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/HyperdriveBinding.ts
@@ -1,7 +1,6 @@
 import type * as runtime from "@cloudflare/workers-types";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import { AlchemyContext } from "../../AlchemyContext.ts";
 import * as Binding from "../../Binding.ts";
@@ -67,13 +66,13 @@ export const HyperdriveBindingLive = Layer.effect(
   HyperdriveBinding,
   Effect.gen(function* () {
     const Policy = yield* HyperdriveBindingPolicy;
+    const env = yield* WorkerEnvironment;
 
     return Effect.fn(function* (hyperdrive: Hyperdrive) {
       yield* Policy(hyperdrive);
-      const hd = yield* Effect.serviceOption(WorkerEnvironment).pipe(
-        Effect.map(Option.getOrUndefined),
-        Effect.map((env) => env?.[hyperdrive.LogicalId]! as runtime.Hyperdrive),
-        Effect.cached,
+      const hd = Effect.sync(
+        () =>
+          (env as Record<string, runtime.Hyperdrive>)[hyperdrive.LogicalId]!,
       );
 
       return {

--- a/packages/alchemy/src/Cloudflare/Hyperdrive/HyperdriveBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/HyperdriveBinding.ts
@@ -6,6 +6,7 @@ import { AlchemyContext } from "../../AlchemyContext.ts";
 import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import type { ResourceLike } from "../../Resource.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import type { Hyperdrive } from "./Hyperdrive.ts";
 import { defaultPort, type HyperdriveDevOrigin } from "./Hyperdrive.ts";
@@ -15,32 +16,36 @@ export interface HyperdriveBindingClient {
    * The raw runtime `Hyperdrive` binding. Use this when integrating with a
    * driver that wants direct access to the Cloudflare object.
    */
-  raw: Effect.Effect<runtime.Hyperdrive>;
+  raw: Effect.Effect<runtime.Hyperdrive, never, RuntimeContext>;
   /**
    * A valid DB connection string for use with a driver/ORM.
    */
-  connectionString: Effect.Effect<Redacted.Redacted<string>>;
+  connectionString: Effect.Effect<
+    Redacted.Redacted<string>,
+    never,
+    RuntimeContext
+  >;
   /**
    * Hostname valid only within the current Worker invocation.
    */
-  host: Effect.Effect<string>;
+  host: Effect.Effect<string, never, RuntimeContext>;
   /**
    * Port to pair with `host`.
    */
-  port: Effect.Effect<number>;
+  port: Effect.Effect<number, never, RuntimeContext>;
   /**
    * Database user.
    */
-  user: Effect.Effect<string>;
+  user: Effect.Effect<string, never, RuntimeContext>;
   /**
    * Randomly generated password valid only within the current Worker
    * invocation.
    */
-  password: Effect.Effect<Redacted.Redacted<string>>;
+  password: Effect.Effect<Redacted.Redacted<string>, never, RuntimeContext>;
   /**
    * Database name.
    */
-  database: Effect.Effect<string>;
+  database: Effect.Effect<string, never, RuntimeContext>;
 }
 
 /**

--- a/packages/alchemy/src/Cloudflare/Images/ImagesBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Images/ImagesBinding.ts
@@ -5,6 +5,7 @@ import * as Layer from "effect/Layer";
 import * as Stream from "effect/Stream";
 import * as Binding from "../../Binding.ts";
 import type { ResourceLike } from "../../Resource.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import { type Images as ImagesLike } from "./Images.ts";
 
@@ -55,7 +56,7 @@ export interface ImageTransformerClient {
  */
 export interface ImagesClient {
   /** Effect resolving to the raw Cloudflare runtime binding. */
-  raw: Effect.Effect<cf.ImagesBinding, never, WorkerEnvironment>;
+  raw: Effect.Effect<cf.ImagesBinding, never, RuntimeContext>;
   /**
    * Read image format and dimensions from a stream of bytes.
    * Fails with {@link ImagesError} (code 9412) if the input is not
@@ -64,7 +65,7 @@ export interface ImagesClient {
   info<E = never, R = never>(
     stream: Stream.Stream<Uint8Array, E, R>,
     options?: cf.ImageInputOptions,
-  ): Effect.Effect<cf.ImageInfoResponse, ImagesError, WorkerEnvironment | R>;
+  ): Effect.Effect<cf.ImageInfoResponse, ImagesError, RuntimeContext | R>;
   /**
    * Begin a transformation pipeline. Subsequent `.transform()` /
    * `.draw()` calls are pure; `.output(opts)` runs the pipeline.
@@ -72,7 +73,7 @@ export interface ImagesClient {
   input<E = never, R = never>(
     stream: Stream.Stream<Uint8Array, E, R>,
     options?: cf.ImageInputOptions,
-  ): Effect.Effect<ImageTransformerClient, never, WorkerEnvironment | R>;
+  ): Effect.Effect<ImageTransformerClient, never, RuntimeContext | R>;
 }
 
 export class ImagesBinding extends Binding.Service<
@@ -84,14 +85,13 @@ export const ImagesBindingLive = Layer.effect(
   ImagesBinding,
   Effect.gen(function* () {
     const Policy = yield* ImagesBindingPolicy;
+    const env = yield* WorkerEnvironment;
 
     return Effect.fn(function* (images: ImagesLike) {
       yield* Policy(images);
-      const env = WorkerEnvironment;
-      const raw = env.pipe(
-        Effect.map(
-          (env) => (env as Record<string, cf.ImagesBinding>)[images.name]!,
-        ),
+      const raw = Effect.sync(
+        // this must be lazy because the WorkerEnvironment is not available yet
+        () => (env as Record<string, cf.ImagesBinding>)[images.name]!,
       );
 
       return {

--- a/packages/alchemy/src/Cloudflare/KV/KVNamespaceBinding.ts
+++ b/packages/alchemy/src/Cloudflare/KV/KVNamespaceBinding.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import type { ResourceLike } from "../../Resource.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import type { KVNamespace } from "./KVNamespace.ts";
 
@@ -17,46 +18,46 @@ export interface KVNamespaceClient<Key extends string = string> {
   get(
     key: Key,
     options?: Partial<KVNamespaceGetOptions<undefined>>,
-  ): Effect.Effect<string | null, KVNamespaceError, WorkerEnvironment>;
+  ): Effect.Effect<string | null, KVNamespaceError, RuntimeContext>;
   get(
     key: Key,
     type: "text",
-  ): Effect.Effect<string | null, KVNamespaceError, WorkerEnvironment>;
+  ): Effect.Effect<string | null, KVNamespaceError, RuntimeContext>;
   get<ExpectedValue = unknown>(
     key: Key,
     type: "json",
-  ): Effect.Effect<ExpectedValue | null, KVNamespaceError, WorkerEnvironment>;
+  ): Effect.Effect<ExpectedValue | null, KVNamespaceError, RuntimeContext>;
   get(
     key: Key,
     type: "arrayBuffer",
-  ): Effect.Effect<ArrayBuffer | null, KVNamespaceError, WorkerEnvironment>;
+  ): Effect.Effect<ArrayBuffer | null, KVNamespaceError, RuntimeContext>;
   get(
     key: Key,
     type: "stream",
-  ): Effect.Effect<ReadableStream | null, KVNamespaceError, WorkerEnvironment>;
+  ): Effect.Effect<ReadableStream | null, KVNamespaceError, RuntimeContext>;
   get(
     key: Key,
     options?: KVNamespaceGetOptions<"text">,
-  ): Effect.Effect<string | null, KVNamespaceError, WorkerEnvironment>;
+  ): Effect.Effect<string | null, KVNamespaceError, RuntimeContext>;
   get<ExpectedValue = unknown>(
     key: Key,
     options?: KVNamespaceGetOptions<"json">,
-  ): Effect.Effect<ExpectedValue | null, KVNamespaceError, WorkerEnvironment>;
+  ): Effect.Effect<ExpectedValue | null, KVNamespaceError, RuntimeContext>;
   get(
     key: Key,
     options?: KVNamespaceGetOptions<"arrayBuffer">,
-  ): Effect.Effect<ArrayBuffer | null, KVNamespaceError, WorkerEnvironment>;
+  ): Effect.Effect<ArrayBuffer | null, KVNamespaceError, RuntimeContext>;
   get(
     key: Key,
     options?: KVNamespaceGetOptions<"stream">,
-  ): Effect.Effect<ReadableStream | null, KVNamespaceError, WorkerEnvironment>;
+  ): Effect.Effect<ReadableStream | null, KVNamespaceError, RuntimeContext>;
   get(
     key: Array<Key>,
     type: "text",
   ): Effect.Effect<
     Map<string, string | null>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   get<ExpectedValue = unknown>(
     key: Array<Key>,
@@ -64,7 +65,7 @@ export interface KVNamespaceClient<Key extends string = string> {
   ): Effect.Effect<
     Map<string, ExpectedValue | null>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   get(
     key: Array<Key>,
@@ -72,7 +73,7 @@ export interface KVNamespaceClient<Key extends string = string> {
   ): Effect.Effect<
     Map<string, string | null>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   get(
     key: Array<Key>,
@@ -80,7 +81,7 @@ export interface KVNamespaceClient<Key extends string = string> {
   ): Effect.Effect<
     Map<string, string | null>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   get<ExpectedValue = unknown>(
     key: Array<Key>,
@@ -88,27 +89,27 @@ export interface KVNamespaceClient<Key extends string = string> {
   ): Effect.Effect<
     Map<string, ExpectedValue | null>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   list<Metadata = unknown>(
     options?: KVNamespaceListOptions,
   ): Effect.Effect<
     KVNamespaceListResult<Metadata, Key>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   put(
     key: Key,
     value: string | ArrayBuffer | ArrayBufferView | ReadableStream,
     options?: KVNamespacePutOptions,
-  ): Effect.Effect<void, KVNamespaceError, WorkerEnvironment>;
+  ): Effect.Effect<void, KVNamespaceError, RuntimeContext>;
   getWithMetadata<Metadata = unknown>(
     key: Key,
     options?: Partial<KVNamespaceGetOptions<undefined>>,
   ): Effect.Effect<
     KVNamespaceGetWithMetadataResult<string, Metadata>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   getWithMetadata<Metadata = unknown>(
     key: Key,
@@ -116,7 +117,7 @@ export interface KVNamespaceClient<Key extends string = string> {
   ): Effect.Effect<
     KVNamespaceGetWithMetadataResult<string, Metadata>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(
     key: Key,
@@ -124,7 +125,7 @@ export interface KVNamespaceClient<Key extends string = string> {
   ): Effect.Effect<
     KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   getWithMetadata<Metadata = unknown>(
     key: Key,
@@ -132,7 +133,7 @@ export interface KVNamespaceClient<Key extends string = string> {
   ): Effect.Effect<
     KVNamespaceGetWithMetadataResult<ArrayBuffer, Metadata>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   getWithMetadata<Metadata = unknown>(
     key: Key,
@@ -140,7 +141,7 @@ export interface KVNamespaceClient<Key extends string = string> {
   ): Effect.Effect<
     KVNamespaceGetWithMetadataResult<ReadableStream, Metadata>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   getWithMetadata<Metadata = unknown>(
     key: Key,
@@ -148,7 +149,7 @@ export interface KVNamespaceClient<Key extends string = string> {
   ): Effect.Effect<
     KVNamespaceGetWithMetadataResult<string, Metadata>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(
     key: Key,
@@ -156,7 +157,7 @@ export interface KVNamespaceClient<Key extends string = string> {
   ): Effect.Effect<
     KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   getWithMetadata<Metadata = unknown>(
     key: Key,
@@ -164,7 +165,7 @@ export interface KVNamespaceClient<Key extends string = string> {
   ): Effect.Effect<
     KVNamespaceGetWithMetadataResult<ArrayBuffer, Metadata>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   getWithMetadata<Metadata = unknown>(
     key: Key,
@@ -172,7 +173,7 @@ export interface KVNamespaceClient<Key extends string = string> {
   ): Effect.Effect<
     KVNamespaceGetWithMetadataResult<ReadableStream, Metadata>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   getWithMetadata<Metadata = unknown>(
     key: Array<Key>,
@@ -180,7 +181,7 @@ export interface KVNamespaceClient<Key extends string = string> {
   ): Effect.Effect<
     Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(
     key: Array<Key>,
@@ -188,7 +189,7 @@ export interface KVNamespaceClient<Key extends string = string> {
   ): Effect.Effect<
     Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   getWithMetadata<Metadata = unknown>(
     key: Array<Key>,
@@ -196,7 +197,7 @@ export interface KVNamespaceClient<Key extends string = string> {
   ): Effect.Effect<
     Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   getWithMetadata<Metadata = unknown>(
     key: Array<Key>,
@@ -204,7 +205,7 @@ export interface KVNamespaceClient<Key extends string = string> {
   ): Effect.Effect<
     Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
   getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(
     key: Array<Key>,
@@ -212,9 +213,9 @@ export interface KVNamespaceClient<Key extends string = string> {
   ): Effect.Effect<
     Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>,
     KVNamespaceError,
-    WorkerEnvironment
+    RuntimeContext
   >;
-  delete(key: Key): Effect.Effect<void, KVNamespaceError, WorkerEnvironment>;
+  delete(key: Key): Effect.Effect<void, KVNamespaceError, RuntimeContext>;
 }
 
 export class KVNamespaceBinding extends Binding.Service<
@@ -226,15 +227,13 @@ export const KVNamespaceBindingLive = Layer.effect(
   KVNamespaceBinding,
   Effect.gen(function* () {
     const bind = yield* KVNamespaceBindingPolicy;
+    const env = yield* WorkerEnvironment;
 
     return Effect.fn(function* (bucket: KVNamespace) {
       yield* bind(bucket);
-      const env = WorkerEnvironment;
-      const raw = env.pipe(
-        Effect.map(
-          (env) =>
-            (env as Record<string, runtime.KVNamespace>)[bucket.LogicalId],
-        ),
+      const raw = Effect.sync(
+        // this must be lazy because the WorkerEnvironment is not available yet
+        () => (env as Record<string, runtime.KVNamespace>)[bucket.LogicalId],
       );
       const tryPromise = <T>(
         fn: () => Promise<T>,
@@ -250,9 +249,10 @@ export const KVNamespaceBindingLive = Layer.effect(
 
       const use = <T>(
         fn: (raw: runtime.KVNamespace<string>) => Promise<T>,
-      ): Effect.Effect<T, KVNamespaceError, WorkerEnvironment> =>
+      ): Effect.Effect<T, KVNamespaceError> =>
         raw.pipe(Effect.flatMap((raw) => tryPromise(() => fn(raw))));
 
+      // @ts-expect-error
       return {
         raw: raw,
         // @ts-expect-error

--- a/packages/alchemy/src/Cloudflare/Queue/QueueBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Queue/QueueBinding.ts
@@ -2,21 +2,22 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import type { ResourceLike } from "../../Resource.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import type { Queue } from "./Queue.ts";
 
 export interface QueueSender {
-  raw: Effect.Effect<any, never, WorkerEnvironment>;
+  raw: Effect.Effect<any, never, RuntimeContext>;
   send(
     body: unknown,
     options?: { contentType?: "json" | "text" },
-  ): Effect.Effect<void, QueueSendError, WorkerEnvironment>;
+  ): Effect.Effect<void, QueueSendError, RuntimeContext>;
   sendBatch(
     messages: ReadonlyArray<{
       body: unknown;
       contentType?: "json" | "text";
     }>,
-  ): Effect.Effect<void, QueueSendError, WorkerEnvironment>;
+  ): Effect.Effect<void, QueueSendError, RuntimeContext>;
 }
 
 import * as Data from "effect/Data";
@@ -68,12 +69,12 @@ export const QueueBindingLive = Layer.effect(
   QueueBinding,
   Effect.gen(function* () {
     const bind = yield* QueueBindingPolicy;
+    const env = yield* WorkerEnvironment;
 
     return Effect.fn(function* (queue: Queue) {
       yield* bind(queue);
-      const env = WorkerEnvironment;
-      const raw = env.pipe(
-        Effect.map((env) => (env as Record<string, any>)[queue.LogicalId]),
+      const raw = Effect.sync(
+        () => (env as Record<string, any>)[queue.LogicalId],
       );
 
       const tryPromise = <T>(

--- a/packages/alchemy/src/Cloudflare/R2/R2BucketBinding.ts
+++ b/packages/alchemy/src/Cloudflare/R2/R2BucketBinding.ts
@@ -6,6 +6,7 @@ import * as Stream from "effect/Stream";
 import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import type { ResourceLike } from "../../Resource.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 import { getRawStream } from "../../Util/Stream.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import type { R2Bucket } from "./R2Bucket.ts";
@@ -66,18 +67,18 @@ export type R2UploadedPart = runtime.R2UploadedPart;
 export interface R2UploadPartOptions extends runtime.R2UploadPartOptions {}
 
 export interface R2BucketClient {
-  raw: Effect.Effect<runtime.R2Bucket, never, WorkerEnvironment>;
-  head(key: string): Effect.Effect<R2Object | null, R2Error, WorkerEnvironment>;
+  raw: Effect.Effect<runtime.R2Bucket, never, RuntimeContext>;
+  head(key: string): Effect.Effect<R2Object | null, R2Error, RuntimeContext>;
   get(
     key: string,
     options: R2GetOptions & {
       onlyIf: runtime.R2Conditional | Headers;
     },
-  ): Effect.Effect<R2ObjectBody | R2Object | null, R2Error, WorkerEnvironment>;
+  ): Effect.Effect<R2ObjectBody | R2Object | null, R2Error, RuntimeContext>;
   get(
     key: string,
     options?: R2GetOptions,
-  ): Effect.Effect<R2ObjectBody | null, R2Error, WorkerEnvironment>;
+  ): Effect.Effect<R2ObjectBody | null, R2Error, RuntimeContext>;
   put<Err = never>(
     key: string,
     value:
@@ -92,7 +93,7 @@ export interface R2BucketClient {
       onlyIf: R2Conditional | Headers;
       contentLength?: number;
     },
-  ): Effect.Effect<R2Object | null, R2Error | Err, WorkerEnvironment>;
+  ): Effect.Effect<R2Object | null, R2Error | Err, RuntimeContext>;
   put<Err = never>(
     key: string,
     value:
@@ -103,7 +104,7 @@ export interface R2BucketClient {
       | null
       | Blob,
     options?: R2PutOptions,
-  ): Effect.Effect<R2Object, R2Error | Err, WorkerEnvironment>;
+  ): Effect.Effect<R2Object, R2Error | Err, RuntimeContext>;
   put<Err = never>(
     key: string,
     value:
@@ -117,21 +118,19 @@ export interface R2BucketClient {
     options: R2PutOptions & {
       contentLength: number;
     },
-  ): Effect.Effect<R2Object, R2Error | Err, WorkerEnvironment>;
-  delete(
-    keys: string | string[],
-  ): Effect.Effect<void, R2Error, WorkerEnvironment>;
+  ): Effect.Effect<R2Object, R2Error | Err, RuntimeContext>;
+  delete(keys: string | string[]): Effect.Effect<void, R2Error, RuntimeContext>;
   list(
     options?: R2ListOptions,
-  ): Effect.Effect<R2Objects, R2Error, WorkerEnvironment>;
+  ): Effect.Effect<R2Objects, R2Error, RuntimeContext>;
   createMultipartUpload(
     key: string,
     options?: R2MultipartOptions,
-  ): Effect.Effect<R2MultipartUpload, R2Error, WorkerEnvironment>;
+  ): Effect.Effect<R2MultipartUpload, R2Error, RuntimeContext>;
   resumeMultipartUpload(
     key: string,
     uploadId: string,
-  ): Effect.Effect<R2MultipartUpload, R2Error, WorkerEnvironment>;
+  ): Effect.Effect<R2MultipartUpload, R2Error, RuntimeContext>;
 }
 
 export class R2BucketBinding extends Binding.Service<
@@ -143,14 +142,12 @@ export const R2BucketBindingLive = Layer.effect(
   R2BucketBinding,
   Effect.gen(function* () {
     const bind = yield* R2BucketBindingPolicy;
+    const env = yield* WorkerEnvironment;
 
     return Effect.fn(function* (bucket: R2Bucket) {
       yield* bind(bucket);
-      const env = WorkerEnvironment;
-      const raw = env.pipe(
-        Effect.map(
-          (env) => (env as Record<string, runtime.R2Bucket>)[bucket.LogicalId],
-        ),
+      const raw = Effect.sync(
+        () => (env as Record<string, runtime.R2Bucket>)[bucket.LogicalId]!,
       );
       const tryPromise = <T>(fn: () => Promise<T>): Effect.Effect<T, R2Error> =>
         Effect.tryPromise({
@@ -164,7 +161,7 @@ export const R2BucketBindingLive = Layer.effect(
 
       const use = <T>(
         fn: (raw: runtime.R2Bucket) => Promise<T>,
-      ): Effect.Effect<T, R2Error, WorkerEnvironment> =>
+      ): Effect.Effect<T, R2Error> =>
         raw.pipe(Effect.flatMap((raw) => tryPromise(() => fn(raw))));
 
       const wrapR2Object = (object: runtime.R2Object): R2Object => ({

--- a/packages/alchemy/src/Cloudflare/SecretsStore/SecretBinding.ts
+++ b/packages/alchemy/src/Cloudflare/SecretsStore/SecretBinding.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Binding from "../../Binding.ts";
 import type { ResourceLike } from "../../Resource.ts";
+import type { RuntimeContext } from "../../RuntimeContext.ts";
 import { isWorker, WorkerEnvironment } from "../Workers/Worker.ts";
 import type { Secret } from "./Secret.ts";
 
@@ -21,16 +22,16 @@ export class SecretError extends Data.TaggedError("SecretError")<{
 export interface SecretClient extends Effect.Effect<
   string,
   SecretError,
-  WorkerEnvironment
+  RuntimeContext
 > {
   /**
    * Effect that resolves to the raw Cloudflare `SecretsStoreSecret` binding.
    */
-  raw: Effect.Effect<runtime.SecretsStoreSecret, never, WorkerEnvironment>;
+  raw: Effect.Effect<runtime.SecretsStoreSecret, never, RuntimeContext>;
   /**
    * Read the current value of the secret.
    */
-  get(): Effect.Effect<string, SecretError, WorkerEnvironment>;
+  get(): Effect.Effect<string, SecretError, RuntimeContext>;
 }
 
 export class SecretBinding extends Binding.Service<
@@ -42,17 +43,13 @@ export const SecretBindingLive = Layer.effect(
   SecretBinding,
   Effect.gen(function* () {
     const bind = yield* SecretBindingPolicy;
+    const env = yield* WorkerEnvironment;
 
     return Effect.fn(function* (secret: Secret) {
       yield* bind(secret);
-      const env = WorkerEnvironment;
-      const raw = env.pipe(
-        Effect.map(
-          (env) =>
-            (env as Record<string, runtime.SecretsStoreSecret>)[
-              secret.LogicalId
-            ],
-        ),
+      const raw = Effect.sync(
+        () =>
+          (env as Record<string, runtime.SecretsStoreSecret>)[secret.LogicalId],
       );
       const tryPromise = <T>(
         fn: () => Promise<T>,
@@ -66,8 +63,9 @@ export const SecretBindingLive = Layer.effect(
             }),
         });
 
-      const getEffect: Effect.Effect<string, SecretError, WorkerEnvironment> =
-        raw.pipe(Effect.flatMap((raw) => tryPromise(() => raw.get())));
+      const getEffect: Effect.Effect<string, SecretError> = raw.pipe(
+        Effect.flatMap((raw) => tryPromise(() => raw.get())),
+      );
 
       return Object.assign(
         Effect.suspend(() => getEffect),

--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectNamespace.ts
@@ -1,12 +1,12 @@
 import type * as cf from "@cloudflare/workers-types";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
-import * as Option from "effect/Option";
 import type { HttpServerError } from "effect/unstable/http/HttpServerError";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import type { HttpEffect } from "../../Http.ts";
 import * as Output from "../../Output.ts";
+import { ALCHEMY_PHASE } from "../../Phase.ts";
 import type { PlatformServices } from "../../Platform.ts";
 import { effectClass, taggedFunction } from "../../Util/effect.ts";
 import { DurableObjectState } from "./DurableObjectState.ts";
@@ -589,12 +589,12 @@ export const DurableObjectNamespace: DurableObjectNamespaceClass =
                 ],
               });
 
-              const binding = yield* Effect.serviceOption(
+              const binding = yield* Effect.all([
                 WorkerEnvironment,
-              ).pipe(
-                Effect.map(Option.getOrUndefined),
-                Effect.flatMap((env) => {
-                  if (env === undefined) {
+                ALCHEMY_PHASE,
+              ]).pipe(
+                Effect.flatMap(([env, phase]) => {
+                  if (env === undefined || phase === "plan") {
                     // should be fine to return undefined here (it is only undefined at plantime)
                     return Effect.succeed(undefined);
                   }

--- a/packages/alchemy/src/Cloudflare/Workers/DynamicWorkerLoader.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DynamicWorkerLoader.ts
@@ -1,5 +1,5 @@
 import * as Effect from "effect/Effect";
-import * as Option from "effect/Option";
+import { ALCHEMY_PHASE } from "../../Phase.ts";
 import { fromCloudflareFetcher, type Fetcher } from "../Fetcher.ts";
 import { makeRpcStub } from "./Rpc.ts";
 import { Worker, WorkerEnvironment } from "./Worker.ts";
@@ -162,10 +162,9 @@ export const DynamicWorkerLoader = Effect.fnUntraced(function* (name: string) {
     bindings: [{ type: "worker_loader", name } as any],
   });
 
-  const binding = yield* Effect.serviceOption(WorkerEnvironment).pipe(
-    Effect.map(Option.getOrUndefined),
-    Effect.flatMap((env) => {
-      if (env === undefined) {
+  const binding = yield* Effect.all([WorkerEnvironment, ALCHEMY_PHASE]).pipe(
+    Effect.flatMap(([env, phase]) => {
+      if (env === undefined || phase === "plan") {
         return Effect.succeed(undefined as any);
       }
       const loader = env[name];

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -136,9 +136,13 @@ export const ExportedHandlerMethods = [
   "queue",
 ] as const satisfies (keyof cf.ExportedHandler)[];
 
-export type WorkerServices = Worker | Request | WorkerExecutionContext;
+export type WorkerServices =
+  | Worker
+  | Request
+  | WorkerExecutionContext
+  | WorkerEnvironment;
 
-export type WorkerShape = Main<WorkerServices | WorkerEnvironment>;
+export type WorkerShape = Main<WorkerServices>;
 
 export type WorkerEnv = Record<
   string,

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerRuntimeContext.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerRuntimeContext.ts
@@ -1,5 +1,6 @@
 import type * as cf from "@cloudflare/workers-types";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import type { HttpEffect } from "../../Http.ts";
@@ -112,6 +113,7 @@ export const makeWorkerRuntimeContext = (id: string): WorkerRuntimeContext => {
       Effect.sync(() => {
         exports[name] = value;
       }),
+    planServices: Layer.succeed(WorkerEnvironment, {}),
     exports: Effect.gen(function* () {
       const handlers = yield* Effect.all(listeners, {
         concurrency: "unbounded",

--- a/packages/alchemy/src/Cloudflare/Workers/Workflow.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Workflow.ts
@@ -1,7 +1,7 @@
 import * as workflows from "@distilled.cloud/cloudflare/workflows";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
-import * as Option from "effect/Option";
+import { ALCHEMY_PHASE } from "../../Phase.ts";
 import type { PlatformServices } from "../../Platform.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
@@ -99,12 +99,9 @@ export const sleepUntil = (
  * reflect that or `yield* WorkerEnvironment` fails to type-check inside a
  * body even though it succeeds at runtime.
  */
-export type WorkflowRunServices =
-  | WorkflowEvent
-  | WorkflowStep
-  | WorkerEnvironment;
+export type WorkflowRunServices = WorkflowEvent | WorkflowStep | WorkerServices;
 
-export type WorkflowServices = WorkerServices | PlatformServices;
+export type WorkflowServices = WorkflowRunServices | PlatformServices;
 
 /**
  * Metadata stored in the worker export map to distinguish workflow exports
@@ -122,7 +119,7 @@ export interface WorkflowExport {
  */
 export type WorkflowImpl<Input = unknown, Result = unknown> = (
   input: Input,
-) => Effect.Effect<Result, never, WorkflowRunServices>;
+) => Effect.Effect<Result, never, WorkflowServices>;
 
 export const isWorkflowExport = (value: unknown): value is WorkflowExport =>
   typeof value === "object" &&
@@ -391,10 +388,12 @@ export const Workflow: WorkflowClass = taggedFunction(WorkflowScope, ((
           const services =
             yield* Effect.context<Effect.Services<typeof impl>>();
 
-          const binding = yield* Effect.serviceOption(WorkerEnvironment).pipe(
-            Effect.map(Option.getOrUndefined),
-            Effect.flatMap((env) => {
-              if (env === undefined) {
+          const binding = yield* Effect.all([
+            WorkerEnvironment,
+            ALCHEMY_PHASE,
+          ]).pipe(
+            Effect.flatMap(([env, phase]) => {
+              if (env === undefined || phase === "plan") {
                 return Effect.succeed(undefined as any);
               }
               const wf = env[name];

--- a/packages/alchemy/src/Phase.ts
+++ b/packages/alchemy/src/Phase.ts
@@ -1,5 +1,7 @@
 import * as Config from "effect/Config";
+import * as Effect from "effect/Effect";
 
 export const ALCHEMY_PHASE = Config.string("ALCHEMY_PHASE").pipe(
   Config.withDefault("plan"),
+  Effect.orDie,
 );

--- a/packages/alchemy/src/Platform.ts
+++ b/packages/alchemy/src/Platform.ts
@@ -10,6 +10,7 @@ import type { PolicyLike } from "./Binding.ts";
 import type { ExecutionContext } from "./ExecutionContext.ts";
 import type { HttpEffect } from "./Http.ts";
 import type { InputProps } from "./Input.ts";
+import { ALCHEMY_PHASE } from "./Phase.ts";
 import type { Provider, ProviderCollectionLike } from "./Provider.ts";
 import { Resource, type ResourceLike } from "./Resource.ts";
 import type { Rpc } from "./Rpc.ts";
@@ -192,7 +193,7 @@ export const Platform = <
   type Impl = Effect.Effect<any>;
 
   const resource = Resource(type);
-  const PlatformContext = RuntimeContext(type);
+  const PlatformContext = RuntimeContext;
 
   const constructor = (
     id?: string,
@@ -351,6 +352,17 @@ export const Platform = <
                       Layer.succeed(resource.Self, instance),
                       Layer.succeed(Platform.Self, instance),
                       Layer.succeed(Self, instance),
+                      runtimeContext.planServices
+                        ? Layer.unwrap(
+                            ALCHEMY_PHASE.pipe(
+                              Effect.map((phase) =>
+                                phase === "plan"
+                                  ? runtimeContext.planServices!
+                                  : Layer.empty,
+                              ),
+                            ),
+                          )
+                        : Layer.empty,
                     ),
                     Layer.succeedContext(outerServices),
                   ),

--- a/packages/alchemy/src/RuntimeContext.ts
+++ b/packages/alchemy/src/RuntimeContext.ts
@@ -1,9 +1,9 @@
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import type { HttpEffect } from "./Http.ts";
 import type { Output } from "./Output.ts";
-import { GenericService } from "./Util/service.ts";
 
 export interface BaseRuntimeContext {
   Type: string;
@@ -17,20 +17,19 @@ export interface BaseRuntimeContext {
     options?: { shape?: Record<string, unknown> },
   ): Effect.Effect<void, never, Req>;
   shape?: () => Record<string, unknown>;
+  /** additional services to provide to the plan  */
+  planServices?: Layer.Layer<any>;
 }
-
-export interface RuntimeContext<
-  Ctx extends BaseRuntimeContext = BaseRuntimeContext,
-> extends Context.Service<`RuntimeContext<${Ctx["Type"]}>`, Ctx> {}
 
 /**
  * Context of the runtime environment.
  *
  * E.g. the context of a running Worker, Task, Process, Function
  */
-export const RuntimeContext = GenericService<{
-  <Ctx extends BaseRuntimeContext>(type: Ctx["Type"]): RuntimeContext<Ctx>;
-}>()("Alchemy::RuntimeContext");
+export class RuntimeContext extends Context.Service<
+  RuntimeContext,
+  BaseRuntimeContext
+>()("RuntimeContext") {}
 
 export const CurrentRuntimeContext = Effect.serviceOption(RuntimeContext).pipe(
   Effect.map(Option.getOrUndefined),

--- a/packages/alchemy/test/Planetscale/MySQL/MySQLBranch.test.ts
+++ b/packages/alchemy/test/Planetscale/MySQL/MySQLBranch.test.ts
@@ -3,7 +3,7 @@ import * as Planetscale from "@/Planetscale";
 import * as RemovalPolicy from "@/RemovalPolicy.ts";
 import * as Test from "@/Test/Vitest";
 import * as ops from "@distilled.cloud/planetscale/Operations";
-import { expect } from "@effect/vitest";
+import { describe, expect } from "@effect/vitest";
 import { Data, Schedule } from "effect";
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
@@ -17,527 +17,529 @@ const logLevel = Effect.provideService(
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-test.provider(
-  "adopts existing branch when adopt is true",
-  (stack) =>
-    Effect.gen(function* () {
-      const dbName = "alchemy-branch-adopt-true";
-      const branchName = "adopted";
+describe.skipIf(!process.env.PLANETSCALE_TEST)(() => {
+  test.provider(
+    "adopts existing branch when adopt is true",
+    (stack) =>
+      Effect.gen(function* () {
+        const dbName = "alchemy-branch-adopt-true";
+        const branchName = "adopted";
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      const { database } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase("Database", {
-            name: dbName,
-            region: { slug: "us-east" },
-            clusterSize: "PS_10",
-          });
-
-          return { database };
-        }),
-      );
-
-      yield* Planetscale.waitForBranchReady(
-        database.organization,
-        dbName,
-        "main",
-      );
-      yield* deleteBranchIfExists(database.organization, dbName, branchName);
-
-      yield* ops.createBranch({
-        organization: database.organization,
-        database: dbName,
-        name: branchName,
-        parent_branch: "main",
-      });
-      yield* Planetscale.waitForBranchReady(
-        database.organization,
-        dbName,
-        branchName,
-      );
-
-      const { branch } = yield* stack
-        .deploy(
+        const { database } = yield* stack.deploy(
           Effect.gen(function* () {
             const database = yield* Planetscale.MySQLDatabase("Database", {
               name: dbName,
               region: { slug: "us-east" },
               clusterSize: "PS_10",
             });
-            const branch = yield* Planetscale.MySQLBranch("AdoptedBranch", {
-              name: branchName,
-              database,
-              parentBranch: "main",
-              isProduction: false,
-            });
 
-            return { database, branch };
+            return { database };
           }),
-        )
-        .pipe(adopt(true));
-
-      expect(branch).toMatchObject({
-        name: branchName,
-        organization: database.organization,
-        database: dbName,
-        parentBranch: "main",
-        production: false,
-        createdAt: expect.any(String),
-        updatedAt: expect.any(String),
-        htmlUrl: expect.any(String),
-        region: { slug: expect.any(String) },
-      });
-
-      yield* stack.destroy();
-      yield* waitForDatabaseToBeDeleted(dbName, database.organization);
-    }).pipe(logLevel),
-  5_000_000,
-);
-
-test.provider(
-  "errors on existing branch when adopt is false",
-  (stack) =>
-    Effect.gen(function* () {
-      const dbName = "alchemy-branch-adopt-false";
-      const branchName = "existing";
-
-      yield* stack.destroy();
-
-      const { database } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase("Database", {
-            name: dbName,
-            region: { slug: "us-east" },
-            clusterSize: "PS_10",
-          });
-
-          return { database };
-        }),
-      );
-
-      yield* Planetscale.waitForBranchReady(
-        database.organization,
-        dbName,
-        "main",
-      );
-      yield* deleteBranchIfExists(database.organization, dbName, branchName);
-
-      yield* ops.createBranch({
-        organization: database.organization,
-        database: dbName,
-        name: branchName,
-        parent_branch: "main",
-      });
-      yield* Planetscale.waitForBranchReady(
-        database.organization,
-        dbName,
-        branchName,
-      );
-
-      const exit = yield* stack
-        .deploy(
-          Effect.gen(function* () {
-            const database = yield* Planetscale.MySQLDatabase("Database", {
-              name: dbName,
-              region: { slug: "us-east" },
-              clusterSize: "PS_10",
-            });
-            const branch = yield* Planetscale.MySQLBranch("ExistingBranch", {
-              name: branchName,
-              database,
-              parentBranch: "main",
-              isProduction: false,
-            });
-
-            return { database, branch };
-          }),
-        )
-        .pipe(Effect.exit);
-
-      yield* deleteBranchIfExists(database.organization, dbName, branchName);
-      yield* stack.destroy();
-      yield* waitForDatabaseToBeDeleted(dbName, database.organization);
-
-      expect(Exit.isFailure(exit)).toBe(true);
-      if (Exit.isFailure(exit)) {
-        const pretty = Cause.pretty(exit.cause);
-        expect(pretty).toContain("Cannot adopt resource");
-        expect(pretty).toContain("Planetscale.MySQLBranch");
-      }
-    }).pipe(logLevel),
-  5_000_000,
-);
-
-test.provider(
-  "can create branch with backup",
-  (stack) =>
-    Effect.gen(function* () {
-      const dbName = "alchemy-branch-backup";
-      const branchName = "restored";
-
-      yield* stack.destroy();
-
-      const { database } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase("Database", {
-            name: dbName,
-            region: { slug: "us-east" },
-            clusterSize: "PS_10",
-          });
-
-          return { database };
-        }),
-      );
-
-      yield* Planetscale.waitForBranchReady(
-        database.organization,
-        dbName,
-        "main",
-      );
-      yield* deleteBranchIfExists(database.organization, dbName, branchName);
-
-      const backup = yield* ops.createBackup({
-        organization: database.organization,
-        database: dbName,
-        branch: "main",
-        name: "alchemy-branch-backup-source",
-        retention_unit: "hour",
-        retention_value: 1,
-      });
-      yield* waitForBackupSuccess(
-        database.organization,
-        dbName,
-        "main",
-        backup.id,
-      );
-
-      const { branch } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase("Database", {
-            name: dbName,
-            region: { slug: "us-east" },
-            clusterSize: "PS_10",
-          });
-          const branch = yield* Planetscale.MySQLBranch("RestoredBranch", {
-            name: branchName,
-            database,
-            parentBranch: "main",
-            isProduction: true,
-            backupId: backup.id,
-            clusterSize: "PS_10",
-          });
-
-          return { database, branch };
-        }),
-      );
-
-      expect(branch).toMatchObject({
-        name: branchName,
-        database: dbName,
-        parentBranch: "main",
-        production: true,
-      });
-
-      const live = yield* Planetscale.waitForBranchReady(
-        database.organization,
-        dbName,
-        branchName,
-      );
-      expect(live.name).toEqual(branchName);
-      expect(live.production).toBe(true);
-      expect(live.cluster_name).toEqual("PS_10");
-
-      yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase("Database", {
-            name: dbName,
-            region: { slug: "us-east" },
-            clusterSize: "PS_10",
-          });
-          const branch = yield* Planetscale.MySQLBranch("RestoredBranch", {
-            name: branchName,
-            database,
-            parentBranch: "main",
-            isProduction: false,
-          });
-
-          return { database, branch };
-        }),
-      );
-
-      yield* stack.destroy();
-      yield* waitForDatabaseToBeDeleted(dbName, database.organization);
-    }).pipe(logLevel),
-  5_000_000,
-);
-
-test.provider(
-  "can enable and disable safe migrations",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      const { database, branch } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase("Database", {
-            clusterSize: "PS_10",
-          });
-          const branch = yield* Planetscale.MySQLBranch("Branch", {
-            database,
-            parentBranch: "main",
-            isProduction: true,
-            clusterSize: "PS_10",
-            safeMigrations: true,
-          });
-
-          return { database, branch };
-        }),
-      );
-
-      const enabled = yield* ops.getBranch({
-        organization: database.organization,
-        database: database.name,
-        branch: branch.name,
-      });
-      expect(enabled.production).toBe(true);
-      expect(enabled.safe_migrations).toBe(true);
-
-      const { updatedBranch } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase("Database", {
-            clusterSize: "PS_10",
-          });
-          const updatedBranch = yield* Planetscale.MySQLBranch("Branch", {
-            database,
-            parentBranch: "main",
-            isProduction: true,
-            clusterSize: "PS_10",
-            safeMigrations: false,
-          });
-
-          return { database, updatedBranch };
-        }),
-      );
-
-      expect(updatedBranch.name).toEqual(branch.name);
-
-      const disabled = yield* ops.getBranch({
-        organization: database.organization,
-        database: database.name,
-        branch: branch.name,
-      });
-      expect(disabled.safe_migrations).toBe(false);
-
-      yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase("Database", {
-            clusterSize: "PS_10",
-          });
-          const branch = yield* Planetscale.MySQLBranch("Branch", {
-            database,
-            parentBranch: "main",
-            isProduction: false,
-          });
-
-          return { database, branch };
-        }),
-      );
-
-      yield* stack.destroy();
-      yield* waitForDatabaseToBeDeleted(database.name, database.organization);
-    }).pipe(logLevel),
-  5_000_000,
-);
-
-test.provider(
-  "can update cluster size",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      const { database, branch } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase("Database", {
-            clusterSize: "PS_10",
-          });
-          const branch = yield* Planetscale.MySQLBranch("Branch", {
-            database,
-            parentBranch: "main",
-            isProduction: true,
-            clusterSize: "PS_10",
-          });
-
-          return { database, branch };
-        }),
-      );
-
-      const initial = yield* Planetscale.waitForBranchReady(
-        database.organization,
-        database.name,
-        branch.name,
-      );
-      expect(initial.cluster_name).toEqual("PS_10");
-
-      const { resizedBranch } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase("Database", {
-            clusterSize: "PS_10",
-          });
-          const resizedBranch = yield* Planetscale.MySQLBranch("Branch", {
-            database,
-            parentBranch: "main",
-            isProduction: true,
-            clusterSize: "PS_20",
-          });
-
-          return { database, resizedBranch };
-        }),
-      );
-
-      expect(resizedBranch.name).toEqual(branch.name);
-
-      const resized = yield* Planetscale.waitForBranchReady(
-        database.organization,
-        database.name,
-        branch.name,
-      );
-      expect(resized.cluster_name).toEqual("PS_20");
-
-      yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase("Database", {
-            clusterSize: "PS_10",
-          });
-          const branch = yield* Planetscale.MySQLBranch("Branch", {
-            database,
-            parentBranch: "main",
-            isProduction: false,
-          });
-
-          return { database, branch };
-        }),
-      );
-
-      yield* stack.destroy();
-      yield* waitForDatabaseToBeDeleted(database.name, database.organization);
-    }).pipe(logLevel),
-  5_000_000,
-);
-
-test.provider(
-  "can create branch with Branch object as parent",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      const { database, parent, child } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase("Database", {
-            clusterSize: "PS_10",
-          });
-          const parent = yield* Planetscale.MySQLBranch("ParentBranch", {
-            database,
-            parentBranch: "main",
-            isProduction: false,
-          });
-          const child = yield* Planetscale.MySQLBranch("ChildBranch", {
-            database,
-            parentBranch: parent,
-            isProduction: false,
-          });
-
-          return { database, parent, child };
-        }),
-      );
-
-      expect(child).toMatchObject({
-        database: database.name,
-        parentBranch: parent.name,
-        production: false,
-      });
-
-      const live = yield* Planetscale.waitForBranchReady(
-        database.organization,
-        database.name,
-        child.name,
-      );
-      expect(live.parent_branch).toEqual(parent.name);
-
-      yield* stack.destroy();
-      yield* waitForDatabaseToBeDeleted(database.name, database.organization);
-    }).pipe(logLevel),
-  5_000_000,
-);
-
-test.provider(
-  "branch with RemovalPolicy.retain(true) should not be deleted via API",
-  (stack) =>
-    Effect.gen(function* () {
-      const dbName = "alchemy-branch-retain";
-      const branchName = "retained";
-
-      yield* stack.destroy();
-
-      const { database } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase("Database", {
-            name: dbName,
-            region: { slug: "us-east" },
-            clusterSize: "PS_10",
-          }).pipe(RemovalPolicy.retain(true));
-
-          return { database };
-        }),
-      );
-
-      yield* Planetscale.waitForBranchReady(
-        database.organization,
-        dbName,
-        "main",
-      );
-      yield* deleteBranchIfExists(database.organization, dbName, branchName);
-
-      const { branch } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase("Database", {
-            name: dbName,
-            region: { slug: "us-east" },
-            clusterSize: "PS_10",
-          }).pipe(RemovalPolicy.retain(true));
-          const branch = yield* Planetscale.MySQLBranch("RetainedBranch", {
-            name: branchName,
-            database,
-            parentBranch: "main",
-            isProduction: false,
-          }).pipe(RemovalPolicy.retain(true));
-
-          return { database, branch };
-        }),
-      );
-
-      expect(branch.name).toEqual(branchName);
-
-      yield* stack.destroy();
-
-      const live = yield* Planetscale.waitForBranchReady(
-        database.organization,
-        dbName,
-        branchName,
-      );
-      expect(live.name).toEqual(branchName);
-
-      yield* deleteBranchIfExists(database.organization, dbName, branchName);
-      yield* ops
-        .deleteDatabase({
+        );
+
+        yield* Planetscale.waitForBranchReady(
+          database.organization,
+          dbName,
+          "main",
+        );
+        yield* deleteBranchIfExists(database.organization, dbName, branchName);
+
+        yield* ops.createBranch({
           organization: database.organization,
           database: dbName,
-        })
-        .pipe(Effect.catchTag("NotFound", () => Effect.void));
-      yield* waitForDatabaseToBeDeleted(dbName, database.organization);
-    }).pipe(logLevel),
-  5_000_000,
-);
+          name: branchName,
+          parent_branch: "main",
+        });
+        yield* Planetscale.waitForBranchReady(
+          database.organization,
+          dbName,
+          branchName,
+        );
+
+        const { branch } = yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              const database = yield* Planetscale.MySQLDatabase("Database", {
+                name: dbName,
+                region: { slug: "us-east" },
+                clusterSize: "PS_10",
+              });
+              const branch = yield* Planetscale.MySQLBranch("AdoptedBranch", {
+                name: branchName,
+                database,
+                parentBranch: "main",
+                isProduction: false,
+              });
+
+              return { database, branch };
+            }),
+          )
+          .pipe(adopt(true));
+
+        expect(branch).toMatchObject({
+          name: branchName,
+          organization: database.organization,
+          database: dbName,
+          parentBranch: "main",
+          production: false,
+          createdAt: expect.any(String),
+          updatedAt: expect.any(String),
+          htmlUrl: expect.any(String),
+          region: { slug: expect.any(String) },
+        });
+
+        yield* stack.destroy();
+        yield* waitForDatabaseToBeDeleted(dbName, database.organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
+
+  test.provider(
+    "errors on existing branch when adopt is false",
+    (stack) =>
+      Effect.gen(function* () {
+        const dbName = "alchemy-branch-adopt-false";
+        const branchName = "existing";
+
+        yield* stack.destroy();
+
+        const { database } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase("Database", {
+              name: dbName,
+              region: { slug: "us-east" },
+              clusterSize: "PS_10",
+            });
+
+            return { database };
+          }),
+        );
+
+        yield* Planetscale.waitForBranchReady(
+          database.organization,
+          dbName,
+          "main",
+        );
+        yield* deleteBranchIfExists(database.organization, dbName, branchName);
+
+        yield* ops.createBranch({
+          organization: database.organization,
+          database: dbName,
+          name: branchName,
+          parent_branch: "main",
+        });
+        yield* Planetscale.waitForBranchReady(
+          database.organization,
+          dbName,
+          branchName,
+        );
+
+        const exit = yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              const database = yield* Planetscale.MySQLDatabase("Database", {
+                name: dbName,
+                region: { slug: "us-east" },
+                clusterSize: "PS_10",
+              });
+              const branch = yield* Planetscale.MySQLBranch("ExistingBranch", {
+                name: branchName,
+                database,
+                parentBranch: "main",
+                isProduction: false,
+              });
+
+              return { database, branch };
+            }),
+          )
+          .pipe(Effect.exit);
+
+        yield* deleteBranchIfExists(database.organization, dbName, branchName);
+        yield* stack.destroy();
+        yield* waitForDatabaseToBeDeleted(dbName, database.organization);
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          const pretty = Cause.pretty(exit.cause);
+          expect(pretty).toContain("Cannot adopt resource");
+          expect(pretty).toContain("Planetscale.MySQLBranch");
+        }
+      }).pipe(logLevel),
+    5_000_000,
+  );
+
+  test.provider(
+    "can create branch with backup",
+    (stack) =>
+      Effect.gen(function* () {
+        const dbName = "alchemy-branch-backup";
+        const branchName = "restored";
+
+        yield* stack.destroy();
+
+        const { database } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase("Database", {
+              name: dbName,
+              region: { slug: "us-east" },
+              clusterSize: "PS_10",
+            });
+
+            return { database };
+          }),
+        );
+
+        yield* Planetscale.waitForBranchReady(
+          database.organization,
+          dbName,
+          "main",
+        );
+        yield* deleteBranchIfExists(database.organization, dbName, branchName);
+
+        const backup = yield* ops.createBackup({
+          organization: database.organization,
+          database: dbName,
+          branch: "main",
+          name: "alchemy-branch-backup-source",
+          retention_unit: "hour",
+          retention_value: 1,
+        });
+        yield* waitForBackupSuccess(
+          database.organization,
+          dbName,
+          "main",
+          backup.id,
+        );
+
+        const { branch } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase("Database", {
+              name: dbName,
+              region: { slug: "us-east" },
+              clusterSize: "PS_10",
+            });
+            const branch = yield* Planetscale.MySQLBranch("RestoredBranch", {
+              name: branchName,
+              database,
+              parentBranch: "main",
+              isProduction: true,
+              backupId: backup.id,
+              clusterSize: "PS_10",
+            });
+
+            return { database, branch };
+          }),
+        );
+
+        expect(branch).toMatchObject({
+          name: branchName,
+          database: dbName,
+          parentBranch: "main",
+          production: true,
+        });
+
+        const live = yield* Planetscale.waitForBranchReady(
+          database.organization,
+          dbName,
+          branchName,
+        );
+        expect(live.name).toEqual(branchName);
+        expect(live.production).toBe(true);
+        expect(live.cluster_name).toEqual("PS_10");
+
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase("Database", {
+              name: dbName,
+              region: { slug: "us-east" },
+              clusterSize: "PS_10",
+            });
+            const branch = yield* Planetscale.MySQLBranch("RestoredBranch", {
+              name: branchName,
+              database,
+              parentBranch: "main",
+              isProduction: false,
+            });
+
+            return { database, branch };
+          }),
+        );
+
+        yield* stack.destroy();
+        yield* waitForDatabaseToBeDeleted(dbName, database.organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
+
+  test.provider(
+    "can enable and disable safe migrations",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const { database, branch } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase("Database", {
+              clusterSize: "PS_10",
+            });
+            const branch = yield* Planetscale.MySQLBranch("Branch", {
+              database,
+              parentBranch: "main",
+              isProduction: true,
+              clusterSize: "PS_10",
+              safeMigrations: true,
+            });
+
+            return { database, branch };
+          }),
+        );
+
+        const enabled = yield* ops.getBranch({
+          organization: database.organization,
+          database: database.name,
+          branch: branch.name,
+        });
+        expect(enabled.production).toBe(true);
+        expect(enabled.safe_migrations).toBe(true);
+
+        const { updatedBranch } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase("Database", {
+              clusterSize: "PS_10",
+            });
+            const updatedBranch = yield* Planetscale.MySQLBranch("Branch", {
+              database,
+              parentBranch: "main",
+              isProduction: true,
+              clusterSize: "PS_10",
+              safeMigrations: false,
+            });
+
+            return { database, updatedBranch };
+          }),
+        );
+
+        expect(updatedBranch.name).toEqual(branch.name);
+
+        const disabled = yield* ops.getBranch({
+          organization: database.organization,
+          database: database.name,
+          branch: branch.name,
+        });
+        expect(disabled.safe_migrations).toBe(false);
+
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase("Database", {
+              clusterSize: "PS_10",
+            });
+            const branch = yield* Planetscale.MySQLBranch("Branch", {
+              database,
+              parentBranch: "main",
+              isProduction: false,
+            });
+
+            return { database, branch };
+          }),
+        );
+
+        yield* stack.destroy();
+        yield* waitForDatabaseToBeDeleted(database.name, database.organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
+
+  test.provider(
+    "can update cluster size",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const { database, branch } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase("Database", {
+              clusterSize: "PS_10",
+            });
+            const branch = yield* Planetscale.MySQLBranch("Branch", {
+              database,
+              parentBranch: "main",
+              isProduction: true,
+              clusterSize: "PS_10",
+            });
+
+            return { database, branch };
+          }),
+        );
+
+        const initial = yield* Planetscale.waitForBranchReady(
+          database.organization,
+          database.name,
+          branch.name,
+        );
+        expect(initial.cluster_name).toEqual("PS_10");
+
+        const { resizedBranch } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase("Database", {
+              clusterSize: "PS_10",
+            });
+            const resizedBranch = yield* Planetscale.MySQLBranch("Branch", {
+              database,
+              parentBranch: "main",
+              isProduction: true,
+              clusterSize: "PS_20",
+            });
+
+            return { database, resizedBranch };
+          }),
+        );
+
+        expect(resizedBranch.name).toEqual(branch.name);
+
+        const resized = yield* Planetscale.waitForBranchReady(
+          database.organization,
+          database.name,
+          branch.name,
+        );
+        expect(resized.cluster_name).toEqual("PS_20");
+
+        yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase("Database", {
+              clusterSize: "PS_10",
+            });
+            const branch = yield* Planetscale.MySQLBranch("Branch", {
+              database,
+              parentBranch: "main",
+              isProduction: false,
+            });
+
+            return { database, branch };
+          }),
+        );
+
+        yield* stack.destroy();
+        yield* waitForDatabaseToBeDeleted(database.name, database.organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
+
+  test.provider(
+    "can create branch with Branch object as parent",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const { database, parent, child } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase("Database", {
+              clusterSize: "PS_10",
+            });
+            const parent = yield* Planetscale.MySQLBranch("ParentBranch", {
+              database,
+              parentBranch: "main",
+              isProduction: false,
+            });
+            const child = yield* Planetscale.MySQLBranch("ChildBranch", {
+              database,
+              parentBranch: parent,
+              isProduction: false,
+            });
+
+            return { database, parent, child };
+          }),
+        );
+
+        expect(child).toMatchObject({
+          database: database.name,
+          parentBranch: parent.name,
+          production: false,
+        });
+
+        const live = yield* Planetscale.waitForBranchReady(
+          database.organization,
+          database.name,
+          child.name,
+        );
+        expect(live.parent_branch).toEqual(parent.name);
+
+        yield* stack.destroy();
+        yield* waitForDatabaseToBeDeleted(database.name, database.organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
+
+  test.provider(
+    "branch with RemovalPolicy.retain(true) should not be deleted via API",
+    (stack) =>
+      Effect.gen(function* () {
+        const dbName = "alchemy-branch-retain";
+        const branchName = "retained";
+
+        yield* stack.destroy();
+
+        const { database } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase("Database", {
+              name: dbName,
+              region: { slug: "us-east" },
+              clusterSize: "PS_10",
+            }).pipe(RemovalPolicy.retain(true));
+
+            return { database };
+          }),
+        );
+
+        yield* Planetscale.waitForBranchReady(
+          database.organization,
+          dbName,
+          "main",
+        );
+        yield* deleteBranchIfExists(database.organization, dbName, branchName);
+
+        const { branch } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase("Database", {
+              name: dbName,
+              region: { slug: "us-east" },
+              clusterSize: "PS_10",
+            }).pipe(RemovalPolicy.retain(true));
+            const branch = yield* Planetscale.MySQLBranch("RetainedBranch", {
+              name: branchName,
+              database,
+              parentBranch: "main",
+              isProduction: false,
+            }).pipe(RemovalPolicy.retain(true));
+
+            return { database, branch };
+          }),
+        );
+
+        expect(branch.name).toEqual(branchName);
+
+        yield* stack.destroy();
+
+        const live = yield* Planetscale.waitForBranchReady(
+          database.organization,
+          dbName,
+          branchName,
+        );
+        expect(live.name).toEqual(branchName);
+
+        yield* deleteBranchIfExists(database.organization, dbName, branchName);
+        yield* ops
+          .deleteDatabase({
+            organization: database.organization,
+            database: dbName,
+          })
+          .pipe(Effect.catchTag("NotFound", () => Effect.void));
+        yield* waitForDatabaseToBeDeleted(dbName, database.organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
+});
 
 const deleteBranchIfExists = Effect.fn(function* (
   organization: string,

--- a/packages/alchemy/test/Planetscale/MySQL/MySQLDatabase.test.ts
+++ b/packages/alchemy/test/Planetscale/MySQL/MySQLDatabase.test.ts
@@ -3,7 +3,7 @@ import * as Planetscale from "@/Planetscale";
 import * as RemovalPolicy from "@/RemovalPolicy.ts";
 import * as Test from "@/Test/Vitest";
 import * as ops from "@distilled.cloud/planetscale/Operations";
-import { expect } from "@effect/vitest";
+import { describe, expect } from "@effect/vitest";
 import { Data, Schedule } from "effect";
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
@@ -19,170 +19,17 @@ const logLevel = Effect.provideService(
 
 const fixturesDir = `${import.meta.dirname}/fixtures`;
 
-test.provider("create database with minimal settings", (stack) =>
-  Effect.gen(function* () {
-    yield* stack.destroy();
-
-    const { database } = yield* stack.deploy(
-      Effect.gen(function* () {
-        const database = yield* Planetscale.MySQLDatabase(
-          "MySQLDatabaseBasic",
-          {
-            clusterSize: "PS_10",
-          },
-        );
-
-        return {
-          database,
-        };
-      }),
-    );
-
-    expect(database).toMatchObject({
-      kind: "mysql",
-      id: expect.any(String),
-      name: expect.any(String),
-      organization: expect.any(String),
-      state: expect.any(String),
-      defaultBranch: "main",
-      plan: expect.any(String),
-      createdAt: expect.any(String),
-      updatedAt: expect.any(String),
-      htmlUrl: expect.any(String),
-      region: {
-        slug: expect.any(String),
-      },
-      clusterSize: "PS_10",
-    });
-
-    const branch = yield* Planetscale.waitForBranchReady(
-      database.organization,
-      database.name,
-      "main",
-    );
-
-    expect(branch.cluster_name).toEqual("PS_10");
-
-    yield* stack.destroy();
-  }).pipe(logLevel),
-);
-
-test.provider("create, update, and delete database", (stack) =>
-  Effect.gen(function* () {
-    yield* stack.destroy();
-
-    const { database } = yield* stack.deploy(
-      Effect.gen(function* () {
-        const database = yield* Planetscale.MySQLDatabase("MySQLDatabaseCRUD", {
-          region: {
-            slug: "us-east",
-          },
-          clusterSize: "PS_10",
-          defaultBranch: "main",
-          allowDataBranching: true,
-          automaticMigrations: true,
-          requireApprovalForDeploy: false,
-          restrictBranchRegion: true,
-          insightsRawQueries: true,
-          productionBranchWebConsole: true,
-          migrationFramework: "rails",
-          migrationTableName: "schema_migrations",
-        });
-
-        return {
-          database,
-        };
-      }),
-    );
-
-    expect(database).toMatchObject({
-      kind: "mysql",
-      id: expect.any(String),
-      name: expect.any(String),
-      organization: expect.any(String),
-      state: expect.any(String),
-      plan: expect.any(String),
-      createdAt: expect.any(String),
-      updatedAt: expect.any(String),
-      htmlUrl: expect.any(String),
-      region: {
-        slug: expect.any(String),
-      },
-      clusterSize: "PS_10",
-      defaultBranch: "main",
-      allowDataBranching: true,
-      automaticMigrations: true,
-      requireApprovalForDeploy: false,
-      restrictBranchRegion: true,
-      insightsRawQueries: true,
-      productionBranchWebConsole: true,
-      migrationFramework: "rails",
-      migrationTableName: "schema_migrations",
-    });
-
-    const { updatedDatabase } = yield* stack.deploy(
-      Effect.gen(function* () {
-        const updatedDatabase = yield* Planetscale.MySQLDatabase(
-          "MySQLDatabaseCRUD",
-          {
-            clusterSize: "PS_20",
-            allowDataBranching: false,
-            automaticMigrations: true,
-            requireApprovalForDeploy: true,
-            restrictBranchRegion: false,
-            insightsRawQueries: false,
-            productionBranchWebConsole: false,
-            defaultBranch: "main",
-            migrationFramework: "django",
-            migrationTableName: "django_migrations",
-          },
-        );
-
-        return {
-          updatedDatabase,
-        };
-      }),
-    );
-
-    expect(updatedDatabase).toMatchObject({
-      allowDataBranching: false,
-      automaticMigrations: true,
-      requireApprovalForDeploy: true,
-      restrictBranchRegion: false,
-      insightsRawQueries: false,
-      productionBranchWebConsole: false,
-      defaultBranch: "main",
-      migrationFramework: "django",
-      migrationTableName: "django_migrations",
-    });
-
-    const branch = yield* Planetscale.waitForBranchReady(
-      database.organization,
-      database.name,
-      "main",
-    );
-
-    expect(branch.cluster_name).toEqual("PS_20");
-
-    yield* stack.destroy();
-
-    yield* waitForDatabaseToBeDeleted(database.name, database.organization);
-  }).pipe(logLevel),
-);
-
-test.provider(
-  "creates non-main default branch if specified",
-  (stack) =>
+describe.skipIf(!process.env.PLANETSCALE_TEST)(() => {
+  test.provider("create database with minimal settings", (stack) =>
     Effect.gen(function* () {
       yield* stack.destroy();
 
       const { database } = yield* stack.deploy(
         Effect.gen(function* () {
           const database = yield* Planetscale.MySQLDatabase(
-            "MySQLDatabaseCustomBranch",
+            "MySQLDatabaseBasic",
             {
               clusterSize: "PS_10",
-              defaultBranch: "custom",
             },
           );
 
@@ -194,41 +41,55 @@ test.provider(
 
       expect(database).toMatchObject({
         kind: "mysql",
-        defaultBranch: "custom",
+        id: expect.any(String),
+        name: expect.any(String),
+        organization: expect.any(String),
+        state: expect.any(String),
+        defaultBranch: "main",
+        plan: expect.any(String),
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
+        htmlUrl: expect.any(String),
+        region: {
+          slug: expect.any(String),
+        },
+        clusterSize: "PS_10",
       });
 
       const branch = yield* Planetscale.waitForBranchReady(
         database.organization,
         database.name,
-        "custom",
+        "main",
       );
 
-      expect(branch.name).toEqual("custom");
-      expect(branch.parent_branch).toEqual("main");
       expect(branch.cluster_name).toEqual("PS_10");
 
       yield* stack.destroy();
-
-      yield* waitForDatabaseToBeDeleted(database.name, database.organization);
     }).pipe(logLevel),
-  5_000_000, // must wait on multiple resizes and branch creation
-);
+  );
 
-test.provider(
-  "applies migrations and import files",
-  (stack) =>
+  test.provider("create, update, and delete database", (stack) =>
     Effect.gen(function* () {
       yield* stack.destroy();
 
-      const importFile = `${fixturesDir}/seed.sql`;
       const { database } = yield* stack.deploy(
         Effect.gen(function* () {
           const database = yield* Planetscale.MySQLDatabase(
-            "MySQLDatabaseMigrations",
+            "MySQLDatabaseCRUD",
             {
+              region: {
+                slug: "us-east",
+              },
               clusterSize: "PS_10",
-              migrationsDir: `${fixturesDir}/migrations`,
-              importFiles: [importFile],
+              defaultBranch: "main",
+              allowDataBranching: true,
+              automaticMigrations: true,
+              requireApprovalForDeploy: false,
+              restrictBranchRegion: true,
+              insightsRawQueries: true,
+              productionBranchWebConsole: true,
+              migrationFramework: "rails",
+              migrationTableName: "schema_migrations",
             },
           );
 
@@ -238,129 +99,273 @@ test.provider(
         }),
       );
 
-      expect(database.migrationsTable).toEqual("planetscale_migrations");
-      expect(database.migrationsHashes["0001_create_widgets.sql"]).toEqual(
-        expect.any(String),
-      );
-      expect(database.importHashes[importFile]).toEqual(expect.any(String));
-
-      yield* stack.destroy();
-
-      yield* waitForDatabaseToBeDeleted(database.name, database.organization);
-    }).pipe(logLevel),
-  5_000_000,
-);
-
-test.provider(
-  "adopt with wrong kind should throw",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      const { database } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase(
-            "PgBaselineWrongKind",
-            {
-              region: { slug: "us-east" },
-              clusterSize: "PS_10",
-              arch: "arm", // arm is slightly faster
-            },
-          );
-
-          return { database };
-        }),
-      );
-
-      yield* Planetscale.waitForDatabaseReady(
-        database.organization,
-        database.name,
-      );
-      const exit = yield* Effect.exit(
-        stack
-          .deploy(
-            Effect.gen(function* () {
-              return yield* Planetscale.MySQLDatabase("MysqlWrongKind", {
-                name: database.name,
-                clusterSize: "PS_10",
-              });
-            }),
-          )
-          .pipe(adopt(true)),
-      );
-
-      expect(Exit.isFailure(exit)).toBe(true);
-
-      if (Exit.isFailure(exit)) {
-        const pretty = Cause.pretty(exit.cause);
-
-        expect(pretty).toContain("postgresql");
-        expect(pretty).toContain("PostgresDatabase");
-      }
-      yield* stack.destroy();
-    }).pipe(logLevel),
-  5_000_000,
-);
-
-test.provider(
-  "database with RemovalPolicy.retain(true) should not be deleted via API",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      const { database } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase(
-            "MySQLDatabaseRetainRemoval",
-            {
-              region: { slug: "us-east" },
-              clusterSize: "PS_10",
-            },
-          ).pipe(RemovalPolicy.retain(true));
-
-          return {
-            database,
-          };
-        }),
-      );
-
-      // Verify database exists
-      const readyDatabase = yield* Planetscale.waitForDatabaseReady(
-        database.organization,
-        database.name,
-      );
-
-      expect(readyDatabase.name).toEqual(database.name);
-
-      // When we call destroy, the database should NOT be deleted via API
-      yield* stack.destroy();
-
-      yield* Planetscale.waitForDatabaseReady(
-        database.organization,
-        database.name,
-      );
-
-      // Verify database still exists (was not deleted via API)
-      const live = yield* ops.getDatabase({
-        organization: database.organization,
-        database: database.name,
+      expect(database).toMatchObject({
+        kind: "mysql",
+        id: expect.any(String),
+        name: expect.any(String),
+        organization: expect.any(String),
+        state: expect.any(String),
+        plan: expect.any(String),
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
+        htmlUrl: expect.any(String),
+        region: {
+          slug: expect.any(String),
+        },
+        clusterSize: "PS_10",
+        defaultBranch: "main",
+        allowDataBranching: true,
+        automaticMigrations: true,
+        requireApprovalForDeploy: false,
+        restrictBranchRegion: true,
+        insightsRawQueries: true,
+        productionBranchWebConsole: true,
+        migrationFramework: "rails",
+        migrationTableName: "schema_migrations",
       });
 
-      // Database should still exist
-      expect(live.name).toEqual(database.name);
-      expect(live.state).toEqual("ready");
-      expect(live.kind).toEqual("mysql");
+      const { updatedDatabase } = yield* stack.deploy(
+        Effect.gen(function* () {
+          const updatedDatabase = yield* Planetscale.MySQLDatabase(
+            "MySQLDatabaseCRUD",
+            {
+              clusterSize: "PS_20",
+              allowDataBranching: false,
+              automaticMigrations: true,
+              requireApprovalForDeploy: true,
+              restrictBranchRegion: false,
+              insightsRawQueries: false,
+              productionBranchWebConsole: false,
+              defaultBranch: "main",
+              migrationFramework: "django",
+              migrationTableName: "django_migrations",
+            },
+          );
 
-      // Clean up manually for the test
-      yield* ops
-        .deleteDatabase({
+          return {
+            updatedDatabase,
+          };
+        }),
+      );
+
+      expect(updatedDatabase).toMatchObject({
+        allowDataBranching: false,
+        automaticMigrations: true,
+        requireApprovalForDeploy: true,
+        restrictBranchRegion: false,
+        insightsRawQueries: false,
+        productionBranchWebConsole: false,
+        defaultBranch: "main",
+        migrationFramework: "django",
+        migrationTableName: "django_migrations",
+      });
+
+      const branch = yield* Planetscale.waitForBranchReady(
+        database.organization,
+        database.name,
+        "main",
+      );
+
+      expect(branch.cluster_name).toEqual("PS_20");
+
+      yield* stack.destroy();
+
+      yield* waitForDatabaseToBeDeleted(database.name, database.organization);
+    }).pipe(logLevel),
+  );
+
+  test.provider(
+    "creates non-main default branch if specified",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const { database } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase(
+              "MySQLDatabaseCustomBranch",
+              {
+                clusterSize: "PS_10",
+                defaultBranch: "custom",
+              },
+            );
+
+            return {
+              database,
+            };
+          }),
+        );
+
+        expect(database).toMatchObject({
+          kind: "mysql",
+          defaultBranch: "custom",
+        });
+
+        const branch = yield* Planetscale.waitForBranchReady(
+          database.organization,
+          database.name,
+          "custom",
+        );
+
+        expect(branch.name).toEqual("custom");
+        expect(branch.parent_branch).toEqual("main");
+        expect(branch.cluster_name).toEqual("PS_10");
+
+        yield* stack.destroy();
+
+        yield* waitForDatabaseToBeDeleted(database.name, database.organization);
+      }).pipe(logLevel),
+    5_000_000, // must wait on multiple resizes and branch creation
+  );
+
+  test.provider(
+    "applies migrations and import files",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const importFile = `${fixturesDir}/seed.sql`;
+        const { database } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase(
+              "MySQLDatabaseMigrations",
+              {
+                clusterSize: "PS_10",
+                migrationsDir: `${fixturesDir}/migrations`,
+                importFiles: [importFile],
+              },
+            );
+
+            return {
+              database,
+            };
+          }),
+        );
+
+        expect(database.migrationsTable).toEqual("planetscale_migrations");
+        expect(database.migrationsHashes["0001_create_widgets.sql"]).toEqual(
+          expect.any(String),
+        );
+        expect(database.importHashes[importFile]).toEqual(expect.any(String));
+
+        yield* stack.destroy();
+
+        yield* waitForDatabaseToBeDeleted(database.name, database.organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
+
+  test.provider(
+    "adopt with wrong kind should throw",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const { database } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.PostgresDatabase(
+              "PgBaselineWrongKind",
+              {
+                region: { slug: "us-east" },
+                clusterSize: "PS_10",
+                arch: "arm", // arm is slightly faster
+              },
+            );
+
+            return { database };
+          }),
+        );
+
+        yield* Planetscale.waitForDatabaseReady(
+          database.organization,
+          database.name,
+        );
+        const exit = yield* Effect.exit(
+          stack
+            .deploy(
+              Effect.gen(function* () {
+                return yield* Planetscale.MySQLDatabase("MysqlWrongKind", {
+                  name: database.name,
+                  clusterSize: "PS_10",
+                });
+              }),
+            )
+            .pipe(adopt(true)),
+        );
+
+        expect(Exit.isFailure(exit)).toBe(true);
+
+        if (Exit.isFailure(exit)) {
+          const pretty = Cause.pretty(exit.cause);
+
+          expect(pretty).toContain("postgresql");
+          expect(pretty).toContain("PostgresDatabase");
+        }
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    5_000_000,
+  );
+
+  test.provider(
+    "database with RemovalPolicy.retain(true) should not be deleted via API",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const { database } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase(
+              "MySQLDatabaseRetainRemoval",
+              {
+                region: { slug: "us-east" },
+                clusterSize: "PS_10",
+              },
+            ).pipe(RemovalPolicy.retain(true));
+
+            return {
+              database,
+            };
+          }),
+        );
+
+        // Verify database exists
+        const readyDatabase = yield* Planetscale.waitForDatabaseReady(
+          database.organization,
+          database.name,
+        );
+
+        expect(readyDatabase.name).toEqual(database.name);
+
+        // When we call destroy, the database should NOT be deleted via API
+        yield* stack.destroy();
+
+        yield* Planetscale.waitForDatabaseReady(
+          database.organization,
+          database.name,
+        );
+
+        // Verify database still exists (was not deleted via API)
+        const live = yield* ops.getDatabase({
           organization: database.organization,
           database: database.name,
-        })
-        .pipe(Effect.catchTag("NotFound", () => Effect.void));
-    }).pipe(logLevel),
-  5_000_000,
-);
+        });
+
+        // Database should still exist
+        expect(live.name).toEqual(database.name);
+        expect(live.state).toEqual("ready");
+        expect(live.kind).toEqual("mysql");
+
+        // Clean up manually for the test
+        yield* ops
+          .deleteDatabase({
+            organization: database.organization,
+            database: database.name,
+          })
+          .pipe(Effect.catchTag("NotFound", () => Effect.void));
+      }).pipe(logLevel),
+    5_000_000,
+  );
+});
 
 const waitForDatabaseToBeDeleted = Effect.fn(function* (
   database: string,

--- a/packages/alchemy/test/Planetscale/MySQL/MySQLPassword.test.ts
+++ b/packages/alchemy/test/Planetscale/MySQL/MySQLPassword.test.ts
@@ -2,7 +2,7 @@ import * as Planetscale from "@/Planetscale";
 import * as RemovalPolicy from "@/RemovalPolicy.ts";
 import * as Test from "@/Test/Vitest";
 import * as ops from "@distilled.cloud/planetscale/Operations";
-import { expect } from "@effect/vitest";
+import { describe, expect } from "@effect/vitest";
 import { Data, Schedule } from "effect";
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
@@ -18,274 +18,279 @@ const logLevel = Effect.provideService(
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-test.provider(
-  "create, update, and delete password",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
+describe.skipIf(!process.env.PLANETSCALE_TEST)(() => {
+  test.provider(
+    "create, update, and delete password",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-      const { database, branch, password } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase("Database", {
-            clusterSize: "PS_10",
-          });
+        const { database, branch, password } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase("Database", {
+              clusterSize: "PS_10",
+            });
 
-          const branch = yield* Planetscale.MySQLBranch("Branch", {
-            database,
-            parentBranch: "main",
-            isProduction: false,
-          });
+            const branch = yield* Planetscale.MySQLBranch("Branch", {
+              database,
+              parentBranch: "main",
+              isProduction: false,
+            });
 
-          const password = yield* Planetscale.MySQLPassword("Password", {
-            database,
-            branch,
-            role: "reader",
-          });
-
-          return { database, branch, password };
-        }),
-      );
-
-      expect(password).toMatchObject({
-        id: expect.any(String),
-        name: expect.any(String),
-        role: "reader",
-        host: expect.any(String),
-        username: expect.any(String),
-        organization: expect.any(String),
-        database: database.name,
-        branch: branch.name,
-      });
-
-      // Verify password was created by querying the API directly
-      const fetched = yield* ops.getPassword({
-        organization: database.organization,
-        database: database.name,
-        branch: branch.name,
-        id: password.id,
-      });
-
-      expect(fetched.id).toEqual(password.id);
-      expect(fetched.name).toEqual(password.name);
-      expect(fetched.role).toEqual("reader");
-
-      // Update the password (only name and cidrs should trigger update, not replace)
-      const { updatedPassword } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const sameDatabase = yield* Planetscale.MySQLDatabase("Database", {
-            clusterSize: "PS_10",
-          });
-
-          const sameBranch = yield* Planetscale.MySQLBranch("Branch", {
-            database: sameDatabase,
-            parentBranch: "main",
-            isProduction: false,
-          });
-
-          const updatedPassword = yield* Planetscale.MySQLPassword("Password", {
-            name: "test-updated-password-name",
-            database: sameDatabase.name,
-            branch: sameBranch.name,
-            role: "reader",
-          });
-
-          return { updatedPassword };
-        }),
-      );
-
-      expect(updatedPassword.id).toEqual(password.id);
-      expect(updatedPassword.name).not.toEqual(password.name);
-
-      // Verify password was updated
-      const fetchedUpdated = yield* ops.getPassword({
-        organization: database.organization,
-        database: database.name,
-        branch: branch.name,
-        id: updatedPassword.id,
-      });
-
-      expect(fetchedUpdated.id).toEqual(password.id);
-      expect(fetchedUpdated.name).toEqual(updatedPassword.name);
-
-      yield* stack.destroy();
-
-      yield* waitForDatabaseToBeDeleted(database.name, database.organization);
-    }).pipe(logLevel),
-  5_000_000,
-);
-
-test.provider(
-  "password gets replaced when properties other than name and cidrs change",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      const { database, branch, password } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase("Database", {
-            clusterSize: "PS_10",
-          });
-
-          const branch = yield* Planetscale.MySQLBranch("Branch", {
-            database,
-            parentBranch: "main",
-            isProduction: false,
-          });
-
-          const password = yield* Planetscale.MySQLPassword("Password", {
-            database,
-            branch,
-            role: "reader",
-            ttl: 3600,
-            cidrs: ["0.0.0.0/0"],
-          });
-          return { database, branch, password };
-        }),
-      );
-
-      const originalId = password.id;
-      expect(password.role).toEqual("reader");
-      expect(password.ttl).toEqual(3600);
-
-      // Change role from reader -> writer (should trigger replace).
-      const { replacedPassword } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase("Database", {
-            clusterSize: "PS_10",
-          });
-
-          const branch = yield* Planetscale.MySQLBranch("Branch", {
-            database,
-            parentBranch: "main",
-            isProduction: false,
-          });
-
-          const replacedPassword = yield* Planetscale.MySQLPassword(
-            "Password",
-            {
+            const password = yield* Planetscale.MySQLPassword("Password", {
               database,
               branch,
-              role: "writer",
-              ttl: 3600,
-              cidrs: ["0.0.0.0/0"],
-            },
-          );
-          return { replacedPassword };
-        }),
-      );
+              role: "reader",
+            });
 
-      // New ID due to replacement.
-      expect(replacedPassword.id).not.toEqual(originalId);
-      expect(replacedPassword.role).toEqual("writer");
+            return { database, branch, password };
+          }),
+        );
 
-      // Old password should have been deleted as part of the replace.
-      const oldExit = yield* ops
-        .getPassword({
+        expect(password).toMatchObject({
+          id: expect.any(String),
+          name: expect.any(String),
+          role: "reader",
+          host: expect.any(String),
+          username: expect.any(String),
+          organization: expect.any(String),
+          database: database.name,
+          branch: branch.name,
+        });
+
+        // Verify password was created by querying the API directly
+        const fetched = yield* ops.getPassword({
           organization: database.organization,
           database: database.name,
           branch: branch.name,
-          id: originalId,
-        })
-        .pipe(Effect.exit);
-      expect(Exit.isFailure(oldExit)).toBe(true);
-      if (Exit.isFailure(oldExit)) {
-        expect(Cause.pretty(oldExit.cause)).toContain("NotFound");
-      }
+          id: password.id,
+        });
 
-      // New password exists with the new role.
-      const newFetched = yield* ops.getPassword({
-        organization: database.organization,
-        database: database.name,
-        branch: branch.name,
-        id: replacedPassword.id,
-      });
-      expect(newFetched.id).toEqual(replacedPassword.id);
-      expect(newFetched.role).toEqual("writer");
+        expect(fetched.id).toEqual(password.id);
+        expect(fetched.name).toEqual(password.name);
+        expect(fetched.role).toEqual("reader");
 
-      yield* stack.destroy();
-      yield* waitForDatabaseToBeDeleted(database.name, database.organization);
-    }).pipe(logLevel),
-  5_000_000,
-);
+        // Update the password (only name and cidrs should trigger update, not replace)
+        const { updatedPassword } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const sameDatabase = yield* Planetscale.MySQLDatabase("Database", {
+              clusterSize: "PS_10",
+            });
 
-test.provider(
-  "password with RemovalPolicy.retain(true) should not be deleted via API",
-  (stack) =>
-    Effect.gen(function* () {
-      const dbName = `alchemy-test-pwd-retain`;
-      const passwordName = `retain-password`;
+            const sameBranch = yield* Planetscale.MySQLBranch("Branch", {
+              database: sameDatabase,
+              parentBranch: "main",
+              isProduction: false,
+            });
 
-      yield* stack.destroy();
+            const updatedPassword = yield* Planetscale.MySQLPassword(
+              "Password",
+              {
+                name: "test-updated-password-name",
+                database: sameDatabase.name,
+                branch: sameBranch.name,
+                role: "reader",
+              },
+            );
 
-      const { database, password } = yield* stack.deploy(
-        Effect.gen(function* () {
-          // Retain the database too — otherwise deleting it would cascade
-          // to the password and we couldn't observe the retain behavior.
-          const database = yield* Planetscale.MySQLDatabase("Database", {
-            name: dbName,
-            clusterSize: "PS_10",
-          }).pipe(RemovalPolicy.retain(true));
-          const password = yield* Planetscale.MySQLPassword("Password", {
-            name: passwordName,
-            database,
-            role: "reader",
-          }).pipe(RemovalPolicy.retain(true));
-          return { database, password };
-        }),
-      );
+            return { updatedPassword };
+          }),
+        );
 
-      // Password exists post-deploy.
-      const fetched = yield* ops.getPassword({
-        organization: database.organization,
-        database: database.name,
-        branch: "main",
-        id: password.id,
-      });
-      expect(fetched.id).toEqual(password.id);
+        expect(updatedPassword.id).toEqual(password.id);
+        expect(updatedPassword.name).not.toEqual(password.name);
 
-      // Destroy the stack — both retained, so neither should be removed.
-      yield* stack.destroy();
+        // Verify password was updated
+        const fetchedUpdated = yield* ops.getPassword({
+          organization: database.organization,
+          database: database.name,
+          branch: branch.name,
+          id: updatedPassword.id,
+        });
 
-      const { organization } = yield* Planetscale.Credentials;
+        expect(fetchedUpdated.id).toEqual(password.id);
+        expect(fetchedUpdated.name).toEqual(updatedPassword.name);
 
-      // Database should still exist and be ready.
-      const liveDb = yield* Planetscale.waitForDatabaseReady(
-        organization,
-        dbName,
-      );
-      expect(liveDb.name).toEqual(dbName);
+        yield* stack.destroy();
 
-      // Password should still exist (was not deleted via API).
-      const stillExists = yield* ops.getPassword({
-        organization,
-        database: dbName,
-        branch: "main",
-        id: password.id,
-      });
-      expect(stillExists.id).toEqual(password.id);
-      expect(stillExists.name).toEqual(password.name);
+        yield* waitForDatabaseToBeDeleted(database.name, database.organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
 
-      // Manual cleanup for the test.
-      yield* ops
-        .deletePassword({
+  test.provider(
+    "password gets replaced when properties other than name and cidrs change",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const { database, branch, password } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase("Database", {
+              clusterSize: "PS_10",
+            });
+
+            const branch = yield* Planetscale.MySQLBranch("Branch", {
+              database,
+              parentBranch: "main",
+              isProduction: false,
+            });
+
+            const password = yield* Planetscale.MySQLPassword("Password", {
+              database,
+              branch,
+              role: "reader",
+              ttl: 3600,
+              cidrs: ["0.0.0.0/0"],
+            });
+            return { database, branch, password };
+          }),
+        );
+
+        const originalId = password.id;
+        expect(password.role).toEqual("reader");
+        expect(password.ttl).toEqual(3600);
+
+        // Change role from reader -> writer (should trigger replace).
+        const { replacedPassword } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase("Database", {
+              clusterSize: "PS_10",
+            });
+
+            const branch = yield* Planetscale.MySQLBranch("Branch", {
+              database,
+              parentBranch: "main",
+              isProduction: false,
+            });
+
+            const replacedPassword = yield* Planetscale.MySQLPassword(
+              "Password",
+              {
+                database,
+                branch,
+                role: "writer",
+                ttl: 3600,
+                cidrs: ["0.0.0.0/0"],
+              },
+            );
+            return { replacedPassword };
+          }),
+        );
+
+        // New ID due to replacement.
+        expect(replacedPassword.id).not.toEqual(originalId);
+        expect(replacedPassword.role).toEqual("writer");
+
+        // Old password should have been deleted as part of the replace.
+        const oldExit = yield* ops
+          .getPassword({
+            organization: database.organization,
+            database: database.name,
+            branch: branch.name,
+            id: originalId,
+          })
+          .pipe(Effect.exit);
+        expect(Exit.isFailure(oldExit)).toBe(true);
+        if (Exit.isFailure(oldExit)) {
+          expect(Cause.pretty(oldExit.cause)).toContain("NotFound");
+        }
+
+        // New password exists with the new role.
+        const newFetched = yield* ops.getPassword({
+          organization: database.organization,
+          database: database.name,
+          branch: branch.name,
+          id: replacedPassword.id,
+        });
+        expect(newFetched.id).toEqual(replacedPassword.id);
+        expect(newFetched.role).toEqual("writer");
+
+        yield* stack.destroy();
+        yield* waitForDatabaseToBeDeleted(database.name, database.organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
+
+  test.provider(
+    "password with RemovalPolicy.retain(true) should not be deleted via API",
+    (stack) =>
+      Effect.gen(function* () {
+        const dbName = `alchemy-test-pwd-retain`;
+        const passwordName = `retain-password`;
+
+        yield* stack.destroy();
+
+        const { database, password } = yield* stack.deploy(
+          Effect.gen(function* () {
+            // Retain the database too — otherwise deleting it would cascade
+            // to the password and we couldn't observe the retain behavior.
+            const database = yield* Planetscale.MySQLDatabase("Database", {
+              name: dbName,
+              clusterSize: "PS_10",
+            }).pipe(RemovalPolicy.retain(true));
+            const password = yield* Planetscale.MySQLPassword("Password", {
+              name: passwordName,
+              database,
+              role: "reader",
+            }).pipe(RemovalPolicy.retain(true));
+            return { database, password };
+          }),
+        );
+
+        // Password exists post-deploy.
+        const fetched = yield* ops.getPassword({
+          organization: database.organization,
+          database: database.name,
+          branch: "main",
+          id: password.id,
+        });
+        expect(fetched.id).toEqual(password.id);
+
+        // Destroy the stack — both retained, so neither should be removed.
+        yield* stack.destroy();
+
+        const { organization } = yield* Planetscale.Credentials;
+
+        // Database should still exist and be ready.
+        const liveDb = yield* Planetscale.waitForDatabaseReady(
+          organization,
+          dbName,
+        );
+        expect(liveDb.name).toEqual(dbName);
+
+        // Password should still exist (was not deleted via API).
+        const stillExists = yield* ops.getPassword({
           organization,
           database: dbName,
           branch: "main",
           id: password.id,
-        })
-        .pipe(Effect.catchTag("NotFound", () => Effect.void));
+        });
+        expect(stillExists.id).toEqual(password.id);
+        expect(stillExists.name).toEqual(password.name);
 
-      yield* ops
-        .deleteDatabase({
-          organization,
-          database: dbName,
-        })
-        .pipe(Effect.catchTag("NotFound", () => Effect.void));
+        // Manual cleanup for the test.
+        yield* ops
+          .deletePassword({
+            organization,
+            database: dbName,
+            branch: "main",
+            id: password.id,
+          })
+          .pipe(Effect.catchTag("NotFound", () => Effect.void));
 
-      yield* waitForDatabaseToBeDeleted(dbName, organization);
-    }).pipe(logLevel),
-  5_000_000,
-);
+        yield* ops
+          .deleteDatabase({
+            organization,
+            database: dbName,
+          })
+          .pipe(Effect.catchTag("NotFound", () => Effect.void));
+
+        yield* waitForDatabaseToBeDeleted(dbName, organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
+});
 
 const waitForDatabaseToBeDeleted = Effect.fn(function* (
   database: string,

--- a/packages/alchemy/test/Planetscale/Postgres/Hyperdrive.test.ts
+++ b/packages/alchemy/test/Planetscale/Postgres/Hyperdrive.test.ts
@@ -1,7 +1,7 @@
 import * as Cloudflare from "@/Cloudflare";
 import * as Planetscale from "@/Planetscale";
 import * as Test from "@/Test/Vitest";
-import { expect } from "@effect/vitest";
+import { describe, expect } from "@effect/vitest";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -10,8 +10,8 @@ import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import HyperdriveWorker from "./fixtures/hyperdrive-worker.ts";
-import { Hyperdrive, PlanetscaleDb } from "./fixtures/Stack.ts";
 import type { Widget } from "./fixtures/schema.ts";
+import { Hyperdrive, PlanetscaleDb } from "./fixtures/Stack.ts";
 
 const { test } = Test.make({
   providers: Layer.mergeAll(Cloudflare.providers(), Planetscale.providers()),
@@ -27,83 +27,87 @@ class WorkerNotReady extends Data.TaggedError("WorkerNotReady")<{
   body: string;
 }> {}
 
-/**
- * End-to-end: deploy a {@link Planetscale.PostgresDatabase} + branch +
- * role, point a {@link Cloudflare.Hyperdrive} at the role's origin, and
- * exercise the Drizzle Effect client over real Postgres via a Worker.
- *
- * Validates that:
- *   - migrations applied from the fixtures dir produce the expected table
- *   - `Cloudflare.Hyperdrive.bind(...) + Drizzle.postgres(...)` produces
- *     a working Effect-native client at runtime
- *   - INSERT / SELECT / DELETE round-trip through Hyperdrive to Planetscale
- */
-test.provider(
-  "PostgresBranch + Hyperdrive + Drizzle round-trips through a Worker",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
+describe.skipIf(!process.env.PLANETSCALE_TEST)(() => {
+  /**
+   * End-to-end: deploy a {@link Planetscale.PostgresDatabase} + branch +
+   * role, point a {@link Cloudflare.Hyperdrive} at the role's origin, and
+   * exercise the Drizzle Effect client over real Postgres via a Worker.
+   *
+   * Validates that:
+   *   - migrations applied from the fixtures dir produce the expected table
+   *   - `Cloudflare.Hyperdrive.bind(...) + Drizzle.postgres(...)` produces
+   *     a working Effect-native client at runtime
+   *   - INSERT / SELECT / DELETE round-trip through Hyperdrive to Planetscale
+   */
+  test.provider(
+    "PostgresBranch + Hyperdrive + Drizzle round-trips through a Worker",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-      const { worker } = yield* stack.deploy(
-        Effect.gen(function* () {
-          yield* PlanetscaleDb;
-          yield* Hyperdrive;
-          const worker = yield* HyperdriveWorker;
-          return { worker };
-        }),
-      );
+        const { worker } = yield* stack.deploy(
+          Effect.gen(function* () {
+            yield* PlanetscaleDb;
+            yield* Hyperdrive;
+            const worker = yield* HyperdriveWorker;
+            return { worker };
+          }),
+        );
 
-      expect(worker.url).toBeTypeOf("string");
-      const baseUrl = (worker.url as string).replace(/\/+$/, "");
+        expect(worker.url).toBeTypeOf("string");
+        const baseUrl = (worker.url as string).replace(/\/+$/, "");
 
-      // workers.dev edge takes a few seconds to start serving; retry the
-      // first request until we get a non-4xx.
-      const initial = yield* HttpClient.get(`${baseUrl}/widgets`).pipe(
-        Effect.flatMap((res) =>
-          res.status === 200
-            ? res.text.pipe(Effect.as(res))
-            : res.text.pipe(
-                Effect.flatMap((body) =>
-                  Effect.fail(new WorkerNotReady({ status: res.status, body })),
+        // workers.dev edge takes a few seconds to start serving; retry the
+        // first request until we get a non-4xx.
+        const initial = yield* HttpClient.get(`${baseUrl}/widgets`).pipe(
+          Effect.flatMap((res) =>
+            res.status === 200
+              ? res.text.pipe(Effect.as(res))
+              : res.text.pipe(
+                  Effect.flatMap((body) =>
+                    Effect.fail(
+                      new WorkerNotReady({ status: res.status, body }),
+                    ),
+                  ),
                 ),
-              ),
-        ),
-        Effect.retry({
-          while: (e): e is WorkerNotReady =>
-            e instanceof WorkerNotReady && e.status >= 400 && e.status < 600,
-          schedule: Schedule.exponential("500 millis").pipe(
-            Schedule.both(Schedule.recurs(20)),
           ),
-        }),
-      );
-      expect(initial.status).toBe(200);
-      const initialBody = (yield* initial.json) as { widgets: Widget[] };
-      expect(Array.isArray(initialBody.widgets)).toBe(true);
+          Effect.retry({
+            while: (e): e is WorkerNotReady =>
+              e instanceof WorkerNotReady && e.status >= 400 && e.status < 600,
+            schedule: Schedule.exponential("500 millis").pipe(
+              Schedule.both(Schedule.recurs(20)),
+            ),
+          }),
+        );
+        expect(initial.status).toBe(200);
+        const initialBody = (yield* initial.json) as { widgets: Widget[] };
+        expect(Array.isArray(initialBody.widgets)).toBe(true);
 
-      const insertRes = yield* HttpClient.execute(
-        HttpClientRequest.post(`${baseUrl}/widgets`).pipe(
-          HttpClientRequest.bodyJsonUnsafe({ id: 1, name: "alpha" }),
-        ),
-      );
-      expect(insertRes.status).toBe(200);
-      const insertBody = (yield* insertRes.json) as { widget: Widget };
-      expect(insertBody.widget).toMatchObject({ id: 1, name: "alpha" });
+        const insertRes = yield* HttpClient.execute(
+          HttpClientRequest.post(`${baseUrl}/widgets`).pipe(
+            HttpClientRequest.bodyJsonUnsafe({ id: 1, name: "alpha" }),
+          ),
+        );
+        expect(insertRes.status).toBe(200);
+        const insertBody = (yield* insertRes.json) as { widget: Widget };
+        expect(insertBody.widget).toMatchObject({ id: 1, name: "alpha" });
 
-      const after = yield* HttpClient.get(`${baseUrl}/widgets`);
-      expect(after.status).toBe(200);
-      const afterBody = (yield* after.json) as { widgets: Widget[] };
-      expect(afterBody.widgets.some((w) => w.id === 1)).toBe(true);
+        const after = yield* HttpClient.get(`${baseUrl}/widgets`);
+        expect(after.status).toBe(200);
+        const afterBody = (yield* after.json) as { widgets: Widget[] };
+        expect(afterBody.widgets.some((w) => w.id === 1)).toBe(true);
 
-      const deleteRes = yield* HttpClient.execute(
-        HttpClientRequest.delete(`${baseUrl}/widgets/1`),
-      );
-      expect(deleteRes.status).toBe(200);
+        const deleteRes = yield* HttpClient.execute(
+          HttpClientRequest.delete(`${baseUrl}/widgets/1`),
+        );
+        expect(deleteRes.status).toBe(200);
 
-      const final = yield* HttpClient.get(`${baseUrl}/widgets`);
-      const finalBody = (yield* final.json) as { widgets: Widget[] };
-      expect(finalBody.widgets.some((w) => w.id === 1)).toBe(false);
+        const final = yield* HttpClient.get(`${baseUrl}/widgets`);
+        const finalBody = (yield* final.json) as { widgets: Widget[] };
+        expect(finalBody.widgets.some((w) => w.id === 1)).toBe(false);
 
-      yield* stack.destroy();
-    }).pipe(logLevel),
-  { timeout: 600_000 },
-);
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 600_000 },
+  );
+});

--- a/packages/alchemy/test/Planetscale/Postgres/PostgresDatabase.test.ts
+++ b/packages/alchemy/test/Planetscale/Postgres/PostgresDatabase.test.ts
@@ -3,7 +3,7 @@ import * as Planetscale from "@/Planetscale";
 import * as RemovalPolicy from "@/RemovalPolicy.ts";
 import * as Test from "@/Test/Vitest";
 import * as ops from "@distilled.cloud/planetscale/Operations";
-import { expect } from "@effect/vitest";
+import { describe, expect } from "@effect/vitest";
 import { Data, Schedule } from "effect";
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
@@ -19,449 +19,451 @@ const logLevel = Effect.provideService(
 
 const fixturesDir = `${import.meta.dirname}/fixtures`;
 
-test.provider(
-  "create database with minimal settings",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
+describe.skipIf(!process.env.PLANETSCALE_TEST)(() => {
+  test.provider(
+    "create database with minimal settings",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-      const { database } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase(
-            "PostgresDatabaseBasic",
-            {
-              clusterSize: "PS_10",
-            },
-          );
-
-          return {
-            database,
-          };
-        }),
-      );
-
-      expect(database).toMatchObject({
-        kind: "postgresql",
-        id: expect.any(String),
-        name: expect.any(String),
-        organization: expect.any(String),
-        state: expect.any(String),
-        defaultBranch: "main",
-        plan: expect.any(String),
-        createdAt: expect.any(String),
-        updatedAt: expect.any(String),
-        htmlUrl: expect.any(String),
-        region: {
-          slug: expect.any(String),
-        },
-        clusterSize: "PS_10",
-      });
-
-      const branch = yield* Planetscale.waitForBranchReady(
-        database.organization,
-        database.name,
-        "main",
-      );
-
-      expect(branch.cluster_name).toEqual("PS_10_AWS_X86");
-
-      yield* stack.destroy();
-    }).pipe(logLevel),
-  5_000_000,
-);
-
-test.provider(
-  "create, update, and delete database",
-  (stack) =>
-    Effect.gen(function* () {
-      const name = `alchemy-test-postgresql-crud`;
-
-      yield* stack.destroy();
-
-      const { database } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase(
-            "PostgresDatabaseCRUD",
-            {
-              name,
-              region: {
-                slug: "us-east",
+        const { database } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.PostgresDatabase(
+              "PostgresDatabaseBasic",
+              {
+                clusterSize: "PS_10",
               },
-              clusterSize: "PS_10",
-              defaultBranch: "main",
-              requireApprovalForDeploy: false,
-              restrictBranchRegion: true,
-              productionBranchWebConsole: true,
-            },
-          );
+            );
 
-          return {
-            database,
-          };
-        }),
-      );
+            return {
+              database,
+            };
+          }),
+        );
 
-      expect(database).toMatchObject({
-        kind: "postgresql",
-        id: expect.any(String),
-        name,
-        organization: expect.any(String),
-        state: expect.any(String),
-        plan: expect.any(String),
-        createdAt: expect.any(String),
-        updatedAt: expect.any(String),
-        htmlUrl: expect.any(String),
-        region: {
-          slug: expect.any(String),
-        },
-        clusterSize: "PS_10",
-        defaultBranch: "main",
-        requireApprovalForDeploy: false,
-        restrictBranchRegion: true,
-        productionBranchWebConsole: true,
-      });
+        expect(database).toMatchObject({
+          kind: "postgresql",
+          id: expect.any(String),
+          name: expect.any(String),
+          organization: expect.any(String),
+          state: expect.any(String),
+          defaultBranch: "main",
+          plan: expect.any(String),
+          createdAt: expect.any(String),
+          updatedAt: expect.any(String),
+          htmlUrl: expect.any(String),
+          region: {
+            slug: expect.any(String),
+          },
+          clusterSize: "PS_10",
+        });
 
-      const { updatedDatabase } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const updatedDatabase = yield* Planetscale.PostgresDatabase(
-            "PostgresDatabaseCRUD",
-            {
-              name,
-              clusterSize: "PS_20",
-              requireApprovalForDeploy: true,
-              restrictBranchRegion: false,
-              productionBranchWebConsole: false,
-              defaultBranch: "main",
-            },
-          );
+        const branch = yield* Planetscale.waitForBranchReady(
+          database.organization,
+          database.name,
+          "main",
+        );
 
-          return {
-            updatedDatabase,
-          };
-        }),
-      );
+        expect(branch.cluster_name).toEqual("PS_10_AWS_X86");
 
-      expect(updatedDatabase).toMatchObject({
-        name,
-        requireApprovalForDeploy: true,
-        restrictBranchRegion: false,
-        productionBranchWebConsole: false,
-        defaultBranch: "main",
-      });
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    5_000_000,
+  );
 
-      const branch = yield* Planetscale.waitForBranchReady(
-        database.organization,
-        database.name,
-        "main",
-      );
+  test.provider(
+    "create, update, and delete database",
+    (stack) =>
+      Effect.gen(function* () {
+        const name = `alchemy-test-postgresql-crud`;
 
-      expect(branch.cluster_name).toEqual("PS_20_AWS_X86");
+        yield* stack.destroy();
 
-      yield* stack.destroy();
-
-      yield* waitForDatabaseToBeDeleted(database.name, database.organization);
-    }).pipe(logLevel),
-  5_000_000,
-);
-
-test.provider(
-  "creates non-main default branch if specified",
-  (stack) =>
-    Effect.gen(function* () {
-      const name = `alchemy-test-postgresql-custom-branch`;
-      const defaultBranch = "custom";
-
-      yield* stack.destroy();
-
-      const { database } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase(
-            "PostgresDatabaseCustomBranch",
-            {
-              name,
-              clusterSize: "PS_10",
-              defaultBranch,
-            },
-          );
-
-          return {
-            database,
-          };
-        }),
-      );
-
-      expect(database).toMatchObject({
-        name,
-        kind: "postgresql",
-        defaultBranch,
-      });
-
-      const branch = yield* Planetscale.waitForBranchReady(
-        database.organization,
-        database.name,
-        defaultBranch,
-      );
-
-      expect(branch.name).toEqual(defaultBranch);
-      expect(branch.parent_branch).toEqual("main");
-      expect(branch.cluster_name).toEqual("PS_10_AWS_X86");
-
-      yield* stack.destroy();
-
-      yield* waitForDatabaseToBeDeleted(database.name, database.organization);
-    }).pipe(logLevel),
-  5_000_000, // must wait on multiple resizes and branch creation
-);
-
-test.provider(
-  "create database with arm arch",
-  (stack) =>
-    Effect.gen(function* () {
-      const name = `alchemy-test-postgresql-basic`;
-      yield* stack.destroy();
-
-      const { database } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase(
-            "PostgresDatabaseBasic",
-            {
-              name,
-              clusterSize: "PS_10",
-              arch: "arm",
-            },
-          );
-
-          return {
-            database,
-          };
-        }),
-      );
-
-      expect(database).toMatchObject({
-        kind: "postgresql",
-        id: expect.any(String),
-        name,
-        arch: "arm",
-        clusterSize: "PS_10",
-      });
-
-      const branch = yield* Planetscale.waitForBranchReady(
-        database.organization,
-        database.name,
-        "main",
-      );
-
-      expect(branch.cluster_name).toEqual("PS_10_AWS_ARM");
-
-      yield* stack.destroy();
-    }).pipe(logLevel),
-  5_000_000,
-);
-
-test.provider(
-  "applies migrations and import files",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      const importFile = `${fixturesDir}/seed.sql`;
-      const { database } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase(
-            "PostgresDatabaseMigrations",
-            {
-              clusterSize: "PS_10",
-              migrationsDir: `${fixturesDir}/migrations`,
-              importFiles: [importFile],
-            },
-          );
-
-          return {
-            database,
-          };
-        }),
-      );
-
-      expect(database.migrationsTable).toEqual("planetscale_migrations");
-      expect(database.migrationsHashes["0001_create_widgets.sql"]).toEqual(
-        expect.any(String),
-      );
-      expect(database.importHashes[importFile]).toEqual(expect.any(String));
-
-      yield* stack.destroy();
-
-      yield* waitForDatabaseToBeDeleted(database.name, database.organization);
-    }).pipe(logLevel),
-  5_000_000,
-);
-
-test.provider(
-  "adopt with wrong kind should throw",
-  (stack) =>
-    Effect.gen(function* () {
-      const name = `alchemy-test-postgresql-kind`;
-
-      yield* stack.destroy();
-
-      const { database } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.MySQLDatabase(
-            "MySQLBaselineWrongKind",
-            {
-              name,
-              region: { slug: "us-east" },
-              clusterSize: "PS_10",
-            },
-          );
-
-          return { database };
-        }),
-      );
-
-      yield* Planetscale.waitForDatabaseReady(database.organization, name);
-
-      const exit = yield* Effect.exit(
-        stack
-          .deploy(
-            Effect.gen(function* () {
-              const database = yield* Planetscale.PostgresDatabase(
-                "PostgresWrongKind",
-                {
-                  name,
-                  clusterSize: "PS_10",
+        const { database } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.PostgresDatabase(
+              "PostgresDatabaseCRUD",
+              {
+                name,
+                region: {
+                  slug: "us-east",
                 },
-              );
+                clusterSize: "PS_10",
+                defaultBranch: "main",
+                requireApprovalForDeploy: false,
+                restrictBranchRegion: true,
+                productionBranchWebConsole: true,
+              },
+            );
 
-              return { database };
-            }),
-          )
-          .pipe(adopt(true)),
-      );
+            return {
+              database,
+            };
+          }),
+        );
 
-      expect(Exit.isFailure(exit)).toBe(true);
+        expect(database).toMatchObject({
+          kind: "postgresql",
+          id: expect.any(String),
+          name,
+          organization: expect.any(String),
+          state: expect.any(String),
+          plan: expect.any(String),
+          createdAt: expect.any(String),
+          updatedAt: expect.any(String),
+          htmlUrl: expect.any(String),
+          region: {
+            slug: expect.any(String),
+          },
+          clusterSize: "PS_10",
+          defaultBranch: "main",
+          requireApprovalForDeploy: false,
+          restrictBranchRegion: true,
+          productionBranchWebConsole: true,
+        });
 
-      if (Exit.isFailure(exit)) {
-        const pretty = Cause.pretty(exit.cause);
-        expect(pretty).toContain("mysql");
-        expect(pretty).toContain("MySQLDatabase");
-      }
+        const { updatedDatabase } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const updatedDatabase = yield* Planetscale.PostgresDatabase(
+              "PostgresDatabaseCRUD",
+              {
+                name,
+                clusterSize: "PS_20",
+                requireApprovalForDeploy: true,
+                restrictBranchRegion: false,
+                productionBranchWebConsole: false,
+                defaultBranch: "main",
+              },
+            );
 
-      yield* stack.destroy();
-    }).pipe(logLevel),
-  5_000_000,
-);
+            return {
+              updatedDatabase,
+            };
+          }),
+        );
 
-test.provider(
-  "adopt with wrong arch should trigger replace",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
+        expect(updatedDatabase).toMatchObject({
+          name,
+          requireApprovalForDeploy: true,
+          restrictBranchRegion: false,
+          productionBranchWebConsole: false,
+          defaultBranch: "main",
+        });
 
-      // Create a database with arm
-      const { database } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase(
-            "PostgresDatabaseWrongArch",
-            {
-              arch: "arm",
-              clusterSize: "PS_10",
-            },
-          );
+        const branch = yield* Planetscale.waitForBranchReady(
+          database.organization,
+          database.name,
+          "main",
+        );
 
-          return {
-            database,
-          };
-        }),
-      );
+        expect(branch.cluster_name).toEqual("PS_20_AWS_X86");
 
-      expect(database.arch).toEqual("arm");
+        yield* stack.destroy();
 
-      // Now try to adopt it with a different arch — should replace
-      const { newDatabase } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const newDatabase = yield* Planetscale.PostgresDatabase(
-            "PostgresDatabaseWrongArch",
-            {
-              arch: "x86",
-              clusterSize: "PS_10",
-            },
-          );
-          return {
-            newDatabase,
-          };
-        }),
-      );
+        yield* waitForDatabaseToBeDeleted(database.name, database.organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
 
-      expect(newDatabase.id).not.toBe(database.id);
+  test.provider(
+    "creates non-main default branch if specified",
+    (stack) =>
+      Effect.gen(function* () {
+        const name = `alchemy-test-postgresql-custom-branch`;
+        const defaultBranch = "custom";
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      yield* waitForDatabaseToBeDeleted(database.name, database.organization);
-      yield* waitForDatabaseToBeDeleted(
-        newDatabase.name,
-        newDatabase.organization,
-      );
-    }).pipe(logLevel),
-  5_000_000,
-);
+        const { database } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.PostgresDatabase(
+              "PostgresDatabaseCustomBranch",
+              {
+                name,
+                clusterSize: "PS_10",
+                defaultBranch,
+              },
+            );
 
-test.provider(
-  "database with RemovalPolicy.retain(true) should not be deleted via API",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
+            return {
+              database,
+            };
+          }),
+        );
 
-      const { database } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase(
-            "PostgresDatabaseRetainRemoval",
-            {
-              region: { slug: "us-east" },
-              clusterSize: "PS_10",
-            },
-          ).pipe(RemovalPolicy.retain(true));
+        expect(database).toMatchObject({
+          name,
+          kind: "postgresql",
+          defaultBranch,
+        });
 
-          return {
-            database,
-          };
-        }),
-      );
+        const branch = yield* Planetscale.waitForBranchReady(
+          database.organization,
+          database.name,
+          defaultBranch,
+        );
 
-      // Verify database exists
-      yield* Planetscale.waitForDatabaseReady(
-        database.organization,
-        database.name,
-      );
+        expect(branch.name).toEqual(defaultBranch);
+        expect(branch.parent_branch).toEqual("main");
+        expect(branch.cluster_name).toEqual("PS_10_AWS_X86");
 
-      // When we call destroy, the database should NOT be deleted via API
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      yield* Planetscale.waitForDatabaseReady(
-        database.organization,
-        database.name,
-      );
+        yield* waitForDatabaseToBeDeleted(database.name, database.organization);
+      }).pipe(logLevel),
+    5_000_000, // must wait on multiple resizes and branch creation
+  );
 
-      // Verify database still exists (was not deleted via API)
-      const live = yield* ops.getDatabase({
-        organization: database.organization,
-        database: database.name,
-      });
+  test.provider(
+    "create database with arm arch",
+    (stack) =>
+      Effect.gen(function* () {
+        const name = `alchemy-test-postgresql-basic`;
+        yield* stack.destroy();
 
-      // Database should still exist
-      expect(live.name).toEqual(database.name);
-      expect(live.state).toEqual("ready");
-      expect(live.kind).toEqual("postgresql");
+        const { database } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.PostgresDatabase(
+              "PostgresDatabaseBasic",
+              {
+                name,
+                clusterSize: "PS_10",
+                arch: "arm",
+              },
+            );
 
-      // Clean up manually for the test
-      yield* ops
-        .deleteDatabase({
+            return {
+              database,
+            };
+          }),
+        );
+
+        expect(database).toMatchObject({
+          kind: "postgresql",
+          id: expect.any(String),
+          name,
+          arch: "arm",
+          clusterSize: "PS_10",
+        });
+
+        const branch = yield* Planetscale.waitForBranchReady(
+          database.organization,
+          database.name,
+          "main",
+        );
+
+        expect(branch.cluster_name).toEqual("PS_10_AWS_ARM");
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    5_000_000,
+  );
+
+  test.provider(
+    "applies migrations and import files",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const importFile = `${fixturesDir}/seed.sql`;
+        const { database } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.PostgresDatabase(
+              "PostgresDatabaseMigrations",
+              {
+                clusterSize: "PS_10",
+                migrationsDir: `${fixturesDir}/migrations`,
+                importFiles: [importFile],
+              },
+            );
+
+            return {
+              database,
+            };
+          }),
+        );
+
+        expect(database.migrationsTable).toEqual("planetscale_migrations");
+        expect(database.migrationsHashes["0001_create_widgets.sql"]).toEqual(
+          expect.any(String),
+        );
+        expect(database.importHashes[importFile]).toEqual(expect.any(String));
+
+        yield* stack.destroy();
+
+        yield* waitForDatabaseToBeDeleted(database.name, database.organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
+
+  test.provider(
+    "adopt with wrong kind should throw",
+    (stack) =>
+      Effect.gen(function* () {
+        const name = `alchemy-test-postgresql-kind`;
+
+        yield* stack.destroy();
+
+        const { database } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.MySQLDatabase(
+              "MySQLBaselineWrongKind",
+              {
+                name,
+                region: { slug: "us-east" },
+                clusterSize: "PS_10",
+              },
+            );
+
+            return { database };
+          }),
+        );
+
+        yield* Planetscale.waitForDatabaseReady(database.organization, name);
+
+        const exit = yield* Effect.exit(
+          stack
+            .deploy(
+              Effect.gen(function* () {
+                const database = yield* Planetscale.PostgresDatabase(
+                  "PostgresWrongKind",
+                  {
+                    name,
+                    clusterSize: "PS_10",
+                  },
+                );
+
+                return { database };
+              }),
+            )
+            .pipe(adopt(true)),
+        );
+
+        expect(Exit.isFailure(exit)).toBe(true);
+
+        if (Exit.isFailure(exit)) {
+          const pretty = Cause.pretty(exit.cause);
+          expect(pretty).toContain("mysql");
+          expect(pretty).toContain("MySQLDatabase");
+        }
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    5_000_000,
+  );
+
+  test.provider(
+    "adopt with wrong arch should trigger replace",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        // Create a database with arm
+        const { database } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.PostgresDatabase(
+              "PostgresDatabaseWrongArch",
+              {
+                arch: "arm",
+                clusterSize: "PS_10",
+              },
+            );
+
+            return {
+              database,
+            };
+          }),
+        );
+
+        expect(database.arch).toEqual("arm");
+
+        // Now try to adopt it with a different arch — should replace
+        const { newDatabase } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const newDatabase = yield* Planetscale.PostgresDatabase(
+              "PostgresDatabaseWrongArch",
+              {
+                arch: "x86",
+                clusterSize: "PS_10",
+              },
+            );
+            return {
+              newDatabase,
+            };
+          }),
+        );
+
+        expect(newDatabase.id).not.toBe(database.id);
+
+        yield* stack.destroy();
+
+        yield* waitForDatabaseToBeDeleted(database.name, database.organization);
+        yield* waitForDatabaseToBeDeleted(
+          newDatabase.name,
+          newDatabase.organization,
+        );
+      }).pipe(logLevel),
+    5_000_000,
+  );
+
+  test.provider(
+    "database with RemovalPolicy.retain(true) should not be deleted via API",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const { database } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.PostgresDatabase(
+              "PostgresDatabaseRetainRemoval",
+              {
+                region: { slug: "us-east" },
+                clusterSize: "PS_10",
+              },
+            ).pipe(RemovalPolicy.retain(true));
+
+            return {
+              database,
+            };
+          }),
+        );
+
+        // Verify database exists
+        yield* Planetscale.waitForDatabaseReady(
+          database.organization,
+          database.name,
+        );
+
+        // When we call destroy, the database should NOT be deleted via API
+        yield* stack.destroy();
+
+        yield* Planetscale.waitForDatabaseReady(
+          database.organization,
+          database.name,
+        );
+
+        // Verify database still exists (was not deleted via API)
+        const live = yield* ops.getDatabase({
           organization: database.organization,
           database: database.name,
-        })
-        .pipe(Effect.catchTag("NotFound", () => Effect.void));
-    }).pipe(logLevel),
-  5_000_000,
-);
+        });
+
+        // Database should still exist
+        expect(live.name).toEqual(database.name);
+        expect(live.state).toEqual("ready");
+        expect(live.kind).toEqual("postgresql");
+
+        // Clean up manually for the test
+        yield* ops
+          .deleteDatabase({
+            organization: database.organization,
+            database: database.name,
+          })
+          .pipe(Effect.catchTag("NotFound", () => Effect.void));
+      }).pipe(logLevel),
+    5_000_000,
+  );
+});
 
 const waitForDatabaseToBeDeleted = Effect.fn(function* (
   database: string,

--- a/packages/alchemy/test/Planetscale/Postgres/PostgresRole.test.ts
+++ b/packages/alchemy/test/Planetscale/Postgres/PostgresRole.test.ts
@@ -2,7 +2,7 @@ import * as Planetscale from "@/Planetscale";
 import * as RemovalPolicy from "@/RemovalPolicy.ts";
 import * as Test from "@/Test/Vitest";
 import * as ops from "@distilled.cloud/planetscale/Operations";
-import { expect } from "@effect/vitest";
+import { describe, expect } from "@effect/vitest";
 import { Redacted } from "effect";
 import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
@@ -17,405 +17,405 @@ const logLevel = Effect.provideService(
   MinimumLogLevel,
   process.env.DEBUG ? "Debug" : "Info",
 );
+describe.skipIf(!process.env.PLANETSCALE_TEST)(() => {
+  test.provider(
+    "default role - create, duplicate fails, forceReset returns new id",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-test.provider(
-  "default role - create, duplicate fails, forceReset returns new id",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      // First: create default role, expect success
-      const { database, role1 } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase("Database", {
-            clusterSize: "PS_10",
-            arch: "arm",
-          });
-          const role1 = yield* Planetscale.PostgresDefaultRole("Role1", {
-            database,
-          });
-
-          return { role1, database };
-        }),
-      );
-
-      expect(role1).toMatchObject({
-        id: expect.any(String),
-        name: expect.any(String),
-        host: expect.any(String),
-        username: expect.any(String),
-        password: expect.any(Object),
-        databaseName: "postgres",
-        branch: "main",
-        organization: database.organization,
-      });
-
-      // Second: create again without forceReset — should fail (default already exists)
-      const exit = yield* stack
-        .deploy(
+        // First: create default role, expect success
+        const { database, role1 } = yield* stack.deploy(
           Effect.gen(function* () {
             const database = yield* Planetscale.PostgresDatabase("Database", {
               clusterSize: "PS_10",
               arch: "arm",
             });
-            const role2 = yield* Planetscale.PostgresDefaultRole("Role2", {
+            const role1 = yield* Planetscale.PostgresDefaultRole("Role1", {
               database,
+            });
+
+            return { role1, database };
+          }),
+        );
+
+        expect(role1).toMatchObject({
+          id: expect.any(String),
+          name: expect.any(String),
+          host: expect.any(String),
+          username: expect.any(String),
+          password: expect.any(Object),
+          databaseName: "postgres",
+          branch: "main",
+          organization: database.organization,
+        });
+
+        // Second: create again without forceReset — should fail (default already exists)
+        const exit = yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              const database = yield* Planetscale.PostgresDatabase("Database", {
+                clusterSize: "PS_10",
+                arch: "arm",
+              });
+              const role2 = yield* Planetscale.PostgresDefaultRole("Role2", {
+                database,
+              });
+
+              return { role2 };
+            }),
+          )
+          .pipe(Effect.exit);
+
+        expect(Exit.isFailure(exit)).toBe(true);
+
+        if (Exit.isFailure(exit)) {
+          expect(Cause.pretty(exit.cause)).toMatch(
+            /Default role already exists.*Use forceReset/,
+          );
+        }
+
+        // Third: create with forceReset — should succeed and return a different role id
+        const { role3 } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.PostgresDatabase("Database", {
+              clusterSize: "PS_10",
+              arch: "arm",
+            });
+            const role3 = yield* Planetscale.PostgresDefaultRole("Role3", {
+              database,
+              forceReset: true,
+            });
+
+            return { role3, database };
+          }),
+        );
+
+        expect(role3).toMatchObject({
+          id: expect.any(String),
+          name: expect.any(String),
+          host: expect.any(String),
+          username: expect.any(String),
+          password: expect.any(Object),
+          databaseName: "postgres",
+          branch: "main",
+          organization: database.organization,
+        });
+
+        // the default role ID is the same, but the password is different
+        expect(Redacted.value(role3.password)).not.toEqual(
+          Redacted.value(role1.password),
+        );
+
+        yield* stack.destroy();
+        yield* waitForDatabaseToBeDeleted(database.name, database.organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
+
+  test.provider(
+    "create and delete role",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        // Create a role
+        const { database, role } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.PostgresDatabase("Database", {
+              clusterSize: "PS_10",
+              arch: "arm",
+            });
+            const role = yield* Planetscale.PostgresRole("Role", {
+              database,
+              // Empty array means no permissions, which is fine for testing.
+              inheritedRoles: [],
+            });
+
+            return { database, role };
+          }),
+        );
+
+        expect(role).toMatchObject({
+          id: expect.any(String),
+          name: expect.any(String),
+          host: expect.any(String),
+          username: expect.any(String),
+          password: expect.any(Object),
+        });
+
+        // Update role with different ttl (should trigger replacement)
+        const { updatedRole } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.PostgresDatabase("Database", {
+              clusterSize: "PS_10",
+              arch: "arm",
+            });
+            const updatedRole = yield* Planetscale.PostgresRole("Role", {
+              database,
+              ttl: 3600,
+              inheritedRoles: [],
+            });
+
+            return { database, updatedRole };
+          }),
+        );
+
+        expect(role.id).not.toEqual(updatedRole.id);
+        expect(updatedRole.ttl).toEqual(3600);
+
+        const found = yield* ops
+          .getRole({
+            id: role.id,
+            database: database.name,
+            organization: database.organization,
+            branch: "main",
+          })
+          .pipe(
+            Effect.map(() => true),
+            Effect.catchTag("NotFound", () => Effect.succeed(false)),
+          );
+
+        expect(found).toBe(false);
+
+        const updatedRoleFromApi = yield* ops.getRole({
+          id: updatedRole.id,
+          database: database.name,
+          organization: database.organization,
+          branch: "main",
+        });
+
+        expect(updatedRoleFromApi.ttl).toEqual(3600);
+
+        yield* stack.destroy();
+
+        yield* waitForDatabaseToBeDeleted(database.name, database.organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
+
+  test.provider(
+    "role gets replaced when properties change",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const { database, role1 } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.PostgresDatabase("Database", {
+              clusterSize: "PS_10",
+              arch: "arm",
+            });
+            const role1 = yield* Planetscale.PostgresRole("RoleReplace", {
+              database: database,
+              inheritedRoles: ["pg_read_all_data"],
+              ttl: 3600,
+            });
+
+            return { database, role1 };
+          }),
+        );
+
+        expect(role1).toMatchObject({
+          id: expect.any(String),
+          name: expect.any(String),
+          inheritedRoles: ["pg_read_all_data"],
+        });
+
+        const originalId = role1.id;
+        const originalName = role1.name;
+
+        const { role2 } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.PostgresDatabase("Database", {
+              clusterSize: "PS_10",
+              arch: "arm",
+            });
+            const role2 = yield* Planetscale.PostgresRole("RoleReplace", {
+              database: database,
+              inheritedRoles: ["postgres"],
+              ttl: 7200,
             });
 
             return { role2 };
           }),
-        )
-        .pipe(Effect.exit);
-
-      expect(Exit.isFailure(exit)).toBe(true);
-
-      if (Exit.isFailure(exit)) {
-        expect(Cause.pretty(exit.cause)).toMatch(
-          /Default role already exists.*Use forceReset/,
-        );
-      }
-
-      // Third: create with forceReset — should succeed and return a different role id
-      const { role3 } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase("Database", {
-            clusterSize: "PS_10",
-            arch: "arm",
-          });
-          const role3 = yield* Planetscale.PostgresDefaultRole("Role3", {
-            database,
-            forceReset: true,
-          });
-
-          return { role3, database };
-        }),
-      );
-
-      expect(role3).toMatchObject({
-        id: expect.any(String),
-        name: expect.any(String),
-        host: expect.any(String),
-        username: expect.any(String),
-        password: expect.any(Object),
-        databaseName: "postgres",
-        branch: "main",
-        organization: database.organization,
-      });
-
-      // the default role ID is the same, but the password is different
-      expect(Redacted.value(role3.password)).not.toEqual(
-        Redacted.value(role1.password),
-      );
-
-      yield* stack.destroy();
-      yield* waitForDatabaseToBeDeleted(database.name, database.organization);
-    }).pipe(logLevel),
-  5_000_000,
-);
-
-test.provider(
-  "create and delete role",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      // Create a role
-      const { database, role } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase("Database", {
-            clusterSize: "PS_10",
-            arch: "arm",
-          });
-          const role = yield* Planetscale.PostgresRole("Role", {
-            database,
-            // Empty array means no permissions, which is fine for testing.
-            inheritedRoles: [],
-          });
-
-          return { database, role };
-        }),
-      );
-
-      expect(role).toMatchObject({
-        id: expect.any(String),
-        name: expect.any(String),
-        host: expect.any(String),
-        username: expect.any(String),
-        password: expect.any(Object),
-      });
-
-      // Update role with different ttl (should trigger replacement)
-      const { updatedRole } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase("Database", {
-            clusterSize: "PS_10",
-            arch: "arm",
-          });
-          const updatedRole = yield* Planetscale.PostgresRole("Role", {
-            database,
-            ttl: 3600,
-            inheritedRoles: [],
-          });
-
-          return { database, updatedRole };
-        }),
-      );
-
-      expect(role.id).not.toEqual(updatedRole.id);
-      expect(updatedRole.ttl).toEqual(3600);
-
-      const found = yield* ops
-        .getRole({
-          id: role.id,
-          database: database.name,
-          organization: database.organization,
-          branch: "main",
-        })
-        .pipe(
-          Effect.map(() => true),
-          Effect.catchTag("NotFound", () => Effect.succeed(false)),
         );
 
-      expect(found).toBe(false);
+        expect(role2).toMatchObject({
+          id: expect.any(String),
+          name: expect.any(String),
+          inheritedRoles: ["postgres"],
+        });
 
-      const updatedRoleFromApi = yield* ops.getRole({
-        id: updatedRole.id,
-        database: database.name,
-        organization: database.organization,
-        branch: "main",
-      });
+        expect(role2.id).not.toEqual(originalId);
+        expect(role2.name).not.toEqual(originalName);
 
-      expect(updatedRoleFromApi.ttl).toEqual(3600);
+        yield* stack.destroy();
 
-      yield* stack.destroy();
+        yield* waitForDatabaseToBeDeleted(database.name, database.organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
 
-      yield* waitForDatabaseToBeDeleted(database.name, database.organization);
-    }).pipe(logLevel),
-  5_000_000,
-);
+  test.provider(
+    "role with RemovalPolicy.retain(true) should not be deleted via API",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
 
-test.provider(
-  "role gets replaced when properties change",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
+        const { organization } = yield* Planetscale.Credentials;
 
-      const { database, role1 } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase("Database", {
-            clusterSize: "PS_10",
-            arch: "arm",
-          });
-          const role1 = yield* Planetscale.PostgresRole("RoleReplace", {
-            database: database,
-            inheritedRoles: ["pg_read_all_data"],
-            ttl: 3600,
-          });
+        const { database, role } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.PostgresDatabase("Database", {
+              clusterSize: "PS_10",
+              arch: "arm",
+            }).pipe(RemovalPolicy.retain(true));
+            const role = yield* Planetscale.PostgresRole("RoleRetainRemoval", {
+              database,
+              inheritedRoles: ["postgres"],
+            }).pipe(RemovalPolicy.retain(true));
 
-          return { database, role1 };
-        }),
-      );
+            return { database, role };
+          }),
+        );
 
-      expect(role1).toMatchObject({
-        id: expect.any(String),
-        name: expect.any(String),
-        inheritedRoles: ["pg_read_all_data"],
-      });
-
-      const originalId = role1.id;
-      const originalName = role1.name;
-
-      const { role2 } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase("Database", {
-            clusterSize: "PS_10",
-            arch: "arm",
-          });
-          const role2 = yield* Planetscale.PostgresRole("RoleReplace", {
-            database: database,
-            inheritedRoles: ["postgres"],
-            ttl: 7200,
-          });
-
-          return { role2 };
-        }),
-      );
-
-      expect(role2).toMatchObject({
-        id: expect.any(String),
-        name: expect.any(String),
-        inheritedRoles: ["postgres"],
-      });
-
-      expect(role2.id).not.toEqual(originalId);
-      expect(role2.name).not.toEqual(originalName);
-
-      yield* stack.destroy();
-
-      yield* waitForDatabaseToBeDeleted(database.name, database.organization);
-    }).pipe(logLevel),
-  5_000_000,
-);
-
-test.provider(
-  "role with RemovalPolicy.retain(true) should not be deleted via API",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      const { organization } = yield* Planetscale.Credentials;
-
-      const { database, role } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase("Database", {
-            clusterSize: "PS_10",
-            arch: "arm",
-          }).pipe(RemovalPolicy.retain(true));
-          const role = yield* Planetscale.PostgresRole("RoleRetainRemoval", {
-            database,
-            inheritedRoles: ["postgres"],
-          }).pipe(RemovalPolicy.retain(true));
-
-          return { database, role };
-        }),
-      );
-
-      expect(role).toMatchObject({
-        id: expect.any(String),
-        name: expect.any(String),
-        database: database.name,
-        inheritedRoles: ["postgres"],
-      });
-
-      yield* stack.destroy();
-
-      const liveRole = yield* ops
-        .getRole({
-          organization,
+        expect(role).toMatchObject({
+          id: expect.any(String),
+          name: expect.any(String),
           database: database.name,
-          branch: "main",
-          id: role.id,
-        })
-        .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined)));
+          inheritedRoles: ["postgres"],
+        });
 
-      expect(liveRole).toBeDefined();
-      expect(liveRole?.id).toEqual(role.id);
+        yield* stack.destroy();
 
-      // deleting the db takes care of deleting the role
-      yield* ops
-        .deleteDatabase({
-          organization,
+        const liveRole = yield* ops
+          .getRole({
+            organization,
+            database: database.name,
+            branch: "main",
+            id: role.id,
+          })
+          .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined)));
+
+        expect(liveRole).toBeDefined();
+        expect(liveRole?.id).toEqual(role.id);
+
+        // deleting the db takes care of deleting the role
+        yield* ops
+          .deleteDatabase({
+            organization,
+            database: database.name,
+          })
+          .pipe(Effect.catchTag("NotFound", () => Effect.void));
+
+        yield* waitForDatabaseToBeDeleted(database.name, database.organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
+
+  test.provider(
+    "role update: successor is updatable without replacement",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const { database, role1 } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.PostgresDatabase("Database", {
+              clusterSize: "PS_10",
+              arch: "arm",
+            });
+            const role1 = yield* Planetscale.PostgresRole("RoleSuccessor", {
+              database,
+              inheritedRoles: ["postgres"],
+              successor: "postgres",
+            });
+
+            return { database, role1 };
+          }),
+        );
+
+        expect(role1).toMatchObject({
+          id: expect.any(String),
+          name: expect.any(String),
+          successor: "postgres",
+        });
+
+        const originalId = role1.id;
+
+        const { role2 } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.PostgresDatabase("Database", {
+              clusterSize: "PS_10",
+              arch: "arm",
+            });
+            const role2 = yield* Planetscale.PostgresRole("RoleSuccessor", {
+              database,
+              inheritedRoles: ["postgres"],
+              successor: "pg_read_all_data",
+            });
+
+            return { role2 };
+          }),
+        );
+
+        expect(role2).toMatchObject({
+          id: originalId,
+          successor: "pg_read_all_data",
+        });
+
+        expect(role2.id).toEqual(originalId);
+
+        yield* stack.destroy();
+
+        yield* waitForDatabaseToBeDeleted(database.name, database.organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
+
+  test.provider(
+    "role with custom branch",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const { database, branch, role } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const database = yield* Planetscale.PostgresDatabase("Database", {
+              clusterSize: "PS_10",
+              arch: "arm",
+            });
+
+            const branch = yield* Planetscale.PostgresBranch("CustomBranch", {
+              database,
+            });
+
+            const role = yield* Planetscale.PostgresRole("RoleCustomBranch", {
+              database,
+              branch,
+              inheritedRoles: ["postgres"],
+            });
+
+            return { database, branch, role };
+          }),
+        );
+
+        expect(role).toMatchObject({
+          id: expect.any(String),
+          name: expect.any(String),
           database: database.name,
-        })
-        .pipe(Effect.catchTag("NotFound", () => Effect.void));
+          branch: branch.name,
+          inheritedRoles: ["postgres"],
+        });
 
-      yield* waitForDatabaseToBeDeleted(database.name, database.organization);
-    }).pipe(logLevel),
-  5_000_000,
-);
+        yield* stack.destroy();
 
-test.provider(
-  "role update: successor is updatable without replacement",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      const { database, role1 } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase("Database", {
-            clusterSize: "PS_10",
-            arch: "arm",
-          });
-          const role1 = yield* Planetscale.PostgresRole("RoleSuccessor", {
-            database,
-            inheritedRoles: ["postgres"],
-            successor: "postgres",
-          });
-
-          return { database, role1 };
-        }),
-      );
-
-      expect(role1).toMatchObject({
-        id: expect.any(String),
-        name: expect.any(String),
-        successor: "postgres",
-      });
-
-      const originalId = role1.id;
-
-      const { role2 } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase("Database", {
-            clusterSize: "PS_10",
-            arch: "arm",
-          });
-          const role2 = yield* Planetscale.PostgresRole("RoleSuccessor", {
-            database,
-            inheritedRoles: ["postgres"],
-            successor: "pg_read_all_data",
-          });
-
-          return { role2 };
-        }),
-      );
-
-      expect(role2).toMatchObject({
-        id: originalId,
-        successor: "pg_read_all_data",
-      });
-
-      expect(role2.id).toEqual(originalId);
-
-      yield* stack.destroy();
-
-      yield* waitForDatabaseToBeDeleted(database.name, database.organization);
-    }).pipe(logLevel),
-  5_000_000,
-);
-
-test.provider(
-  "role with custom branch",
-  (stack) =>
-    Effect.gen(function* () {
-      yield* stack.destroy();
-
-      const { database, branch, role } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const database = yield* Planetscale.PostgresDatabase("Database", {
-            clusterSize: "PS_10",
-            arch: "arm",
-          });
-
-          const branch = yield* Planetscale.PostgresBranch("CustomBranch", {
-            database,
-          });
-
-          const role = yield* Planetscale.PostgresRole("RoleCustomBranch", {
-            database,
-            branch,
-            inheritedRoles: ["postgres"],
-          });
-
-          return { database, branch, role };
-        }),
-      );
-
-      expect(role).toMatchObject({
-        id: expect.any(String),
-        name: expect.any(String),
-        database: database.name,
-        branch: branch.name,
-        inheritedRoles: ["postgres"],
-      });
-
-      yield* stack.destroy();
-
-      yield* waitForDatabaseToBeDeleted(database.name, database.organization);
-    }).pipe(logLevel),
-  5_000_000,
-);
-
+        yield* waitForDatabaseToBeDeleted(database.name, database.organization);
+      }).pipe(logLevel),
+    5_000_000,
+  );
+});
 const waitForDatabaseToBeDeleted = Effect.fn(function* (
   database: string,
   organization: string,

--- a/packages/alchemy/test/Secret.test.ts
+++ b/packages/alchemy/test/Secret.test.ts
@@ -10,8 +10,6 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
 
-const TestRuntime = RuntimeContext("AlchemyTest::Secret");
-
 interface Stored {
   env: Record<string, Output.Output>;
 }
@@ -35,10 +33,7 @@ const makeTestRuntime = () => {
         return key;
       }),
   };
-  const layer = Layer.mergeAll(
-    Layer.succeed(TestRuntime, ctx),
-    Layer.succeed(RuntimeContext, ctx),
-  );
+  const layer = Layer.mergeAll(Layer.succeed(RuntimeContext, ctx));
   return { stored, layer };
 };
 

--- a/packages/better-auth/src/BetterAuth.ts
+++ b/packages/better-auth/src/BetterAuth.ts
@@ -1,3 +1,4 @@
+import type { RuntimeContext } from "alchemy";
 import type { HttpEffect } from "alchemy/Http";
 import { type Auth } from "better-auth";
 import * as Context from "effect/Context";
@@ -6,7 +7,7 @@ import * as Effect from "effect/Effect";
 export class BetterAuth extends Context.Service<
   BetterAuth,
   {
-    auth: Effect.Effect<Auth<any>>;
-    fetch: HttpEffect;
+    auth: Effect.Effect<Auth<any>, never, RuntimeContext>;
+    fetch: HttpEffect<RuntimeContext>;
   }
 >()("BetterAuth") {}

--- a/website/src/content/docs/concepts/layers.mdx
+++ b/website/src/content/docs/concepts/layers.mdx
@@ -1,215 +1,279 @@
 ---
 title: Layers
-description: Use Effect Layers to encapsulate infrastructure behind a clean interface — define a service once, swap implementations across stacks, providers, and tests.
+description: A Layer encapsulates a slice of infrastructure (resources, bindings, runtime logic) behind a typed service interface. Code that depends on the interface stays cloud-agnostic; swapping the implementation swaps the underlying infrastructure.
 sidebar:
   order: 9
 ---
 
-A [Binding](/concepts/binding) is the smallest unit of "use this
-resource". A **Layer** is the next step up: take a *group* of
-resources and bindings, hide them behind a typed interface, and
-hand callers an object that just **does the thing**.
+A [Binding](/concepts/binding) connects one [Resource](/concepts/resource)
+to a [Platform](/concepts/platform). A **Layer** is the next abstraction
+up: a unit of *encapsulated infrastructure*. It owns whatever resources
+and bindings it needs, returns a typed implementation of a service
+interface, and hides everything behind that interface.
 
-This is how alchemy lets a single Worker swap from D1 to Postgres,
-or from in-memory mocks to live cloud, by changing one line of
-configuration.
+Layers are the mechanism that makes Alchemy code portable. A Worker
+written against an abstract `JobService` doesn't know whether its
+underlying storage is a KV namespace, a DynamoDB table, or an
+in-memory map — it depends on the *service*, and a Layer wires up
+the rest.
 
-## The problem layers solve
+## The encapsulation problem
 
-A real authentication module needs at least:
-
-- A database
-- A connection
-- A secret
-- Adapter glue between an HTTP handler and the auth library
-
-Inlining all of that in every Worker that needs auth is fine for
-one project. By the fifth Worker, you've copy-pasted four versions
-of the same setup with subtle differences. By the time you want to
-move from D1 to Postgres, every Worker has to change.
-
-Layers fix this by defining the **contract** once and the
-**implementation** separately.
-
-## Step 1 — Define the service interface
-
-A service is a `Context.Service` — a typed Tag that says "somewhere
-in the program, an implementation of this exists":
+Say you want a simple `getJob(id)` function backed by a KV namespace.
+The straightforward thing is to call the binding directly:
 
 ```typescript
-// packages/better-auth/src/BetterAuth.ts
-import type { HttpEffect } from "alchemy/Http";
-import { type Auth } from "better-auth";
-import * as Context from "effect/Context";
+import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 
-export class BetterAuth extends Context.Service<
-  BetterAuth,
-  {
-    auth: Effect.Effect<Auth<any>>;
-    fetch: HttpEffect;
-  }
->()("BetterAuth") {}
+const getJob = (id: string) =>
+  Effect.gen(function* () {
+    const kv = yield* Cloudflare.KVNamespaceBinding.bind(MyKV);
+    return yield* kv.get<Job>(id, "json");
+  });
 ```
 
-Anyone who depends on `BetterAuth` writes `yield* BetterAuth` and
-gets the typed object — no idea where it comes from. That's the
-whole point.
-
-## Step 2 — Implement it as a Layer
-
-A Layer creates whatever resources it needs and returns a value
-satisfying the service. Here's the real
-[`@alchemy/better-auth`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/better-auth/src/CloudflareD1.ts)
-implementation backed by Cloudflare D1:
+Look at the inferred type:
 
 ```typescript
-// packages/better-auth/src/CloudflareD1.ts
-import { Random } from "alchemy";
+const getJob: (id: string) => Effect.Effect<
+  Job | null,
+  KVNamespaceError,
+  WorkerEnvironment  // ← leaks Cloudflare runtime
+>;
+```
+
+`WorkerEnvironment` is only available inside a deployed Cloudflare
+Worker. By appearing in `getJob`'s signature, it pins the function
+— and everything that calls it — to running inside a Cloudflare
+Worker. You can't reuse `getJob` from a Lambda, a container, a
+test, or any other runtime; the type system has tied it to one
+specific cloud.
+
+A Layer is the answer.
+
+## A service is a contract
+
+A service is a `Context.Service` — a typed Tag that names a
+capability without saying how it's provided:
+
+```typescript
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Alchemy from "alchemy";
+
+export class JobService extends Context.Service<
+  JobService,
+  {
+    getJob(id: string): Effect.Effect<Job, JobError, Alchemy.RuntimeContext>;
+  }
+>()("JobService") {}
+```
+
+A consumer writes `yield* JobService` and gets the typed object —
+nothing else. The signature deliberately mentions
+`Alchemy.RuntimeContext` (more on this below) but says nothing about
+KV, DynamoDB, or any specific cloud primitive.
+
+## A Layer encapsulates the infrastructure
+
+A Layer is the implementation side of a service. It declares the
+resources it needs, wires up bindings, and returns the typed value:
+
+```typescript
 import * as Cloudflare from "alchemy/Cloudflare";
-import { betterAuth as makeBetterAuth } from "better-auth";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import * as Redacted from "effect/Redacted";
-import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
-import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
-import { BetterAuth } from "./BetterAuth.ts";
 
-export const CloudflareD1 = Layer.effect(
-  BetterAuth,
+export const JobServiceKV = Layer.effect(
+  JobService,
   Effect.gen(function* () {
-    // 1. Declare the infrastructure this Layer needs.
-    const d1 = yield* Cloudflare.D1Database("BetterAuth");
-    const connection = yield* Cloudflare.D1Connection.bind(d1);
-    const secret = yield* Random("BETTER_AUTH_SECRET");
+    const MyKV = yield* Cloudflare.KVNamespace("MyKV");
+    const kv = yield* Cloudflare.KVNamespaceBinding.bind(MyKV);
 
-    // 2. Build the better-auth instance, cached so it's created once.
-    const betterAuth = yield* Effect.gen(function* () {
-      return makeBetterAuth({
-        database: yield* connection.raw,
-        secret: yield* secret.text.pipe(Effect.map(Redacted.value)),
-      });
-    }).pipe(Effect.cached);
-
-    // 3. Return the service implementation.
     return {
-      auth: betterAuth,
-      fetch: Effect.gen(function* () {
-        const request = yield* HttpServerRequest;
-        const auth = yield* betterAuth;
-        const response = yield* Effect.promise(() =>
-          auth.handler(request.source as Request),
-        );
-        return HttpServerResponse.fromWeb(response);
+      getJob: Effect.fn(function* (id: string) {
+        return yield* kv.get<Job>(id, "json");
       }),
     };
   }),
-).pipe(Layer.provide(Cloudflare.D1ConnectionLive));
+);
 ```
 
 Three things happen in one expression:
 
-1. **Infrastructure is declared** — the D1 database and connection
-   are real resources. They go through plan/create/update like any
-   other.
-2. **Bindings are wired** — `D1Connection.bind(d1)` connects the
-   database to whatever Worker eventually consumes this Layer.
-3. **A typed implementation is returned** — `auth` and `fetch`
-   satisfy the `BetterAuth` interface.
+1. **The KV namespace is a real resource.** It joins the
+   [Stack](/concepts/stack), goes through plan/create/update like
+   anything else.
+2. **The binding is wired** — `KVNamespaceBinding.bind(MyKV)`
+   attaches the KV namespace to whichever Worker eventually consumes
+   this Layer.
+3. **A typed `JobService` is returned.** Callers see only `getJob`.
 
-## Step 3 — Provide the Layer to a Platform
+## Cloud-agnostic consumers
 
-A Worker that wants auth doesn't reach for D1 or `better-auth`
-directly. It depends on `BetterAuth` and provides whichever
-implementation it likes:
+A Worker that wants jobs depends on `JobService` and provides a
+Layer to satisfy it:
 
 ```typescript
-// src/Api.ts
-import * as Cloudflare from "alchemy/Cloudflare";
-import { BetterAuth, CloudflareD1 } from "@alchemy/better-auth";
-import * as Effect from "effect/Effect";
-
 export default Cloudflare.Worker(
   "Api",
-  { main: import.meta.path },
+  { main: import.meta.filename },
   Effect.gen(function* () {
-    const auth = yield* BetterAuth;
+    const jobs = yield* JobService;
 
     return {
-      fetch: auth.fetch,
+      fetch: Effect.gen(function* () {
+        return yield* jobs.getJob("job-1");
+      }),
     };
-  }).pipe(Effect.provide(CloudflareD1)),
+  }).pipe(Effect.provide(JobServiceKV)),
 );
 ```
 
-The Worker handler doesn't know D1 exists. It asks for `BetterAuth`
-and gets it. `Effect.provide(CloudflareD1)` wires in the D1 layer
-— and along with it, the database resource itself joins the Stack.
+The handler never mentions KV. Swapping the implementation is a
+one-line change:
 
-## Step 4 — Swap the implementation
-
-Because the Worker depends on `BetterAuth`, not `CloudflareD1`,
-moving from D1 to Postgres is a one-line change. Imagine a
-hypothetical `PostgresLayer`:
-
-```typescript
-// before
-.pipe(Effect.provide(CloudflareD1))
-
-// after
-.pipe(Effect.provide(BetterAuthPostgres))
+```diff lang="typescript"
+-.pipe(Effect.provide(JobServiceKV))
++.pipe(Effect.provide(JobServiceDynamo))
 ```
 
-The next deploy:
+The next deploy tears down the KV namespace and creates whatever
+`JobServiceDynamo` declares. The handler is untouched.
 
-- Tears down the D1 database (no longer declared)
-- Creates whatever `BetterAuthPostgres` declares (a `Hyperdrive`
-  binding, a Neon database…)
-- Updates the Worker's bindings accordingly
-- Leaves the handler code untouched
+## Where runtime requirements live
 
-The same trick works in tests: provide an in-memory layer, run the
-Worker as a normal Effect, assert on the result.
-
-## Composing layers
-
-Layers compose with the standard Effect combinators:
-
-| Combinator              | Use it for                                                |
-| ----------------------- | --------------------------------------------------------- |
-| `Layer.mergeAll(a, b)`  | Provide multiple independent services                     |
-| `Layer.provideMerge`    | A Layer that supplies *and* exposes a service             |
-| `Layer.provide`         | Satisfy a Layer's dependencies privately                  |
-
-A typical app stack looks like this:
+The leaky `getJob` from earlier:
 
 ```typescript
-.pipe(Effect.provide(Layer.mergeAll(
-  CloudflareD1,        // provides BetterAuth
-  JobStorageDynamoDB,  // provides JobStorage
-  RateLimiterKV,       // provides RateLimiter
-)))
+Effect.Effect<Job | null, KVNamespaceError, WorkerEnvironment>
 ```
 
-For the deploy-time mechanics that make these layers work — IAM,
-typed clients, env injection — see [Binding](/concepts/binding).
-For Workers that reference each other across Layers, see
-[Circular Bindings](/guides/circular-bindings).
+The Layer-wrapped equivalent:
 
-## Why this works
+```typescript
+Effect.Effect<Job, NotFound, Alchemy.RuntimeContext>
+```
 
-The trick is that **resources are Effects**. They participate in
-Effect's dependency injection like any other value. So a `Layer`
-that creates a database, binds it, and returns a typed service is
-just a normal Effect Layer — no special mechanism, no extra runtime.
+`WorkerEnvironment` is gone. It hasn't disappeared — it's been
+absorbed by the Layer:
 
-That means:
+```typescript
+export const KVNamespaceBindingLive = Layer.effect(
+  KVNamespaceBinding,
+  Effect.gen(function* () {
+    const env = yield* WorkerEnvironment; // ← required here, once
+    // ...returns a client that closes over env
+  }),
+);
+```
 
-- **Distribute on npm** — A Service is just a TypeScript module
-  exporting an interface and a Layer. Publish `@org/sessions`,
-  `npm install` it elsewhere, `Effect.provide` it.
-- **Test against any backend** — Provide an in-memory Layer in
-  tests; provide the cloud Layer in CI. The handler under test
-  never changes.
-- **Migrate without rewrites** — Moving from one cloud primitive
-  to another is a Layer swap, not a Worker rewrite.
+The Worker that consumes `KVNamespaceBindingLive` satisfies
+`WorkerEnvironment` in one place; downstream callers see only
+`RuntimeContext`. Try the swap on a Cloudflare Worker:
+
+```diff lang="typescript"
+-.pipe(Effect.provide(JobServiceKV))         // requires WorkerEnvironment ✓
++.pipe(Effect.provide(JobServiceDynamo))     // requires AWS.FunctionEnvironment ✗
+```
+
+The Cloudflare Worker can't satisfy `AWS.FunctionEnvironment`, so
+the program won't type-check. Platforms and Layers fit together by
+type, not by convention.
+
+## Runtime as a colored function
+
+A Platform program has two [phases](/concepts/phases): the **init**
+closure (outer) runs at both plantime and cold start, and the
+**runtime** closure (inner) runs only inside the deployed handler.
+Bindings live in init; the actual cloud calls live in runtime:
+
+```typescript
+Cloudflare.Worker(
+  "Api",
+  { main: import.meta.filename },
+  Effect.gen(function* () {
+    // ─── Init: declare dependencies ───
+    const kv = yield* Cloudflare.KVNamespaceBinding.bind(MyKV);
+
+    return {
+      // ─── Runtime: use them ───
+      fetch: Effect.gen(function* () {
+        return yield* kv.get<Job>("job-1", "json");
+      }),
+    };
+  }),
+);
+```
+
+`Alchemy.RuntimeContext` is the Effect service that exists *only*
+inside the runtime closure. It is not provided at plantime, cold
+start init, or anywhere else. So an Effect like:
+
+```typescript
+kv.get(...): Effect.Effect<Job | null, KVNamespaceError, Alchemy.RuntimeContext>
+```
+
+is one the type system *guarantees* can only run in the runtime
+phase. Move that call up into the init closure and the type checker
+rejects it — `RuntimeContext` is not satisfied there.
+
+You can think of it as a "color" in the sense of
+[colored functions](https://journal.stuffwithstuff.com/2015/02/01/what-color-is-your-function/):
+
+```ts
+runtime function getJob(id: string): Job
+```
+
+TypeScript doesn't have keyword-level coloring, so Alchemy encodes
+the color as an Effect requirement. The compiler enforces the
+init/runtime boundary for you.
+
+## What you compose with
+
+A typical app stack mixes several Layers, one per capability:
+
+```typescript
+.pipe(
+  Effect.provide(Layer.mergeAll(
+    JobServiceKV,         // provides JobService
+    BetterAuthD1,         // provides BetterAuth
+    RateLimiterDurable,   // provides RateLimiter
+  )),
+)
+```
+
+Each Layer brings its own resources into the Stack and its own
+typed service into scope. Consumers stay declarative and ignorant
+of the underlying primitives.
+
+| Combinator             | Use it for                                                |
+| ---------------------- | --------------------------------------------------------- |
+| `Layer.mergeAll(a, b)` | Provide multiple independent services                     |
+| `Layer.provideMerge`   | A Layer that supplies *and* exposes a service             |
+| `Layer.provide`        | Satisfy one Layer's dependencies privately from another   |
+
+For the deploy-time mechanics that make Layers possible — typed
+clients, IAM, env injection — see [Binding](/concepts/binding). For
+the step-by-step of building one yourself, see
+[Building Infrastructure Layers](/guides/infrastructure-layers).
+
+## Why this matters
+
+Because Layers are normal Effect Layers, the patterns scale all the
+way out:
+
+- **Distribute on npm.** A service is just a TypeScript module
+  exporting a `Context.Service` and one or more Layers. Publish
+  `@org/jobs`, `npm install` it, `Effect.provide` it.
+- **Substitute for tests.** Provide a `JobServiceMemory` Layer
+  backed by a `Map`; the Worker under test never knows.
+- **Migrate without rewrites.** Moving from KV to DynamoDB is a
+  Layer swap, not a Worker rewrite.
+- **Type-safe portability.** Cloud-specific requirements are
+  confined to Layer construction; the consumer-facing surface
+  speaks only `RuntimeContext`.
+
+Infrastructure becomes a value you can encapsulate, name, and
+substitute — like any other module.

--- a/website/src/content/docs/concepts/phases.mdx
+++ b/website/src/content/docs/concepts/phases.mdx
@@ -1,6 +1,6 @@
 ---
 title: Phases
-description: Alchemy programs run in two phases — plantime/init drives the deploy, runtime/exec handles requests. Knowing which is which is the key to using Platforms.
+description: Alchemy programs run in two phases — plantime/init drives the deploy, runtime handles requests. Knowing which is which is the key to using Platforms.
 sidebar:
   order: 6
 ---
@@ -8,7 +8,7 @@ sidebar:
 import DAG from "../../../components/DAG.astro";
 
 :::tip
-Read this after [Platform](/concepts/platform). The init/exec
+Read this after [Platform](/concepts/platform). The init/runtime
 pattern shown there is what this page explains in depth.
 :::
 
@@ -22,7 +22,7 @@ Every alchemy program operates in two distinct phases:
 Platform resources express both in a single program by **returning
 an Effect from inside an Effect**.
 
-## Init vs Exec
+## Init vs Runtime
 
 ```typescript
 Cloudflare.Worker(
@@ -33,7 +33,7 @@ Cloudflare.Worker(
     const bucket = yield* Cloudflare.R2Bucket.bind(Bucket);
 
     return {
-      // ─── Exec phase ───
+      // ─── Runtime phase ───
       fetch: Effect.gen(function* () {
         const obj = yield* bucket.get("key");
         return HttpServerResponse.text(yield* obj.text());
@@ -43,19 +43,25 @@ Cloudflare.Worker(
 );
 ```
 
-| Phase | Code   | When it runs                          |
-| ----- | ------ | ------------------------------------- |
-| Init  | outer  | At plantime **and** at cold start     |
-| Exec  | inner  | Only at runtime, per request          |
+| Phase   | Code   | When it runs                          |
+| ------- | ------ | ------------------------------------- |
+| Init    | outer  | At plantime **and** at cold start     |
+| Runtime | inner  | Only inside a deployed handler        |
 
 The `bucket` value is established once during init and captured by
-exec. Init runs at most once per cold start; exec runs per request
-with everything already wired up.
+the runtime closure. Init runs at most once per cold start; the
+runtime body runs per request with everything already wired up.
+
+The runtime phase is the *only* place where `Alchemy.RuntimeContext`
+is available. Any Effect whose requirements include `RuntimeContext`
+can only execute inside the runtime closure — the type system
+rejects it everywhere else. See
+[Layers › Runtime as a colored function](/concepts/layers#runtime-as-a-colored-function).
 
 ## What runs when
 
 <DAG
-  caption="Plantime (top) records bindings and builds the plan. Runtime (bottom) starts on cold start and runs exec per request."
+  caption="Plantime (top) records bindings and builds the plan. Runtime (bottom) starts on cold start and runs the handler per request."
   nodes={[
     { id: "Plan", label: "alchemy deploy", type: "plantime", tone: "accent" },
     { id: "InitP", label: "init()", type: "records bindings" },
@@ -63,14 +69,14 @@ with everything already wired up.
     { id: "Deploy", label: "deployed", type: "Worker / Lambda" },
     { id: "Cold", label: "cold start", type: "runtime", tone: "accent", layer: 0 },
     { id: "InitR", label: "init()", type: "builds SDK clients", layer: 1 },
-    { id: "Exec", label: "fetch()", type: "per request", layer: 2 },
+    { id: "Runtime", label: "fetch()", type: "per request", layer: 2 },
   ]}
   edges={[
     { from: "Plan", to: "InitP" },
     { from: "InitP", to: "Apply" },
     { from: "Apply", to: "Deploy" },
     { from: "Cold", to: "InitR" },
-    { from: "InitR", to: "Exec" },
+    { from: "InitR", to: "Runtime" },
   ]}
 />
 
@@ -80,9 +86,9 @@ with everything already wired up.
 - At **runtime cold start**, init runs again — this time inside the
   deployed Worker, where the same `bind()` calls return live SDK
   clients backed by the deployed resource.
-- **Exec** only runs at runtime. It never executes at plantime, so
-  you can put real per-request work there without affecting deploy
-  speed.
+- The **runtime body** only runs in the deployed handler. It never
+  executes at plantime, so you can put real per-request work there
+  without affecting deploy speed.
 
 ## `ALCHEMY_PHASE`
 
@@ -120,14 +126,15 @@ provisioning lives in `Policy`, not `Service`.
 
 ## Why this matters
 
-The init/exec split lets you write code that:
+The init/runtime split lets you write code that:
 
 1. **Resolves infrastructure references at deploy time** — bindings
    know which bucket ARN, queue URL, etc. to inject.
 2. **Initializes SDK clients once at cold start** — not on every
    request.
 3. **Handles requests with a pre-configured context** — the `bucket`
-   variable in exec already knows which resource to talk to.
+   variable in the runtime body already knows which resource to
+   talk to.
 
 ```typescript
 Effect.gen(function* () {
@@ -136,7 +143,7 @@ Effect.gen(function* () {
   const kv = yield* Cloudflare.KVNamespace.bind(KV);
 
   return {
-    // Exec: runs per request
+    // Runtime: runs per request
     fetch: Effect.gen(function* () {
       const obj = yield* bucket.get("key");
       // ...

--- a/website/src/content/docs/concepts/platform.mdx
+++ b/website/src/content/docs/concepts/platform.mdx
@@ -33,7 +33,7 @@ export default Cloudflare.Worker(
     const bucket = yield* Cloudflare.R2Bucket.bind(Bucket);
 
     return {
-      // Exec: per-request handler.
+      // Runtime: per-request handler.
       fetch: Effect.gen(function* () {
         const obj = yield* bucket.get("hello.txt");
         return obj

--- a/website/src/content/docs/concepts/secrets.mdx
+++ b/website/src/content/docs/concepts/secrets.mdx
@@ -26,7 +26,7 @@ type.
 
 `yield*`-ing `Alchemy.Secret` in the Worker's **Init** phase
 registers the binding and returns an accessor. `yield*`-ing the
-accessor inside `fetch` (the **Exec** phase) resolves the value:
+accessor inside `fetch` (the **Runtime** phase) resolves the value:
 
 ```typescript
 export default Cloudflare.Worker(
@@ -45,7 +45,7 @@ export default Cloudflare.Worker(
 );
 ```
 
-See [Phases](/concepts/phases) for why Init and Exec run separately.
+See [Phases](/concepts/phases) for why Init and Runtime run separately.
 
 ## Resolve from `.env`
 

--- a/website/src/content/docs/guides/infrastructure-layers.mdx
+++ b/website/src/content/docs/guides/infrastructure-layers.mdx
@@ -1,0 +1,265 @@
+---
+title: Building Infrastructure Layers
+description: Package resources + bindings + runtime glue into a typed Effect Layer that callers can swap between clouds or replace with an in-memory mock.
+sidebar:
+  order: 7
+---
+
+A [Layer](/concepts/layers) packages infrastructure behind a typed
+service. This guide builds a `JobService` backed by a Cloudflare KV
+namespace, plugs it into a Worker, then swaps the storage backend
+to an in-memory implementation without touching the Worker.
+
+## Define the service interface
+
+Start with the abstract contract — no infrastructure, no cloud.
+
+```typescript
+// src/JobService.ts
+import * as Alchemy from "alchemy";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+
+export interface Job {
+  id: string;
+  status: "pending" | "done";
+}
+
+export class JobService extends Context.Service<
+  JobService,
+  {
+    getJob(id: string): Effect.Effect<Job | null, never, Alchemy.RuntimeContext>;
+    putJob(job: Job): Effect.Effect<void, never, Alchemy.RuntimeContext>;
+  }
+>()("JobService") {}
+```
+
+`Alchemy.RuntimeContext` on the return types marks these methods as
+runtime-only. The compiler will reject any attempt to call them
+from a deploy script.
+
+## Scaffold the Layer
+
+`Layer.effect(Tag, effect)` says "to build the service identified
+by `Tag`, run this Effect". Start with the methods stubbed out:
+
+```typescript
+// src/JobService.KV.ts
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { JobService, type Job } from "./JobService.ts";
+
+export const JobServiceKV = Layer.effect(
+  JobService,
+  Effect.gen(function* () {
+    return {
+      getJob: Effect.fn(function* (id: string) {
+        // TODO: read from KV
+      }),
+      putJob: Effect.fn(function* (job: Job) {
+        // TODO: write to KV
+      }),
+    };
+  }),
+);
+```
+
+`Effect.fn(function* …)` is sugar for an Effect-returning function;
+it preserves the inferred argument types.
+
+## Declare the KV namespace
+
+`Cloudflare.KVNamespace("Jobs")` describes a real resource. Yielding
+it inside the Layer attaches it to whichever Stack consumes the
+Layer.
+
+```diff lang="typescript"
++import * as Cloudflare from "alchemy/Cloudflare";
+ import * as Effect from "effect/Effect";
+ import * as Layer from "effect/Layer";
+ import { JobService, type Job } from "./JobService.ts";
+
+ export const JobServiceKV = Layer.effect(
+   JobService,
+   Effect.gen(function* () {
++    const Namespace = yield* Cloudflare.KVNamespace("Jobs");
++
+     return {
+       // ...
+     };
+   }),
+ );
+```
+
+## Bind the namespace
+
+`KVNamespaceBinding.bind(Namespace)` wires the namespace into the
+consuming Worker — binding name, IAM, env injection — and returns
+a typed client.
+
+```diff lang="typescript"
+ export const JobServiceKV = Layer.effect(
+   JobService,
+   Effect.gen(function* () {
+     const Namespace = yield* Cloudflare.KVNamespace("Jobs");
++    const kv = yield* Cloudflare.KVNamespaceBinding.bind(Namespace);
+
+     return {
+       // ...
+     };
+   }),
+ );
+```
+
+`kv.get` / `kv.put` carry an `Alchemy.RuntimeContext` requirement,
+which matches what `JobService` declared.
+
+## Implement the methods
+
+Replace the TODO bodies with calls to the typed client:
+
+```diff lang="typescript"
+     return {
+       getJob: Effect.fn(function* (id: string) {
+-        // TODO: read from KV
++        return yield* kv.get<Job>(id, "json");
+       }),
+       putJob: Effect.fn(function* (job: Job) {
+-        // TODO: write to KV
++        yield* kv.put(job.id, JSON.stringify(job));
+       }),
+     };
+```
+
+## Scaffold the Worker
+
+Start with a minimal Worker that responds to every request with a
+placeholder. Init and runtime closures are both empty.
+
+```typescript
+// src/Api.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+export default Cloudflare.Worker(
+  "Api",
+  { main: import.meta.filename },
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.gen(function* () {
+        return HttpServerResponse.text("ok");
+      }),
+    };
+  }),
+);
+```
+
+## Resolve the service
+
+Yield `JobService` in the init closure to get a typed handle, then
+call it from `fetch`:
+
+```diff lang="typescript"
+ import * as Cloudflare from "alchemy/Cloudflare";
+ import * as Effect from "effect/Effect";
+ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
++import { JobService } from "./JobService.ts";
+
+ export default Cloudflare.Worker(
+   "Api",
+   { main: import.meta.filename },
+   Effect.gen(function* () {
++    const jobs = yield* JobService;
++
+     return {
+       fetch: Effect.gen(function* () {
+-        return HttpServerResponse.text("ok");
++        const job = yield* jobs.getJob("job-1");
++        return yield* HttpServerResponse.json(job);
+       }),
+     };
+   }),
+ );
+```
+
+At this point the Worker doesn't type-check — `JobService` is in the
+requirements but nothing satisfies it.
+
+## Provide the Layer
+
+`Effect.provide(JobServiceKV)` satisfies `JobService` and brings the
+KV namespace resource into the Stack:
+
+```diff lang="typescript"
+ import * as Cloudflare from "alchemy/Cloudflare";
+ import * as Effect from "effect/Effect";
++import * as Layer from "effect/Layer";
+ import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+ import { JobService } from "./JobService.ts";
++import { JobServiceKV } from "./JobService.KV.ts";
+
+ export default Cloudflare.Worker(
+   "Api",
+   { main: import.meta.filename },
+   Effect.gen(function* () {
+     // ...
+-  }),
++  }).pipe(Effect.provide(JobServiceKV)),
+ );
+```
+
+The Worker still doesn't type-check — `JobServiceKV` itself depends
+on `KVNamespaceBinding`, which is satisfied by
+`KVNamespaceBindingLive`.
+
+## Provide the runtime binding
+
+`Layer.provide` satisfies `JobServiceKV`'s dependency on
+`KVNamespaceBinding` privately, so the consumer only sees `JobService`:
+
+```diff lang="typescript"
+   }).pipe(
+     Effect.provide(
+-      JobServiceKV,
++      JobServiceKV.pipe(Layer.provide(Cloudflare.KVNamespaceBindingLive)),
+     ),
+   ),
+```
+
+`KVNamespaceBindingLive` requires `WorkerEnvironment`, which the
+Cloudflare Worker runtime satisfies automatically at cold start.
+
+## Reuse a Layer across Workers
+
+A Layer is just a value. Any Worker that provides `JobServiceKV`
+shares the same KV namespace, because `Cloudflare.KVNamespace("Jobs")`
+has a stable logical id:
+
+```diff lang="typescript"
+ // src/Admin.ts
+ export default Cloudflare.Worker(
+   "Admin",
+   { main: import.meta.filename },
+   Effect.gen(function* () {
+     const jobs = yield* JobService;
+     // ...
+   }).pipe(
+     Effect.provide(
++      JobServiceKV.pipe(Layer.provide(Cloudflare.KVNamespaceBindingLive)),
+     ),
+   ),
+ );
+```
+
+The Stack ends up with one `Jobs` KV namespace, bound to both `Api`
+and `Admin` with the correct env vars on each.
+
+## Related
+
+- [Layers](/concepts/layers) — the concept behind this guide
+- [Binding](/concepts/binding) — what `.bind(...)` does under the hood
+- [Phases](/concepts/phases) — when init vs runtime code runs
+- [Circular Bindings](/guides/circular-bindings) — two Layers
+  referencing each other

--- a/website/src/content/docs/tutorial/cloudflare/workflows.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/workflows.mdx
@@ -301,7 +301,7 @@ input shapes (literals, `Effect`, `Config`, …).
 
 ## Use the secret in a task
 
-The accessor returned in init is yielded inside Exec to resolve a
+The accessor returned in init is yielded inside the Runtime phase to resolve a
 `Redacted<string>`. Unwrap with `Redacted.value` only at the call
 site that needs it (here, an `Authorization` header):
 
@@ -348,7 +348,7 @@ site that needs it (here, an `Authorization` header):
  ) {}
 ```
 
-`yield* apiKey` lives inside the body Effect — the Exec phase —
+`yield* apiKey` lives inside the body Effect — the Runtime phase —
 not at module scope. `HttpClient.execute` runs inside
 `Cloudflare.task`, so the response is checkpointed and the
 request only fires once across replays. `Redacted.value` is

--- a/website/src/content/docs/tutorial/part-2.mdx
+++ b/website/src/content/docs/tutorial/part-2.mdx
@@ -42,7 +42,7 @@ export default Cloudflare.Worker(
 :::note
 Notice the "Effect returning an Effect" pattern. The outer generator
 is the **Init phase** — it runs at both plan time and runtime. The
-inner `fetch` generator is the **Exec phase** — it runs only when
+inner `fetch` generator is the **Runtime phase** — it runs only when
 handling a request.
 :::
 


### PR DESCRIPTION
We had a bug in the design of Cloudflare Workers and Bindings, especially the KVNamespace one where the `kv.get`, `kv.put`, etc. had a requirement on `WorkerEnvironment`. While this is technically correct, it breaks encapsulation and prevents building layers.

E.g. imagine a simple service that provide a `getJob` API:
```ts
export class JobService extends Context.Service<JobService, {
  getJob(id: string): Effect.Effect<Job>
}>()("JobService") {}
```

It was unergonomic to build a KV namespace one:
```ts
export const JobServiceKV = Layer.effect(JobService, Effect.gen(function*() {
  const MyKV = yield* Cloudflare.KVNamespace("MyKV")
  const kv = yield* KVNamespace.bind(MyKV)

  return {
    getJob: (id) => kv.get(id).pipe(..)
  }
})
```

Because `kv.get(id).pipe(..)`would pollute the requirement with `WorkerEnvironment`, meaning you could not satisfy `getJob(id: string): Effect.Effect<Job>` without `kv.get(id).pipe(Effect.provide(Layer.succeed(WorkerEnvironment ,env))` which proliferates everywhere. 

Instead, we want to resolve these requirements ON the Layer instead of on the call:
```ts
export default Worker("Worker", { main: import.meta.filename }, Effect.gen(function*() {
  const jobService = yield* JobService;

  return {
    fetch: Effect.gen(function*() {
      return yield* jobService.getJob("job") // OK Now!
    })
  }
}).pipe(Effect.provide(Cloudflare.KVNamespaceBindingLive)) // <- this is now where WorkerEnvironment is required
```

Because `Cloudflare.KVNamespaceBindingLive` is what brings the `WorkerEnvironment` requirement and is satisfied by the `Worker`, this all type checks and is properly encapsulated.

If we were to, for example, provide `AWS.KVNamespaceBindingLive` instead, this would not typecheck, because it would require `AWS.FunctionEnvironment` instead which can't be satisfied in a Cloudflare Worker environment. But, we can build these specific binding implementations for each one and allow the user to write cloud-agnostic code. Code written against the JobService layer is abstract of its underlying infrastructure.

However, we want to still enable the type system to guarantee that we don't call runtime-only code during plan code. For this reason, the `kv.get` function call still has a requirement, but it is now cloud agnostic:
```ts
get(id: string): Effect.Effect<string, never, Alchemy.RuntimeContext>
```

`Alchemy.RuntimeContext` is an Effect service that is only available in code that runs at runtime. By adding this, we protect the user (at the type level) from writing code that will fail at runtime.

Finally, the service would look like this:

```ts
export class JobService extends Context.Service<JobService, {
  getJob(id: string): Effect.Effect<Job, never, Alchemy.RuntimeContext>
}>()("JobService") {}
```

Think of this like a colored function in a hypothetical language:
```ts
runtime function getJob(id: string): Job
```

Since we are not a separate language, we model this color with Effect requirements.