### PR TITLE
feat(cloudflare): worker.url now tries to infer canonical url & domain order is preserved

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -378,7 +378,7 @@ export const LocalWorkerProvider = () =>
           url,
           tags: [],
           durableObjectNamespaces: config.durableObjectNamespaces,
-          urls: [url],
+          domains: [url],
           crons: Array.from(
             new Set([...getCronBindings(bindings), ...(props.crons ?? [])]),
           ),

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -378,7 +378,7 @@ export const LocalWorkerProvider = () =>
           url,
           tags: [],
           durableObjectNamespaces: config.durableObjectNamespaces,
-          domains: [],
+          urls: [url],
           crons: Array.from(
             new Set([...getCronBindings(bindings), ...(props.crons ?? [])]),
           ),

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -276,7 +276,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
     tags: string[] | undefined;
     durableObjectNamespaces: Record<string, string>;
     accountId: string;
-    urls: string[];
+    domains: string[];
     crons: string[];
     hash?: {
       assets: string | undefined;
@@ -1641,19 +1641,19 @@ export const LiveWorkerProvider = () =>
           );
         }
         const desiredDomains = normalizeDomains(news.domain);
-        const previousUrls = output?.urls ?? [];
-        if (desiredDomains.length > 0 || previousUrls.length > 0) {
+        const previousDomains = output?.domains ?? [];
+        if (desiredDomains.length > 0 || previousDomains.length > 0) {
           yield* session.note(
             `Reconciling custom domains (${desiredDomains.length}) ...`,
           );
         }
-        const domains = yield* reconcileDomains(name, desiredDomains);
+        const reconciled = yield* reconcileDomains(name, desiredDomains);
         const workersDevUrl =
           news.url !== false
             ? `https://${name}.${yield* getAccountSubdomain(accountId)}.workers.dev`
             : undefined;
-        const urls = [
-          ...domains.map((d) => `https://${d.hostname}`),
+        const domains = [
+          ...reconciled.map((d) => `https://${d.hostname}`),
           ...(workersDevUrl ? [workersDevUrl] : []),
         ];
         const crons = yield* reconcileCrons(
@@ -1666,11 +1666,11 @@ export const LiveWorkerProvider = () =>
           workerId: worker.id ?? name,
           workerName: name,
           logpush: worker.logpush ?? undefined,
-          url: urls[0],
+          url: domains[0],
           tags: settings.tags ?? metadata.tags,
           durableObjectNamespaces,
           accountId,
-          urls,
+          domains,
           crons,
           hash,
         } satisfies Worker["Attributes"];
@@ -1770,7 +1770,7 @@ export const LiveWorkerProvider = () =>
           const newDomains = normalizeDomains(news.domain)
             .map((h) => `https://${h}`)
             .sort();
-          const oldDomains = (output?.urls ?? [])
+          const oldDomains = (output?.domains ?? [])
             .filter((u) => !u.endsWith(".workers.dev"))
             .sort();
           const domainsChanged =
@@ -1933,7 +1933,7 @@ export const LiveWorkerProvider = () =>
             tags: existingSettings?.tags ?? tags,
             durableObjectNamespaces,
             accountId,
-            urls: [],
+            domains: [],
             crons: [],
           } satisfies Worker["Attributes"];
         }),
@@ -1968,7 +1968,7 @@ export const LiveWorkerProvider = () =>
             ]);
             // Preserve the order the user provided in `olds.domain`. The
             // Cloudflare API returns domains in non-deterministic order,
-            // which would cause downstream `worker.urls[0]` reads to flip
+            // which would cause downstream `worker.domains[0]` reads to flip
             // between deploys. Drift (domains we don't know about) is
             // appended after the user-ordered ones.
             const userOrder = normalizeDomains(olds?.domain);
@@ -1986,7 +1986,7 @@ export const LiveWorkerProvider = () =>
             const workersDevUrl = subdomain.enabled
               ? `https://${workerName}.${yield* getAccountSubdomain(accountId)}.workers.dev`
               : undefined;
-            const urls = [
+            const domains = [
               ...orderedHostnames.map((h) => `https://${h}`),
               ...(workersDevUrl ? [workersDevUrl] : []),
             ];
@@ -1999,12 +1999,12 @@ export const LiveWorkerProvider = () =>
               workerId: workerName,
               workerName,
               logpush: settings.logpush ?? undefined,
-              url: urls[0],
+              url: domains[0],
               tags: settings.tags ?? undefined,
               durableObjectNamespaces: getDurableObjectNamespaces(
                 settings.bindings,
               ),
-              urls,
+              domains,
               crons,
             } satisfies Worker["Attributes"];
 

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1965,15 +1965,26 @@ export const LiveWorkerProvider = () =>
               listDomains({
                 accountId,
                 service: workerName,
-              }).pipe(
-                Effect.map(
-                  (r) =>
-                    r.result.sort((a, b) =>
-                      (a.hostname ?? "").localeCompare(b.hostname ?? ""),
-                    ) ?? [],
-                ),
-              ),
+              }).pipe(Effect.map((r) => r.result ?? [])),
             ]);
