### PR TITLE
fix(cloudflare): dev hyperdrive binding fails for vite/async workers

### DIFF
--- a/packages/alchemy/src/Cloudflare/Hyperdrive/Hyperdrive.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/Hyperdrive.ts
@@ -1,5 +1,6 @@
 import * as hyperdrive from "@distilled.cloud/cloudflare/hyperdrive";
 import * as Effect from "effect/Effect";
+import * as Predicate from "effect/Predicate";
 import * as Redacted from "effect/Redacted";
 
 import { AlchemyContext } from "../../AlchemyContext.ts";
@@ -156,6 +157,10 @@ export type Hyperdrive = Resource<
 export const Hyperdrive = Resource<Hyperdrive>("Cloudflare.Hyperdrive")({
   bind: HyperdriveBinding.bind,
 });
+
+export const isHyperdrive = (value: unknown): value is Hyperdrive =>
+  Predicate.hasProperty(value, "Type") &&
+  value.Type === "Cloudflare.Hyperdrive";
 
 export const HyperdriveProvider = () =>
   Provider.effect(

--- a/packages/alchemy/src/Cloudflare/Hyperdrive/HyperdriveBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/HyperdriveBinding.ts
@@ -113,38 +113,6 @@ export const HyperdriveBindingPolicyLive = HyperdriveBindingPolicy.layer.effect(
         );
       }
 
-      const origin = Output.map(
-        Output.all(hyperdrive.dev, hyperdrive.origin, hyperdrive.mtls),
-        ([dev, origin, mtls]): Required<HyperdriveDevOrigin> => {
-          if (dev) {
-            return {
-              scheme: dev.scheme,
-              host: dev.host,
-              port: dev.port ?? defaultPort(dev.scheme),
-              user: dev.user,
-              database: dev.database,
-              password: dev.password,
-              sslmode: dev.sslmode ?? "prefer",
-            };
-          }
-          if ("accessClientId" in origin) {
-            throw new Error(
-              `Hyperdrive instance ${hyperdrive.LogicalId} has an origin that requires Cloudflare Access. This is not supported in development mode. ` +
-                "Select a different origin or set the `dev` property to an origin that does not require Cloudflare Access.",
-            );
-          }
-          return {
-            scheme: origin.scheme,
-            host: origin.host,
-            port: origin.port ?? defaultPort(origin.scheme),
-            user: origin.user,
-            database: origin.database,
-            password: origin.password,
-            sslmode: mtls?.sslmode ?? "require",
-          };
-        },
-      );
-
       yield* host.bind`${hyperdrive}`({
         bindings: [
           {
@@ -153,15 +121,48 @@ export const HyperdriveBindingPolicyLive = HyperdriveBindingPolicy.layer.effect(
             id: hyperdrive.hyperdriveId as unknown as string,
           },
         ],
-        hyperdrives: ctx.dev
-          ? (Output.map(
-              Output.all(hyperdrive.hyperdriveId, Output.asOutput(origin)),
-              ([id, origin]) => ({
-                [id]: origin,
-              }),
-            ) as unknown as Record<string, Required<HyperdriveDevOrigin>>)
-          : undefined,
+        hyperdrives: ctx.dev ? getHyperdriveDevOrigin(hyperdrive) : undefined,
       });
     });
   }),
 );
+
+export const getHyperdriveDevOrigin = (hyperdrive: Hyperdrive) => {
+  const origin = Output.map(
+    Output.all(hyperdrive.dev, hyperdrive.origin, hyperdrive.mtls),
+    ([dev, origin, mtls]): Required<HyperdriveDevOrigin> => {
+      if (dev) {
+        return {
+          scheme: dev.scheme,
+          host: dev.host,
+          port: dev.port ?? defaultPort(dev.scheme),
+          user: dev.user,
+          database: dev.database,
+          password: dev.password,
+          sslmode: dev.sslmode ?? "prefer",
+        };
+      }
+      if ("accessClientId" in origin) {
+        throw new Error(
+          `Hyperdrive instance ${hyperdrive.LogicalId} has an origin that requires Cloudflare Access. This is not supported in development mode. ` +
+            "Select a different origin or set the `dev` property to an origin that does not require Cloudflare Access.",
+        );
+      }
+      return {
+        scheme: origin.scheme,
+        host: origin.host,
+        port: origin.port ?? defaultPort(origin.scheme),
+        user: origin.user,
+        database: origin.database,
+        password: origin.password,
+        sslmode: mtls?.sslmode ?? "require",
+      };
+    },
+  );
+  return Output.map(
+    Output.all(hyperdrive.hyperdriveId, Output.asOutput(origin)),
+    ([id, origin]) => ({
+      [id]: origin,
+    }),
+  ) as unknown as Record<string, Required<HyperdriveDevOrigin>>;
+};

--- a/packages/alchemy/src/Cloudflare/Hyperdrive/HyperdriveBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/HyperdriveBinding.ts
@@ -2,7 +2,6 @@ import type * as runtime from "@cloudflare/workers-types";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
-import { AlchemyContext } from "../../AlchemyContext.ts";
 import * as Binding from "../../Binding.ts";
 import * as Output from "../../Output.ts";
 import type { ResourceLike } from "../../Resource.ts";
