### PR TITLE
feat(alchemy): add KeyPair resource

### DIFF
--- a/packages/alchemy/src/AWS/Providers.ts
+++ b/packages/alchemy/src/AWS/Providers.ts
@@ -19,6 +19,7 @@ import * as HttpClientError from "effect/unstable/http/HttpClientError";
 import { CredentialsStoreLive } from "../Auth/Credentials.ts";
 import { Command, CommandProvider } from "../Build/Command.ts";
 import * as Provider from "../Provider.ts";
+import { KeyPair, KeyPairProvider } from "../KeyPair.ts";
 import { Random, RandomProvider } from "../Random.ts";
 import * as ACM from "./ACM/index.ts";
 import * as ApiGateway from "./ApiGateway/index.ts";
@@ -63,6 +64,7 @@ export const providers = () =>
     Providers,
     Provider.collection([
       Command,
+      KeyPair,
       Random,
       ACM.Certificate,
       ApiGateway.Account,
@@ -571,6 +573,7 @@ export const providers = () =>
     Layer.provideMerge(
       Layer.mergeAll(
         CommandProvider(),
+        KeyPairProvider(),
         RandomProvider(),
         Assets.AssetsProvider(),
       ),

--- a/packages/alchemy/src/Cloudflare/Providers.ts
+++ b/packages/alchemy/src/Cloudflare/Providers.ts
@@ -10,6 +10,7 @@ import * as Build from "../Build/index.ts";
 import * as Provider from "../Provider.ts";
 import { CredentialsStoreLive } from "../Auth/Credentials.ts";
 import { ProfileLive } from "../Auth/Profile.ts";
+import { KeyPair, KeyPairProvider } from "../KeyPair.ts";
 import { Random, RandomProvider } from "../Random.ts";
 import * as Access from "./Access.ts";
 import * as AiGateway from "./AiGateway/index.ts";
@@ -81,6 +82,7 @@ export const providers = () =>
       SecretsStore.Secret,
       Tunnel.Tunnel,
       VpcService.VpcService,
+      KeyPair,
       Random,
       Workers.BindWorkerPolicy,
       Workers.CronEventSourcePolicy,
@@ -131,7 +133,11 @@ export const providers = () =>
       ),
     ),
     Layer.provideMerge(
-      Layer.mergeAll(Build.CommandProvider(), RandomProvider()),
+      Layer.mergeAll(
+        Build.CommandProvider(),
+        KeyPairProvider(),
+        RandomProvider(),
+      ),
     ),
     Layer.provideMerge(Credentials.fromAuthProvider()),
     Layer.provideMerge(CloudflareEnvironment.fromProfile()),

--- a/packages/alchemy/src/KeyPair.ts
+++ b/packages/alchemy/src/KeyPair.ts
@@ -37,9 +37,50 @@ export type KeyPair = Resource<
 /**
  * A deterministic-in-state public/private keypair generator.
  *
- * The keypair is generated once on create and then persisted in state so
- * subsequent deploys keep the same keys unless the resource is replaced.
- * `privateKey` is PEM-encoded `pkcs8` and `publicKey` is PEM-encoded `spki`.
+ * The keypair is generated once on first reconcile and then persisted in
+ * state so subsequent deploys keep the same keys unless the resource is
+ * replaced. `privateKey` is PEM-encoded `pkcs8` and `publicKey` is
+ * PEM-encoded `spki`.
+ *
+ * @resource
+ *
+ * @section Generating a Keypair
+ * @example Default ed25519 keypair
+ * ```typescript
+ * const keys = yield* KeyPair("signing-key");
+ * // keys.privateKey: Redacted<string>  (PEM pkcs8)
+ * // keys.publicKey:  string            (PEM spki)
+ * // keys.algorithm:  "ed25519"
+ * ```
+ *
+ * @example RSA keypair
+ * ```typescript
+ * const keys = yield* KeyPair("rsa-key", {
+ *   algorithm: "rsa",
+ *   modulusLength: 2048,
+ * });
+ * ```
+ *
+ * @example EC keypair on a named curve
+ * ```typescript
+ * const keys = yield* KeyPair("ec-key", {
+ *   algorithm: "ec",
+ *   namedCurve: "P-256",
+ * });
+ * ```
+ *
+ * @section Consuming the Keys
+ * @example Pass the private key to a Worker as a secret
+ * ```typescript
+ * const keys = yield* KeyPair("signing-key");
+ * export const Worker = Cloudflare.Worker("Worker", {
+ *   main: "./src/worker.ts",
+ *   bindings: {
+ *     SIGNING_KEY: keys.privateKey,
+ *     PUBLIC_KEY: keys.publicKey,
+ *   },
+ * });
+ * ```
  */
 export const KeyPair = Resource<KeyPair>("Alchemy.KeyPair");
 

--- a/packages/alchemy/src/KeyPair.ts
+++ b/packages/alchemy/src/KeyPair.ts
@@ -1,0 +1,105 @@
+import * as NodeCrypto from "node:crypto";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import * as Provider from "./Provider.ts";
+import { Resource } from "./Resource.ts";
+
+export type KeyPairAlgorithm = "ed25519" | "rsa" | "ec";
+
+export interface KeyPairProps {
+  /**
+   * Key algorithm used to generate the pair.
+   * @default "ed25519"
+   */
+  algorithm?: KeyPairAlgorithm;
+  /**
+   * Modulus length in bits. Only used when {@link algorithm} is `"rsa"`.
+   * @default 2048
+   */
+  modulusLength?: number;
+  /**
+   * Named curve. Only used when {@link algorithm} is `"ec"`.
+   * @default "P-256"
+   */
+  namedCurve?: string;
+}
+
+export type KeyPair = Resource<
+  "Alchemy.KeyPair",
+  KeyPairProps,
+  {
+    algorithm: KeyPairAlgorithm;
+    privateKey: Redacted.Redacted<string>;
+    publicKey: string;
+  }
+>;
+
+/**
+ * A deterministic-in-state public/private keypair generator.
+ *
+ * The keypair is generated once on create and then persisted in state so
+ * subsequent deploys keep the same keys unless the resource is replaced.
+ * `privateKey` is PEM-encoded `pkcs8` and `publicKey` is PEM-encoded `spki`.
+ */
+export const KeyPair = Resource<KeyPair>("Alchemy.KeyPair");
+
+const pemEncoding = {
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+} as const;
+
+const generate = (
+  props: KeyPairProps,
+): {
+  privateKey: string;
+  publicKey: string;
+  algorithm: KeyPairAlgorithm;
+} => {
+  const algorithm = props.algorithm ?? "ed25519";
+  if (algorithm === "rsa") {
+    const { privateKey, publicKey } = NodeCrypto.generateKeyPairSync("rsa", {
+      modulusLength: props.modulusLength ?? 2048,
+      ...pemEncoding,
+    });
+    return { algorithm, privateKey, publicKey };
+  }
+  if (algorithm === "ec") {
+    const { privateKey, publicKey } = NodeCrypto.generateKeyPairSync("ec", {
+      namedCurve: props.namedCurve ?? "P-256",
+      ...pemEncoding,
+    });
+    return { algorithm, privateKey, publicKey };
+  }
+  const { privateKey, publicKey } = NodeCrypto.generateKeyPairSync(
+    "ed25519",
+    pemEncoding,
+  );
+  return { algorithm, privateKey, publicKey };
+};
+
+export const KeyPairProvider = () =>
+  Provider.succeed(KeyPair, {
+    reconcile: Effect.fn(function* ({ news = {}, output }) {
+      // Observe — there is no remote state. The cached `output` is the
+      // authoritative current value; once minted the keypair is preserved
+      // across reconciles to keep it stable.
+      if (output?.privateKey && output?.publicKey) {
+        return output;
+      }
+
+      // Ensure — no observed value: mint a fresh keypair. The next
+      // reconcile will see this in `output` and short-circuit above.
+      const generated = yield* Effect.sync(() => generate(news));
+      return {
+        algorithm: generated.algorithm,
+        privateKey: Redacted.make(generated.privateKey),
+        publicKey: generated.publicKey,
+      };
+    }),
+    delete: Effect.fn(function* () {
+      return undefined;
+    }),
+    read: Effect.fn(function* ({ output }) {
+      return output;
+    }),
+  });

--- a/packages/alchemy/src/index.ts
+++ b/packages/alchemy/src/index.ts
@@ -25,6 +25,7 @@ export type { Output } from "./Output.ts";
 export * from "./PhysicalName.ts";
 export * as Plan from "./Plan.ts";
 export { Provider, ProviderCollection } from "./Provider.ts";
+export * from "./KeyPair.ts";
 export * from "./Random.ts";
 export * from "./Ref.ts";
 export * as RemovalPolicy from "./RemovalPolicy.ts";

--- a/packages/alchemy/test/KeyPair.test.ts
+++ b/packages/alchemy/test/KeyPair.test.ts
@@ -1,0 +1,77 @@
+import * as NodeCrypto from "node:crypto";
+import { KeyPair, KeyPairProvider } from "@/KeyPair";
+import { Provider } from "@/Provider";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+
+const invokeReconcile = (
+  news: KeyPair["Props"],
+  output?: KeyPair["Attributes"],
+) =>
+  Effect.gen(function* () {
+    const provider = yield* Provider<KeyPair>(KeyPair.Type);
+    return yield* provider.reconcile({
+      id: "test",
+      instanceId: "test",
+      news,
+      olds: undefined,
+      output,
+      session: undefined as any,
+      bindings: {} as any,
+    });
+  }).pipe(Effect.provide(KeyPairProvider()));
+
+const assertPemKeyPair = (attrs: KeyPair["Attributes"]) => {
+  const priv = Redacted.value(attrs.privateKey);
+  expect(priv).toMatch(/^-----BEGIN PRIVATE KEY-----/);
+  expect(priv).toMatch(/-----END PRIVATE KEY-----/);
+  expect(attrs.publicKey).toMatch(/^-----BEGIN PUBLIC KEY-----/);
+  expect(attrs.publicKey).toMatch(/-----END PUBLIC KEY-----/);
+  // Node will throw if the PEM is malformed.
+  NodeCrypto.createPrivateKey(priv);
+  NodeCrypto.createPublicKey(attrs.publicKey);
+};
+
+describe("Alchemy.KeyPair", () => {
+  it.effect("mints an ed25519 keypair by default", () =>
+    Effect.gen(function* () {
+      const attrs = yield* invokeReconcile({});
+      expect(attrs.algorithm).toBe("ed25519");
+      assertPemKeyPair(attrs);
+    }),
+  );
+
+  it.effect("mints an rsa keypair when requested", () =>
+    Effect.gen(function* () {
+      const attrs = yield* invokeReconcile({
+        algorithm: "rsa",
+        modulusLength: 2048,
+      });
+      expect(attrs.algorithm).toBe("rsa");
+      assertPemKeyPair(attrs);
+    }),
+  );
+
+  it.effect("mints an ec keypair when requested", () =>
+    Effect.gen(function* () {
+      const attrs = yield* invokeReconcile({
+        algorithm: "ec",
+        namedCurve: "P-256",
+      });
+      expect(attrs.algorithm).toBe("ec");
+      assertPemKeyPair(attrs);
+    }),
+  );
+
+  it.effect("preserves the keypair across reconciles", () =>
+    Effect.gen(function* () {
+      const first = yield* invokeReconcile({});
+      const second = yield* invokeReconcile({}, first);
+      expect(Redacted.value(second.privateKey)).toBe(
+        Redacted.value(first.privateKey),
+      );
+      expect(second.publicKey).toBe(first.publicKey);
+    }),
+  );
+});

--- a/packages/alchemy/test/KeyPair.test.ts
+++ b/packages/alchemy/test/KeyPair.test.ts
@@ -1,73 +1,82 @@
 import * as NodeCrypto from "node:crypto";
 import { KeyPair, KeyPairProvider } from "@/KeyPair";
-import { Provider } from "@/Provider";
-import { describe, expect, it } from "@effect/vitest";
+import { inMemoryState } from "@/State";
+import * as Test from "@/Test/Vitest";
+import { describe, expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 
-const invokeReconcile = (
-  news: KeyPair["Props"],
-  output?: KeyPair["Attributes"],
-) =>
-  Effect.gen(function* () {
-    const provider = yield* Provider<KeyPair>(KeyPair.Type);
-    return yield* provider.reconcile({
-      id: "test",
-      instanceId: "test",
-      news,
-      olds: undefined,
-      output,
-      session: undefined as any,
-      bindings: {} as any,
-    });
-  }).pipe(Effect.provide(KeyPairProvider()));
+const { test } = Test.make({
+  providers: KeyPairProvider(),
+  state: inMemoryState(),
+});
 
-const assertPemKeyPair = (attrs: KeyPair["Attributes"]) => {
+const assertPemKeyPair = (attrs: {
+  privateKey: Redacted.Redacted<string>;
+  publicKey: string;
+}) => {
   const priv = Redacted.value(attrs.privateKey);
   expect(priv).toMatch(/^-----BEGIN PRIVATE KEY-----/);
   expect(priv).toMatch(/-----END PRIVATE KEY-----/);
   expect(attrs.publicKey).toMatch(/^-----BEGIN PUBLIC KEY-----/);
   expect(attrs.publicKey).toMatch(/-----END PUBLIC KEY-----/);
-  // Node will throw if the PEM is malformed.
+  // Node throws if the PEM is malformed.
   NodeCrypto.createPrivateKey(priv);
   NodeCrypto.createPublicKey(attrs.publicKey);
 };
 
 describe("Alchemy.KeyPair", () => {
-  it.effect("mints an ed25519 keypair by default", () =>
+  test.provider("mints an ed25519 keypair by default", (stack) =>
     Effect.gen(function* () {
-      const attrs = yield* invokeReconcile({});
+      const attrs = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* KeyPair("ed25519-default");
+        }),
+      );
       expect(attrs.algorithm).toBe("ed25519");
       assertPemKeyPair(attrs);
     }),
   );
 
-  it.effect("mints an rsa keypair when requested", () =>
+  test.provider("mints an rsa keypair when requested", (stack) =>
     Effect.gen(function* () {
-      const attrs = yield* invokeReconcile({
-        algorithm: "rsa",
-        modulusLength: 2048,
-      });
+      const attrs = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* KeyPair("rsa-key", {
+            algorithm: "rsa",
+            modulusLength: 2048,
+          });
+        }),
+      );
       expect(attrs.algorithm).toBe("rsa");
       assertPemKeyPair(attrs);
     }),
   );
 
-  it.effect("mints an ec keypair when requested", () =>
+  test.provider("mints an ec keypair when requested", (stack) =>
     Effect.gen(function* () {
-      const attrs = yield* invokeReconcile({
-        algorithm: "ec",
-        namedCurve: "P-256",
-      });
+      const attrs = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* KeyPair("ec-key", {
+            algorithm: "ec",
+            namedCurve: "P-256",
+          });
+        }),
+      );
       expect(attrs.algorithm).toBe("ec");
       assertPemKeyPair(attrs);
     }),
   );
 
-  it.effect("preserves the keypair across reconciles", () =>
+  test.provider("preserves the keypair across deploys", (stack) =>
     Effect.gen(function* () {
-      const first = yield* invokeReconcile({});
-      const second = yield* invokeReconcile({}, first);
+      const program = Effect.gen(function* () {
+        return yield* KeyPair("stable-key");
+      });
+
+      const first = yield* stack.deploy(program);
+      const second = yield* stack.deploy(program);
+
       expect(Redacted.value(second.privateKey)).toBe(
         Redacted.value(first.privateKey),
       );


### PR DESCRIPTION
Adds an `Alchemy.KeyPair` resource that generates a public/private keypair on first reconcile and persists it in state — same deterministic-in-state pattern as `Random`.

```ts
const keys = yield* KeyPair("signing-key");
// keys.privateKey: Redacted<string>  (PEM pkcs8)
// keys.publicKey:  string            (PEM spki)
// keys.algorithm:  "ed25519" | "rsa" | "ec"
```

Defaults to `ed25519`; supports `rsa` (`modulusLength`) and `ec` (`namedCurve`). Registered in both `AWS.providers()` and `Cloudflare.providers()` next to `Random`.
