### PR TITLE
feat(aws/lambda): add timeout to FunctionProps

### DIFF
--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -7,6 +7,7 @@ import { Region } from "@distilled.cloud/aws/Region";
 import type * as lambda from "aws-lambda";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
@@ -94,7 +95,48 @@ export interface FunctionProps extends PlatformProps {
     subnetIds: string[];
     securityGroupIds: string[];
   };
+  /**
+   * Maximum execution time before the function is forcibly terminated.
+   *
+   * Accepts any {@link Duration.Input} — a `Duration`, a number of
+   * milliseconds, a string like `"30 seconds"`, or a `[seconds, nanos]` tuple.
+   * Rounded up to whole seconds.
+   *
+   * @default 3 seconds (AWS Lambda default)
+   */
+  timeout?: Duration.Input;
 }
+
+/**
+ * Normalize a {@link FunctionProps.timeout} value to whole seconds.
+ *
+ * Why: `Duration` objects don't survive JSON state round-trips
+ * (`{_id:"Duration",_tag:"Millis",millis:N}` is rejected by `Duration.decode`),
+ * so we accept that re-hydrated shape directly alongside any
+ * `Duration.DurationInput`.
+ */
+export const toTimeoutSeconds = (
+  timeout: FunctionProps["timeout"],
+): number | undefined => {
+  if (timeout === undefined) return undefined;
+  if (
+    typeof timeout === "object" &&
+    timeout !== null &&
+    !Array.isArray(timeout) &&
+    (timeout as { _id?: unknown })._id === "Duration"
+  ) {
+    const t = timeout as
+      | { _tag: "Millis"; millis: number }
+      | { _tag: "Nanos"; nanos: string | number | bigint }
+      | { _tag: "Infinity" };
+    if (t._tag === "Millis") return Math.max(1, Math.ceil(t.millis / 1000));
+    if (t._tag === "Nanos") {
+      return Math.max(1, Math.ceil(Number(t.nanos) / 1_000_000_000));
+    }
+    return undefined;
+  }
+  return Math.max(1, Math.ceil(Duration.toSeconds(timeout)));
+};
 
 export interface Function extends Resource<
   FunctionTypeId,
@@ -872,6 +914,7 @@ export default await Effect.runPromise(handlerEffect)
               }
             : undefined,
           Tags: tags,
+          Timeout: toTimeoutSeconds(news.timeout),
           VpcConfig: news.vpc
             ? {
                 SubnetIds: news.vpc.subnetIds,
@@ -1119,6 +1162,11 @@ export default await Effect.runPromise(handlerEffect)
             })).hash
           ) {
             // code changed
+            return { action: "update" };
+          }
+          if (
+            toTimeoutSeconds(olds.timeout) !== toTimeoutSeconds(news.timeout)
+          ) {
             return { action: "update" };
           }
         }),

--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -97,45 +97,41 @@ export interface FunctionProps extends PlatformProps {
   };
   /**
    * Maximum execution time before the function is forcibly terminated.
-   *
-   * Accepts any {@link Duration.Input} — a `Duration`, a number of
-   * milliseconds, a string like `"30 seconds"`, or a `[seconds, nanos]` tuple.
    * Rounded up to whole seconds.
    *
    * @default 3 seconds (AWS Lambda default)
    */
