### PR TITLE
docs(blog): beta.45 release post — RpcWorker + RpcDurableObjectNamespace

### DIFF
--- a/website/src/content/docs/blog/2026-05-26-beta-45.md
+++ b/website/src/content/docs/blog/2026-05-26-beta-45.md
@@ -1,0 +1,257 @@
+---
+title: alchemy@2.0.0-beta.45
+date: 2026-05-26T06:00:00Z
+category: release
+excerpt: v2.0.0-beta.45 ships `Cloudflare.RpcWorker` and `Cloudflare.RpcDurableObjectNamespace` — typed Effect RPC servers with cross-script binding between Workers and Durable Objects.
+---
+
+`v2.0.0-beta.45` ships two new Cloudflare primitives:
+[`Cloudflare.RpcWorker`](/providers/Cloudflare/RpcWorker) and
+[`Cloudflare.RpcDurableObjectNamespace`](/providers/Cloudflare/RpcDurableObjectNamespace).
+Both serve an Effect `RpcGroup` directly on `fetch`, and both
+ship in two flavors — an **inline** form for self-contained
+classes and a **modular** form (`Class.make(impl)` /
+`Class.from(Worker)`) that lets one Worker host a typed
+namespace and any other Worker bind to it cross-script.
+
+The combined effect: a typed `RpcClient<...>` is the only
+surface between two scripts. No `RpcServer.toHttpEffect` /
+`RpcClient.layerProtocolHttp` plumbing at the call sites, no
+hand-written service bindings, no `JSON.stringify` round-trips
+that strip `Schema.Class` identity.
+
+## Define the RPC group
+
+Pure schemas — same value imported by the host, every consumer,
+and any test client.
+
+```typescript
+// src/rpcs.ts
+import * as Schema from "effect/Schema";
+import { Rpc, RpcGroup } from "effect/unstable/rpc";
+
+export class CounterRpcs extends RpcGroup.make(
+  Rpc.make("setTitle", {
+    payload: { title: Schema.String },
+    success: Schema.Void,
+  }),
+  Rpc.make("getTitle", { payload: {}, success: Schema.String }),
+) {}
+```
+
+## `RpcDurableObjectNamespace` — inline form
+
+The DO's `fetch` is just `RpcServer.toHttpEffect(group)` piped
+with its handler layer. Consumers see
+`counters.getByName(id)` as an `Effect<RpcClient<CounterRpcs>>`.
+
+```typescript
+// src/counter.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
+import { CounterRpcs } from "./rpcs.ts";
+
+export default class Counter extends Cloudflare.RpcDurableObjectNamespace<Counter>()(
+  "Counter",
+  { schema: CounterRpcs },
+  Effect.gen(function* () {
+    return Effect.gen(function* () {
+      const state = yield* Cloudflare.DurableObjectState;
+      const handlers = CounterRpcs.toLayer({
+        setTitle: ({ title }) => state.storage.put("title", title),
+        getTitle: () =>
+          Effect.map(state.storage.get<string>("title"), (t) => t ?? ""),
+      });
+      return RpcServer.toHttpEffect(CounterRpcs).pipe(
+        Effect.provide(Layer.mergeAll(handlers, RpcSerialization.layerNdjson)),
+      );
+    });
+  }),
+) {}
+```
+
+Drop-in replacement for alchemy's built-in DO method bridge
+whenever return values contain `Schema.Class` instances. The
+built-in bridge `JSON.stringify`s every value and loses class
+identity; this namespace round-trips through the shared
+`RpcSerialization` codec.
+
+## `RpcWorker` — same shape, no `{ fetch }` wrapper
+
+Identical pattern for the Worker side. The init returns the
+piped `RpcServer.toHttpEffect` Effect directly.
+
+```typescript
+// src/worker.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
+import { CounterRpcs } from "./rpcs.ts";
+
+export default class TasksWorker extends Cloudflare.RpcWorker<TasksWorker>()(
+  "TasksWorker",
+  { main: import.meta.filename, schema: CounterRpcs },
+  Effect.gen(function* () {
+    const handlers = CounterRpcs.toLayer({
+      setTitle: () => Effect.void,
+      getTitle: () => Effect.succeed("hi"),
+    });
+    return RpcServer.toHttpEffect(CounterRpcs).pipe(
+      Effect.provide(Layer.mergeAll(handlers, RpcSerialization.layerNdjson)),
+    );
+  }),
+) {}
+```
+
+From any other Worker,
+`Cloudflare.RpcWorker.bind(TasksWorker)` registers the
+service binding and returns a typed `RpcClient` that goes
+over the in-account binding — no public URL.
+
+```typescript
+const tasks = yield* Cloudflare.RpcWorker.bind(TasksWorker);
+const title = yield* tasks.getTitle({});
+```
+
+## Modular form — split the class from its runtime
+
+The inline form bundles the runtime into the class declaration,
+which is fine for one host. The **two-arg form** declares the
+class as a pure tagged identifier, and `Class.make(impl)`
+provides the runtime as a `Layer`. Consumer scripts can import
+the class without pulling the host's runtime into their bundle.
+
+```typescript
+// src/counter.ts
+export class Counter extends Cloudflare.RpcDurableObjectNamespace<Counter>()(
+  "Counter",
+  { schema: CounterRpcs },
+) {}
+
+export default Counter.make(
+  Effect.gen(function* () {
+    return Effect.gen(function* () {
+      const state = yield* Cloudflare.DurableObjectState;
+      const handlers = CounterRpcs.toLayer({
+        setTitle: ({ title }) => state.storage.put("title", title),
+        getTitle: () =>
+          Effect.map(state.storage.get<string>("title"), (t) => t ?? ""),
+      });
+      return RpcServer.toHttpEffect(CounterRpcs).pipe(
+        Effect.provide(Layer.mergeAll(handlers, RpcSerialization.layerNdjson)),
+      );
+    });
+  }),
+);
+```
+
+## Cross-script: one Worker hosts, others bind
+
+The host Worker declares `Counter` in its `Deps` (the new third
+type argument of `Cloudflare.Worker<Self, Bindings, Deps>` or
+second of `Cloudflare.RpcWorker<Self, Deps>`) and provides
+`CounterLive`. That `, Counter` is what unlocks
+`Counter.from(WorkerA)` from any other script — without it,
+`.from(...)` is a TypeScript error.
+
+```typescript
+// src/workerA.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import CounterLive, { Counter } from "./counter.ts";
+import { CounterRpcs } from "./rpcs.ts";
+
+export class WorkerA extends Cloudflare.RpcWorker<WorkerA, Counter>()(
+  "WorkerA",
+  { main: import.meta.filename, schema: CounterRpcs },
+) {}
+
+export default WorkerA.make(
+  Effect.gen(function* () {
+    const counter = yield* Counter;
+    const handlers = CounterRpcs.toLayer({
+      setTitle: ({ title }) =>
+        counter
+          .getByName("default")
+          .pipe(Effect.flatMap((c) => c.setTitle({ title })), Effect.orDie),
+      getTitle: () =>
+        counter
+          .getByName("default")
+          .pipe(Effect.flatMap((c) => c.getTitle({})), Effect.orDie),
+    });
+    return RpcServer.toHttpEffect(CounterRpcs).pipe(
+      Effect.provide(Layer.mergeAll(handlers, RpcSerialization.layerNdjson)),
+    );
+  }).pipe(Effect.provide(CounterLive)),
+);
+```
+
+A second Worker — different script, doesn't host the DO —
+binds via `Counter.from(WorkerA)`. Writes through either
+Worker's `getByName(name)` are visible from the other.
+
+```typescript
+// src/workerB.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { Counter } from "./counter.ts";
+import { WorkerA } from "./workerA.ts";
+
+export default class WorkerB extends Cloudflare.Worker<WorkerB>()(
+  "WorkerB",
+  { main: import.meta.filename },
+  Effect.gen(function* () {
+    const counter = yield* Counter.from(WorkerA);
+    return {
+      fetch: Effect.gen(function* () {
+        const stub = yield* counter.getByName("default");
+        yield* stub.setTitle({ title: "from WorkerB" }).pipe(Effect.orDie);
+        const title = yield* stub.getTitle({}).pipe(Effect.orDie);
+        return HttpServerResponse.text(title);
+      }).pipe(Effect.scoped),
+    };
+  }),
+) {}
+```
+
+Under the hood, `Counter.from(WorkerA)` emits a Cloudflare
+binding with `scriptName: "WorkerA"` so the runtime routes
+every call to WorkerA's hosted instance. WorkerB's bundle
+never sees the DO class — Rolldown tree-shakes `CounterLive`
+out because WorkerB only imports the class.
+
+A Worker can also host its **own** isolated namespace by
+declaring `Counter` in its own `Deps` and providing
+`CounterLive`. Use `Counter.from(Self)` inside that Worker to
+be explicit:
+
+```typescript
+export class WorkerC extends Cloudflare.Worker<WorkerC, {}, Counter>()(
+  "WorkerC",
+  { main: import.meta.filename },
+) {}
+
+export default WorkerC.make(
+  Effect.gen(function* () {
+    const counter = yield* Counter.from(WorkerC); // isolated namespace
+    // ... fetch handler ...
+  }).pipe(Effect.provide(CounterLive)),
+);
+```
+
+WorkerC's `Counter` instances are completely separate from
+WorkerA's. Same class, three deployment topologies.
+
+## Where to go next
+
+- [`Cloudflare.RpcWorker` API reference](/providers/Cloudflare/RpcWorker)
+- [`Cloudflare.RpcDurableObjectNamespace` API reference](/providers/Cloudflare/RpcDurableObjectNamespace)
+- [RPC Worker tutorial](/tutorial/cloudflare/rpc-worker) — single-worker walkthrough, then cross-Worker `RpcWorker.bind`
+- [RPC Durable Object tutorial](/tutorial/cloudflare/rpc-durable-object) — single DO walkthrough, then modular + cross-script `Counter.from(Worker)`
+- [Effect RPC guide](/guides/effect-rpc) — `RpcGroup`, schemas, streaming, the long-form `Cloudflare.Worker` recipe these primitives wrap
+- [Bind to another Worker's Durable Object](/tutorial/cloudflare/cross-worker-durable-object) — the same `Deps` / `.from(Worker)` pattern for the regular `DurableObjectNamespace`
+- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md) · [v2.0.0-beta.44 → v2.0.0-beta.45](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.44...v2.0.0-beta.45)


### PR DESCRIPTION
Release post for the upcoming `v2.0.0-beta.45`, headlining `Cloudflare.RpcWorker` and `Cloudflare.RpcDurableObjectNamespace`.

Structure mirrors the [beta.43 post](https://v2.alchemy.run/blog/2026-05-21-beta-43/):

- One-line excerpt + headline paragraph
- Pure-schema `RpcGroup` first
- Inline form: `RpcDurableObjectNamespace`, then `RpcWorker` (+ `bind`)
- Modular form: `Class.make(impl)` returns a `Layer`
- Cross-script: `RpcWorker<Self, Deps>()` + `Counter.from(WorkerA)`, plus the `Counter.from(Self)` self-hosted isolation case
- Links to both provider API references, both tutorials, the Effect RPC guide, the cross-Worker DO tutorial, and the changelog compare
