### PR TITLE
fix(bundle): support Vite-style ?raw imports

### DIFF
--- a/packages/alchemy/src/Bundle/Bundle.ts
+++ b/packages/alchemy/src/Bundle/Bundle.ts
@@ -11,6 +11,7 @@ import {
   type BundleAnalyzerPluginOptions,
 } from "./BundleAnalyzerPlugin.ts";
 import { purePlugin, type PurePluginOptions } from "./PurePlugin.ts";
+import { rawPlugin } from "./RawPlugin.ts";
 
 /**
  * Extra options accepted by {@link build} / {@link watch} on top of the
@@ -298,6 +299,7 @@ function builtInPlugins(
         )
       : undefined,
     extra?.pure !== false ? purePlugin(extra?.pure ?? {}) : undefined,
+    rawPlugin(),
   ];
 }
 

--- a/packages/alchemy/src/Bundle/RawPlugin.ts
+++ b/packages/alchemy/src/Bundle/RawPlugin.ts
@@ -1,0 +1,82 @@
+import type * as rolldown from "rolldown";
+
+/**
+ * Matches `?raw` or `&raw` query suffixes, mirroring Vite's `rawRE`
+ * (see `vite/src/node/utils.ts`). Used to gate both `resolveId` and
+ * `load` so the plugin only inspects ids that opt in.
+ */
+export const RAW_RE: RegExp = /(\?|&)raw(?:&|$)/;
+
+/**
+ * Rolldown plugin that adds Vite-style `?raw` import support to the
+ * Alchemy bundler.
+ *
+ * Importing a file with the `?raw` suffix inlines its contents as the
+ * default export of a JS module:
+ *
+ * ```ts
+ * import sql from "./schema.sql?raw";
+ * //         ^ string — the file contents read as UTF-8
+ * ```
+ *
+ * This plugin only implements `?raw`. Vite's `?url` and `?inline`
+ * variants both rely on a browser asset pipeline (URL serving / `data:`
+ * fallback) that has no analogue in the server-side bundles produced
+ * here (Cloudflare Workers, AWS Lambda), so they are intentionally
+ * omitted.
+ */
+export const rawPlugin = (): rolldown.Plugin => ({
+  name: "alchemy:raw",
+  resolveId: {
+    filter: { id: RAW_RE },
+    async handler(source, importer) {
+      const [base, query] = splitFileAndPostfix(source);
+      const resolved = await this.resolve(base, importer, { skipSelf: true });
+      if (!resolved || resolved.external) return null;
+      return { id: resolved.id + query, moduleSideEffects: false };
+    },
+  },
+  load: {
+    filter: { id: RAW_RE },
+    async handler(id) {
+      const file = id.replace(/[?#].*$/, "");
+      const contents = await this.fs.readFile(file, { encoding: "utf8" });
+      return {
+        code: `export default ${JSON.stringify(contents)};`,
+        // Empty mappings = "this module has no meaningful source map".
+        // The generated code is a synthetic `export default "..."` that
+        // doesn't correspond line-for-line to any source file (the
+        // underlying file isn't JS), so there's nothing to map. Supplying
+        // `{ mappings: "" }` (rather than omitting `map`) opts the module
+        // out of source-map generation without making rolldown synthesize
+        // a default one from the loaded code.
+        map: { mappings: "" },
+        // NOTE: matches Vite — avoids a double `export default` if the
+        // file extension would otherwise be picked up by another loader
+        // (e.g. `?raw&.json`).
+        moduleType: "js",
+      };
+    },
+  },
+});
+
+/**
+ * Splits an id into its file portion and the query/hash postfix (kept
+ * with the leading `?` / `#`). Matches Vite's `splitFileAndPostfix`.
+ *
+ * @example
+ *   splitFileAndPostfix("./foo.txt?raw") // => ["./foo.txt", "?raw"]
+ *   splitFileAndPostfix("./foo.txt")     // => ["./foo.txt", ""]
+ */
+export function splitFileAndPostfix(id: string): [string, string] {
+  const queryIdx = id.indexOf("?");
+  const hashIdx = id.indexOf("#");
+  const idx =
+    queryIdx === -1
+      ? hashIdx
+      : hashIdx === -1
+        ? queryIdx
+        : Math.min(queryIdx, hashIdx);
+  if (idx === -1) return [id, ""];
+  return [id.slice(0, idx), id.slice(idx)];
+}

--- a/packages/alchemy/src/Bundle/index.ts
+++ b/packages/alchemy/src/Bundle/index.ts
@@ -2,4 +2,5 @@ export * from "./Bundle.ts";
 export * from "./BundleAnalyzerPlugin.ts";
 export * from "./Docker.ts";
 export * from "./PurePlugin.ts";
+export * from "./RawPlugin.ts";
 export * from "./TempRoot.ts";

--- a/packages/alchemy/test/Bundle/RawPlugin.test.ts
+++ b/packages/alchemy/test/Bundle/RawPlugin.test.ts
@@ -1,0 +1,199 @@
+import * as Bundle from "@/Bundle/Bundle";
+import { rawPlugin, RAW_RE, splitFileAndPostfix } from "@/Bundle/RawPlugin";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+describe("RAW_RE", () => {
+  it("matches `?raw`", () => {
+    expect(RAW_RE.test("/foo/bar.txt?raw")).toBe(true);
+  });
+
+  it("matches `?raw&foo`", () => {
+    expect(RAW_RE.test("/foo/bar.txt?raw&foo")).toBe(true);
+  });
+
+  it("matches `?other&raw`", () => {
+    expect(RAW_RE.test("/foo/bar.txt?other&raw")).toBe(true);
+  });
+
+  it("does NOT match ids without ?raw", () => {
+    expect(RAW_RE.test("/foo/bar.txt")).toBe(false);
+    expect(RAW_RE.test("/foo/bar.txt?url")).toBe(false);
+    expect(RAW_RE.test("/foo/bar.txt?rawish")).toBe(false);
+  });
+});
+
+describe("splitFileAndPostfix", () => {
+  it("splits at the first `?`", () => {
+    expect(splitFileAndPostfix("./foo.txt?raw")).toEqual(["./foo.txt", "?raw"]);
+  });
+
+  it("splits at the first `#`", () => {
+    expect(splitFileAndPostfix("./foo.txt#frag")).toEqual([
+      "./foo.txt",
+      "#frag",
+    ]);
+  });
+
+  it("returns empty postfix when no query/hash", () => {
+    expect(splitFileAndPostfix("./foo.txt")).toEqual(["./foo.txt", ""]);
+  });
+
+  it("splits at whichever of `?` / `#` comes first", () => {
+    expect(splitFileAndPostfix("./foo.txt#frag?raw")).toEqual([
+      "./foo.txt",
+      "#frag?raw",
+    ]);
+  });
+});
+
+/**
+ * Invokes a plugin's `load` hook directly with a stubbed plugin
+ * context. The handler only reads `id`, so an empty `this` is fine.
+ */
+async function callLoad(
+  plugin: ReturnType<typeof rawPlugin>,
+  id: string,
+): Promise<unknown> {
+  const load = plugin.load;
+  if (load === undefined) throw new Error("plugin has no load hook");
+  const handler = typeof load === "function" ? load : load.handler;
+  return await (handler as (...args: any[]) => unknown).call({} as any, id);
+}
+
+describe("rawPlugin load hook", () => {
+  it.effect("inlines a .txt file as a JSON-encoded default export", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectory({ prefix: "alchemy-raw-load-" });
+      const file = path.join(root, "hello.txt");
+      yield* fs.writeFileString(file, "Hello, World!\n");
+
+      const plugin = rawPlugin();
+      const result = (yield* Effect.promise(() =>
+        callLoad(plugin, `${file}?raw`),
+      )) as { code: string; moduleType: string };
+
+      expect(result.code).toBe(`export default "Hello, World!\\n";`);
+      expect(result.moduleType).toBe("js");
+
+      yield* fs.remove(root, { recursive: true });
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("inlines a .json file verbatim (no parsing)", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectory({ prefix: "alchemy-raw-json-" });
+      const file = path.join(root, "data.json");
+      const raw = `{"a": 1, "b": "two"}`;
+      yield* fs.writeFileString(file, raw);
+
+      const plugin = rawPlugin();
+      const result = (yield* Effect.promise(() =>
+        callLoad(plugin, `${file}?raw`),
+      )) as { code: string };
+
+      expect(result.code).toBe(`export default ${JSON.stringify(raw)};`);
+
+      yield* fs.remove(root, { recursive: true });
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("strips additional query params before reading the file", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectory({ prefix: "alchemy-raw-q-" });
+      const file = path.join(root, "page.html");
+      yield* fs.writeFileString(file, "<h1>hi</h1>");
+
+      const plugin = rawPlugin();
+      const result = (yield* Effect.promise(() =>
+        callLoad(plugin, `${file}?raw&t=12345`),
+      )) as { code: string };
+
+      expect(result.code).toBe(`export default "<h1>hi</h1>";`);
+
+      yield* fs.remove(root, { recursive: true });
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+});
+
+describe("Bundle.build with rawPlugin", () => {
+  it.effect("inlines a sibling file imported with ?raw", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectory({
+        prefix: "alchemy-raw-bundle-",
+      });
+      yield* fs.writeFileString(
+        path.join(root, "hello.txt"),
+        "HELLO_RAW_MARKER",
+      );
+      const entry = path.join(root, "entry.ts");
+      yield* fs.writeFileString(
+        entry,
+        `import txt from "./hello.txt?raw";\nconsole.log(txt);\n`,
+      );
+
+      const result = yield* Bundle.build({
+        input: entry,
+        cwd: root,
+      });
+
+      const code = result.files
+        .filter((f) => typeof f.content === "string")
+        .map((f) => f.content as string)
+        .join("\n");
+      expect(code).toContain(`"HELLO_RAW_MARKER"`);
+      // The bundle should not emit hello.txt as a separate asset.
+      expect(result.files.every((f) => !f.path.endsWith("hello.txt"))).toBe(
+        true,
+      );
+
+      yield* fs.remove(root, { recursive: true });
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("resolves ?raw imports through subdirectories", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectory({
+        prefix: "alchemy-raw-subdir-",
+      });
+      yield* fs.makeDirectory(path.join(root, "sub"), { recursive: true });
+      yield* fs.writeFileString(
+        path.join(root, "sub", "foo.json"),
+        `{"marker":"SUBDIR_RAW_MARKER"}`,
+      );
+      const entry = path.join(root, "entry.ts");
+      yield* fs.writeFileString(
+        entry,
+        `import foo from "./sub/foo.json?raw";\nconsole.log(foo);\n`,
+      );
+
+      const result = yield* Bundle.build({
+        input: entry,
+        cwd: root,
+      });
+
+      const code = result.files
+        .filter((f) => typeof f.content === "string")
+        .map((f) => f.content as string)
+        .join("\n");
+      expect(code).toContain("SUBDIR_RAW_MARKER");
+
+      yield* fs.remove(root, { recursive: true });
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+});
+
+void Bundle;

--- a/packages/alchemy/test/Bundle/RawPlugin.test.ts
+++ b/packages/alchemy/test/Bundle/RawPlugin.test.ts
@@ -5,125 +5,7 @@ import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
-
-describe("RAW_RE", () => {
-  it("matches `?raw`", () => {
-    expect(RAW_RE.test("/foo/bar.txt?raw")).toBe(true);
-  });
-
-  it("matches `?raw&foo`", () => {
-    expect(RAW_RE.test("/foo/bar.txt?raw&foo")).toBe(true);
-  });
-
-  it("matches `?other&raw`", () => {
-    expect(RAW_RE.test("/foo/bar.txt?other&raw")).toBe(true);
-  });
-
-  it("does NOT match ids without ?raw", () => {
-    expect(RAW_RE.test("/foo/bar.txt")).toBe(false);
-    expect(RAW_RE.test("/foo/bar.txt?url")).toBe(false);
-    expect(RAW_RE.test("/foo/bar.txt?rawish")).toBe(false);
-  });
-});
-
-describe("splitFileAndPostfix", () => {
-  it("splits at the first `?`", () => {
-    expect(splitFileAndPostfix("./foo.txt?raw")).toEqual(["./foo.txt", "?raw"]);
-  });
-
-  it("splits at the first `#`", () => {
-    expect(splitFileAndPostfix("./foo.txt#frag")).toEqual([
-      "./foo.txt",
-      "#frag",
-    ]);
-  });
-
-  it("returns empty postfix when no query/hash", () => {
-    expect(splitFileAndPostfix("./foo.txt")).toEqual(["./foo.txt", ""]);
-  });
-
-  it("splits at whichever of `?` / `#` comes first", () => {
-    expect(splitFileAndPostfix("./foo.txt#frag?raw")).toEqual([
-      "./foo.txt",
-      "#frag?raw",
-    ]);
-  });
-});
-
-/**
- * Invokes a plugin's `load` hook directly with a stubbed plugin
- * context. The handler only reads `id`, so an empty `this` is fine.
- */
-async function callLoad(
-  plugin: ReturnType<typeof rawPlugin>,
-  id: string,
-): Promise<unknown> {
-  const load = plugin.load;
-  if (load === undefined) throw new Error("plugin has no load hook");
-  const handler = typeof load === "function" ? load : load.handler;
-  return await (handler as (...args: any[]) => unknown).call({} as any, id);
-}
-
-describe("rawPlugin load hook", () => {
-  it.effect("inlines a .txt file as a JSON-encoded default export", () =>
-    Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-      const root = yield* fs.makeTempDirectory({ prefix: "alchemy-raw-load-" });
-      const file = path.join(root, "hello.txt");
-      yield* fs.writeFileString(file, "Hello, World!\n");
-
-      const plugin = rawPlugin();
-      const result = (yield* Effect.promise(() =>
-        callLoad(plugin, `${file}?raw`),
-      )) as { code: string; moduleType: string };
-
-      expect(result.code).toBe(`export default "Hello, World!\\n";`);
-      expect(result.moduleType).toBe("js");
-
-      yield* fs.remove(root, { recursive: true });
-    }).pipe(Effect.provide(NodeServices.layer)),
-  );
-
-  it.effect("inlines a .json file verbatim (no parsing)", () =>
-    Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-      const root = yield* fs.makeTempDirectory({ prefix: "alchemy-raw-json-" });
-      const file = path.join(root, "data.json");
-      const raw = `{"a": 1, "b": "two"}`;
-      yield* fs.writeFileString(file, raw);
-
-      const plugin = rawPlugin();
-      const result = (yield* Effect.promise(() =>
-        callLoad(plugin, `${file}?raw`),
-      )) as { code: string };
-
-      expect(result.code).toBe(`export default ${JSON.stringify(raw)};`);
-
-      yield* fs.remove(root, { recursive: true });
-    }).pipe(Effect.provide(NodeServices.layer)),
-  );
-
-  it.effect("strips additional query params before reading the file", () =>
-    Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-      const root = yield* fs.makeTempDirectory({ prefix: "alchemy-raw-q-" });
-      const file = path.join(root, "page.html");
-      yield* fs.writeFileString(file, "<h1>hi</h1>");
-
-      const plugin = rawPlugin();
-      const result = (yield* Effect.promise(() =>
-        callLoad(plugin, `${file}?raw&t=12345`),
-      )) as { code: string };
-
-      expect(result.code).toBe(`export default "<h1>hi</h1>";`);
-
-      yield* fs.remove(root, { recursive: true });
-    }).pipe(Effect.provide(NodeServices.layer)),
-  );
-});
+import * as nodeFs from "node:fs/promises";
 
 describe("Bundle.build with rawPlugin", () => {
   it.effect("inlines a sibling file imported with ?raw", () =>
@@ -195,5 +77,129 @@ describe("Bundle.build with rawPlugin", () => {
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 });
+
+describe("rawPlugin load hook", () => {
+  it.effect("inlines a .txt file as a JSON-encoded default export", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectory({ prefix: "alchemy-raw-load-" });
+      const file = path.join(root, "hello.txt");
+      yield* fs.writeFileString(file, "Hello, World!\n");
+
+      const plugin = rawPlugin();
+      const result = (yield* Effect.promise(() =>
+        callLoad(plugin, `${file}?raw`),
+      )) as { code: string; moduleType: string };
+
+      expect(result.code).toBe(`export default "Hello, World!\\n";`);
+      expect(result.moduleType).toBe("js");
+
+      yield* fs.remove(root, { recursive: true });
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("inlines a .json file verbatim (no parsing)", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectory({ prefix: "alchemy-raw-json-" });
+      const file = path.join(root, "data.json");
+      const raw = `{"a": 1, "b": "two"}`;
+      yield* fs.writeFileString(file, raw);
+
+      const plugin = rawPlugin();
+      const result = (yield* Effect.promise(() =>
+        callLoad(plugin, `${file}?raw`),
+      )) as { code: string };
+
+      expect(result.code).toBe(`export default ${JSON.stringify(raw)};`);
+
+      yield* fs.remove(root, { recursive: true });
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("strips additional query params before reading the file", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectory({ prefix: "alchemy-raw-q-" });
+      const file = path.join(root, "page.html");
+      yield* fs.writeFileString(file, "<h1>hi</h1>");
+
+      const plugin = rawPlugin();
+      const result = (yield* Effect.promise(() =>
+        callLoad(plugin, `${file}?raw&t=12345`),
+      )) as { code: string };
+
+      expect(result.code).toBe(`export default "<h1>hi</h1>";`);
+
+      yield* fs.remove(root, { recursive: true });
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+});
+
+describe("RAW_RE", () => {
+  it("matches `?raw`", () => {
+    expect(RAW_RE.test("/foo/bar.txt?raw")).toBe(true);
+  });
+
+  it("matches `?raw&foo`", () => {
+    expect(RAW_RE.test("/foo/bar.txt?raw&foo")).toBe(true);
+  });
+
+  it("matches `?other&raw`", () => {
+    expect(RAW_RE.test("/foo/bar.txt?other&raw")).toBe(true);
+  });
+
+  it("does NOT match ids without ?raw", () => {
+    expect(RAW_RE.test("/foo/bar.txt")).toBe(false);
+    expect(RAW_RE.test("/foo/bar.txt?url")).toBe(false);
+    expect(RAW_RE.test("/foo/bar.txt?rawish")).toBe(false);
+  });
+});
+
+describe("splitFileAndPostfix", () => {
+  it("splits at the first `?`", () => {
+    expect(splitFileAndPostfix("./foo.txt?raw")).toEqual(["./foo.txt", "?raw"]);
+  });
+
+  it("splits at the first `#`", () => {
+    expect(splitFileAndPostfix("./foo.txt#frag")).toEqual([
+      "./foo.txt",
+      "#frag",
+    ]);
+  });
+
+  it("returns empty postfix when no query/hash", () => {
+    expect(splitFileAndPostfix("./foo.txt")).toEqual(["./foo.txt", ""]);
+  });
+
+  it("splits at whichever of `?` / `#` comes first", () => {
+    expect(splitFileAndPostfix("./foo.txt#frag?raw")).toEqual([
+      "./foo.txt",
+      "#frag?raw",
+    ]);
+  });
+});
+
+/**
+ * Invokes a plugin's `load` hook directly with a stubbed plugin
+ * context. The handler reads through `this.fs` (rolldown's
+ * plugin-context filesystem); we stub it with `node:fs/promises` so the
+ * disk read works without booting a full rolldown build.
+ */
+async function callLoad(
+  plugin: ReturnType<typeof rawPlugin>,
+  id: string,
+): Promise<unknown> {
+  const load = plugin.load;
+  if (load === undefined) throw new Error("plugin has no load hook");
+  const handler = typeof load === "function" ? load : load.handler;
+  return await (handler as (...args: any[]) => unknown).call(
+    { fs: nodeFs } as any,
+    id,
+  );
+}
 
 void Bundle;

--- a/packages/alchemy/test/Bundle/RawPlugin.test.ts
+++ b/packages/alchemy/test/Bundle/RawPlugin.test.ts
@@ -1,13 +1,14 @@
 import * as Bundle from "@/Bundle/Bundle";
-import { rawPlugin, RAW_RE, splitFileAndPostfix } from "@/Bundle/RawPlugin";
+import { RAW_RE, rawPlugin, splitFileAndPostfix } from "@/Bundle/RawPlugin";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { describe, expect, it } from "@effect/vitest";
+import { assert, describe, expect, it, layer } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
-import * as nodeFs from "node:fs/promises";
+import * as Predicate from "effect/Predicate";
+import * as NodeFs from "node:fs/promises";
 
-describe("Bundle.build with rawPlugin", () => {
+layer(NodeServices.layer)("Bundle.build with rawPlugin", (it) => {
   it.effect("inlines a sibling file imported with ?raw", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
@@ -41,7 +42,7 @@ describe("Bundle.build with rawPlugin", () => {
       );
 
       yield* fs.remove(root, { recursive: true });
-    }).pipe(Effect.provide(NodeServices.layer)),
+    }),
   );
 
   it.effect("resolves ?raw imports through subdirectories", () =>
@@ -74,11 +75,31 @@ describe("Bundle.build with rawPlugin", () => {
       expect(code).toContain("SUBDIR_RAW_MARKER");
 
       yield* fs.remove(root, { recursive: true });
-    }).pipe(Effect.provide(NodeServices.layer)),
+    }),
   );
 });
 
-describe("rawPlugin load hook", () => {
+layer(NodeServices.layer)("rawPlugin load hook", (it) => {
+  /**
+   * Invokes a plugin's `load` hook directly with a stubbed plugin
+   * context. The handler reads through `this.fs` (rolldown's
+   * plugin-context filesystem); we stub it with `node:fs/promises` so the
+   * disk read works without booting a full rolldown build.
+   */
+  const load = (id: string) =>
+    Effect.promise(async () => {
+      const plugin = rawPlugin();
+      assert(
+        Predicate.hasProperty(plugin, "load") &&
+          Predicate.hasProperty(plugin.load, "handler") &&
+          typeof plugin.load.handler === "function",
+        "plugin has no load hook",
+      );
+      const result = await plugin.load.handler.call({ fs: NodeFs } as any, id);
+      assert(Predicate.isObject(result), "load hook returned non-object");
+      return result;
+    });
+
   it.effect("inlines a .txt file as a JSON-encoded default export", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
@@ -87,16 +108,13 @@ describe("rawPlugin load hook", () => {
       const file = path.join(root, "hello.txt");
       yield* fs.writeFileString(file, "Hello, World!\n");
 
-      const plugin = rawPlugin();
-      const result = (yield* Effect.promise(() =>
-        callLoad(plugin, `${file}?raw`),
-      )) as { code: string; moduleType: string };
+      const result = yield* load(file);
 
       expect(result.code).toBe(`export default "Hello, World!\\n";`);
       expect(result.moduleType).toBe("js");
 
       yield* fs.remove(root, { recursive: true });
-    }).pipe(Effect.provide(NodeServices.layer)),
+    }),
   );
 
   it.effect("inlines a .json file verbatim (no parsing)", () =>
@@ -108,15 +126,12 @@ describe("rawPlugin load hook", () => {
       const raw = `{"a": 1, "b": "two"}`;
       yield* fs.writeFileString(file, raw);
 
-      const plugin = rawPlugin();
-      const result = (yield* Effect.promise(() =>
-        callLoad(plugin, `${file}?raw`),
-      )) as { code: string };
+      const result = yield* load(`${file}?raw`);
 
       expect(result.code).toBe(`export default ${JSON.stringify(raw)};`);
 
       yield* fs.remove(root, { recursive: true });
-    }).pipe(Effect.provide(NodeServices.layer)),
+    }),
   );
 
   it.effect("strips additional query params before reading the file", () =>
@@ -127,15 +142,12 @@ describe("rawPlugin load hook", () => {
       const file = path.join(root, "page.html");
       yield* fs.writeFileString(file, "<h1>hi</h1>");
 
-      const plugin = rawPlugin();
-      const result = (yield* Effect.promise(() =>
-        callLoad(plugin, `${file}?raw&t=12345`),
-      )) as { code: string };
+      const result = yield* load(`${file}?raw&t=12345`);
 
       expect(result.code).toBe(`export default "<h1>hi</h1>";`);
 
       yield* fs.remove(root, { recursive: true });
-    }).pipe(Effect.provide(NodeServices.layer)),
+    }),
   );
 });
 