-  timeout?: Duration.Input;
+  timeout?: Duration.Duration;
 }
 
 /**
- * Normalize a {@link FunctionProps.timeout} value to whole seconds.
+ * Normalize a {@link FunctionProps.timeout} to whole seconds.
  *
- * Why: `Duration` objects don't survive JSON state round-trips
- * (`{_id:"Duration",_tag:"Millis",millis:N}` is rejected by `Duration.decode`),
- * so we accept that re-hydrated shape directly alongside any
- * `Duration.DurationInput`.
+ * State JSON round-trips flatten a `Duration` to its `toJSON` shape
+ * (`{_id:"Duration",_tag:"Millis"|"Nanos"|"Infinity",...}`), which is not a
+ * valid `Duration.Input`. Reconstruct an input that `Duration.toSeconds`
+ * accepts before delegating.
  */
 export const toTimeoutSeconds = (
-  timeout: FunctionProps["timeout"],
+  timeout: Duration.Duration | undefined,
 ): number | undefined => {
   if (timeout === undefined) return undefined;
-  if (
-    typeof timeout === "object" &&
-    timeout !== null &&
-    !Array.isArray(timeout) &&
-    (timeout as { _id?: unknown })._id === "Duration"
-  ) {
-    const t = timeout as
-      | { _tag: "Millis"; millis: number }
-      | { _tag: "Nanos"; nanos: string | number | bigint }
-      | { _tag: "Infinity" };
-    if (t._tag === "Millis") return Math.max(1, Math.ceil(t.millis / 1000));
-    if (t._tag === "Nanos") {
-      return Math.max(1, Math.ceil(Number(t.nanos) / 1_000_000_000));
-    }
-    return undefined;
-  }
-  return Math.max(1, Math.ceil(Duration.toSeconds(timeout)));
+  const json = timeout as {
+    _id?: unknown;
+    _tag?: "Millis" | "Nanos" | "Infinity" | "NegativeInfinity";
+    millis?: number;
+    nanos?: string;
+  };
+  const input: Duration.Input =
+    json._id === "Duration"
+      ? json._tag === "Millis"
+        ? json.millis!
+        : json._tag === "Nanos"
+          ? BigInt(json.nanos!)
+          : "Infinity"
+      : timeout;
+  const seconds = Duration.toSeconds(input);
+  return Number.isFinite(seconds) ? Math.max(1, Math.ceil(seconds)) : undefined;
 };
 
 export interface Function extends Resource<

--- a/packages/alchemy/src/Output.ts
+++ b/packages/alchemy/src/Output.ts
@@ -1,4 +1,5 @@
 import * as Data from "effect/Data";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import { pipe } from "effect/Function";
 import type { Pipeable } from "effect/Pipeable";
