### PR TITLE
fix(cloudflare): pass DO scriptName through async bindings

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectNamespace.ts
@@ -104,9 +104,15 @@ export type DurableObjectServices =
 
 export interface DurableObjectNamespaceProps {
   /**
+   * Name of the exported `DurableObject` class.
+   *
    * @default name
    */
   className?: string;
+  /**
+   * Worker script that hosts the Durable Object class. Omit this when the
+   * namespace is hosted by the Worker that declares the binding.
+   */
   scriptName?: Input<string> | undefined;
   // environment?: string | undefined;
   // sqlite?: boolean | undefined;
@@ -639,7 +645,8 @@ export class DurableObjectNamespaceScope extends Context.Service<
  * runtime), declare Durable Objects in the `bindings` prop of the
  * Worker resource. Pass a `DurableObjectNamespace` reference with a
  * `className` matching the exported `DurableObject` subclass in your
- * worker source file. Use `Cloudflare.InferEnv` to get a fully typed
+ * worker source file. If `className` is omitted, it defaults to the
+ * namespace name. Use `Cloudflare.InferEnv` to get a fully typed
  * `env` object that includes the namespace.
  *
  * @example Declaring a DO binding in the stack
@@ -652,9 +659,7 @@ export class DurableObjectNamespaceScope extends Context.Service<
  * export const Worker = Cloudflare.Worker("Worker", {
  *   main: "./src/worker.ts",
  *   bindings: {
- *     Counter: Cloudflare.DurableObjectNamespace<Counter>("Counter", {
- *       className: "Counter",
- *     }),
+ *     Counter: Cloudflare.DurableObjectNamespace<Counter>("Counter"),
  *   },
  * });
  * ```
@@ -679,6 +684,52 @@ export class DurableObjectNamespaceScope extends Context.Service<
  *     return ++this.counter;
  *   }
  * }
+ * ```
+ *
+ * @section Cross-Script Binding in an Async Worker
+ * Async Workers can also bind to a Durable Object hosted by another
+ * Worker script. The host Worker declares and exports the DO class. The
+ * consumer Worker declares a `DurableObjectNamespace` with `scriptName`
+ * set to the host Worker's script name.
+ *
+ * Cross-script async bindings are references only: the consumer uploads
+ * the binding metadata, but Alchemy does not drive class migrations for
+ * the foreign class. Deploy the host first so Cloudflare can verify that
+ * the target script exports the requested class.
+ *
+ * @example Host Worker owns the Durable Object class
+ * ```typescript
+ * const host = yield* Cloudflare.Worker("Host", {
+ *   main: "./src/host.ts",
+ *   bindings: {
+ *     Counter: Cloudflare.DurableObjectNamespace<Counter>("Counter"),
+ *   },
+ * });
+ * ```
+ *
+ * @example Consumer Worker binds to the host script
+ * ```typescript
+ * const consumer = yield* Cloudflare.Worker("Consumer", {
+ *   main: "./src/consumer.ts",
+ *   bindings: {
+ *     Counter: Cloudflare.DurableObjectNamespace<Counter>("Counter", {
+ *       scriptName: host.workerName,
+ *     }),
+ *   },
+ * });
+ * ```
+ *
+ * @example Binding to a different exported class name
+ * ```typescript
+ * const consumer = yield* Cloudflare.Worker("Consumer", {
+ *   main: "./src/consumer.ts",
+ *   bindings: {
+ *     Counter: Cloudflare.DurableObjectNamespace<Counter>("Counter", {
+ *       className: "CounterV2",
+ *       scriptName: host.workerName,
+ *     }),
+ *   },
+ * });
  * ```
  */
 export const DurableObjectNamespace: DurableObjectNamespaceClass =

--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectNamespace.ts
@@ -54,6 +54,8 @@ export interface DurableObjectNamespaceLike<Shape = any> {
   /** @internal phantom */
   className?: string;
   /** @internal phantom */
+  scriptName?: Input<string>;
+  /** @internal phantom */
   Shape?: Shape;
 }
 