+            // Preserve the order the user provided in `olds.domain`. The
+            // Cloudflare API returns domains in non-deterministic order,
+            // which would cause downstream `worker.domains[0]` reads to
+            // flip between deploys. Drift (domains we don't know about)
+            // is appended after the user-ordered ones.
+            const userOrder = normalizeDomains(olds?.domain);
+            const byHostname = new Map(
+              domainsList.flatMap((d) => (d.hostname ? [[d.hostname, d]] : [])),
+            );
+            const orderedDomains = [
+              ...userOrder.flatMap((h) => {
+                const d = byHostname.get(h);
+                return d ? [d] : [];
+              }),
+              ...domainsList.filter(
+                (d) => !d.hostname || !userOrder.includes(d.hostname),
+              ),
+            ];
             const crons = yield* getWorkerCrons(workerName);
             yield* Effect.logInfo(
               `Cloudflare Worker read: found ${workerName}`,
@@ -1990,7 +2001,7 @@ export const LiveWorkerProvider = () =>
               durableObjectNamespaces: getDurableObjectNamespaces(
                 settings.bindings,
               ),
-              domains: domainsList.flatMap((d) =>
+              domains: orderedDomains.flatMap((d) =>
                 d.id && d.hostname && d.zoneId
                   ? [{ id: d.id, hostname: d.hostname, zoneId: d.zoneId }]
                   : [],

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1973,14 +1973,10 @@ export const LiveWorkerProvider = () =>
             // flip between deploys. Drift (domains we don't know about)
             // is appended after the user-ordered ones.
             const userOrder = normalizeDomains(olds?.domain);
-            const byHostname = new Map(
-              domainsList.flatMap((d) => (d.hostname ? [[d.hostname, d]] : [])),
-            );
             const orderedDomains = [
-              ...userOrder.flatMap((h) => {
-                const d = byHostname.get(h);
-                return d ? [d] : [];
-              }),
+              ...userOrder.flatMap(
+                (h) => domainsList.find((d) => d.hostname === h) ?? [],
+              ),
               ...domainsList.filter(
                 (d) => !d.hostname || !userOrder.includes(d.hostname),
               ),

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1965,7 +1965,14 @@ export const LiveWorkerProvider = () =>
               listDomains({
                 accountId,
                 service: workerName,
-              }).pipe(Effect.map((r) => r.result ?? [])),
+              }).pipe(
+                Effect.map(
+                  (r) =>
+                    r.result.sort((a, b) =>
+                      (a.hostname ?? "").localeCompare(b.hostname ?? ""),
+                    ) ?? [],
+                ),
+              ),
             ]);
             const crons = yield* getWorkerCrons(workerName);
             yield* Effect.logInfo(

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -276,7 +276,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
     tags: string[] | undefined;
     durableObjectNamespaces: Record<string, string>;
     accountId: string;
-    domains: { hostname: string; id: string; zoneId: string }[];
+    urls: string[];
     crons: string[];
     hash?: {
       assets: string | undefined;
@@ -883,11 +883,7 @@ export const LiveWorkerProvider = () =>
           );
         });
 
-      const reconcileDomains = (
-        scriptName: string,
-        desired: string[],
-        _previous: Worker["Attributes"]["domains"],
-      ) =>
+      const reconcileDomains = (scriptName: string, desired: string[]) =>
         Effect.gen(function* () {
           // Always query the live state of domains attached to *this*
           // Worker rather than trusting `_previous` from local state.
@@ -1645,17 +1641,21 @@ export const LiveWorkerProvider = () =>
           );
         }
         const desiredDomains = normalizeDomains(news.domain);
