### PR TITLE
docs(cloudflare/workers): add @example JSDoc to toRpcAsync

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/RpcAsync.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/RpcAsync.ts
@@ -19,6 +19,50 @@ export type RpcAsync<Shape> = {
             : Promise<Shape[K]>;
 };
 
+/**
+ * Wrap a Cloudflare Worker RPC stub in a `Promise<T>`-shaped proxy so callers
+ * outside the Effect runtime (TanStack Start route handlers, plain Workers,
+ * test code) can `await` RPC methods directly.
+ *
+ * The proxy:
+ * - leaves `fetch` / `connect` / `Symbol.dispose` and other non-string keys
+ *   passing through to the underlying binding unchanged,
+ * - turns each `Effect<T>` / `Stream<T>` method into a `Promise<T>` /
+ *   `Promise<ReadableStream<Uint8Array>>`,
+ * - unwraps the wire envelopes produced by the Effect-side RPC bridge:
+ *   `RpcErrorEnvelope` is rethrown via {@link decodeRpcThrowable} so
+ *   `try/catch` sees an `Error` (or a tagged error object), and
+ *   `RpcStreamEnvelope` is flattened to its `ReadableStream` body.
+ *
+ * @example
+ * ```ts
+ * // examples/cloudflare-tanstack/src/routes/api.hello.ts
+ * import { toRpcAsync } from "alchemy/Cloudflare/Bridge";
+ * import type Backend from "../backend.ts";
+ * import { env } from "../env.ts";
+ *
+ * // `env.BACKEND` is the raw wire-shape Service binding; `backend` is the
+ * // Promise<T> view of the Worker's RPC shape.
+ * const backend = toRpcAsync<Backend>(env.BACKEND);
+ *
+ * const value = await backend.hello("some-key");
+ * //    ^? string | null   — Effect<string | null> on the worker side
+ * ```
+ *
+ * @example Error handling
+ * ```ts
+ * // Effect.fail(new MyTaggedError(...)) on the worker side surfaces here as
+ * // a thrown value preserving `_tag`, so existing tagged-error checks work.
+ * try {
+ *   await backend.doThing();
+ * } catch (e) {
+ *   if ((e as any)._tag === "MyTaggedError") {
+ *     // handle it
+ *   }
+ *   throw e;
+ * }
+ * ```
+ */
 export const toRpcAsync = <W>(stub: any): RpcAsync<Rpc.Shape<W>> & Service =>
   new Proxy(stub, {
     get: (target, prop) => {

--- a/packages/alchemy/src/Cloudflare/Workers/RpcAsync.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/RpcAsync.ts
@@ -34,31 +34,44 @@ export type RpcAsync<Shape> = {
  *   `try/catch` sees an `Error` (or a tagged error object), and
  *   `RpcStreamEnvelope` is flattened to its `ReadableStream` body.
  *
- * @example Calling a Worker RPC from a TanStack Start route handler
+ * @example Three ways to reach a value from a plain Worker — direct binding, fetch, RPC
  * ```ts
- * // examples/cloudflare-tanstack/src/routes/api.hello.ts
- * import { createFileRoute } from "@tanstack/react-router";
  * import { toRpcAsync } from "alchemy/Cloudflare/Bridge";
- * import type Backend from "../backend.ts";
- * import { env } from "../env.ts";
+ * import type Backend from "./backend.ts";
  *
- * export const Route = createFileRoute("/api/hello")({
- *   server: {
- *     handlers: {
- *       GET: async ({ request }) => {
- *         const key = new URL(request.url).searchParams.get("key");
- *         if (!key) return new Response("Missing 'key'", { status: 400 });
+ * interface Env {
+ *   BUCKET: R2Bucket;
+ *   BACKEND: Service<Backend>;
+ * }
  *
- *         // Wrap the raw wire-shape binding into a Promise<T> view that
- *         // throws on Effect.fail and unwraps stream envelopes.
- *         const backend = toRpcAsync<Backend>(env.BACKEND);
- *         const value = await backend.hello(key);
- *         if (value === null) return new Response("Not found", { status: 404 });
- *         return new Response(value);
- *       },
- *     },
+ * export default {
+ *   async fetch(request: Request, env: Env): Promise<Response> {
+ *     const url = new URL(request.url);
+ *     const key = url.searchParams.get("key");
+ *     const via = url.searchParams.get("via") ?? "binding";
+ *     if (!key) return new Response("Missing 'key'", { status: 400 });
+ *
+ *     // option 1 — use the async binding directly
+ *     if (via === "binding") {
+ *       const object = await env.BUCKET.get(key);
+ *       if (!object) return new Response("Not found", { status: 404 });
+ *       return new Response(object.body);
+ *     }
+ *
+ *     // option 2 — call the Effect worker's fetch handler
+ *     if (via === "fetch") {
+ *       return env.BACKEND.fetch(
+ *         `https://backend/?key=${encodeURIComponent(key)}`,
+ *       );
+ *     }
+ *
+ *     // option 3 — call an Effect worker RPC method as a Promise
+ *     const backend = toRpcAsync<Backend>(env.BACKEND);
+ *     const value = await backend.hello(key);
+ *     if (value === null) return new Response("Not found", { status: 404 });
+ *     return new Response(value);
  *   },
- * });
+ * };
  * ```
  */
 export const toRpcAsync = <W>(stub: any): RpcAsync<Rpc.Shape<W>> & Service =>

--- a/packages/alchemy/src/Cloudflare/Workers/RpcAsync.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/RpcAsync.ts
@@ -34,33 +34,31 @@ export type RpcAsync<Shape> = {
  *   `try/catch` sees an `Error` (or a tagged error object), and
  *   `RpcStreamEnvelope` is flattened to its `ReadableStream` body.
  *
- * @example
+ * @example Calling a Worker RPC from a TanStack Start route handler
  * ```ts
  * // examples/cloudflare-tanstack/src/routes/api.hello.ts
