### PR TITLE
docs(blog): trim low-level details from beta.43 post

### DIFF
--- a/website/src/content/docs/blog/2026-05-21-beta-43.md
+++ b/website/src/content/docs/blog/2026-05-21-beta-43.md
@@ -83,18 +83,6 @@ export const Db = Effect.gen(function* () {
 });
 ```
 
-A few things worth knowing:
-
-- `region` and `arch` on the database are stable — changing
-  either replaces the cluster. `clusterSize` resizes in place.
-- For MySQL, swap to `MySQLDatabase` / `MySQLBranch` /
-  `MySQLPassword`. Branches take one extra flag,
-  `isProduction: true | false`, and the password takes
-  `role: "reader" | "writer" | "admin" | "readwriter"`.
-
-The role exposes an `origin` shaped exactly like what
-`Cloudflare.Hyperdrive` accepts as input.
-
 ## Snap Hyperdrive on top
 
 Because `role.origin` is an `Output`, the deploy graph orders


### PR DESCRIPTION
Drop the "A few things worth knowing" block from the beta.43 release post — region/arch stability, `clusterSize` resize semantics, MySQL property deltas (`isProduction`, password `role`), and the `origin` shape note. That's reference-doc material; the post should stay focused on the walkthrough.

```diff
 });
 ```

-A few things worth knowing:
-
-- `region` and `arch` on the database are stable — changing
-  either replaces the cluster. `clusterSize` resizes in place.
-- For MySQL, swap to `MySQLDatabase` / `MySQLBranch` /
-  `MySQLPassword`. Branches take one extra flag,
-  `isProduction: true | false`, and the password takes
-  `role: "reader" | "writer" | "admin" | "readwriter"`.
-
-The role exposes an `origin` shaped exactly like what
-`Cloudflare.Hyperdrive` accepts as input.
-
 ## Snap Hyperdrive on top
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01VaJvQewtXAyAUqYycGy6Rg)_