-        const previousDomains = output?.domains ?? [];
-        if (desiredDomains.length > 0 || previousDomains.length > 0) {
+        const previousUrls = output?.urls ?? [];
+        if (desiredDomains.length > 0 || previousUrls.length > 0) {
           yield* session.note(
             `Reconciling custom domains (${desiredDomains.length}) ...`,
           );
         }
-        const domains = yield* reconcileDomains(
-          name,
-          desiredDomains,
-          previousDomains,
-        );
+        const domains = yield* reconcileDomains(name, desiredDomains);
+        const workersDevUrl =
+          news.url !== false
+            ? `https://${name}.${yield* getAccountSubdomain(accountId)}.workers.dev`
+            : undefined;
+        const urls = [
+          ...domains.map((d) => `https://${d.hostname}`),
+          ...(workersDevUrl ? [workersDevUrl] : []),
+        ];
         const crons = yield* reconcileCrons(
           name,
           normalizeCrons([...getCronBindings(bindings), ...(news.crons ?? [])]),
@@ -1666,14 +1666,11 @@ export const LiveWorkerProvider = () =>
           workerId: worker.id ?? name,
           workerName: name,
           logpush: worker.logpush ?? undefined,
-          url:
-            news.url !== false
-              ? `https://${name}.${yield* getAccountSubdomain(accountId)}.workers.dev`
-              : undefined,
+          url: urls[0],
           tags: settings.tags ?? metadata.tags,
           durableObjectNamespaces,
           accountId,
-          domains,
+          urls,
           crons,
           hash,
         } satisfies Worker["Attributes"];
@@ -1770,9 +1767,11 @@ export const LiveWorkerProvider = () =>
           if (!output) {
             return;
           }
-          const newDomains = normalizeDomains(news.domain).sort();
-          const oldDomains = (output?.domains ?? [])
-            .map((d) => d.hostname)
+          const newDomains = normalizeDomains(news.domain)
+            .map((h) => `https://${h}`)
+            .sort();
+          const oldDomains = (output?.urls ?? [])
+            .filter((u) => !u.endsWith(".workers.dev"))
             .sort();
           const domainsChanged =
             newDomains.length !== oldDomains.length ||
@@ -1934,7 +1933,7 @@ export const LiveWorkerProvider = () =>
             tags: existingSettings?.tags ?? tags,
             durableObjectNamespaces,
             accountId,
-            domains: [],
+            urls: [],
             crons: [],
           } satisfies Worker["Attributes"];
         }),
@@ -1969,17 +1968,27 @@ export const LiveWorkerProvider = () =>
             ]);
             // Preserve the order the user provided in `olds.domain`. The
             // Cloudflare API returns domains in non-deterministic order,
-            // which would cause downstream `worker.domains[0]` reads to
-            // flip between deploys. Drift (domains we don't know about)
-            // is appended after the user-ordered ones.
+            // which would cause downstream `worker.urls[0]` reads to flip
+            // between deploys. Drift (domains we don't know about) is
+            // appended after the user-ordered ones.
             const userOrder = normalizeDomains(olds?.domain);
