### PR TITLE
fix(Cloudflare): allow Outputs as input to Cloudflare.Worker

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -662,7 +662,7 @@ export const Worker: Platform<
   >(
     id: string,
     props:
-      | WorkerProps<Bindings, Env, Assets>
+      | InputProps<WorkerProps<Bindings, Env, Assets>>
       | Effect.Effect<
           InputProps<WorkerProps<Bindings, Env, Assets>>,
           never,


### PR DESCRIPTION
The async `Cloudflare.Worker("..", { .. }))` did not allow Outputs as inputs.