### PR TITLE
feat(cloudflare): cross-script durable object binding

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectNamespace.ts
@@ -1,14 +1,18 @@
 import type * as cf from "@cloudflare/workers-types";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import type { HttpServerError } from "effect/unstable/http/HttpServerError";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import type { Dependencies } from "../../Dependencies.ts";
 import type { HttpEffect } from "../../Http.ts";
+import type { Input } from "../../Input.ts";
 import * as Output from "../../Output.ts";
 import { ALCHEMY_PHASE } from "../../Phase.ts";
 import type { PlatformServices } from "../../Platform.ts";
 import { effectClass, taggedFunction } from "../../Util/effect.ts";
+import { asEffect } from "../../Util/types.ts";
 import { DurableObjectState } from "./DurableObjectState.ts";
 import { makeRpcStub } from "./Rpc.ts";
 import { type DurableWebSocket } from "./WebSocket.ts";
@@ -112,6 +116,35 @@ export interface DurableObjectNamespaceClass extends Effect.Effect<
   never,
   DurableObjectNamespace
 > {
+  <Self, Shape>(): {
+    <Name extends string>(
+      name: Name,
+    ): Effect.Effect<DurableObjectNamespace<Self>, never, Worker | Self> & {
+      new (_: never): Shape & {
+        /** @internal */
+        "~alchemy/name": Name;
+      };
+      from(
+        scriptName: Input<string>,
+      ): Effect.Effect<DurableObjectNamespace<Self>, never, Worker>;
+      from<Req = never>(
+        worker:
+          | Dependencies<Self>
+          | Effect.Effect<Dependencies<Self>, never, Req>,
+      ): Effect.Effect<DurableObjectNamespace<Self>, never, Worker | Req>;
+      make<InitReq = never>(
+        impl: Effect.Effect<
+          Effect.Effect<Shape, never, DurableObjectServices>,
+          never,
+          InitReq
+        >,
+      ): Layer.Layer<
+        Self,
+        never,
+        Worker | Exclude<InitReq, DurableObjectServices>
+      >;
+    };
+  };
   <Self>(): {
     <Shape, InitReq = never>(
       name: string,
@@ -234,7 +267,7 @@ export class DurableObjectNamespaceScope extends Context.Service<
  * @example Modular Durable Object (class + .make() in one file)
  * ```typescript
  * // src/Counter.ts
- * export default class Counter extends Cloudflare.DurableObjectNamespace<Counter>()(
+ * export class Counter extends Cloudflare.DurableObjectNamespace<Counter>()(
  *   "Counter",
  * ) {}
  *
@@ -277,6 +310,115 @@ export class DurableObjectNamespaceScope extends Context.Service<
  *     return HttpServerResponse.text(String(yield* counter.get()));
  *   }),
  * };
+ * ```
+ *
+ * @section Cross-Worker Binding
+ * A Durable Object is _hosted_ by exactly one Worker, but any
+ * number of other Workers can bind to the same DO. This is how
+ * you share state across Workers: one Worker hosts the DO, every
+ * other Worker addresses it by `scriptName` and gets a typed stub.
+ *
+ * To make this type-safe, the **host Worker** must declare the DO
+ * as part of its public contract via the third type argument to
+ * `Cloudflare.Worker<Self, Bindings, Deps>()`. `Deps` is the set
+ * of DO classes (or other Workers) the script exposes for other
+ * scripts to bind to.
+ *
+ * @example Host Worker declares the DO in its contract
+ * ```typescript
+ * // workerA.ts — hosts Counter
+ * import { Counter, CounterLive } from "./object.ts";
+ *
+ * //                                       ^^^^^^^ declared as part of WorkerA's public contract
+ * export class WorkerA extends Cloudflare.Worker<WorkerA, {}, Counter>()(
+ *   "WorkerA",
+ *   { main: import.meta.filename },
+ * ) {}
+ *
+ * // WorkerA's Layer also provides the DO's Live implementation.
+ * export default WorkerA.make(
+ *   Effect.gen(function* () {
+ *     const counter = yield* Counter;
+ *     return { fetch: Effect.gen(function* () { ... }) };
+ *   }).pipe(Effect.provide(CounterLive)),
+ * );
+ * ```
+ *
+ * @example Consumer Worker binds the DO via `Counter.from(WorkerA)`
+ * ```typescript
+ * // workerB.ts — binds to the same Counter, hosted by WorkerA
+ * import { Counter } from "./object.ts";
+ * import { WorkerA } from "./workerA.ts";
+ *
+ * export default class WorkerB extends Cloudflare.Worker<WorkerB>()(
+ *   "WorkerB",
+ *   { main: import.meta.filename },
+ *   Effect.gen(function* () {
+ *     //              ^^^^^^^^^^^^ scriptName-bound stub of WorkerA's Counter
+ *     const counter = yield* Counter.from(WorkerA);
+ *     return {
+ *       fetch: Effect.gen(function* () {
+ *         const value = yield* counter.getByName("shared").get();
+ *         return HttpServerResponse.text(String(value));
+ *       }),
+ *     };
+ *   }),
+ * ) {}
+ * ```
+ *
+ * :::tip
+ * The `, Counter` in `Worker<WorkerA, {}, Counter>` is what makes
+ * `Counter.from(WorkerA)` type-check. You can still bind across
+ * scripts without it (the runtime works either way), but consumers
+ * will get a TypeScript error because `WorkerA` doesn't declare
+ * `Counter` as part of its public contract.
+ * :::
+ *
+ * Only the host Worker's Stack provides `CounterLive` — the
+ * consumer Worker just imports the `Counter` class as a typed
+ * identifier. Rolldown tree-shakes `CounterLive` (and its
+ * dependencies) out of WorkerB's bundle.
+ *
+ * @section Using `.from(Self)` Inside the Host
+ * Inside the host Worker, `yield* Counter` and
+ * `yield* Counter.from(Self)` resolve to the same local namespace.
+ * The `.from(Self)` form is preferred — especially in code that
+ * may be extracted into a reusable Layer — because it makes the
+ * scriptName explicit and lets the same Layer shape work whether
+ * the consumer is the host or another script.
+ *
+ * @example `Counter.from(WorkerA)` inside WorkerA itself
+ * ```typescript
+ * // workerA.ts — host uses `.from(Self)` instead of bare `yield* Counter`
+ * export default WorkerA.make(
+ *   Effect.gen(function* () {
+ *     const counter = yield* Counter.from(WorkerA); // same as `yield* Counter`
+ *     return { fetch: Effect.gen(function* () { ... }) };
+ *   }).pipe(Effect.provide(CounterLive)),
+ * );
+ * ```
+ *
+ * A Worker can also host its **own isolated** namespace this way.
+ * If a second host Worker declares `Counter` in its contract and
+ * provides `CounterLive`, the DO instances under that script are
+ * separate from the original host's — same class, two namespaces.
+ *
+ * @example Two hosts, two isolated namespaces
+ * ```typescript
+ * // workerC.ts — another host of Counter, isolated from WorkerA
+ * export class WorkerC extends Cloudflare.Worker<WorkerC, {}, Counter>()(
+ *   "WorkerC",
+ *   { main: import.meta.filename },
+ * ) {}
+ *
+ * export default WorkerC.make(
+ *   Effect.gen(function* () {
+ *     // .from(WorkerC) binds to WorkerC's own Counter namespace —
+ *     // writes here are NOT visible from WorkerA's Counter.
+ *     const counter = yield* Counter.from(WorkerC);
+ *     return { fetch: Effect.gen(function* () { ... }) };
+ *   }).pipe(Effect.provide(CounterLive)),
+ * );
  * ```
  *
  * @section RPC Methods
@@ -538,126 +680,189 @@ export class DurableObjectNamespaceScope extends Context.Service<
  * ```
  */
 export const DurableObjectNamespace: DurableObjectNamespaceClass =
-  taggedFunction(DurableObjectNamespaceScope, ((
-    ...args:
-      | []
-      | [name: string, props?: DurableObjectNamespaceProps]
-      | [
-          name: string,
-          impl: Effect.Effect<
-            Effect.Effect<
-              DurableObjectNamespace<any>,
-              never,
-              DurableObjectState
-            >
-          >,
-        ]
-  ) =>
-    args.length === 0
-      ? DurableObjectNamespace
-      : !Effect.isEffect(args[1])
-        ? ({
-            kind: TypeId,
-            name: args[0],
-            className: (args[1] as DurableObjectNamespaceProps | undefined)
-              ?.className,
-          } satisfies DurableObjectNamespaceLike<any>)
-        : effectClass(
-            Effect.gen(function* () {
-              const [namespace, impl] = args as any as [
-                name: string,
-                impl: Effect.Effect<
-                  Effect.Effect<DurableObjectShape, never, DurableObjectState>
-                >,
-              ];
-              const worker = yield* Worker;
+  taggedFunction(
+    DurableObjectNamespaceScope,
+    function (
+      ...args:
+        | []
+        | [
+            name: string,
+            props?: DurableObjectNamespaceProps,
+            // phantom argument
+            isClassForm?: true,
+          ]
+        | [
+            name: string,
+            impl: Effect.Effect<
+              Effect.Effect<
+                DurableObjectNamespace<any>,
+                never,
+                DurableObjectState
+              >
+            >,
+            // phantom argument
+            isClassForm?: true,
+          ]
+    ) {
+      if (args.length === 0) {
+        return (name: string, propsOrImpl?: any) =>
+          // @ts-expect-error
+          DurableObjectNamespace(name, propsOrImpl, true);
+      }
+      const namespace = args[0];
+      const isClassForm = args[2] === true;
+      const propsOrImpl = args[1];
+      const tag = Context.Service(namespace);
 
-              yield* worker.bind`${namespace}`({
-                // TODO(sam): automate class migrations, probably in the provider
-                bindings: [
-                  {
-                    type: "durable_object_namespace",
-                    name: namespace,
-                    className: namespace,
-                    // scriptName:
-                    //   binding.scriptName === props.workerName
-                    //     ? undefined
-                    //     : binding.scriptName,
-                    // environment: binding.environment,
-                    // namespaceId: binding.namespaceId,
-                  },
-                ],
-              });
+      const binding = (scriptName?: Input<string>) =>
+        Effect.gen(function* () {
+          const worker = yield* Worker;
 
-              const binding = yield* Effect.all([
-                WorkerEnvironment,
-                ALCHEMY_PHASE,
-              ]).pipe(
-                Effect.flatMap(([env, phase]) => {
-                  if (env === undefined || phase === "plan") {
-                    // should be fine to return undefined here (it is only undefined at plantime)
-                    return Effect.succeed(undefined);
-                  }
-                  const ns = env[namespace];
-                  if (!ns) {
-                    return Effect.die(
-                      new Error(
-                        `DurableObjectNamespace '${namespace}' not found`,
-                      ),
-                    );
-                  } else if (typeof ns.getByName === "function") {
-                    return Effect.succeed(ns);
-                  } else {
-                    return Effect.die(
-                      new Error(
-                        `DurableObjectNamespace '${namespace}' is not a DurableObjectNamespace`,
-                      ),
-                    );
-                  }
-                }),
-              );
-
-              const namespaceId = worker.durableObjectNamespaces.pipe(
-                Output.map(
-                  (durableObjectNamespaces) =>
-                    durableObjectNamespaces?.[namespace],
-                ),
-              );
-
-              const self = {
-                Type: TypeId,
-                LogicalId: namespace,
+          yield* worker.bind`${namespace}`({
+            // TODO(sam): automate class migrations, probably in the provider
+            bindings: [
+              {
+                type: "durable_object_namespace",
                 name: namespace,
-                namespaceId,
-                getByName: (name: string) =>
-                  makeRpcStub(binding.getByName(name)),
-                // newUniqueId: () => use((ns) => ns.newUniqueId()),
-                // idFromName: (name: string) => use((ns) => ns.idFromName(name)),
-                // idFromString: (id: string) => use((ns) => ns.idFromString(id)),
-                // get: (
-                //   id: cf.DurableObjectId,
-                //   options?: cf.DurableObjectNamespaceGetDurableObjectOptions,
-                // ) => use((ns) => makeRpcStub(ns.get(id, options))),
-                // jurisdiction: (jurisdiction: cf.DurableObjectJurisdiction) =>
-                //   use((ns) => ns.jurisdiction(jurisdiction) as any),
-              };
+                className: namespace,
+                scriptName,
+              },
+            ],
+          });
 
-              yield* worker.export(namespace, {
-                kind: "durableObject",
-                // initialize the object's constructor (apply infra dependencies)
-                constructor: yield* impl.pipe(
-                  Effect.provideService(
-                    DurableObjectNamespaceScope,
-                    self as any,
+          const binding = yield* Effect.all([
+            WorkerEnvironment,
+            ALCHEMY_PHASE,
+          ]).pipe(
+            Effect.flatMap(([env, phase]) => {
+              if (env === undefined || phase === "plan") {
+                // should be fine to return undefined here (it is only undefined at plantime)
+                return Effect.succeed(undefined);
+              }
+              const ns = env[namespace];
+              if (!ns) {
+                return Effect.die(
+                  new Error(`DurableObjectNamespace '${namespace}' not found`),
+                );
+              } else if (typeof ns.getByName === "function") {
+                return Effect.succeed(ns);
+              } else {
+                return Effect.die(
+                  new Error(
+                    `DurableObjectNamespace '${namespace}' is not a DurableObjectNamespace`,
                   ),
-                ),
-                // grab the object's infra dependencies so we can apply them when calling the instance's methods
-                services: yield* Effect.context<Effect.Services<typeof impl>>(),
-              } satisfies DurableObjectExport);
-
-              return self;
+                );
+              }
             }),
-          )) as any);
+          );
+
+          return {
+            Type: TypeId,
+            LogicalId: namespace,
+            name: namespace,
+            namespaceId: worker.durableObjectNamespaces.pipe(
+              Output.map(
+                (durableObjectNamespaces) =>
+                  durableObjectNamespaces?.[namespace],
+              ),
+            ),
+            getByName: (name: string) => makeRpcStub(binding.getByName(name)),
+            // newUniqueId: () => use((ns) => ns.newUniqueId()),
+            // idFromName: (name: string) => use((ns) => ns.idFromName(name)),
+            // idFromString: (id: string) => use((ns) => ns.idFromString(id)),
+            // get: (
+            //   id: cf.DurableObjectId,
+            //   options?: cf.DurableObjectNamespaceGetDurableObjectOptions,
+            // ) => use((ns) => makeRpcStub(ns.get(id, options))),
+            // jurisdiction: (jurisdiction: cf.DurableObjectJurisdiction) =>
+            //   use((ns) => ns.jurisdiction(jurisdiction) as any),
+          };
+        });
+
+      const make = Effect.fnUntraced(function* (
+        impl: Effect.Effect<
+          Effect.Effect<DurableObjectShape, never, DurableObjectState>
+        >,
+      ) {
+        // Register the local DO binding (no `scriptName`) and obtain the
+        // namespace handle. We provide this same handle as
+        // `DurableObjectNamespaceScope` to the user's constructor effect
+        // and also return it so a `Layer.effect(tag, make(impl))` Layer
+        // resolves the tag to a concrete namespace value.
+        const self = yield* binding();
+        yield* (yield* Worker).export(namespace, {
+          kind: "durableObject",
+          // initialize the object's constructor (apply infra dependencies)
+          constructor: yield* impl.pipe(
+            Effect.provideService(DurableObjectNamespaceScope, self as any),
+          ),
+          // grab the object's infra dependencies so we can apply them when calling the instance's methods
+          services: yield* Effect.context<Effect.Services<typeof impl>>(),
+        } satisfies DurableObjectExport);
+        return self;
+      });
+
+      if (!isClassForm && !Effect.isEffect(args[1])) {
+        // this is an in-line, async only DO (no implementation, props only)
+        return {
+          kind: TypeId,
+          name: namespace,
+          className:
+            (args[1] as DurableObjectNamespaceProps)?.className || namespace,
+        };
+      } else if (Effect.isEffect(propsOrImpl)) {
+        // inline Effect DO
+        return effectClass(
+          Effect.tap(binding(), () => make(propsOrImpl as any)),
+        );
+      } else {
+        // Tagged Effect DO. Yielding the class resolves the `tag`, which
+        // forces the `CounterLive` Layer (built by `Counter.make(impl)`) to
+        // run so `worker.export(namespace, …)` is invoked — without this,
+        // the class would never be registered with the Worker's exports
+        // map and the deployed bundle would have no DO class for
+        // Cloudflare to instantiate.
+        return class extends effectClass(
+          tag as Effect.Effect<any, never, any>,
+        ) {
+          static make = <Req = never>(
+            impl: Effect.Effect<
+              Effect.Effect<DurableObjectShape, never, DurableObjectState | Req>
+            >,
+          ) => Layer.effect(tag, make(impl as any));
+
+          static from = (
+            worker: string | Worker | Effect.Effect<Worker, any, any>,
+          ) => {
+            // Resolve `worker` to an Effect that yields the actual Worker
+            // instance (or a plain string scriptName).
+            //
+            // A class produced by `Cloudflare.Worker<T>()(...)` exposes
+            // `asEffect()` returning the Self tag — yielding that tag
+            // resolves to the live Worker instance whose `workerName`
+            // is a `PropExpr`, which is what we need so the engine can:
+            //   1) Track WorkerB → WorkerA as a binding-level upstream
+            //      dependency (so WorkerA reconciles first).
+            //   2) Persist `scriptName` as a real value (not `undefined`)
+            //      on the cross-script binding so the migration code in
+            //      Worker.ts can detect it and skip emitting class
+            //      migrations for the foreign class.
+            // Plain Effects and string literals are passed through as-is.
+            const resolved: Effect.Effect<Worker | string, any, any> =
+              typeof worker === "string"
+                ? Effect.succeed(worker)
+                : asEffect(worker);
+
+            return resolved.pipe(
+              Effect.flatMap((w) =>
+                binding(typeof w === "string" ? w : w.workerName),
+              ),
+            );
+          };
+        };
+      }
+    },
+  ) as any;
 
 export type DurableObjectStub<Shape> = {
   // TODO(sam): do we need to transform? hopefully not

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -245,7 +245,7 @@ export const LocalWorkerProvider = () =>
           hyperdrives,
           bundleOptions: {
             id,
-            main: props.main,
+            main: props.main!,
             compatibility,
             entry: props.isExternal
               ? { kind: "external" }

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -8,6 +8,7 @@ import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
+import * as crypto from "node:crypto";
 import { Unowned } from "../../AdoptPolicy.ts";
 import { AlchemyContext } from "../../AlchemyContext.ts";
 import * as Artifacts from "../../Artifacts.ts";
@@ -223,7 +224,19 @@ export interface WorkerProps<
    */
   observability?: WorkerObservability;
   tags?: string[];
-  main: string;
+  /**
+   * Path to the Worker's entry module. Bundled with rolldown before
+   * upload. Mutually exclusive with {@link script} — provide exactly one.
+   */
+  main?: string;
+  /**
+   * Raw module source for the Worker. When provided, bundling is bypassed
+   * entirely and this string is uploaded as a single ESM module
+   * (`main.js`). Useful for tiny inline workers (tests, fixtures,
+   * one-offs) and any case where you've already produced the final
+   * bundle elsewhere. Mutually exclusive with {@link main}.
+   */
+  script?: string;
   compatibility?: {
     date?: string;
     flags?: ("nodejs_compat" | "nodejs_als" | (string & {}))[];
@@ -1099,7 +1112,7 @@ export const LiveWorkerProvider = () =>
         bundler
           .build({
             id,
-            main: props.main,
+            main: props.main!,
             compatibility: getCompatibility(props),
             entry: props.isExternal
               ? {
@@ -1113,6 +1126,11 @@ export const LiveWorkerProvider = () =>
             extraOptions: props.build,
           })
           .pipe(Artifacts.cached("build"));
+
+      const hashScript = (script: string) =>
+        Effect.sync(() =>
+          crypto.createHash("sha256").update(script).digest("hex"),
+        );
 
       const viteBuild = Effect.fnUntraced(function* (props: WorkerProps) {
         const compatibility = getCompatibility(props);
@@ -1156,6 +1174,24 @@ export const LiveWorkerProvider = () =>
         opts: { skipAssetsRead?: boolean } = {},
       ) =>
         Effect.gen(function* () {
+          if (props.script !== undefined) {
+            const [assets, bundleHash] = yield* Effect.all(
+              [
+                opts.skipAssetsRead
+                  ? Effect.succeed(undefined)
+                  : prepareAssets(props.assets),
+                hashScript(props.script),
+              ],
+              { concurrency: "unbounded" },
+            );
+            return {
+              assets,
+              bundle: {
+                files: [{ path: "main.js", content: props.script }],
+                hash: bundleHash,
+              },
+            };
+          }
           if (props.vite) {
             const [{ assets, bundle }, input] = yield* Effect.all(
               [
@@ -1403,16 +1439,19 @@ export const LiveWorkerProvider = () =>
         }
 
         // Backward compatibility for old workers that have DO bindings but no
-        // alchemy:do tags yet.
+        // alchemy:do tags yet. Cross-script bindings (`scriptName` set to
+        // anything other than this worker) are NEVER candidates for
+        // delete-class migrations — the class lives on the foreign script
+        // and we don't own its lifecycle.
         if (Object.keys(oldDoClassNameByLogicalId).length === 0) {
           for (const oldBinding of oldBindings) {
+            const ownedLocally =
+              !("scriptName" in oldBinding) || oldBinding.scriptName === name;
             if (
               oldBinding.type === "durable_object_namespace" &&
               "className" in oldBinding &&
               oldBinding.className &&
-              (!("scriptName" in oldBinding) ||
-                !oldBinding.scriptName ||
-                oldBinding.scriptName === name) &&
+              ownedLocally &&
               !currentDoBindings.some(
                 (binding) => binding.bindingName === oldBinding.name,
               )
@@ -1641,6 +1680,25 @@ export const LiveWorkerProvider = () =>
         props: WorkerProps,
         output: Worker["Attributes"],
       ) {
+        if (props.script !== undefined) {
+          const scriptHash = yield* hashScript(props.script);
+          if (scriptHash !== output.hash?.bundle) {
+            return true;
+          }
+          if (!props.assets) {
+            return false;
+          }
+          const assetsHash =
+            typeof props.assets === "object" &&
+            "path" in props.assets &&
+            "hash" in props.assets
+              ? (props.assets.hash as string)
+              : undefined;
+          if (assetsHash === undefined) {
+            return true;
+          }
+          return assetsHash !== output.hash?.assets;
+        }
         if (props.vite) {
           const input = yield* hashDirectory({
             cwd: props.vite.rootDir,
@@ -2090,23 +2148,38 @@ function getDurableObjectBindings(
   bindings: ReadonlyArray<ResourceBinding>,
   workerName: string,
 ) {
+  // Resource authors (and the `make`/`yield* Tag`/plan-vs-apply machinery)
+  // can register the same DO binding multiple times under the same logical
+  // id — `binding()` is a plain `worker.bind` and intentionally has no
+  // dedup. Collapse duplicates here so each `(logicalId, bindingName,
+  // className)` tuple appears at most once. We also exclude cross-script
+  // references: a `scriptName` pointing to *another* worker means this
+  // worker just references a foreign class — ship the binding to
+  // Cloudflare, but don't drive class migrations for it.
+  const seen = new Set<string>();
   return bindings.flatMap((binding) =>
-    (binding.data.bindings ?? []).flatMap((item: WorkerBinding) =>
-      item.type === "durable_object_namespace" &&
-      "className" in item &&
-      item.className &&
-      (!("scriptName" in item) ||
-        !item.scriptName ||
-        item.scriptName === workerName)
-        ? [
-            {
-              logicalId: binding.sid,
-              bindingName: item.name,
-              className: item.className,
-            },
-          ]
-        : [],
-    ),
+    (binding.data.bindings ?? []).flatMap((item: WorkerBinding) => {
+      if (
+        item.type !== "durable_object_namespace" ||
+        !("className" in item) ||
+        !item.className
+      ) {
+        return [];
+      }
+      if (item.scriptName !== undefined && item.scriptName !== workerName) {
+        return [];
+      }
+      const dedupKey = `${binding.sid}::${item.name}::${item.className}`;
+      if (seen.has(dedupKey)) return [];
+      seen.add(dedupKey);
+      return [
+        {
+          logicalId: binding.sid,
+          bindingName: item.name,
+          className: item.className,
+        },
+      ];
+    }),
   );
 }
 

--- a/packages/alchemy/src/Dependencies.ts
+++ b/packages/alchemy/src/Dependencies.ts
@@ -1,0 +1,10 @@
+import type * as Types from "effect/Types";
+
+export interface Dependencies<A> {
+  /**
+   * Contravariant because it's checked as input to a function (E.g. Counter.from(WorkerA))
+   *
+   * @internal phantom type used to tag the dependencies of a resource
+   */
+  "~alchemy/dependencies": Types.Contravariant<A>;
+}

--- a/packages/alchemy/src/Platform.ts
+++ b/packages/alchemy/src/Platform.ts
@@ -7,6 +7,7 @@ import type { Scope } from "effect/Scope";
 import type { HttpClient } from "effect/unstable/http/HttpClient";
 import { SingleShotGen } from "effect/Utils";
 import type { PolicyLike } from "./Binding.ts";
+import type { Dependencies } from "./Dependencies.ts";
 import type { ExecutionContext } from "./ExecutionContext.ts";
 import type { HttpEffect } from "./Http.ts";
 import type { InputProps } from "./Input.ts";
@@ -65,16 +66,16 @@ export interface Platform<
   Type: Resource["Type"];
   Provider: Provider<Resource>;
 
-  <Self, Shape>(): {
+  <Self, Shape, Deps = never>(): {
     <PropsReq = never>(
       id: string,
       props:
         | InputProps<Resource["Props"]>
         | Effect.Effect<InputProps<Resource["Props"]>, never, PropsReq>,
     ): Effect.Effect<
-      Resource & Rpc<Self>,
+      Resource & Rpc<Self> & Dependencies<Deps>,
       never,
-      Self | Resource["Providers"] | PropsReq
+      Resource["Providers"] | PropsReq
     > & {
       make<InitReq = never>(
         impl: Effect.Effect<Shape, never, InitReq>,

--- a/packages/alchemy/src/Util/types.ts
+++ b/packages/alchemy/src/Util/types.ts
@@ -18,8 +18,15 @@ export const assertDefined = <T>(value: T | undefined, message: string): T => {
 };
 
 export const asEffect = <T, Err = never, Req = never>(
-  effect: T | Effect.Effect<T, Err, Req>,
+  effect:
+    | T
+    | Effect.Effect<T, Err, Req>
+    | { asEffect: () => Effect.Effect<T, Err, Req> },
 ): Effect.Effect<T, Err, Req> =>
-  Effect.isEffect(effect) ? effect : Effect.succeed(effect);
+  typeof (effect as any)?.asEffect === "function"
+    ? (effect as any).asEffect()
+    : Effect.isEffect(effect)
+      ? effect
+      : Effect.succeed(effect as T);
 
 export type IsNever<T> = [T] extends [never] ? true : false;

--- a/packages/alchemy/src/index.ts
+++ b/packages/alchemy/src/index.ts
@@ -45,6 +45,7 @@ export * as Construct from "./Construct.ts";
 // downstream `.d.ts` emissions (fixes TS2883 in user files).
 export { AuthProviders } from "./Auth/AuthProvider.ts";
 export { Cli } from "./Cli/Cli.ts";
+export type { Dependencies } from "./Dependencies.ts";
 export type * from "./Platform.ts";
 export { Platform } from "./Platform.ts";
 export type { ProviderCollectionLike } from "./Provider.ts";

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
@@ -43,3 +43,110 @@ test(
   }).pipe(logLevel),
   { timeout: 180_000 },
 );
+
+const fetchReady = (url: string) =>
+  Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient;
+    const res = yield* client.get(url).pipe(
+      Effect.flatMap((r) =>
+        r.status === 200
+          ? Effect.succeed(r)
+          : Effect.fail(new Error(`Worker not ready: ${r.status}`)),
+      ),
+      Effect.retry({
+        schedule: Schedule.exponential("500 millis"),
+        times: 15,
+      }),
+    );
+    return yield* res.text;
+  });
+
+// Walk an async worker through four redeploys against the same scratch state,
+// each one swapping in a new script + bindings shape so we exercise the
+// migration paths `putWorker` relies on:
+//   v1 — create with a single DO class `DO_A`
+//   v2 — rename `DO_A` → `DO_A_v2` (className change, same binding id)
+//   v3 — add a brand-new DO class `DO_B` alongside `DO_A_v2`
+//   v4 — delete `DO_A`, keep only `DO_B`
+test.provider(
+  "durable object class migrations across redeploys",
+  (scratch) =>
+    Effect.gen(function* () {
+      const v1 = yield* scratch.deploy(
+        Effect.gen(function* () {
+          return {
+            worker: yield* Cloudflare.Worker("worker", {
+              script: `import { DurableObject } from "cloudflare:workers";
+export class DO_A extends DurableObject {}
+export default { async fetch() { return new Response("v1"); } };
+`,
+              bindings: {
+                DO_A: Cloudflare.DurableObjectNamespace("DO_A"),
+              },
+            }),
+          };
+        }),
+      );
+      expect(yield* fetchReady(v1.worker.url!)).toBe("v1");
+
+      const v2 = yield* scratch.deploy(
+        Effect.gen(function* () {
+          return {
+            worker: yield* Cloudflare.Worker("worker", {
+              script: `import { DurableObject } from "cloudflare:workers";
+export class DO_A_v2 extends DurableObject {}
+export default { async fetch() { return new Response("v2"); } };
+`,
+              bindings: {
+                DO_A: Cloudflare.DurableObjectNamespace("DO_A", {
+                  className: "DO_A_v2",
+                }),
+              },
+            }),
+          };
+        }),
+      );
+      expect(yield* fetchReady(v2.worker.url!)).toBe("v2");
+
+      const v3 = yield* scratch.deploy(
+        Effect.gen(function* () {
+          return {
+            worker: yield* Cloudflare.Worker("worker", {
+              script: `import { DurableObject } from "cloudflare:workers";
+export class DO_A_v2 extends DurableObject {}
+export class DO_B extends DurableObject {}
+export default { async fetch() { return new Response("v3"); } };
+`,
+              bindings: {
+                DO_A: Cloudflare.DurableObjectNamespace("DO_A", {
+                  className: "DO_A_v2",
+                }),
+                DO_B: Cloudflare.DurableObjectNamespace("DO_B"),
+              },
+            }),
+          };
+        }),
+      );
+      expect(yield* fetchReady(v3.worker.url!)).toBe("v3");
+
+      const v4 = yield* scratch.deploy(
+        Effect.gen(function* () {
+          return {
+            worker: yield* Cloudflare.Worker("worker", {
+              script: `import { DurableObject } from "cloudflare:workers";
+export class DO_B extends DurableObject {}
+export default { async fetch() { return new Response("v4"); } };
+`,
+              bindings: {
+                DO_B: Cloudflare.DurableObjectNamespace("DO_B"),
+              },
+            }),
+          };
+        }),
+      );
+      expect(yield* fetchReady(v4.worker.url!)).toBe("v4");
+
+      yield* scratch.destroy();
+    }).pipe(logLevel),
+  { timeout: 300_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/TaggedDO.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/TaggedDO.test.ts
@@ -1,0 +1,233 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import type { HttpClientResponse } from "effect/unstable/http/HttpClientResponse";
+import Stack from "./fixtures/tagged-do/stack.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const stack = beforeAll(deploy(Stack));
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
+
+const testTimeout = 180_000;
+const requestTimeout = "5 seconds";
+// Fresh `*.workers.dev` URLs propagate through the edge over a few seconds —
+// the first requests routinely return 404 / 500 before the script is
+// resolvable. `Effect.retry` only fires on Effect failures, not on HTTP
+// status codes, so we explicitly `Effect.fail` non-2xx responses to force a
+// retry through `readinessRetry`.
+const readinessRetry = {
+  schedule: Schedule.exponential("500 millis"),
+  times: 15,
+} as const;
+
+const requestUntilReady = (
+  effect: Effect.Effect<HttpClientResponse, unknown, never>,
+) =>
+  effect.pipe(
+    Effect.timeout(requestTimeout),
+    Effect.flatMap(
+      Effect.fnUntraced(function* (res) {
+        return res.status >= 200 && res.status < 300
+          ? res
+          : yield* Effect.fail(
+              new Error(`Worker not ready: ${res.status} ${yield* res.text}`),
+            );
+      }),
+    ),
+    Effect.retry(readinessRetry),
+  );
+
+// Each test addresses its own DO instance via a unique counter key so the
+// tests are safe to run in parallel. The fixture Workers read this header
+// and forward it as the argument to `counter.getByName(key)`.
+const withCounterKey = (key: string) =>
+  HttpClient.mapRequest(HttpClientRequest.setHeader("x-counter-key", key));
+
+const reset = (url: string) =>
+  Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient;
+    yield* requestUntilReady(client.post(`${url}/reset`));
+  });
+
+test(
+  "D1 counter writes from WorkerA are visible from WorkerB (cross-script DO)",
+  Effect.gen(function* () {
+    const { urlA, urlB } = yield* stack;
+    const client = (yield* HttpClient.HttpClient).pipe(
+      withCounterKey("d1-cross"),
+    );
+
+    yield* reset(urlA).pipe(
+      Effect.provideService(HttpClient.HttpClient, client),
+    );
+    yield* reset(urlB).pipe(
+      Effect.provideService(HttpClient.HttpClient, client),
+    );
+
+    const first = yield* client
+      .post(`${urlA}/d1/increment`)
+      .pipe(Effect.timeout(requestTimeout), Effect.retry(readinessRetry));
+    expect(first.status).toBe(200);
+    expect((yield* first.json) as { value: number }).toEqual({ value: 1 });
+
+    const second = yield* client
+      .post(`${urlA}/d1/increment`)
+      .pipe(Effect.timeout(requestTimeout));
+    expect((yield* second.json) as { value: number }).toEqual({ value: 2 });
+
+    const fromB = yield* client
+      .get(`${urlB}/d1`)
+      .pipe(Effect.timeout(requestTimeout), Effect.retry(readinessRetry));
+    expect(fromB.status).toBe(200);
+    expect((yield* fromB.json) as { value: number }).toEqual({ value: 2 });
+  }).pipe(logLevel),
+  { timeout: testTimeout },
+);
+
+test(
+  "DO storage counter writes from WorkerA are visible from WorkerB (cross-script DO)",
+  Effect.gen(function* () {
+    const { urlA, urlB } = yield* stack;
+    const client = (yield* HttpClient.HttpClient).pipe(
+      withCounterKey("do-cross"),
+    );
+
+    yield* reset(urlA).pipe(
+      Effect.provideService(HttpClient.HttpClient, client),
+    );
+    yield* reset(urlB).pipe(
+      Effect.provideService(HttpClient.HttpClient, client),
+    );
+
+    const first = yield* client
+      .post(`${urlA}/do/increment`)
+      .pipe(Effect.timeout(requestTimeout), Effect.retry(readinessRetry));
+    expect(first.status).toBe(200);
+    expect((yield* first.json) as { value: number }).toEqual({ value: 1 });
+
+    const second = yield* client
+      .post(`${urlA}/do/increment`)
+      .pipe(Effect.timeout(requestTimeout));
+    expect((yield* second.json) as { value: number }).toEqual({ value: 2 });
+
+    const fromB = yield* client
+      .get(`${urlB}/do`)
+      .pipe(Effect.timeout(requestTimeout), Effect.retry(readinessRetry));
+    expect(fromB.status).toBe(200);
+    expect((yield* fromB.json) as { value: number }).toEqual({ value: 2 });
+  }).pipe(logLevel),
+  { timeout: testTimeout },
+);
+
+test(
+  "WorkerC hosts its own isolated Counter (writes from A/B are not visible from C)",
+  Effect.gen(function* () {
+    const { urlA, urlB, urlC } = yield* stack;
+    const client = (yield* HttpClient.HttpClient).pipe(
+      withCounterKey("isolation"),
+    );
+
+    yield* reset(urlA).pipe(
+      Effect.provideService(HttpClient.HttpClient, client),
+    );
+    yield* reset(urlB).pipe(
+      Effect.provideService(HttpClient.HttpClient, client),
+    );
+    yield* reset(urlC).pipe(
+      Effect.provideService(HttpClient.HttpClient, client),
+    );
+
+    // Increment via WorkerA and WorkerB (both route to WorkerA's hosted Counter).
+    yield* client
+      .post(`${urlA}/do/increment`)
+      .pipe(Effect.timeout(requestTimeout), Effect.retry(readinessRetry));
+    yield* client
+      .post(`${urlB}/do/increment`)
+      .pipe(Effect.timeout(requestTimeout));
+
+    const fromA = yield* client
+      .get(`${urlA}/do`)
+      .pipe(Effect.timeout(requestTimeout));
+    expect((yield* fromA.json) as { value: number }).toEqual({ value: 2 });
+
+    // WorkerC hosts its own Counter namespace via `Counter.from(WorkerC)`,
+    // so its DO instance has never been written to.
+    const fromC = yield* client
+      .get(`${urlC}/do`)
+      .pipe(Effect.timeout(requestTimeout), Effect.retry(readinessRetry));
+    expect((yield* fromC.json) as { value: number }).toEqual({ value: 0 });
+
+    // Writes through WorkerC do not leak back to WorkerA/B either.
+    yield* client
+      .post(`${urlC}/do/increment`)
+      .pipe(Effect.timeout(requestTimeout));
+    yield* client
+      .post(`${urlC}/do/increment`)
+      .pipe(Effect.timeout(requestTimeout));
+    yield* client
+      .post(`${urlC}/do/increment`)
+      .pipe(Effect.timeout(requestTimeout));
+
+    const cAfter = yield* client
+      .get(`${urlC}/do`)
+      .pipe(Effect.timeout(requestTimeout));
+    expect((yield* cAfter.json) as { value: number }).toEqual({ value: 3 });
+
+    const aAfter = yield* client
+      .get(`${urlA}/do`)
+      .pipe(Effect.timeout(requestTimeout));
+    expect((yield* aAfter.json) as { value: number }).toEqual({ value: 2 });
+  }).pipe(logLevel),
+  { timeout: testTimeout },
+);
+
+test(
+  "Writes from WorkerB are visible from WorkerA (bidirectional cross-script DO)",
+  Effect.gen(function* () {
+    const { urlA, urlB } = yield* stack;
+    const client = (yield* HttpClient.HttpClient).pipe(
+      withCounterKey("bidirectional"),
+    );
+
+    yield* reset(urlA).pipe(
+      Effect.provideService(HttpClient.HttpClient, client),
+    );
+    yield* reset(urlB).pipe(
+      Effect.provideService(HttpClient.HttpClient, client),
+    );
+
+    yield* client
+      .post(`${urlB}/d1/increment`)
+      .pipe(Effect.timeout(requestTimeout), Effect.retry(readinessRetry));
+    yield* client
+      .post(`${urlB}/d1/increment`)
+      .pipe(Effect.timeout(requestTimeout));
+    yield* client
+      .post(`${urlB}/do/increment`)
+      .pipe(Effect.timeout(requestTimeout));
+
+    const d1FromA = yield* client
+      .get(`${urlA}/d1`)
+      .pipe(Effect.timeout(requestTimeout));
+    const doFromA = yield* client
+      .get(`${urlA}/do`)
+      .pipe(Effect.timeout(requestTimeout));
+
+    expect((yield* d1FromA.json) as { value: number }).toEqual({ value: 2 });
+    expect((yield* doFromA.json) as { value: number }).toEqual({ value: 1 });
+  }).pipe(logLevel),
+  { timeout: testTimeout },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-do/object.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-do/object.ts
@@ -1,0 +1,84 @@
+import type { RuntimeContext } from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+
+export const MyDB = Cloudflare.D1Database("MyDB");
+
+const DO_COUNT_KEY = "do_count";
+
+// Tag — D1 RPC methods take an explicit row `key` so the shared D1 table
+// can be partitioned per-caller. The DO storage methods don't need one
+// because per-instance storage is already isolated by `getByName(name)`.
+export class Counter extends Cloudflare.DurableObjectNamespace<
+  Counter,
+  {
+    incrementD1: (key: string) => Effect.Effect<number, never, RuntimeContext>;
+    getD1: (key: string) => Effect.Effect<number, never, RuntimeContext>;
+    incrementDO: () => Effect.Effect<number, never, RuntimeContext>;
+    getDO: () => Effect.Effect<number, never, RuntimeContext>;
+    reset: (key: string) => Effect.Effect<void, never, RuntimeContext>;
+  }
+>()("Counter") {}
+
+// Layer
+export const CounterLive = Counter.make(
+  Effect.gen(function* () {
+    const db = yield* Cloudflare.D1Connection.bind(MyDB);
+
+    return Effect.gen(function* () {
+      const state = yield* Cloudflare.DurableObjectState;
+
+      // D1's `exec()` splits on newlines and rejects multi-line statements
+      // ("incomplete input: SQLITE_ERROR"). Keep the DDL on a single line.
+      yield* db.exec(
+        "CREATE TABLE IF NOT EXISTS d1_counters (id TEXT PRIMARY KEY, value INTEGER NOT NULL DEFAULT 0)",
+      );
+
+      const readD1 = (key: string) =>
+        db
+          .prepare("SELECT value FROM d1_counters WHERE id = ?")
+          .bind(key)
+          .first<{ value: number }>()
+          .pipe(Effect.map((row) => row?.value ?? 0));
+
+      const writeD1 = (key: string, value: number) =>
+        db
+          .prepare(
+            "INSERT INTO d1_counters (id, value) VALUES (?, ?) ON CONFLICT(id) DO UPDATE SET value = excluded.value",
+          )
+          .bind(key, value)
+          .run()
+          .pipe(Effect.asVoid);
+
+      const readDO = () =>
+        state.storage
+          .get<number>(DO_COUNT_KEY)
+          .pipe(Effect.map((value) => value ?? 0));
+
+      const writeDO = (value: number) =>
+        state.storage.put(DO_COUNT_KEY, value).pipe(Effect.asVoid);
+
+      return {
+        incrementD1: (key: string) =>
+          Effect.gen(function* () {
+            const next = (yield* readD1(key)) + 1;
+            yield* writeD1(key, next);
+            return next;
+          }),
+        getD1: (key: string) => readD1(key),
+        incrementDO: () =>
+          Effect.gen(function* () {
+            const next = (yield* readDO()) + 1;
+            yield* writeDO(next);
+            return next;
+          }),
+        getDO: () => readDO(),
+        reset: (key: string) =>
+          Effect.gen(function* () {
+            yield* writeD1(key, 0);
+            yield* writeDO(0);
+          }),
+      };
+    });
+  }),
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-do/stack.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-do/stack.ts
@@ -1,0 +1,25 @@
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import WorkerALayer, { WorkerA } from "./workerA.ts";
+import WorkerB from "./workerB.ts";
+import WorkerCLayer, { WorkerC } from "./workerC.ts";
+
+export default Alchemy.Stack(
+  "TaggedDOExample",
+  {
+    state: Cloudflare.state(),
+    providers: Cloudflare.providers(),
+  },
+  Effect.gen(function* () {
+    const workerA = yield* WorkerA;
+    const workerB = yield* WorkerB;
+    const workerC = yield* WorkerC;
+
+    return {
+      urlA: workerA.url.as<string>(),
+      urlB: workerB.url.as<string>(),
+      urlC: workerC.url.as<string>(),
+    };
+  }).pipe(Effect.provide(WorkerALayer), Effect.provide(WorkerCLayer)),
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-do/workerA.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-do/workerA.ts
@@ -1,0 +1,62 @@
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { Counter, CounterLive } from "./object.ts";
+
+// Tag
+export class WorkerA extends Cloudflare.Worker<WorkerA, {}, Counter>()(
+  "WorkerA",
+  {
+    main: import.meta.filename,
+  },
+) {}
+
+// Layer
+export default WorkerA.make(
+  Effect.gen(function* () {
+    const counter = yield* Counter;
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const key = request.headers["x-counter-key"] ?? "default";
+        const stub = counter.getByName(key);
+        const url = new URL(request.url, "http://x");
+
+        if (request.method === "POST" && url.pathname === "/reset") {
+          yield* stub.reset(key);
+          return yield* HttpServerResponse.json({ ok: true });
+        }
+
+        if (request.method === "POST" && url.pathname === "/d1/increment") {
+          const value = yield* stub.incrementD1(key);
+          return yield* HttpServerResponse.json({ value });
+        }
+
+        if (request.method === "GET" && url.pathname === "/d1") {
+          const value = yield* stub.getD1(key);
+          return yield* HttpServerResponse.json({ value });
+        }
+
+        if (request.method === "POST" && url.pathname === "/do/increment") {
+          const value = yield* stub.incrementDO();
+          return yield* HttpServerResponse.json({ value });
+        }
+
+        if (request.method === "GET" && url.pathname === "/do") {
+          const value = yield* stub.getDO();
+          return yield* HttpServerResponse.json({ value });
+        }
+
+        return HttpServerResponse.text("Not Found", { status: 404 });
+      }),
+    };
+  }).pipe(
+    Effect.provide(
+      // WorkerA needs to provide it
+      CounterLive.pipe(Layer.provide(Cloudflare.D1ConnectionLive)),
+    ),
+  ),
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-do/workerB.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-do/workerB.ts
@@ -1,0 +1,53 @@
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+import { Counter } from "./object.ts";
+import { WorkerA } from "./workerA.ts";
+
+export default class WorkerB extends Cloudflare.Worker<WorkerB>()(
+  "WorkerB",
+  {
+    main: import.meta.filename,
+  },
+  Effect.gen(function* () {
+    const counter = yield* Counter.from(WorkerA);
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const key = request.headers["x-counter-key"] ?? "default";
+        const stub = counter.getByName(key);
+        const url = new URL(request.url, "http://x");
+
+        if (request.method === "POST" && url.pathname === "/reset") {
+          yield* stub.reset(key);
+          return yield* HttpServerResponse.json({ ok: true });
+        }
+
+        if (request.method === "POST" && url.pathname === "/d1/increment") {
+          const value = yield* stub.incrementD1(key);
+          return yield* HttpServerResponse.json({ value });
+        }
+
+        if (request.method === "GET" && url.pathname === "/d1") {
+          const value = yield* stub.getD1(key);
+          return yield* HttpServerResponse.json({ value });
+        }
+
+        if (request.method === "POST" && url.pathname === "/do/increment") {
+          const value = yield* stub.incrementDO();
+          return yield* HttpServerResponse.json({ value });
+        }
+
+        if (request.method === "GET" && url.pathname === "/do") {
+          const value = yield* stub.getDO();
+          return yield* HttpServerResponse.json({ value });
+        }
+
+        return HttpServerResponse.text("Not Found", { status: 404 });
+      }),
+    };
+  }),
+) {}

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-do/workerC.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/tagged-do/workerC.ts
@@ -1,0 +1,56 @@
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { Counter, CounterLive } from "./object.ts";
+
+// Tag — WorkerC also hosts its OWN Counter (declared in its public contract).
+// Because each Worker hosts its own DO namespace, the instances under
+// WorkerC are isolated from the instances under WorkerA/B.
+export class WorkerC extends Cloudflare.Worker<WorkerC, {}, Counter>()(
+  "WorkerC",
+  {
+    main: import.meta.filename,
+  },
+) {}
+
+// Layer — uses `Counter.from(WorkerC)` (self-reference) instead of
+// `yield* Counter`. The two forms are equivalent inside the host; the
+// `.from(Self)` form is the recommended style for code that may be
+// extracted into a reusable Layer.
+export default WorkerC.make(
+  Effect.gen(function* () {
+    const counter = yield* Counter.from(WorkerC);
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const key = request.headers["x-counter-key"] ?? "default";
+        const stub = counter.getByName(key);
+        const url = new URL(request.url, "http://x");
+
+        if (request.method === "POST" && url.pathname === "/reset") {
+          yield* stub.reset(key);
+          return yield* HttpServerResponse.json({ ok: true });
+        }
+
+        if (request.method === "POST" && url.pathname === "/do/increment") {
+          const value = yield* stub.incrementDO();
+          return yield* HttpServerResponse.json({ value });
+        }
+
+        if (request.method === "GET" && url.pathname === "/do") {
+          const value = yield* stub.getDO();
+          return yield* HttpServerResponse.json({ value });
+        }
+
+        return HttpServerResponse.text("Not Found", { status: 404 });
+      }),
+    };
+  }).pipe(
+    Effect.provide(
+      CounterLive.pipe(Layer.provide(Cloudflare.D1ConnectionLive)),
+    ),
+  ),
+);