-            const orderedDomains = [
+            const orderedHostnames = [
               ...userOrder.flatMap(
-                (h) => domainsList.find((d) => d.hostname === h) ?? [],
+                (h) =>
+                  domainsList.find((d) => d.hostname === h)?.hostname ?? [],
               ),
-              ...domainsList.filter(
-                (d) => !d.hostname || !userOrder.includes(d.hostname),
+              ...domainsList.flatMap((d) =>
+                d.hostname && !userOrder.includes(d.hostname)
+                  ? [d.hostname]
+                  : [],
               ),
+            ];
+            const workersDevUrl = subdomain.enabled
+              ? `https://${workerName}.${yield* getAccountSubdomain(accountId)}.workers.dev`
+              : undefined;
+            const urls = [
+              ...orderedHostnames.map((h) => `https://${h}`),
+              ...(workersDevUrl ? [workersDevUrl] : []),
             ];
             const crons = yield* getWorkerCrons(workerName);
             yield* Effect.logInfo(
@@ -1990,18 +1999,12 @@ export const LiveWorkerProvider = () =>
               workerId: workerName,
               workerName,
               logpush: settings.logpush ?? undefined,
-              url: subdomain.enabled
-                ? `https://${workerName}.${yield* getAccountSubdomain(accountId)}.workers.dev`
-                : undefined,
+              url: urls[0],
               tags: settings.tags ?? undefined,
               durableObjectNamespaces: getDurableObjectNamespaces(
                 settings.bindings,
               ),
-              domains: orderedDomains.flatMap((d) =>
-                d.id && d.hostname && d.zoneId
-                  ? [{ id: d.id, hostname: d.hostname, zoneId: d.zoneId }]
-                  : [],
-              ),
+              urls,
               crons,
             } satisfies Worker["Attributes"];
 
@@ -2086,13 +2089,30 @@ export const LiveWorkerProvider = () =>
           yield* Effect.logInfo(
             `Cloudflare Worker delete: deleting ${output.workerName}`,
           );
-          if (output.domains?.length) {
+          // Look up live domain IDs rather than trusting persisted state.
+          // We no longer track `{ id, zoneId }` on the output; fetching
+          // straight from Cloudflare handles both the normal case and
+          // adopted workers whose domains we never recorded.
+          const liveDomains = yield* listDomains({
+            accountId: output.accountId,
+            service: output.workerName,
+          }).pipe(
+            Effect.map((r) => r.result ?? []),
+            Effect.catch(() => Effect.succeed([])),
+          );
+          if (liveDomains.length) {
             yield* Effect.all(
-              output.domains.map((d) =>
-                deleteDomain({
-                  accountId: output.accountId,
-                  domainId: d.id,
-                }).pipe(Effect.catchTag("DomainNotFound", () => Effect.void)),
+              liveDomains.flatMap((d) =>
+                d.id
+                  ? [
+                      deleteDomain({
+                        accountId: output.accountId,
+                        domainId: d.id,
+                      }).pipe(
+                        Effect.catchTag("DomainNotFound", () => Effect.void),
+                      ),
+                    ]
+                  : [],
               ),
               { concurrency: "unbounded" },
             );

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -716,6 +716,96 @@ describe.concurrent("Cloudflare.Worker", () => {
       }).pipe(logLevel),
   );
 
+  // `urls` should reflect the workers.dev URL when the subdomain is
+  // enabled and be empty when it isn't. `worker.url` is just `urls[0]`,
+  // so the two must stay in lockstep across deploys.
+  test.provider(
+    "urls reflects the workers.dev subdomain and tracks url",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        const deploy = (url: boolean) =>
+          stack.deploy(
+            Effect.gen(function* () {
+              return yield* Cloudflare.Worker("UrlsWorker", {
+                main,
+                url,
+                compatibility: { date: "2024-01-01" },
+              });
+            }),
+          );
+
+        const enabled = yield* deploy(true);
+        expect(enabled.urls).toHaveLength(1);
+        expect(enabled.urls[0]).toMatch(/\.workers\.dev$/);
+        expect(enabled.url).toEqual(enabled.urls[0]);
+
+        const disabled = yield* deploy(false);
+        expect(disabled.urls).toEqual([]);
+        expect(disabled.url).toBeUndefined();
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(enabled.workerName, accountId);
+      }).pipe(logLevel),
+  );
+
+  // When custom domains are attached, they come first in `urls` (in the
+  // order the user provided them), followed by the workers.dev URL when
+  // the subdomain is enabled. `worker.url` is `urls[0]`, so the custom
+  // domain wins.
+  const customDomainZone = process.env.CLOUDFLARE_TEST_WORKER_DOMAIN_ZONE_NAME;
+  test.provider.skipIf(!customDomainZone)(
+    "urls puts custom domains before workers.dev and url is the first",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* CloudflareEnvironment;
+        const suffix = process.env.PULL_REQUEST ?? process.env.USER ?? "local";
+        const domainA = `alchemy-worker-a-${suffix}.${customDomainZone}`;
+        const domainB = `alchemy-worker-b-${suffix}.${customDomainZone}`;
+
+        yield* stack.destroy();
+
+        const worker = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Worker("CustomDomainWorker", {
+              main,
+              domain: [domainA, domainB],
+              compatibility: { date: "2024-01-01" },
+            });
+          }),
+        );
+
+        expect(worker.urls.slice(0, 2)).toEqual([
+          `https://${domainA}`,
+          `https://${domainB}`,
+        ]);
+        expect(worker.urls[2]).toMatch(/\.workers\.dev$/);
+        expect(worker.url).toEqual(`https://${domainA}`);
+
+        // Reorder — `urls[0]` should follow.
+        const swapped = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Worker("CustomDomainWorker", {
+              main,
+              domain: [domainB, domainA],
+              compatibility: { date: "2024-01-01" },
+            });
+          }),
+        );
+        expect(swapped.urls.slice(0, 2)).toEqual([
+          `https://${domainB}`,
+          `https://${domainA}`,
+        ]);
+        expect(swapped.url).toEqual(`https://${domainB}`);
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(worker.workerName, accountId);
+      }).pipe(logLevel),
+  );
+
   // Cloudflare supports `json` env bindings — number, boolean, array,
   // object — that arrive in the worker as the parsed JS value rather
   // than a string. Redacted strings still go via `secret_text`.

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -716,11 +716,11 @@ describe.concurrent("Cloudflare.Worker", () => {
       }).pipe(logLevel),
   );
 