@@ -182,24 +194,3 @@ describe("splitFileAndPostfix", () => {
     ]);
   });
 });
-
-/**
- * Invokes a plugin's `load` hook directly with a stubbed plugin
- * context. The handler reads through `this.fs` (rolldown's
- * plugin-context filesystem); we stub it with `node:fs/promises` so the
- * disk read works without booting a full rolldown build.
- */
-async function callLoad(
-  plugin: ReturnType<typeof rawPlugin>,
-  id: string,
-): Promise<unknown> {
-  const load = plugin.load;
-  if (load === undefined) throw new Error("plugin has no load hook");
-  const handler = typeof load === "function" ? load : load.handler;
-  return await (handler as (...args: any[]) => unknown).call(
-    { fs: nodeFs } as any,
-    id,
-  );
-}
-
-void Bundle;


### PR DESCRIPTION
Inline file contents as a string when imported with the Vite-style `?raw` suffix.

```ts
import schema from "./schema.sql?raw";
//        ^ string — file contents read as UTF-8
```

Implemented as a new built-in rolldown plugin (`alchemy:raw`) enabled by default in `builtInPlugins` — no option, nothing to configure.

`?url` and `?inline` are intentionally omitted: both rely on Vite's browser asset pipeline (URL serving, `data:` fallback) that has no analogue in the server-side bundles produced here (Workers, Lambda).