@@ -102,8 +101,6 @@ export class HyperdriveBindingPolicy extends Binding.Policy<
 
 export const HyperdriveBindingPolicyLive = HyperdriveBindingPolicy.layer.effect(
   Effect.gen(function* () {
-    const ctx = yield* AlchemyContext;
-
     return Effect.fn(function* (host: ResourceLike, hyperdrive: Hyperdrive) {
       if (!isWorker(host)) {
         return yield* Effect.die(
@@ -121,7 +118,7 @@ export const HyperdriveBindingPolicyLive = HyperdriveBindingPolicy.layer.effect(
             id: hyperdrive.hyperdriveId as unknown as string,
           },
         ],
-        hyperdrives: ctx.dev ? getHyperdriveDevOrigin(hyperdrive) : undefined,
+        hyperdrives: getHyperdriveDevOrigin(hyperdrive),
       });
     });
   }),

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -1,6 +1,5 @@
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
-import { AlchemyContext } from "../../AlchemyContext.ts";
 import type { InputProps } from "../../Input.ts";
 import * as Output from "../../Output.ts";
 import type { ResourceBinding } from "../../Resource.ts";
@@ -21,7 +20,6 @@ export const bindWorkerAsyncBindings = Effect.fnUntraced(function* (
   resource: Worker,
   props: InputProps<WorkerProps<WorkerBindingProps>>,
 ) {
-  const ctx = yield* AlchemyContext;
   if (props.bindings) {
     for (const bindingName in props.bindings) {
       // @ts-expect-error
@@ -140,10 +138,9 @@ export const bindWorkerAsyncBindings = Effect.fnUntraced(function* (
       if (bindingMeta) {
         yield* resource.bind`${bindingName}`({
           bindings: [bindingMeta],
-          hyperdrives:
-            ctx.dev && isHyperdrive(binding)
-              ? getHyperdriveDevOrigin(binding)
-              : undefined,
+          hyperdrives: isHyperdrive(binding)
+            ? getHyperdriveDevOrigin(binding)
+            : undefined,
         });
       } else {
         return yield* Effect.die(`Unknown binding type: ${bindingName}`);

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -1,5 +1,6 @@
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
+import { AlchemyContext } from "../../AlchemyContext.ts";
 import type { InputProps } from "../../Input.ts";
 import * as Output from "../../Output.ts";
 import type { ResourceBinding } from "../../Resource.ts";
@@ -7,6 +8,8 @@ import { isYieldableEffectLike } from "../../Util/effect.ts";
 import { isAnalyticsEngineDataset } from "../AnalyticsEngine/AnalyticsEngineDataset.ts";
 import { isArtifacts } from "../Artifacts/Artifacts.ts";
 import { isSendEmail } from "../Email/SendEmail.ts";
+import { isHyperdrive } from "../Hyperdrive/Hyperdrive.ts";
+import { getHyperdriveDevOrigin } from "../Hyperdrive/HyperdriveBinding.ts";
 import { isImages } from "../Images/Images.ts";
 import { isAssets } from "./Assets.ts";
 import { isDurableObjectNamespaceLike } from "./DurableObjectNamespace.ts";
@@ -18,6 +21,7 @@ export const bindWorkerAsyncBindings = Effect.fnUntraced(function* (
   resource: Worker,
   props: InputProps<WorkerProps<WorkerBindingProps>>,
 ) {
+  const ctx = yield* AlchemyContext;
   if (props.bindings) {
     for (const bindingName in props.bindings) {
       // @ts-expect-error
@@ -118,7 +122,7 @@ export const bindWorkerAsyncBindings = Effect.fnUntraced(function* (
                                       type: "ai",
                                       name: bindingName,
                                     }
-                                  : binding.Type === "Cloudflare.Hyperdrive"
+                                  : isHyperdrive(binding)
                                     ? {
                                         type: "hyperdrive",
                                         name: bindingName,
@@ -136,6 +140,10 @@ export const bindWorkerAsyncBindings = Effect.fnUntraced(function* (
       if (bindingMeta) {
         yield* resource.bind`${bindingName}`({
           bindings: [bindingMeta],
+          hyperdrives:
+            ctx.dev && isHyperdrive(binding)
+              ? getHyperdriveDevOrigin(binding)
+              : undefined,
         });
       } else {
         return yield* Effect.die(`Unknown binding type: ${bindingName}`);

--- a/packages/alchemy/src/Platform.ts
+++ b/packages/alchemy/src/Platform.ts
@@ -185,7 +185,10 @@ export const Platform = <
   type: R["Type"],
   hooks: {
     createRuntimeContext: (id: string) => BaseRuntimeContext;
-    onCreate?: (resource: R, props: any) => Effect.Effect<void>;
+    onCreate?: (
+      resource: R,
+      props: any,
+    ) => Effect.Effect<void, never, StackServices>;
   },
   methods?: { [key: string]: any },
 ): any => {

--- a/packages/alchemy/src/Platform.ts
+++ b/packages/alchemy/src/Platform.ts
@@ -185,10 +185,7 @@ export const Platform = <
   type: R["Type"],
   hooks: {
     createRuntimeContext: (id: string) => BaseRuntimeContext;
-    onCreate?: (
-      resource: R,
-      props: any,
-    ) => Effect.Effect<void, never, StackServices>;
+    onCreate?: (resource: R, props: any) => Effect.Effect<void>;
   },
   methods?: { [key: string]: any },
 ): any => {


### PR DESCRIPTION
During development, Hyperdrive bindings don't work for external workers because the `HyperdriveBindingPolicy`, which passes along the dev origin for use by the local worker, is not used.

This updates `bindWorkerAsyncBindings` to include the same dev origin logic.

Note: That binding policies need to be implemented in two places - the Effect resource binding and `bindWorkerAsyncBindings` - seems less than ideal. Wonder if we can make it so that we simply reuse the policies from the Effect binding?