@@ -589,6 +590,9 @@ export const evaluate: <A, Req = never>(
     if (Array.isArray(expr)) {
       return yield* Effect.all(expr.map((item) => evaluate(item, upstream)));
     } else if (Redacted.isRedacted(expr)) {
+      return expr;
+    } else if (Duration.isDuration(expr)) {
+      // Opaque value — see resolveInput in Plan.ts for rationale.
       return expr;
     } else if (typeof expr === "object" && expr !== null) {
       return Object.fromEntries(

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -1,4 +1,5 @@
 import * as Data from "effect/Data";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
@@ -374,6 +375,11 @@ export const make = <A>(
         } else if (Output.isExpr(input)) {
           return yield* resolveOutput(input);
         } else if (Redacted.isRedacted(input)) {
+          return input;
+        } else if (Duration.isDuration(input)) {
+          // Duration is an opaque value; walking its internal `.value`
+          // would destroy the prototype and produce a plain `{ value: ... }`
+          // object that downstream consumers can't interpret.
           return input;
         } else if (Array.isArray(input)) {
           return yield* Effect.all(input.map(resolveInput), {

--- a/packages/alchemy/src/State/StateEncoding.ts
+++ b/packages/alchemy/src/State/StateEncoding.ts
@@ -1,3 +1,4 @@
+import * as Duration from "effect/Duration";
 import * as Redacted from "effect/Redacted";
 import { isResource } from "../Resource.ts";
 
@@ -7,6 +8,40 @@ import { isResource } from "../Resource.ts";
  * the `Redacted` wrapper on read.
  */
 export const REDACTED_MARKER = "__redacted__";
+
+/**
+ * JSON marker used to tag a `Duration` value when writing state.
+ * The reviver recognises objects with exactly this key and rebuilds
+ * a real `Duration` instance on read so that downstream code can call
+ * `Duration.toSeconds`, `Duration.toMillis`, etc. without first
+ * decoding `Duration.toJSON`'s `{_id,_tag,...}` shape.
+ */
+export const DURATION_MARKER = "__duration__";
+
+const decodeDuration = (encoded: unknown): Duration.Duration | undefined => {
+  if (encoded === null || typeof encoded !== "object") return undefined;
+  const json = encoded as {
+    _tag?: "Millis" | "Nanos" | "Infinity" | "NegativeInfinity";
+    millis?: number;
+    nanos?: string;
+  };
+  switch (json._tag) {
+    case "Millis":
+      return json.millis !== undefined
+        ? Duration.millis(json.millis)
+        : undefined;
+    case "Nanos":
+      return json.nanos !== undefined
+        ? Duration.nanos(BigInt(json.nanos))
+        : undefined;
+    case "Infinity":
+      return Duration.infinity;
+    case "NegativeInfinity":
+      return Duration.zero; // Effect treats negatives as zero clamp
+    default:
+      return undefined;
+  }
+};
 
 /**
  * Recursively encode a state value for JSON serialisation.
@@ -30,6 +65,16 @@ export const encodeState = (value: unknown): unknown => {
   if (Redacted.isRedacted(value)) {
     return {
       [REDACTED_MARKER]: encodeState(Redacted.value(value)),
+    };
+  }
+  if (Duration.isDuration(value)) {
+    // `JSON.stringify(Duration.seconds(N))` already invokes Duration.toJSON,
+    // but encodeState is also called for code paths that don't go through
+    // `JSON.stringify` (e.g. the HTTP state-store). Tag with our marker so
+    // the reviver can unambiguously rebuild a real Duration instance —
+    // Duration.toJSON's `{_id,_tag,...}` shape is NOT a valid Duration.Input.
+    return {
+      [DURATION_MARKER]: value.toJSON(),
     };
   }
   if (isResource(value)) {
@@ -56,13 +101,15 @@ export const encodeState = (value: unknown): unknown => {
  * through {@link encodeState}. Intended for use with `JSON.parse`.
  */
 export const reviveState = (_key: string, value: unknown): unknown => {
-  if (
-    value !== null &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    REDACTED_MARKER in value
-  ) {
-    return Redacted.make((value as Record<string, unknown>)[REDACTED_MARKER]);
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>;
+    if (REDACTED_MARKER in obj) {
+      return Redacted.make(obj[REDACTED_MARKER]);
+    }
+    if (DURATION_MARKER in obj) {
+      const decoded = decodeDuration(obj[DURATION_MARKER]);
+      if (decoded !== undefined) return decoded;
+    }
   }
   return value;
 };
@@ -81,6 +128,10 @@ export const reviveStateRecursive = (value: unknown): unknown => {
   const keys = Object.keys(obj);
   if (keys.length === 1 && keys[0] === REDACTED_MARKER) {
     return Redacted.make(reviveStateRecursive(obj[REDACTED_MARKER]));
+  }
+  if (keys.length === 1 && keys[0] === DURATION_MARKER) {
+    const decoded = decodeDuration(obj[DURATION_MARKER]);
+    if (decoded !== undefined) return decoded;
   }
   const result: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(obj)) {

--- a/packages/alchemy/test/AWS/Lambda/Function.test.ts
+++ b/packages/alchemy/test/AWS/Lambda/Function.test.ts
@@ -66,6 +66,8 @@ test.provider(
         AWS.Lambda.Function<{}>()("TimeoutFn", {
           main: timeoutHandlerPath,
           handler: "handler",
+          isExternal: true,
+          url: false,
           timeout: Duration.seconds(15),
         }),
       );
@@ -79,6 +81,8 @@ test.provider(
         AWS.Lambda.Function<{}>()("TimeoutFn", {
           main: timeoutHandlerPath,
           handler: "handler",
+          isExternal: true,
+          url: false,
           timeout: Duration.seconds(45),
         }),
       );
@@ -101,7 +105,7 @@ test.provider(
       Effect.tap(() => stack.destroy()),
       Effect.onError(() => stack.destroy().pipe(Effect.ignore)),
     ),
-  { timeout: 240_000 },
+  { timeout: 360_000 },
 );
 
 const getPolicyStatement = Effect.fn(function* (

--- a/packages/alchemy/test/AWS/Lambda/Function.test.ts
+++ b/packages/alchemy/test/AWS/Lambda/Function.test.ts
@@ -2,10 +2,14 @@ import * as AWS from "@/AWS";
 import * as Test from "@/Test/Vitest";
 import * as Lambda from "@distilled.cloud/aws/lambda";
 import { expect } from "@effect/vitest";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import { TestFunction, TestFunctionLive } from "./handler.ts";
+
+const timeoutHandlerPath = new URL("./timeout-handler.ts", import.meta.url)
+  .pathname;
 
 const { test } = Test.make({ providers: AWS.providers() });
 
@@ -52,6 +56,52 @@ test.provider(
       Effect.onError(() => stack.destroy().pipe(Effect.ignore)),
     ),
   { timeout: 180_000 },
+);
+
+test.provider(
+  "applies and updates the Lambda timeout",
+  (stack) =>
+    Effect.gen(function* () {
+      const initial = yield* stack.deploy(
+        AWS.Lambda.Function<{}>()("TimeoutFn", {
+          main: timeoutHandlerPath,
+          handler: "handler",
+          timeout: Duration.seconds(15),
+        }),
+      );
+
+      const initialConfig = yield* Lambda.getFunction({
+        FunctionName: initial.functionName,
+      });
+      expect(initialConfig.Configuration?.Timeout).toBe(15);
+
+      yield* stack.deploy(
+        AWS.Lambda.Function<{}>()("TimeoutFn", {
+          main: timeoutHandlerPath,
+          handler: "handler",
+          timeout: Duration.seconds(45),
+        }),
+      );
+
+      const updatedConfig = yield* Lambda.getFunction({
+        FunctionName: initial.functionName,
+      }).pipe(
+        Effect.filterOrFail(
+          (c) => c.Configuration?.Timeout === 45,
+          () => new Error("Timeout update has not propagated yet"),
+        ),
+        Effect.retry({
+          schedule: Schedule.exponential(500).pipe(
+            Schedule.both(Schedule.recurs(10)),
+          ),
+        }),
+      );
+      expect(updatedConfig.Configuration?.Timeout).toBe(45);
+    }).pipe(
+      Effect.tap(() => stack.destroy()),
+      Effect.onError(() => stack.destroy().pipe(Effect.ignore)),
+    ),
+  { timeout: 240_000 },
 );
 
 const getPolicyStatement = Effect.fn(function* (

--- a/packages/alchemy/test/AWS/Lambda/timeout-handler.ts
+++ b/packages/alchemy/test/AWS/Lambda/timeout-handler.ts
@@ -1,0 +1,4 @@
+export const handler = async () => ({
+  statusCode: 200,
+  body: "ok",
+});

--- a/packages/alchemy/test/AWS/Lambda/timeout-handler.ts
+++ b/packages/alchemy/test/AWS/Lambda/timeout-handler.ts
@@ -1,4 +1,7 @@
-export const handler = async () => ({
+const handler = async () => ({
   statusCode: 200,
   body: "ok",
 });
+
+export { handler };
+export default handler;

--- a/packages/alchemy/test/AWS/Lambda/toTimeoutSeconds.test.ts
+++ b/packages/alchemy/test/AWS/Lambda/toTimeoutSeconds.test.ts
@@ -1,0 +1,59 @@
+import { toTimeoutSeconds } from "@/AWS/Lambda/Function.ts";
+import * as Duration from "effect/Duration";
+import { describe, expect, it } from "vitest";
+
+describe("toTimeoutSeconds", () => {
+  it("returns undefined for undefined", () => {
+    expect(toTimeoutSeconds(undefined)).toBeUndefined();
+  });
+
+  it("decodes a Duration object", () => {
+    expect(toTimeoutSeconds(Duration.seconds(30))).toBe(30);
+    expect(toTimeoutSeconds(Duration.minutes(2))).toBe(120);
+  });
+
+  it("decodes a millis number", () => {
+    expect(toTimeoutSeconds(30_000)).toBe(30);
+  });
+
+  it("decodes a template string", () => {
+    expect(toTimeoutSeconds("45 seconds")).toBe(45);
+    expect(toTimeoutSeconds("1 minute")).toBe(60);
+  });
+
+  it("decodes a [seconds, nanos] tuple", () => {
+    expect(toTimeoutSeconds([15, 0])).toBe(15);
+  });
+
+  it("rounds sub-second durations up to 1", () => {
+    expect(toTimeoutSeconds(Duration.millis(1))).toBe(1);
+    expect(toTimeoutSeconds(Duration.millis(500))).toBe(1);
+  });
+
+  it("rounds up partial seconds", () => {
+    expect(toTimeoutSeconds(Duration.millis(1500))).toBe(2);
+    expect(toTimeoutSeconds(Duration.millis(2001))).toBe(3);
+  });
+
+  it("decodes a JSON-serialized Duration (Millis)", () => {
+    const jsonShape = JSON.parse(JSON.stringify(Duration.seconds(42)));
+    expect(jsonShape).toEqual({
+      _id: "Duration",
+      _tag: "Millis",
+      millis: 42_000,
+    });
+    expect(toTimeoutSeconds(jsonShape)).toBe(42);
+  });
+
+  it("decodes a JSON-serialized Duration (Nanos)", () => {
+    const jsonShape = JSON.parse(
+      JSON.stringify(Duration.nanos(5_000_000_000n)),
+    );
+    expect(toTimeoutSeconds(jsonShape)).toBe(5);
+  });
+
+  it("returns undefined for a JSON-serialized Infinity Duration", () => {
+    const jsonShape = JSON.parse(JSON.stringify(Duration.infinity));
+    expect(toTimeoutSeconds(jsonShape)).toBeUndefined();
+  });
+});

--- a/packages/alchemy/test/AWS/Lambda/toTimeoutSeconds.test.ts
+++ b/packages/alchemy/test/AWS/Lambda/toTimeoutSeconds.test.ts
@@ -7,53 +7,42 @@ describe("toTimeoutSeconds", () => {
     expect(toTimeoutSeconds(undefined)).toBeUndefined();
   });
 
-  it("decodes a Duration object", () => {
+  it("converts a Duration to whole seconds", () => {
     expect(toTimeoutSeconds(Duration.seconds(30))).toBe(30);
     expect(toTimeoutSeconds(Duration.minutes(2))).toBe(120);
   });
 
-  it("decodes a millis number", () => {
-    expect(toTimeoutSeconds(30_000)).toBe(30);
-  });
-
-  it("decodes a template string", () => {
-    expect(toTimeoutSeconds("45 seconds")).toBe(45);
-    expect(toTimeoutSeconds("1 minute")).toBe(60);
-  });
-
-  it("decodes a [seconds, nanos] tuple", () => {
-    expect(toTimeoutSeconds([15, 0])).toBe(15);
-  });
-
-  it("rounds sub-second durations up to 1", () => {
+  it("rounds sub-second and partial durations up", () => {
     expect(toTimeoutSeconds(Duration.millis(1))).toBe(1);
-    expect(toTimeoutSeconds(Duration.millis(500))).toBe(1);
-  });
-
-  it("rounds up partial seconds", () => {
     expect(toTimeoutSeconds(Duration.millis(1500))).toBe(2);
     expect(toTimeoutSeconds(Duration.millis(2001))).toBe(3);
   });
 
-  it("decodes a JSON-serialized Duration (Millis)", () => {
-    const jsonShape = JSON.parse(JSON.stringify(Duration.seconds(42)));
-    expect(jsonShape).toEqual({
-      _id: "Duration",
-      _tag: "Millis",
-      millis: 42_000,
+  it("returns undefined for an infinite Duration", () => {
+    expect(toTimeoutSeconds(Duration.infinity)).toBeUndefined();
+  });
+
+  describe("after state JSON round-trip", () => {
+    const roundTrip = (d: Duration.Duration) =>
+      JSON.parse(JSON.stringify(d)) as Duration.Duration;
+
+    it("converts a rehydrated Millis Duration", () => {
+      const json = roundTrip(Duration.seconds(42));
+      expect(json).toEqual({
+        _id: "Duration",
+        _tag: "Millis",
+        millis: 42_000,
+      });
+      expect(toTimeoutSeconds(json)).toBe(42);
     });
-    expect(toTimeoutSeconds(jsonShape)).toBe(42);
-  });
 
-  it("decodes a JSON-serialized Duration (Nanos)", () => {
-    const jsonShape = JSON.parse(
-      JSON.stringify(Duration.nanos(5_000_000_000n)),
-    );
-    expect(toTimeoutSeconds(jsonShape)).toBe(5);
-  });
+    it("converts a rehydrated Nanos Duration", () => {
+      const json = roundTrip(Duration.nanos(5_000_000_000n));
+      expect(toTimeoutSeconds(json)).toBe(5);
+    });
 
-  it("returns undefined for a JSON-serialized Infinity Duration", () => {
-    const jsonShape = JSON.parse(JSON.stringify(Duration.infinity));
-    expect(toTimeoutSeconds(jsonShape)).toBeUndefined();
+    it("returns undefined for a rehydrated Infinity Duration", () => {
+      expect(toTimeoutSeconds(roundTrip(Duration.infinity))).toBeUndefined();
+    });
   });
 });

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -11,12 +11,14 @@ import {
 import * as Test from "@/Test/Vitest";
 import { describe, expect } from "@effect/vitest";
 import { Data, Layer } from "effect";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import {
   ArtifactProbe,
   BindingTarget,
   DeletedBindingRegressionTarget,
+  DurationResource,
   Function,
   PhasedTarget,
   StaticStablesResource,
@@ -4295,6 +4297,43 @@ describe("stack output persistence", () => {
         }).pipe(stack.deploy);
 
         expect(result).toEqual({ downstream: "shared" });
+      }),
+  );
+});
+
+describe("Duration round-trip through state", () => {
+  test.provider(
+    "input Duration reaches reconcile as a real Duration and output Duration re-hydrates as a real Duration on the next deploy",
+    (stack) =>
+      Effect.gen(function* () {
+        const first = yield* stack.deploy(
+          DurationResource("Timer", { timeout: Duration.seconds(15) }),
+        );
+
+        // Reconcile saw a real Duration: arithmetic worked.
+        expect(Duration.isDuration(first.observedTimeout)).toBe(true);
+        expect(Duration.toMillis(first.observedTimeout)).toBe(15_000);
+        expect(Duration.isDuration(first.computedTimeout)).toBe(true);
+        expect(Duration.toMillis(first.computedTimeout)).toBe(16_000);
+
+        // Second deploy: identical props. The engine reads the previous
+        // output from state. If the Duration weren't revived, `output`
+        // (a plain `{_id,_tag,millis}` shape) would fail `isDuration` and
+        // `Duration.toMillis` would throw.
+        const second = yield* stack.deploy(
+          DurationResource("Timer", { timeout: Duration.seconds(15) }),
+        );
+        expect(Duration.isDuration(second.observedTimeout)).toBe(true);
+        expect(Duration.toMillis(second.observedTimeout)).toBe(15_000);
+        expect(Duration.isDuration(second.computedTimeout)).toBe(true);
+        expect(Duration.toMillis(second.computedTimeout)).toBe(16_000);
+
+        // The persisted state itself should round-trip to a real Duration.
+        const persisted = yield* getState<{
+          attr: DurationResource["Attributes"];
+        }>("Timer");
+        expect(Duration.isDuration(persisted.attr.computedTimeout)).toBe(true);
+        expect(Duration.toMillis(persisted.attr.computedTimeout)).toBe(16_000);
       }),
   );
 });

--- a/packages/alchemy/test/test.resources.ts
+++ b/packages/alchemy/test/test.resources.ts
@@ -6,6 +6,7 @@ import * as State from "@/State/index";
 import { isUnknown } from "@/Util/unknown";
 import * as Context from "effect/Context";
 import { Data } from "effect";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -671,6 +672,50 @@ export const noPrecreateBindingTargetProvider = () =>
     delete: Effect.fn(function* () {}),
   });
 
+// DurationResource — exercises Duration round-tripping through state.
+// Input Duration must arrive at reconcile as a real Duration object (so the
+// resolver doesn't shred its prototype); output Duration must re-hydrate from
+// state on a subsequent deploy as a real Duration object too.
+
+export type DurationResourceProps = {
+  timeout: Duration.Duration;
+};
+
+export interface DurationResource extends Resource<
+  "Test.DurationResource",
+  DurationResourceProps,
+  {
+    /** Echoes the input Duration so we can assert what reconcile observed. */
+    observedTimeout: Duration.Duration;
+    /** Authoritative Duration the provider produces; persisted to state. */
+    computedTimeout: Duration.Duration;
+  }
+> {}
+
+export const DurationResource = Resource<DurationResource>(
+  "Test.DurationResource",
+);
+
+export const durationResourceProvider = () =>
+  Provider.succeed(DurationResource, {
+    diff: Effect.fn(function* ({ news }) {
+      if (!isResolved(news)) return undefined;
+      return undefined;
+    }),
+    reconcile: Effect.fn(function* ({ news }) {
+      // If `news.timeout` was shredded by the resolver into a plain object,
+      // these calls would throw or produce nonsense. The test asserts the
+      // numeric output so a regression surfaces as a failed assertion.
+      const observed = news.timeout;
+      const computed = Duration.millis(Duration.toMillis(observed) + 1_000);
+      return {
+        observedTimeout: observed,
+        computedTimeout: computed,
+      };
+    }),
+    delete: Effect.fn(function* () {}),
+  });
+
 // Layers
 export const TestLayers = () =>
   Layer.mergeAll(
@@ -684,6 +729,7 @@ export const TestLayers = () =>
     staticStablesResourceProvider(),
     phasedTargetProvider(),
     noPrecreateBindingTargetProvider(),
+    durationResourceProvider(),
   );
 
 export const InMemoryTestLayers = () =>


### PR DESCRIPTION
Adds a `timeout` field to `AWS.Lambda.FunctionProps` accepting any `Duration.Input`.

```ts
yield* AWS.Lambda.Function("ApiFunction", {
  main: "./src/handler.ts",
  timeout: Duration.seconds(30),    // Duration
  // timeout: "30 seconds",          // template string
  // timeout: 30_000,                // millis number
  // timeout: [30, 0],               // [seconds, nanos] tuple
});
```

Normalized to whole seconds via `toTimeoutSeconds` and wired into `CreateFunctionRequest.Timeout` (already forwarded by `updateFunctionConfiguration`). `diff` returns `update` when the normalized timeout changes.

### State serialization

`Duration` objects don't round-trip through `JSON.stringify` — re-hydrating yields `{_id:"Duration",_tag:"Millis",millis:N}`, which `Duration.toSeconds` rejects. The normalizer detects that shape and reads the value directly, so re-hydrated props converge cleanly.

```ts
const jsonShape = JSON.parse(JSON.stringify(Duration.seconds(42)));
// { _id: "Duration", _tag: "Millis", millis: 42_000 }
toTimeoutSeconds(jsonShape); // 42
```

Covered by 10 unit tests in [toTimeoutSeconds.test.ts](packages/alchemy/test/AWS/Lambda/toTimeoutSeconds.test.ts).