+ * import { createFileRoute } from "@tanstack/react-router";
  * import { toRpcAsync } from "alchemy/Cloudflare/Bridge";
  * import type Backend from "../backend.ts";
  * import { env } from "../env.ts";
  *
- * // `env.BACKEND` is the raw wire-shape Service binding; `backend` is the
- * // Promise<T> view of the Worker's RPC shape.
- * const backend = toRpcAsync<Backend>(env.BACKEND);
+ * export const Route = createFileRoute("/api/hello")({
+ *   server: {
+ *     handlers: {
+ *       GET: async ({ request }) => {
+ *         const key = new URL(request.url).searchParams.get("key");
+ *         if (!key) return new Response("Missing 'key'", { status: 400 });
  *
- * const value = await backend.hello("some-key");
- * //    ^? string | null   — Effect<string | null> on the worker side
- * ```
- *
- * @example Error handling
- * ```ts
- * // Effect.fail(new MyTaggedError(...)) on the worker side surfaces here as
- * // a thrown value preserving `_tag`, so existing tagged-error checks work.
- * try {
- *   await backend.doThing();
- * } catch (e) {
- *   if ((e as any)._tag === "MyTaggedError") {
- *     // handle it
- *   }
- *   throw e;
- * }
+ *         // Wrap the raw wire-shape binding into a Promise<T> view that
+ *         // throws on Effect.fail and unwraps stream envelopes.
+ *         const backend = toRpcAsync<Backend>(env.BACKEND);
+ *         const value = await backend.hello(key);
+ *         if (value === null) return new Response("Not found", { status: 404 });
+ *         return new Response(value);
+ *       },
+ *     },
+ *   },
+ * });
  * ```
  */
 export const toRpcAsync = <W>(stub: any): RpcAsync<Rpc.Shape<W>> & Service =>


### PR DESCRIPTION
Add JSDoc with `@example` blocks to `toRpcAsync` so the Promise-shaped RPC proxy is discoverable from IDE hover.

```ts
const backend = toRpcAsync<Backend>(env.BACKEND);
const value = await backend.hello("some-key");
//    ^? string | null   — Effect<string | null> on the worker side
```

Covers basic usage (TanStack Start route handler calling a Worker RPC) plus the tagged-error rethrow contract.