@@ -104,8 +106,8 @@ export interface DurableObjectNamespaceProps {
   /**
    * @default name
    */
-  className: string;
-  // scriptName?: string | undefined;
+  className?: string;
+  scriptName?: Input<string> | undefined;
   // environment?: string | undefined;
   // sqlite?: boolean | undefined;
   // namespaceId?: string | undefined;
@@ -809,6 +811,7 @@ export const DurableObjectNamespace: DurableObjectNamespaceClass =
           name: namespace,
           className:
             (args[1] as DurableObjectNamespaceProps)?.className || namespace,
+          scriptName: (args[1] as DurableObjectNamespaceProps)?.scriptName,
         };
       } else if (Effect.isEffect(propsOrImpl)) {
         // inline Effect DO

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1037,11 +1037,15 @@ export const LiveWorkerProvider = () =>
 
       const getExpectedDurableObjectClassNames = (
         bindings: readonly WorkerBinding[] | undefined,
+        workerName: string,
       ) =>
         Array.from(
           new Set(
             bindings?.flatMap((binding) =>
-              binding.type === "durable_object_namespace" && binding.className
+              binding.type === "durable_object_namespace" &&
+              binding.className &&
+              (binding.scriptName === undefined ||
+                binding.scriptName === workerName)
                 ? [binding.className]
                 : [],
             ) ?? [],
@@ -1294,7 +1298,7 @@ export const LiveWorkerProvider = () =>
         } satisfies Worker["Attributes"]["hash"];
         const metadataBindings = bindings.flatMap((b) => b.data.bindings ?? []);
         const expectedDurableObjectClassNames =
-          getExpectedDurableObjectClassNames(metadataBindings);
+          getExpectedDurableObjectClassNames(metadataBindings, name);
         let metadataAssets:
           | workers.PutScriptRequest["metadata"]["assets"]
           | undefined;

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -89,6 +89,7 @@ export const bindWorkerAsyncBindings = Effect.fnUntraced(function* (
                               type: "durable_object_namespace",
                               name: bindingName,
                               className: binding.className ?? binding.name,
+                              scriptName: binding.scriptName,
                             }
                           : binding.Type === "Cloudflare.D1Database"
                             ? {

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
@@ -71,6 +71,131 @@ const fetchReady = (url: string, expected: string) =>
     );
   });
 
+const fetchJsonReady = <T>(url: string) =>
+  Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient;
+    const res = yield* client.get(url).pipe(
+      Effect.flatMap((r) =>
+        r.status === 200
+          ? Effect.succeed(r)
+          : Effect.fail(new Error(`Worker not ready: ${r.status}`)),
+      ),
+      Effect.retry({ schedule: readinessSchedule, times: 15 }),
+    );
+    return (yield* res.json) as T;
+  });
+
+const hostWorkerScript = `import { DurableObject } from "cloudflare:workers";
+export class Counter extends DurableObject {
+  async increment() {
+    const value = (await this.ctx.storage.get("count")) ?? 0;
+    const next = value + 1;
+    await this.ctx.storage.put("count", next);
+    return next;
+  }
+  async reset() {
+    await this.ctx.storage.delete("count");
+  }
+  async get() {
+    return (await this.ctx.storage.get("count")) ?? 0;
+  }
+}
+export default {
+  async fetch(request, env) {
+    const stub = env.Counter.getByName("shared");
+    const url = new URL(request.url);
+    if (url.pathname === "/increment") {
+      return Response.json({ value: await stub.increment() });
+    }
+    if (url.pathname === "/get") {
+      return Response.json({ value: await stub.get() });
+    }
+    if (url.pathname === "/reset") {
+      await stub.reset();
+      return Response.json({ ok: true });
+    }
+    return new Response("Not Found", { status: 404 });
+  },
+};
+`;
+
+const consumerWorkerScript = `export default {
+  async fetch(request, env) {
+    const stub = env.Counter.getByName("shared");
+    const url = new URL(request.url);
+    if (url.pathname === "/increment") {
+      return Response.json({ value: await stub.increment() });
+    }
+    if (url.pathname === "/get") {
+      return Response.json({ value: await stub.get() });
+    }
+    if (url.pathname === "/reset") {
+      await stub.reset();
+      return Response.json({ ok: true });
+    }
+    return new Response("Not Found", { status: 404 });
+  },
+};
+`;
+
+test.provider(
+  "async worker durable object binding accepts scriptName",
+  (scratch) =>
+    Effect.gen(function* () {
+      yield* scratch.deploy(
+        Effect.gen(function* () {
+          return {
+            host: yield* Cloudflare.Worker("host-worker", {
+              script: hostWorkerScript,
+              bindings: {
+                Counter: Cloudflare.DurableObjectNamespace("Counter"),
+              },
+            }),
+          };
+        }),
+      );
+
+      const deployed = yield* scratch.deploy(
+        Effect.gen(function* () {
+          const host = yield* Cloudflare.Worker("host-worker", {
+            script: hostWorkerScript,
+            bindings: {
+              Counter: Cloudflare.DurableObjectNamespace("Counter"),
+            },
+          });
+          const consumer = yield* Cloudflare.Worker("consumer-worker", {
+            script: consumerWorkerScript,
+            bindings: {
+              Counter: Cloudflare.DurableObjectNamespace("Counter", {
+                scriptName: host.workerName,
+              }),
+            },
+          });
+
+          return { consumer, host };
+        }),
+      );
+
+      const reset = yield* fetchJsonReady<{ ok: boolean }>(
+        `${deployed.host.url}/reset`,
+      );
+      expect(reset.ok).toBe(true);
+
+      const first = yield* fetchJsonReady<{ value: number }>(
+        `${deployed.consumer.url}/increment`,
+      );
+      expect(first.value).toBe(1);
+
+      const second = yield* fetchJsonReady<{ value: number }>(
+        `${deployed.host.url}/get`,
+      );
+      expect(second.value).toBe(1);
+
+      yield* scratch.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);
+
 // Walk an async worker through four redeploys against the same scratch state,
 // each one swapping in a new script + bindings shape so we exercise the
 // migration paths `putWorker` relies on:


### PR DESCRIPTION
Allow async Worker Durable Object bindings to target a namespace hosted by another script.

```ts
Cloudflare.DurableObjectNamespace("Counter", {
  scriptName: host.workerName,
})
```

Cross-script bindings are still uploaded, but excluded from local DO namespace waits and migrations so the consumer does not wait for a foreign namespace id.
