### PR TITLE
docs(blog): beta.43 release notes leading with PlanetScale

### DIFF
--- a/website/src/content/docs/blog/2026-05-09-beta-36.md
+++ b/website/src/content/docs/blog/2026-05-09-beta-36.md
@@ -130,7 +130,7 @@ export default class Api extends Cloudflare.Worker<Api>()(
 — *Thanks to **Baptiste Arnaud**
 ([#282](https://github.com/alchemy-run/alchemy-effect/pull/282))
 for the contribution.*
-[Tutorial › Neon + Hyperdrive](/tutorial/cloudflare/neon-hyperdrive)
+[Tutorial › Hyperdrive](/tutorial/cloudflare/hyperdrive)
 
 ## R2 lifecycle rules
 

--- a/website/src/content/docs/blog/2026-05-21-beta-43.md
+++ b/website/src/content/docs/blog/2026-05-21-beta-43.md
@@ -1,0 +1,271 @@
+---
+title: alchemy@2.0.0-beta.43
+date: 2026-05-21T22:00:00Z
+category: release
+excerpt: PlanetScale lands as a first-class provider — MySQL and Postgres clusters, branches, credentials, and a Drizzle workflow that snaps straight into Cloudflare Hyperdrive. Plus a small but load-bearing change to how Infrastructure Layers thread `WorkerEnvironment`.
+---
+
+The headline of `v2.0.0-beta.43` is **PlanetScale**. The new
+`alchemy/Planetscale` provider gives you typed `MySQLDatabase`
+and `PostgresDatabase` resources, branches, credentials, and a
+Drizzle integration that plugs straight into Cloudflare
+Hyperdrive — the same way every other Alchemy provider plugs
+into the rest of the graph. ([#113](https://github.com/alchemy-run/alchemy-effect/pull/113))
+
+We'll walk it end-to-end against Postgres. The MySQL deltas are
+noted along the way — the shape is one-for-one.
+
+| MySQL                       | Postgres                       |
+| --------------------------- | ------------------------------ |
+| `Planetscale.MySQLDatabase` | `Planetscale.PostgresDatabase` |
+| `Planetscale.MySQLBranch`   | `Planetscale.PostgresBranch`   |
+| `Planetscale.MySQLPassword` | `Planetscale.PostgresRole`     |
+
+## Register the provider
+
+Add `Planetscale.providers()` to your stack. This registers the
+deploy-time policy bindings and an auth step that, on next
+`bun alchemy login`, either reads `PLANETSCALE_API_TOKEN_ID`,
+`PLANETSCALE_API_TOKEN`, and `PLANETSCALE_ORGANIZATION` from the
+environment or stores them under
+`~/.alchemy/credentials/<profile>/planetscale-stored.json`.
+
+```diff lang="typescript"
+ // alchemy.run.ts
+ import * as Alchemy from "alchemy";
+ import * as Cloudflare from "alchemy/Cloudflare";
++import * as Planetscale from "alchemy/Planetscale";
++import * as Layer from "effect/Layer";
+
+ export default Alchemy.Stack("App", {
+-  providers: Cloudflare.providers(),
++  providers: Layer.mergeAll(
++    Cloudflare.providers(),
++    Planetscale.providers(),
++  ),
+   state: Alchemy.localState(),
+ }, /* ... */);
+```
+
+## Cluster → branch → role
+
+The three database resources mirror PlanetScale's own model: the
+**cluster** owns storage and region, **branches** are cheap
+forks per environment, and **roles** mint credentials against a
+branch.
+
+```typescript
+// src/Db.ts
+import * as Planetscale from "alchemy/Planetscale";
+import * as Effect from "effect/Effect";
+
+export const Db = Effect.gen(function* () {
+  const database = yield* Planetscale.PostgresDatabase("app-db", {
+    region: { slug: "us-east" },
+    clusterSize: "PS_10",
+  });
+
+  const branch = yield* Planetscale.PostgresBranch("app-branch", {
+    database,
+  });
+
+  const role = yield* Planetscale.PostgresRole("app-role", {
+    database,
+    branch,
+    inheritedRoles: ["postgres"],
+  });
+
+  return { database, branch, role };
+});
+```
+
+A few things worth knowing:
+
+- `region` and `arch` on the database are stable — changing
+  either replaces the cluster. `clusterSize` resizes in place.
+- For MySQL, swap to `MySQLDatabase` / `MySQLBranch` /
+  `MySQLPassword`. Branches take one extra flag,
+  `isProduction: true | false`, and the password takes
+  `role: "reader" | "writer" | "admin" | "readwriter"`.
+- `role.password` is `Redacted` end-to-end — never in plan
+  output, state files, or serialised events.
+
+The role exposes an `origin` shaped exactly like what
+`Cloudflare.Hyperdrive` accepts:
+
+```typescript
+role.origin: {
+  scheme: "postgres" | "postgresql";
+  host: string;
+  port: number;
+  database: string;
+  user: string;
+  password: Redacted.Redacted<string>;
+};
+```
+
+## Snap Hyperdrive on top
+
+Because `role.origin` is an `Output`, the deploy graph orders
+itself: `PostgresDatabase` → `PostgresBranch` → `PostgresRole` →
+`Hyperdrive` → `Worker`. No `dependsOn`, no `await` — the graph
+follows the dataflow.
+
+```typescript
+import * as Cloudflare from "alchemy/Cloudflare";
+
+export const Hyperdrive = Effect.gen(function* () {
+  const { role } = yield* Db;
+  return yield* Cloudflare.Hyperdrive("app-hyperdrive", {
+    origin: role.origin,
+  });
+});
+```
+
+For MySQL, pass `password.origin`; Hyperdrive sees
+`scheme: "mysql"` and provisions a MySQL pooler.
+
+## Drizzle on Hyperdrive
+
+`Cloudflare.Hyperdrive.bind(Hyperdrive)` returns a binding whose
+`connectionString` resolves at runtime to a `Redacted` pooled
+endpoint. The new `Drizzle.postgres` helper takes that
+connection string and returns a chainable proxy over
+`EffectPgDatabase` — every method builds an Effect, so
+`db.select().from(Users)` is just `yield*`-able, errors land on
+the error channel, and the pool lives in an isolated never-closing
+`Scope` (one pool per JS realm, shared across requests).
+
+```typescript
+// src/Api.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Drizzle from "alchemy/Drizzle";
+import * as Effect from "effect/Effect";
+import { relations, Users } from "./schema.ts";
+import { Hyperdrive } from "./Db.ts";
+
+export default class Api extends Cloudflare.Worker<Api>()(
+  "Api",
+  { main: import.meta.filename },
+  Effect.gen(function* () {
+    const conn = yield* Cloudflare.Hyperdrive.bind(Hyperdrive);
+    const db = yield* Drizzle.postgres(conn.connectionString, { relations });
+
+    return {
+      fetch: Effect.gen(function* () {
+        const users = yield* db.select().from(Users);
+        return yield* HttpServerResponse.json({ users });
+      }),
+    };
+  }).pipe(Effect.provide(Cloudflare.HyperdriveBindingLive)),
+) {}
+```
+
+(For MySQL there's no `Drizzle.mysql` helper yet — pair with
+`mysql2` directly inside `fetch`.)
+
+## Migrations as a resource
+
+`Drizzle.Schema` wraps drizzle-kit's programmatic API as an
+Alchemy resource. On each deploy it diffs `./src/schema.ts`
+against the latest snapshot and, if it drifted, writes a new
+migration directory. Wire its `out` into the branch's
+`migrationsDir` and the branch scans the directory and applies
+new SQL files transactionally — schema → migration files →
+applied migrations, in one deploy.
+
+```diff lang="typescript"
+ export const Db = Effect.gen(function* () {
++  const schema = yield* Drizzle.Schema("app-schema", {
++    schema: "./src/schema.ts",
++    out: "./migrations",
++  });
+
+   const database = yield* Planetscale.PostgresDatabase("app-db", { /* ... */ });
+
+   const branch = yield* Planetscale.PostgresBranch("app-branch", {
+     database,
++    migrationsDir: schema.out,
+   });
+   // role / hyperdrive unchanged
+ });
+```
+
+Don't forget to add `Drizzle.providers()` alongside
+`Planetscale.providers()` in the stack.
+
+## `.ref()` — fork from a centralised staging database
+
+The walkthrough so far creates a fresh `PostgresDatabase` for
+every stage. That's right for `dev_<user>` and `prod`, but wrong
+for PR previews — spinning up a new Postgres cluster per PR is
+slow, expensive, and out of step with how PlanetScale itself
+thinks about branching.
+
+beta.43 ships `Resource.ref()` on every resource type. It reads
+output attributes from another stage's state instead of
+provisioning, returns a handle of the same type, and is
+indistinguishable from the owned resource to anything
+downstream. Combined with a two-tier stage layout —
+`staging-*` owns long-lived databases, `pr-*` owns ephemeral
+compute — the fork point collapses into one ternary:
+
+```diff lang="typescript"
+ export const Db = Effect.gen(function* () {
++  const { stage } = yield* Alchemy.Stack;
+
+-  const database = yield* Planetscale.PostgresDatabase("app-db", {
+-    region: { slug: "us-east" },
+-    clusterSize: "PS_10",
+-  });
++  const database = stage.startsWith("pr-")
++    ? yield* Planetscale.PostgresDatabase.ref("app-db", {
++        stage: `staging-${stage}`,
++      })
++    : yield* Planetscale.PostgresDatabase("app-db", {
++        region: { slug: "us-east" },
++        clusterSize: "PS_10",
++      });
+   // branch / role / hyperdrive stay the same
+ });
+```
+
+When `pr-123` deploys, `staging-pr-123` has already run and
+owns the cluster; `pr-123` references it and provisions only
+its own branch, role, Hyperdrive, and Worker. Tear-down on PR
+close drops the per-PR resources without touching the cluster.
+Same code, three deployment topologies.
+
+## Also in this release
+
+A smaller but load-bearing change: **Infrastructure Layers no
+longer leak `WorkerEnvironment`**. Every binding API method
+(`kv.get`, `db.prepare(...).first()`, `Hyperdrive.bind`) used
+to return an `Effect` whose `R` channel carried
+`WorkerEnvironment`, which propagated up through every Layer
+that wrapped it. `WorkerEnvironment` is now resolved once
+inside each `*BindingLive` Layer and closed over, leaving only
+`Alchemy.RuntimeContext` — the cloud-agnostic color for "runs
+inside a deployed Function or Worker" — in the requirement
+channel.
+
+```diff lang="typescript"
+-kv.get(key, "json"): Effect.Effect<Job | null, KVNamespaceError, WorkerEnvironment>
++kv.get(key, "json"): Effect.Effect<Job | null, KVNamespaceError, RuntimeContext>
+```
+
+A `JobService` wrapping KV can now expose
+`Effect<Job, _, RuntimeContext>` to consumers without
+mentioning Cloudflare at all. Full write-up:
+[**Layers — infrastructure behind a typed interface**](/blog/2026-05-21-infrastructure-layers).
+([#383](https://github.com/alchemy-run/alchemy-effect/pull/383),
+[#386](https://github.com/alchemy-run/alchemy-effect/pull/386))
+
+## Where to go next
+
+- [Hyperdrive tutorial](/tutorial/cloudflare/neon-hyperdrive) — PlanetScale Postgres and MySQL tabs alongside Neon
+- [Drizzle tutorial](/tutorial/cloudflare/drizzle) — `Drizzle.Schema` and deploy-driven migrations
+- [Branch from a shared database](/tutorial/cloudflare/branch-from-shared-database) — `.ref()` as a guided tutorial
+- [PlanetScale Postgres + Drizzle example](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-planetscale-postgres-drizzle)
+- [PlanetScale MySQL + Drizzle example](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-planetscale-mysql-drizzle)
+- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md) · [v2.0.0-beta.42 → v2.0.0-beta.43](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.42...v2.0.0-beta.43)

--- a/website/src/content/docs/blog/2026-05-21-beta-43.md
+++ b/website/src/content/docs/blog/2026-05-21-beta-43.md
@@ -256,14 +256,13 @@ channel.
 
 A `JobService` wrapping KV can now expose
 `Effect<Job, _, RuntimeContext>` to consumers without
-mentioning Cloudflare at all. Full write-up:
-[**Layers — infrastructure behind a typed interface**](/blog/2026-05-21-infrastructure-layers).
+mentioning Cloudflare at all.
 ([#383](https://github.com/alchemy-run/alchemy-effect/pull/383),
 [#386](https://github.com/alchemy-run/alchemy-effect/pull/386))
 
 ## Where to go next
 
-- [Hyperdrive tutorial](/tutorial/cloudflare/neon-hyperdrive) — PlanetScale Postgres and MySQL tabs alongside Neon
+- [Hyperdrive tutorial](/tutorial/cloudflare/hyperdrive) — PlanetScale Postgres and MySQL tabs alongside Neon
 - [Drizzle tutorial](/tutorial/cloudflare/drizzle) — `Drizzle.Schema` and deploy-driven migrations
 - [Branch from a shared database](/tutorial/cloudflare/branch-from-shared-database) — `.ref()` as a guided tutorial
 - [PlanetScale Postgres + Drizzle example](https://github.com/alchemy-run/alchemy-effect/tree/main/examples/cloudflare-planetscale-postgres-drizzle)

--- a/website/src/content/docs/blog/2026-05-21-beta-43.md
+++ b/website/src/content/docs/blog/2026-05-21-beta-43.md
@@ -2,15 +2,19 @@
 title: alchemy@2.0.0-beta.43
 date: 2026-05-21T22:00:00Z
 category: release
-excerpt: PlanetScale lands as a first-class provider — MySQL and Postgres clusters, branches, credentials, and a Drizzle workflow that snaps straight into Cloudflare Hyperdrive. Plus a small but load-bearing change to how Infrastructure Layers thread `WorkerEnvironment`.
+excerpt: v2.0.0-beta.43 includes a new `alchemy/Planetscale` provider, improvements to how Resources and Bindings are encapsulated in Layers, and a handful of other fixes.
 ---
 
-The headline of `v2.0.0-beta.43` is **PlanetScale**. The new
-`alchemy/Planetscale` provider gives you typed `MySQLDatabase`
-and `PostgresDatabase` resources, branches, credentials, and a
+`v2.0.0-beta.43` includes a new `alchemy/Planetscale` provider,
+improvements to how Resources and Bindings are encapsulated in
+Layers, and a handful of other fixes.
+
+The headline is **PlanetScale** — typed `MySQLDatabase` and
+`PostgresDatabase` resources, branches, credentials, and a
 Drizzle integration that plugs straight into Cloudflare
-Hyperdrive — the same way every other Alchemy provider plugs
-into the rest of the graph. ([#113](https://github.com/alchemy-run/alchemy-effect/pull/113))
+Hyperdrive, the same way every other Alchemy provider plugs
+into the rest of the graph.
+([#113](https://github.com/alchemy-run/alchemy-effect/pull/113))
 
 We'll walk it end-to-end against Postgres. The MySQL deltas are
 noted along the way — the shape is one-for-one.
@@ -87,22 +91,9 @@ A few things worth knowing:
   `MySQLPassword`. Branches take one extra flag,
   `isProduction: true | false`, and the password takes
   `role: "reader" | "writer" | "admin" | "readwriter"`.
-- `role.password` is `Redacted` end-to-end — never in plan
-  output, state files, or serialised events.
 
 The role exposes an `origin` shaped exactly like what
-`Cloudflare.Hyperdrive` accepts:
-
-```typescript
-role.origin: {
-  scheme: "postgres" | "postgresql";
-  host: string;
-  port: number;
-  database: string;
-  user: string;
-  password: Redacted.Redacted<string>;
-};
-```
+`Cloudflare.Hyperdrive` accepts as input.
 
 ## Snap Hyperdrive on top
 
@@ -130,35 +121,33 @@ For MySQL, pass `password.origin`; Hyperdrive sees
 `Cloudflare.Hyperdrive.bind(Hyperdrive)` returns a binding whose
 `connectionString` resolves at runtime to a `Redacted` pooled
 endpoint. The new `Drizzle.postgres` helper takes that
-connection string and returns a chainable proxy over
-`EffectPgDatabase` — every method builds an Effect, so
-`db.select().from(Users)` is just `yield*`-able, errors land on
-the error channel, and the pool lives in an isolated never-closing
-`Scope` (one pool per JS realm, shared across requests).
+connection string and gives you an Effect-native Drizzle client
+— queries are `yield*`-able and errors land on the Effect error
+channel.
 
-```typescript
-// src/Api.ts
-import * as Cloudflare from "alchemy/Cloudflare";
-import * as Drizzle from "alchemy/Drizzle";
-import * as Effect from "effect/Effect";
-import { relations, Users } from "./schema.ts";
-import { Hyperdrive } from "./Db.ts";
+```diff lang="typescript"
+ // src/Api.ts
+ import * as Cloudflare from "alchemy/Cloudflare";
++import * as Drizzle from "alchemy/Drizzle";
+ import * as Effect from "effect/Effect";
++import { relations, Users } from "./schema.ts";
+ import { Hyperdrive } from "./Db.ts";
 
-export default class Api extends Cloudflare.Worker<Api>()(
-  "Api",
-  { main: import.meta.filename },
-  Effect.gen(function* () {
-    const conn = yield* Cloudflare.Hyperdrive.bind(Hyperdrive);
-    const db = yield* Drizzle.postgres(conn.connectionString, { relations });
+ export default class Api extends Cloudflare.Worker<Api>()(
+   "Api",
+   { main: import.meta.filename },
+   Effect.gen(function* () {
+     const conn = yield* Cloudflare.Hyperdrive.bind(Hyperdrive);
++    const db = yield* Drizzle.postgres(conn.connectionString, { relations });
 
-    return {
-      fetch: Effect.gen(function* () {
-        const users = yield* db.select().from(Users);
-        return yield* HttpServerResponse.json({ users });
-      }),
-    };
-  }).pipe(Effect.provide(Cloudflare.HyperdriveBindingLive)),
-) {}
+     return {
+       fetch: Effect.gen(function* () {
++        const users = yield* db.select().from(Users);
+         return yield* HttpServerResponse.json({ users });
+       }),
+     };
+   }).pipe(Effect.provide(Cloudflare.HyperdriveBindingLive)),
+ ) {}
 ```
 
 (For MySQL there's no `Drizzle.mysql` helper yet — pair with
@@ -256,7 +245,9 @@ channel.
 
 A `JobService` wrapping KV can now expose
 `Effect<Job, _, RuntimeContext>` to consumers without
-mentioning Cloudflare at all.
+mentioning Cloudflare at all. See
+[Concepts › Layers](https://v2.alchemy.run/concepts/layers/) for
+the underlying model.
 ([#383](https://github.com/alchemy-run/alchemy-effect/pull/383),
 [#386](https://github.com/alchemy-run/alchemy-effect/pull/386))
 

--- a/website/src/content/docs/tutorial/cloudflare/branch-from-shared-database.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/branch-from-shared-database.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
-In the [Neon + Hyperdrive](/tutorial/cloudflare/neon-hyperdrive)
+In the [Hyperdrive](/tutorial/cloudflare/hyperdrive)
 tutorial you provisioned a `Neon.Project` and a `Neon.Branch`, then
 [Drizzle](/tutorial/cloudflare/drizzle) layered automatic
 migrations on top. Both work fine with a single stage — but the


### PR DESCRIPTION
## Summary
- Rewrites the beta.43 release post as a single PlanetScale-led narrative walkthrough — provider registration, cluster/branch/role, Hyperdrive on top, `Drizzle.postgres` on Hyperdrive, `Drizzle.Schema` migrations, and the `.ref()` pattern for PR previews.
- Infrastructure Layers / `WorkerEnvironment` change is demoted to a short "Also in this release" section that points at the existing deep-dive at `/blog/2026-05-21-infrastructure-layers`.
- MySQL is covered inline as deltas from Postgres rather than duplicated.

Replaces the closed PR #399, which split things into a stub release post plus two long deep-dives. This is a single release post with PlanetScale as the primary focus.

## Test plan
- [ ] `bun run build` in `website/` renders without broken-link warnings
- [ ] Visual check of `/blog/2026-05-21-beta-43` — code blocks, table, diff highlights
- [ ] Internal links resolve: `/blog/2026-05-21-infrastructure-layers`, `/tutorial/cloudflare/neon-hyperdrive`, `/tutorial/cloudflare/drizzle`, `/tutorial/cloudflare/branch-from-shared-database`

🤖 Generated with [Claude Code](https://claude.com/claude-code)