### PR TITLE
feat(cloudflare/worker): include WorkerProps.env types in InferEnv

### DIFF
--- a/examples/cloudflare-worker-async/alchemy.run.ts
+++ b/examples/cloudflare-worker-async/alchemy.run.ts
@@ -33,6 +33,10 @@ export const Worker = Cloudflare.Worker("Worker", {
     Queue,
     Counter,
   },
+  env: {
+    GREETING: "hello from env",
+    MAX_ITEMS: 10,
+  },
 });
 
 export default Alchemy.Stack(

--- a/examples/cloudflare-worker-async/src/worker.ts
+++ b/examples/cloudflare-worker-async/src/worker.ts
@@ -36,6 +36,13 @@ export default {
       });
     }
 
+    if (request.method === "GET" && path === "/env") {
+      return new Response(
+        JSON.stringify({ greeting: env.GREETING, maxItems: env.MAX_ITEMS }),
+        { headers: { "content-type": "application/json" } },
+      );
+    }
+
     if (request.method === "GET") {
       return new Response((await env.Bucket.get(path))?.body ?? null);
     } else if (request.method === "PUT") {

--- a/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
@@ -9,10 +9,12 @@ import type { RpcErrorEnvelope, RpcStreamEnvelope } from "./Rpc.ts";
 import type { Worker } from "./Worker.ts";
 
 export type InferEnv<W> = W extends
-  | Worker<infer Bindings>
-  | Effect.Effect<Worker<infer Bindings>, any, any>
+  | Worker<infer Bindings, infer Env>
+  | Effect.Effect<Worker<infer Bindings, infer Env>, any, any>
   ? {
       [K in keyof Bindings]: GetBindingType<UnwrapEffect<Bindings[K]>>;
+    } & {
+      [K in keyof Env]: Env[K];
     }
   : never;
 

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -231,11 +231,23 @@ type NormalizedBindings<
 
 export type WorkerAssetsConfig = string | AssetsProps | AssetsWithHash;
 
+export type WorkerEnvProps = Record<
+  string,
+  | string
+  | number
+  | boolean
+  | null
+  | readonly unknown[]
+  | { readonly [key: string]: unknown }
+  | Redacted.Redacted<string>
+>;
+
 export interface WorkerProps<
   Bindings extends WorkerBindingProps = any,
   Assets extends WorkerAssetsConfig | undefined =
     | WorkerAssetsConfig
     | undefined,
+  Env extends WorkerEnvProps = WorkerEnvProps,
 > extends PlatformProps {
   /**
    * Worker name override. If omitted, Alchemy derives a deterministic physical
@@ -282,16 +294,7 @@ export interface WorkerProps<
   };
   limits?: WorkerLimits;
   placement?: WorkerPlacement;
-  env?: Record<
-    string,
-    | string
-    | number
-    | boolean
-    | null
-    | readonly unknown[]
-    | { readonly [key: string]: unknown }
-    | Redacted.Redacted<string>
-  >;
+  env?: Env;
   exports?: string[];
   bindings?: Bindings;
   /**
@@ -326,9 +329,12 @@ export interface WorkerProps<
   };
 }
 
-export type Worker<Bindings extends WorkerBindings = any> = Resource<
+export type Worker<
+  Bindings extends WorkerBindings = any,
+  Env extends WorkerEnvProps = WorkerEnvProps,
+> = Resource<
   WorkerTypeId,
-  WorkerProps<Bindings>,
+  WorkerProps<Bindings, WorkerAssetsConfig | undefined, Env>,
   {
     workerId: string;
     workerName: string;
@@ -720,19 +726,27 @@ export const Worker: Platform<
   <
     const Bindings extends WorkerBindingProps,
     const Assets extends WorkerAssetsConfig | undefined = undefined,
+    const Env extends WorkerEnvProps = {},
     Req = never,
   >(
     id: string,
     props:
-      | InputProps<WorkerProps<Bindings, Assets>>
-      | Effect.Effect<InputProps<WorkerProps<Bindings, Assets>>, never, Req>,
+      | (InputProps<WorkerProps<Bindings, Assets>> & { env?: Env })
+      | Effect.Effect<
+          InputProps<WorkerProps<Bindings, Assets>> & { env?: Env },
+          never,
+          Req
+        >,
   ): Effect.Effect<
-    Worker<{
-      [binding in keyof NormalizedBindings<
-        Bindings,
-        Assets
-      >]: NormalizedBindings<Bindings, Assets>[binding];
-    }>,
+    Worker<
+      {
+        [binding in keyof NormalizedBindings<
+          Bindings,
+          Assets
+        >]: NormalizedBindings<Bindings, Assets>[binding];
+      },
+      Env
+    >,
     never,
     Req | Providers
   >;


### PR DESCRIPTION
`Cloudflare.InferEnv<typeof Worker>` now includes the literal types of `WorkerProps.env` values alongside bindings.

```ts
export const Worker = Cloudflare.Worker("Worker", {
  main: "./src/worker.ts",
  bindings: { DB, Bucket },
  env: {
    GREETING: "hello from env",
    MAX_ITEMS: 10,
  },
});

export type WorkerEnv = Cloudflare.InferEnv<typeof Worker>;
// { DB: D1Database; Bucket: R2Bucket; GREETING: "hello from env"; MAX_ITEMS: 10 }
```

- `Worker<Bindings, Env>` / `WorkerProps<Bindings, Assets, Env>` carry an `Env` type param (defaults preserve backward compatibility).
- The factory infers `const Env` from `props.env`.
- `InferEnv<W>` intersects the bindings shape with `Env`.