-  // `urls` should reflect the workers.dev URL when the subdomain is
-  // enabled and be empty when it isn't. `worker.url` is just `urls[0]`,
+  // `domains` should reflect the workers.dev URL when the subdomain is
+  // enabled and be empty when it isn't. `worker.url` is just `domains[0]`,
   // so the two must stay in lockstep across deploys.
   test.provider(
-    "urls reflects the workers.dev subdomain and tracks url",
+    "domains reflects the workers.dev subdomain and tracks url",
     (stack) =>
       Effect.gen(function* () {
         const { accountId } = yield* CloudflareEnvironment;
@@ -730,7 +730,7 @@ describe.concurrent("Cloudflare.Worker", () => {
         const deploy = (url: boolean) =>
           stack.deploy(
             Effect.gen(function* () {
-              return yield* Cloudflare.Worker("UrlsWorker", {
+              return yield* Cloudflare.Worker("DomainsWorker", {
                 main,
                 url,
                 compatibility: { date: "2024-01-01" },
@@ -739,12 +739,12 @@ describe.concurrent("Cloudflare.Worker", () => {
           );
 
         const enabled = yield* deploy(true);
-        expect(enabled.urls).toHaveLength(1);
-        expect(enabled.urls[0]).toMatch(/\.workers\.dev$/);
-        expect(enabled.url).toEqual(enabled.urls[0]);
+        expect(enabled.domains).toHaveLength(1);
+        expect(enabled.domains[0]).toMatch(/\.workers\.dev$/);
+        expect(enabled.url).toEqual(enabled.domains[0]);
 
         const disabled = yield* deploy(false);
-        expect(disabled.urls).toEqual([]);
+        expect(disabled.domains).toEqual([]);
         expect(disabled.url).toBeUndefined();
 
         yield* stack.destroy();
@@ -752,13 +752,13 @@ describe.concurrent("Cloudflare.Worker", () => {
       }).pipe(logLevel),
   );
 
-  // When custom domains are attached, they come first in `urls` (in the
-  // order the user provided them), followed by the workers.dev URL when
-  // the subdomain is enabled. `worker.url` is `urls[0]`, so the custom
-  // domain wins.
+  // When custom domains are attached, they come first in `domains` (in
+  // the order the user provided them), followed by the workers.dev URL
+  // when the subdomain is enabled. `worker.url` is `domains[0]`, so the
+  // custom domain wins.
   const customDomainZone = process.env.CLOUDFLARE_TEST_WORKER_DOMAIN_ZONE_NAME;
   test.provider.skipIf(!customDomainZone)(
-    "urls puts custom domains before workers.dev and url is the first",
+    "domains puts custom domains before workers.dev and url is the first",
     (stack) =>
       Effect.gen(function* () {
         const { accountId } = yield* CloudflareEnvironment;
@@ -778,14 +778,14 @@ describe.concurrent("Cloudflare.Worker", () => {
           }),
         );
 
-        expect(worker.urls.slice(0, 2)).toEqual([
+        expect(worker.domains.slice(0, 2)).toEqual([
           `https://${domainA}`,
           `https://${domainB}`,
         ]);
-        expect(worker.urls[2]).toMatch(/\.workers\.dev$/);
+        expect(worker.domains[2]).toMatch(/\.workers\.dev$/);
         expect(worker.url).toEqual(`https://${domainA}`);
 
-        // Reorder — `urls[0]` should follow.
+        // Reorder — `domains[0]` should follow.
         const swapped = yield* stack.deploy(
           Effect.gen(function* () {
             return yield* Cloudflare.Worker("CustomDomainWorker", {
@@ -795,7 +795,7 @@ describe.concurrent("Cloudflare.Worker", () => {
             });
           }),
         );
-        expect(swapped.urls.slice(0, 2)).toEqual([
+        expect(swapped.domains.slice(0, 2)).toEqual([
           `https://${domainB}`,
           `https://${domainA}`,
         ]);


### PR DESCRIPTION
`domains` property on worker comes from a cloudflare api call, prior to this pr that means the order wasn't deterministic.

people do things like this:
```ts
  const worker = yield* SolZeroWorker
  const url = Output.map(Output.all(worker.domains, worker.url), ([domains, workerUrl]) => {
    const primaryDomain = domains[0]
    return primaryDomain ? `https://${primaryDomain.hostname}` : workerUrl
  })
```

which can produce different results based on cf outputs.

now we sort domains to mirror the input order and include other domain (just as the workers.dev url).

Worker.url now tries to infer the first value in domains as the canonical url