--- a/website/src/content/docs/tutorial/cloudflare/cross-worker-durable-object.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/cross-worker-durable-object.mdx
@@ -1,0 +1,313 @@
+---
+title: Bind to another Worker's Durable Object
+description: Share a Durable Object across multiple Workers — one Worker hosts the runtime, others bind to it by scriptName for a typed RPC stub.
+sidebar:
+  order: 1.5
+---
+
+A Durable Object is _hosted_ by exactly one Worker, but any
+number of **other** Workers can bind to the same DO. This is how
+you share state across Workers: one Worker hosts the DO, every
+other Worker addresses it by `scriptName` and gets a typed RPC
+stub.
+
+By the end of this part you'll have two Workers, `WorkerA` and
+`WorkerB`, sharing a single `Counter` Durable Object. Writes
+through either Worker are visible from the other.
+
+## Move the DO into its own module
+
+The DO class lives in a separate file so both Workers can import
+it as a typed identifier without pulling in the runtime
+implementation.
+
+```typescript
+// src/object.ts
+import type { RuntimeContext } from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+
+export class Counter extends Cloudflare.DurableObjectNamespace<
+  Counter,
+  {
+    increment: () => Effect.Effect<number, never, RuntimeContext>;
+    get: () => Effect.Effect<number, never, RuntimeContext>;
+  }
+>()("Counter") {}
+```
+
+The class is purely a tagged identifier. Both Workers can import
+it without dragging in the runtime — the bundler tree-shakes
+`.make()` (which we'll add next) out of any consumer that
+doesn't actually host the DO.
+
+## Add the runtime implementation
+
+`Counter.make(...)` provides the per-instance Effect that runs
+inside the DO. Export it as `default` so it can be tree-shaken
+when imported by name.
+
+```diff lang="typescript"
+// src/object.ts
+ export class Counter extends Cloudflare.DurableObjectNamespace<
+   Counter,
+   {
+     increment: () => Effect.Effect<number, never, RuntimeContext>;
+     get: () => Effect.Effect<number, never, RuntimeContext>;
+   }
+ >()("Counter") {}
+
++export default Counter.make(
++  Effect.gen(function* () {
++    return Effect.gen(function* () {
++      const state = yield* Cloudflare.DurableObjectState;
++      let count = (yield* state.storage.get<number>("count")) ?? 0;
++
++      return {
++        increment: () =>
++          Effect.gen(function* () {
++            count += 1;
++            yield* state.storage.put("count", count);
++            return count;
++          }),
++        get: () => Effect.succeed(count),
++      };
++    });
++  }),
++);
+```
+
+Only Workers that import this file as `import CounterLive from "./object.ts"`
+will pull in the runtime. Workers that only import the class
+(`import { Counter } from "./object.ts"`) get just the type.
+
+## Declare WorkerA as the host
+
+`WorkerA` _hosts_ `Counter` — its bundle contains the DO runtime
+and Cloudflare runs the DO class inside WorkerA's script.
+
+The key move is the **third type argument** on `Cloudflare.Worker`:
+
+```typescript
+// src/workerA.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+import { Counter } from "./object.ts";
+
+export class WorkerA extends Cloudflare.Worker<WorkerA, {}, Counter>()(
+  "WorkerA",
+  { main: import.meta.filename },
+) {}
+```
+
+`Worker<Self, Bindings, Deps>` — the third slot `Deps` is what
+the script publishes as part of its public contract. By writing
+`, Counter`, we're saying "WorkerA hosts Counter; other scripts
+may bind to it."
+
+:::caution[The third type argument is what unlocks cross-script binding]
+You can omit `, Counter` and the runtime still works — but
+`Counter.from(WorkerA)` from another Worker will be a **TypeScript
+error** because `WorkerA` doesn't declare `Counter` as part of its
+contract. Always declare cross-script DOs in `Deps`.
+:::
+
+## Provide the DO runtime from WorkerA
+
+`WorkerA.make(...)` is where the runtime lives. Provide
+`CounterLive` (the default export from `object.ts`) so that
+WorkerA's bundle actually contains the DO class:
+
+```diff lang="typescript"
+// src/workerA.ts
+ import * as Cloudflare from "alchemy/Cloudflare";
+ import * as Effect from "effect/Effect";
++import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
++import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+-import { Counter } from "./object.ts";
++import CounterLive, { Counter } from "./object.ts";
+
+ export class WorkerA extends Cloudflare.Worker<WorkerA, {}, Counter>()(
+   "WorkerA",
+   { main: import.meta.filename },
+ ) {}
+
++export default WorkerA.make(
++  Effect.gen(function* () {
++    const counters = yield* Counter;
++    return {
++      fetch: Effect.gen(function* () {
++        const request = yield* HttpServerRequest;
++        const name = new URL(request.url, "http://x").pathname.slice(1);
++        const next = yield* counters.getByName(name).increment();
++        return HttpServerResponse.json({ value: next });
++      }),
++    };
++  }).pipe(Effect.provide(CounterLive)),
++);
+```
+
+`yield* Counter` inside WorkerA's init binds the DO _locally_ —
+WorkerA's `env.Counter` is wired up at deploy time and the class
+ships in the bundle.
+
+## Bind WorkerA's Counter from WorkerB
+
+`WorkerB` does **not** host the DO. It imports `WorkerA` purely
+as a type and uses `Counter.from(WorkerA)` to declare a binding
+to the existing namespace running under WorkerA's script:
+
+```typescript
+// src/workerB.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { Counter } from "./object.ts";
+import { WorkerA } from "./workerA.ts";
+
+export default class WorkerB extends Cloudflare.Worker<WorkerB>()(
+  "WorkerB",
+  { main: import.meta.filename },
+  Effect.gen(function* () {
+    const counters = yield* Counter.from(WorkerA);
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const name = new URL(request.url, "http://x").pathname.slice(1);
+        const value = yield* counters.getByName(name).get();
+        return HttpServerResponse.json({ value });
+      }),
+    };
+  }),
+) {}
+```
+
+`Counter.from(WorkerA)` reads `WorkerA`'s `Deps` to confirm that
+`Counter` is part of its public contract, then produces a typed
+namespace stub. Under the hood it emits a Cloudflare binding with
+`scriptName: "WorkerA"` so the runtime routes every call to
+WorkerA's hosted instance.
+
+:::tip[Only the host provides `CounterLive`]
+WorkerB imports `Counter` but **never** `CounterLive`. Rolldown
+tree-shakes the runtime out of WorkerB's bundle — only WorkerA
+ships the DO class. This keeps consumer bundles small and avoids
+duplicate runtime instances.
+:::
+
+## Deploy both Workers from one Stack
+
+The Stack composes both Workers. WorkerA's Layer is provided so
+its `Counter` runtime is hooked up; WorkerB consumes it via
+binding only:
+
+```typescript
+// alchemy.run.ts
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import WorkerALive, { WorkerA } from "./src/workerA.ts";
+import WorkerB from "./src/workerB.ts";
+
+export default Alchemy.Stack(
+  "CrossWorkerDO",
+  { state: Cloudflare.state(), providers: Cloudflare.providers() },
+  Effect.gen(function* () {
+    const a = yield* WorkerA;
+    const b = yield* WorkerB;
+    return {
+      urlA: a.url.as<string>(),
+      urlB: b.url.as<string>(),
+    };
+  }).pipe(Effect.provide(WorkerALive)),
+);
+```
+
+`Effect.provide(WorkerALive)` is the only place the DO runtime
+enters the program. Without it, `yield* WorkerA` would fail to
+resolve.
+
+## Verify shared state
+
+Hit `urlA/foo` to increment, then `urlB/foo` to read — both
+Workers route to the same DO instance by name:
+
+```typescript
+// test/integ.test.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Test from "alchemy/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import Stack from "../alchemy.run.ts";
+
+const { test, beforeAll, deploy } = Test.make({
+  providers: Cloudflare.providers(),
+});
+
+const stack = beforeAll(deploy(Stack));
+
+test(
+  "WorkerB reads counter written by WorkerA",
+  Effect.gen(function* () {
+    const { urlA, urlB } = yield* stack;
+    const client = yield* HttpClient.HttpClient;
+
+    yield* client.post(`${urlA}/`);
+    yield* client.post(`${urlA}/`);
+
+    const res = yield* client.get(`${urlB}/`);
+    expect((yield* res.json) as { value: number }).toEqual({ value: 2 });
+  }),
+);
+```
+
+## Prefer `Counter.from(Self)` inside Layers
+
+Inside `WorkerA.make` we wrote `yield* Counter` to bind the
+locally-hosted DO. That works, but it's not the form you want
+when the code might be extracted into a reusable Layer or shared
+between scripts.
+
+`Counter.from(WorkerA)` also works inside `WorkerA` itself —
+calling `.from(Self)` on the host resolves to the same local
+namespace as `yield* Counter`:
+
+```diff lang="typescript"
+// src/workerA.ts
+ export default WorkerA.make(
+   Effect.gen(function* () {
+-    const counters = yield* Counter;
++    const counters = yield* Counter.from(WorkerA);
+     return {
+       fetch: Effect.gen(function* () { ... }),
+     };
+   }).pipe(Effect.provide(CounterLive)),
+ );
+```
+
+This matters most when you extract `fetch` logic into a Layer
+(or any service) that wants a `Counter` namespace. With
+`Counter.from(Self)`, the service is explicit about _which_
+script's Counter it talks to. A Worker that hosts its own
+isolated namespace uses `.from(Self)`; a consumer Worker uses
+`.from(Host)`. The shape is identical, which keeps the Layer
+host-agnostic.
+
+:::tip[A Worker can host its own isolated namespace]
+If `WorkerC` declares `Counter` in its own contract
+(`Worker<WorkerC, {}, Counter>`) and provides `CounterLive`,
+then `Counter.from(WorkerC)` from inside `WorkerC` binds to a
+**separate** DO namespace — instances under WorkerC are
+isolated from WorkerA's. This is how you give each script its
+own private set of DO instances using the same class.
+:::
+
+## Closing
+
+Two Workers, one DO, type-safe end-to-end. The third type argument
+`, Counter` on `WorkerA` is the small but critical piece that
+makes `Counter.from(WorkerA)` type-check from `WorkerB` — and
+that same form (`Counter.from(Self)`) lets a host script bind to
+its own DO from inside a Layer without caring whether it's the
+host or a consumer.


### PR DESCRIPTION
Lets a Worker bind to a Durable Object hosted by another Worker. The host declares DO classes in its public contract via the new third type argument on `Cloudflare.Worker`, and consumers bind via `Counter.from(HostWorker)`.

### DO class lives in its own module

```ts
// object.ts
export class Counter extends Cloudflare.DurableObjectNamespace<
  Counter,
  {
    increment: () => Effect.Effect<number, never, RuntimeContext>;
    get: () => Effect.Effect<number, never, RuntimeContext>;
  }
>()("Counter") {}

export const CounterLive = Counter.make(/* runtime impl */);
```

### Host Worker declares the DO in its contract

The third type argument `Deps` is what the script publishes for other scripts to bind to:

```ts
// workerA.ts
export class WorkerA extends Cloudflare.Worker<WorkerA, {}, Counter>()(
  //                                           ^^^^^^^^^^^^^^^^^^^^ public contract
  "WorkerA",
  { main: import.meta.filename },
) {}

export default WorkerA.make(
  Effect.gen(function* () {
    const counter = yield* Counter.from(WorkerA); // .from(Self) works inside the host
    return { fetch: /* ... */ };
  }).pipe(Effect.provide(CounterLive)),
);
```

### Consumer Worker binds the DO by scriptName

```ts
// workerB.ts
import { Counter } from "./object.ts";
import { WorkerA } from "./workerA.ts";

export default class WorkerB extends Cloudflare.Worker<WorkerB>()(
  "WorkerB",
  { main: import.meta.filename },
  Effect.gen(function* () {
    const counter = yield* Counter.from(WorkerA); // scriptName-bound to WorkerA
    return { fetch: /* ... */ };
  }),
) {}
```

Omitting `, Counter` on `WorkerA` makes `Counter.from(WorkerA)` a TypeScript error (the runtime still works, but consumers lose the type check).

### Second host = isolated namespace

A Worker that declares `Counter` and provides `CounterLive` on its own hosts a **separate** DO namespace — same class, isolated instances:

```ts
// workerC.ts — hosts its own Counter, isolated from WorkerA's
export class WorkerC extends Cloudflare.Worker<WorkerC, {}, Counter>()(
  "WorkerC",
  { main: import.meta.filename },
) {}

export default WorkerC.make(
  Effect.gen(function* () {
    const counter = yield* Counter.from(WorkerC); // distinct from WorkerA's
    return { fetch: /* ... */ };
  }).pipe(Effect.provide(CounterLive)),
);
```

### Changes

- `Worker<Self, Bindings, Deps>` — new third type argument for DO/Worker dependencies the script publishes
- `DurableObjectNamespace.from(scriptName | Worker)` — type-safe cross-script binding
- New tutorial: `Bind to another Worker's Durable Object`
- JSDoc: `@section Cross-Worker Binding` and `@section Using \`.from(Self)\` Inside the Host`
- New fixtures + integration tests covering A↔B cross-script sharing and WorkerC isolation
