### PR TITLE
chore(website): move /privacy out of docs into standalone page

### DIFF
--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -76,7 +76,6 @@ Standalone how-to pages. Each solves a specific problem; read in any order.
 - [Frontend frameworks](https://v2.alchemy.run/guides/frontends) — Deploy Vite-based frameworks (TanStack Start, Astro, SolidStart, Nuxt, React) and any custom-built static site (Hugo, Eleventy) to Cloudflare with one declaration.
 - [Migrating from v1](https://v2.alchemy.run/guides/migrating-from-v1) — Migrate your Alchemy v1 (async/await) project to Alchemy v2.
 - [Monorepos](https://v2.alchemy.run/guides/monorepo) — Two patterns for organizing an Alchemy monorepo with a backend API and a frontend website — one shared stack (recommended) or one stack per package — with the trade-offs and a working example for each.
-- [Privacy & Telemetry](https://v2.alchemy.run/guides/privacy) — What data the Alchemy CLI and Cloudflare State Store collect, where it goes, and how to opt out.
 - [Secrets and env vars](https://v2.alchemy.run/guides/secrets) — Wire OPENAI_API_KEY (or any .env value) into a Cloudflare Worker as a secret_text binding using Alchemy.Secret and Effect's Config.
 - [Shared database across stages](https://v2.alchemy.run/guides/shared-database) — Have ephemeral PR-preview stages reference a long-lived Neon Postgres project from staging instead of provisioning their own — fast previews, copy-on-write branches, no extra Postgres clusters.
 

--- a/website/src/components/marketing/Footer.astro
+++ b/website/src/components/marketing/Footer.astro
@@ -35,6 +35,7 @@ const cols: FooterCol[] = [
       { label: "GitHub", href: "https://github.com/alchemy-run/alchemy-effect" },
       { label: "X / Twitter", href: "https://x.com/alchemy_run" },
       { label: "Blog", href: "/blog" },
+      { label: "Privacy", href: "/privacy" },
     ],
   },
   // todo(sam): write the comparison pages and re-enable this whole

--- a/website/src/pages/privacy.mdx
+++ b/website/src/pages/privacy.mdx
@@ -1,9 +1,12 @@
 ---
-title: Privacy & Telemetry
+layout: ../layouts/Marketing.astro
+title: "Privacy & Telemetry — alchemy"
 description: What data the Alchemy CLI and Cloudflare State Store collect, where it goes, and how to opt out.
-sidebar:
-  order: 9
 ---
+
+<div class="alc-privacy">
+
+# Privacy & Telemetry
 
 The Alchemy CLI and the Cloudflare State Store worker emit
 OpenTelemetry traces, metrics, and logs to a relay we operate at
@@ -142,9 +145,111 @@ NO_TRACK=1 alchemy deploy
 `noTrack` only suppresses the account-hash attribute on state-store
 spans. To stop the worker from emitting signals at all, you'd need
 to remove the OTLP layer in your own fork of `Api.ts`, or run a
-custom HTTP state store via [`makeHttpStateStore`](/guides/custom-state-store).
+custom HTTP state store via [/guides/custom-state-store](/guides/custom-state-store).
 
 ## Questions
 
 Email [sam@alchemy.run](mailto:sam@alchemy.run) or open an issue at
 [alchemy-run/alchemy-effect](https://github.com/alchemy-run/alchemy-effect/issues).
+
+</div>
+
+<style is:global>
+  .alc-privacy {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 56px 24px 80px;
+    color: var(--alc-fg-2);
+    font-size: 15px;
+    line-height: 1.7;
+  }
+  .alc-privacy h1 {
+    font-family: var(--alc-font-serif);
+    font-weight: 500;
+    font-size: 44px;
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+    color: var(--alc-fg-1);
+    margin: 0 0 28px;
+  }
+  .alc-privacy h2 {
+    font-family: var(--alc-font-serif);
+    font-weight: 500;
+    font-size: 26px;
+    color: var(--alc-fg-1);
+    margin: 44px 0 14px;
+    letter-spacing: -0.01em;
+  }
+  .alc-privacy h3 {
+    font-family: var(--alc-font-sans);
+    font-weight: 600;
+    font-size: 16px;
+    color: var(--alc-fg-1);
+    margin: 28px 0 10px;
+  }
+  .alc-privacy p {
+    margin: 0 0 16px;
+  }
+  .alc-privacy a {
+    color: var(--alc-accent-deep);
+    text-decoration: none;
+  }
+  .alc-privacy a:hover {
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+  .alc-privacy ul {
+    padding-left: 22px;
+    margin: 0 0 18px;
+  }
+  .alc-privacy li {
+    margin: 6px 0;
+  }
+  .alc-privacy code {
+    font-family: var(--alc-font-mono);
+    font-size: 0.88em;
+    background: var(--alc-bg-code);
+    border: 1px solid var(--alc-hairline);
+    border-radius: 4px;
+    padding: 1px 5px;
+  }
+  .alc-privacy pre {
+    background: var(--alc-bg-code);
+    border: 1px solid var(--alc-hairline);
+    border-radius: 8px;
+    padding: 14px 16px;
+    overflow-x: auto;
+    font-size: 13px;
+    line-height: 1.55;
+    margin: 0 0 18px;
+  }
+  .alc-privacy pre code {
+    background: transparent;
+    border: 0;
+    padding: 0;
+  }
+  .alc-privacy table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0 0 22px;
+    font-size: 14px;
+  }
+  .alc-privacy th,
+  .alc-privacy td {
+    text-align: left;
+    vertical-align: top;
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--alc-hairline);
+  }
+  .alc-privacy th {
+    font-family: var(--alc-font-mono);
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--alc-fg-4);
+    font-weight: 500;
+  }
+  .alc-privacy strong {
+    color: var(--alc-fg-1);
+  }
+</style>


### PR DESCRIPTION
Move `/guides/privacy` out of the docs sidebar to a standalone marketing page at `/privacy`, linked from the footer.

- New page: `website/src/pages/privacy.mdx` (Marketing layout, self-contained prose styles)
- Removed: `website/src/content/docs/guides/privacy.mdx`
- Footer Community column now includes a Privacy link
