### PR TITLE
fix(cloudflare): remove extraneous logs

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectBridge.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectBridge.ts
@@ -81,7 +81,6 @@ export const makeDurableObjectBridge =
 
         return new Proxy(this, {
           get: (target, prop) => {
-            console.log(target, prop, prop in target);
             const bind = (f: any) =>
               typeof f === "function" ? f.bind(target) : f;
             if (typeof prop !== "string") return bind((target as any)[prop]);

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -323,7 +323,6 @@ export const LocalWorkerProvider = () =>
         const config = yield* buildConfig(options);
         const url = yield* localProxy.registerWorker(id);
         if (props.vite) {
-          console.log("starting vite dev server", id);
           const devServer = yield* Vite.viteDev(
             props.vite.rootDir,
             props.env ?? {},
@@ -342,7 +341,6 @@ export const LocalWorkerProvider = () =>
               context,
             },
           );
-          console.log("vite dev server started", id);
           const localAddress = devServer.resolvedUrls!.local[0].slice(0, -1);
           yield* localProxy.setLocalAddress(id, localAddress);
         } else {

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
@@ -138,7 +138,6 @@ export const makeWorkerBridge = (
                       ),
                     );
                   }
-                  console.log("dispatcher", dispatcher.toString());
                   return Effect.succeed([
                     dispatcher(...args) as Effect.Effect<any>,
                     Context.empty(),
@@ -272,7 +271,6 @@ export const makeRpcProxy = (
                   ),
                 );
               }
-              console.log("dispatcher", dispatcher.toString());
               return dispatcher(...args) as Effect.Effect<any>;
             }),
             processEvent,


### PR DESCRIPTION
Found some extra logs hanging around. The `DurableObjectBridge` one was polluting the logs a lot when connecting to a DO over websocket. This removes a few that I found.

(Not sure if this should be a "chore" or a "fix"?)