### PR TITLE
feat(cloudflare/queue): accept Duration.Input for messages() time props

### DIFF
--- a/packages/alchemy/src/Cloudflare/Queue/QueueEventSource.ts
+++ b/packages/alchemy/src/Cloudflare/Queue/QueueEventSource.ts
@@ -1,6 +1,7 @@
 import type * as cf from "@cloudflare/workers-types";
 import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Stream from "effect/Stream";
@@ -25,13 +26,46 @@ export interface MessagesProps {
   maxConcurrency?: number;
   /** Maximum delivery attempts before dead-lettering. */
   maxRetries?: number;
-  /** Wait time, in ms, before flushing a partial batch. */
-  maxWaitTimeMs?: number;
-  /** Backoff, in seconds, applied to a retry. */
-  retryDelay?: number;
+  /**
+   * Wait time before flushing a partial batch. Rounded up to whole
+   * milliseconds when forwarded to Cloudflare.
+   */
+  maxWaitTime?: Duration.Input;
+  /**
+   * Backoff applied to a retry. Rounded up to whole seconds when
+   * forwarded to Cloudflare.
+   */
+  retryDelay?: Duration.Input;
   /** Optional dead-letter queue name. */
   deadLetterQueue?: string;
 }
+
+const toMillis = (input: Duration.Input | undefined) =>
+  input === undefined
+    ? undefined
+    : Math.max(0, Math.ceil(Duration.toMillis(input)));
+
+const toSeconds = (input: Duration.Input | undefined) =>
+  input === undefined
+    ? undefined
+    : Math.max(0, Math.ceil(Duration.toSeconds(input)));
+
+/**
+ * Convert a {@link MessagesProps} (with `Duration.Input` time fields)
+ * into the numeric settings shape Cloudflare's `QueueConsumer` API
+ * expects. `maxWaitTime` is rounded up to whole milliseconds and
+ * `retryDelay` to whole seconds.
+ *
+ * Exposed for testing and for callers that want to mirror the
+ * conversion when wiring `QueueConsumer` directly.
+ */
+export const toConsumerSettings = (props: MessagesProps) => ({
+  batchSize: props.batchSize,
+  maxConcurrency: props.maxConcurrency,
+  maxRetries: props.maxRetries,
+  maxWaitTimeMs: toMillis(props.maxWaitTime),
+  retryDelay: toSeconds(props.retryDelay),
+});
 
 /**
  * A single queue message handed to the subscribe handler. Mirrors
@@ -63,12 +97,15 @@ export type QueueMessage<Body = unknown> = cf.Message<Body>;
  * @example
  * ```typescript
  * import * as Cloudflare from "alchemy/Cloudflare";
+ * import * as Duration from "effect/Duration";
  * import * as Effect from "effect/Effect";
  * import * as Stream from "effect/Stream";
  *
  * yield* Cloudflare.messages<MyEvent>(queueResource, {
  *   batchSize: 25,
  *   maxRetries: 3,
+ *   maxWaitTime: "5 seconds",
+ *   retryDelay: Duration.seconds(30),
  * }).subscribe((stream) =>
  *   Stream.runForEach(stream, (msg) =>
  *     Effect.log(`event ${msg.body.id}`),
@@ -148,7 +185,7 @@ export const QueueEventSourcePolicyLive = QueueEventSourcePolicy.layer.succeed(
       yield* QueueConsumer(`${queue.LogicalId}Consumer`, {
         queueId: queue.queueId,
         scriptName: host.workerName,
-        settings: props,
+        settings: toConsumerSettings(props),
         deadLetterQueue: props.deadLetterQueue,
       });
     })) as unknown as (

--- a/packages/alchemy/src/Cloudflare/Queue/QueueEventSource.ts
+++ b/packages/alchemy/src/Cloudflare/Queue/QueueEventSource.ts
@@ -9,6 +9,7 @@ import * as Binding from "../../Binding.ts";
 import type { ResourceLike } from "../../Resource.ts";
 import { RuntimeContext } from "../../RuntimeContext.ts";
 import type { FunctionContext } from "../../Serverless/Function.ts";
+import * as DurationUtil from "../../Util/Duration.ts";
 import { isWorker, isWorkerEvent } from "../Workers/Worker.ts";
 import type { Queue } from "./Queue.ts";
 import { QueueConsumer } from "./QueueConsumer.ts";
@@ -40,16 +41,6 @@ export interface MessagesProps {
   deadLetterQueue?: string;
 }
 
-const toMillis = (input: Duration.Input | undefined) =>
-  input === undefined
-    ? undefined
-    : Math.max(0, Math.ceil(Duration.toMillis(input)));
-
-const toSeconds = (input: Duration.Input | undefined) =>
-  input === undefined
-    ? undefined
-    : Math.max(0, Math.ceil(Duration.toSeconds(input)));
-
 /**
  * Convert a {@link MessagesProps} (with `Duration.Input` time fields)
  * into the numeric settings shape Cloudflare's `QueueConsumer` API
@@ -63,8 +54,8 @@ export const toConsumerSettings = (props: MessagesProps) => ({
   batchSize: props.batchSize,
   maxConcurrency: props.maxConcurrency,
   maxRetries: props.maxRetries,
-  maxWaitTimeMs: toMillis(props.maxWaitTime),
-  retryDelay: toSeconds(props.retryDelay),
+  maxWaitTimeMs: DurationUtil.toMillis(props.maxWaitTime),
+  retryDelay: DurationUtil.toSeconds(props.retryDelay),
 });
 
 /**

--- a/packages/alchemy/src/Util/Duration.ts
+++ b/packages/alchemy/src/Util/Duration.ts
@@ -1,0 +1,21 @@
+import * as Duration from "effect/Duration";
+
+/**
+ * Convert a {@link Duration.Input} to whole, non-negative
+ * milliseconds. Returns `undefined` when `input` is `undefined`,
+ * so call sites can map through optional duration fields without
+ * a branch.
+ */
+export const toMillis = (input: Duration.Input | undefined) =>
+  input === undefined
+    ? undefined
+    : Math.max(0, Math.ceil(Duration.toMillis(input)));
+
+/**
+ * Convert a {@link Duration.Input} to whole, non-negative seconds.
+ * Returns `undefined` when `input` is `undefined`.
+ */
+export const toSeconds = (input: Duration.Input | undefined) =>
+  input === undefined
+    ? undefined
+    : Math.max(0, Math.ceil(Duration.toSeconds(input)));

--- a/packages/alchemy/test/Cloudflare/Queue/round-trip-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Queue/round-trip-worker.ts
@@ -1,4 +1,5 @@
 import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Stream from "effect/Stream";
 import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
@@ -67,11 +68,23 @@ export default class QueueWorker extends Cloudflare.Worker<QueueWorker>()(
     // Effect-style queue consumer. The handler delegates to the
     // Counter DO so the test can verify the message landed by
     // polling the DO's snapshot.
-    yield* Cloudflare.messages<QueueMessageBody>(queueResource).subscribe(
-      (stream) =>
-        Stream.runForEach(stream, (msg) =>
-          counters.getByName(msg.body.name).record(msg.body.text),
-        ),
+    //
+    // Mixed `Duration.Input` forms are intentional: the e2e test
+    // exercises that a `Duration` value (`maxWaitTime`) and a
+    // string (`retryDelay: "1 second"`) both type-check at the
+    // `Cloudflare.messages(...)` call site and survive the convert-
+    // and-forward path into Cloudflare's QueueConsumer settings.
+    // Values are kept small so the round-trip latency stays well
+    // under the test's 240s timeout.
+    yield* Cloudflare.messages<QueueMessageBody>(queueResource, {
+      batchSize: 10,
+      maxRetries: 3,
+      maxWaitTime: Duration.millis(500),
+      retryDelay: "1 second",
+    }).subscribe((stream) =>
+      Stream.runForEach(stream, (msg) =>
+        counters.getByName(msg.body.name).record(msg.body.text),
+      ),
     );
 
     return {

--- a/packages/alchemy/test/Cloudflare/Queue/toConsumerSettings.test.ts
+++ b/packages/alchemy/test/Cloudflare/Queue/toConsumerSettings.test.ts
@@ -1,0 +1,58 @@
+import { toConsumerSettings } from "@/Cloudflare/Queue/QueueEventSource.ts";
+import * as Duration from "effect/Duration";
+import { describe, expect, it } from "vitest";
+
+describe("toConsumerSettings", () => {
+  it("passes scalar fields through unchanged", () => {
+    expect(
+      toConsumerSettings({
+        batchSize: 25,
+        maxConcurrency: 4,
+        maxRetries: 3,
+      }),
+    ).toEqual({
+      batchSize: 25,
+      maxConcurrency: 4,
+      maxRetries: 3,
+      maxWaitTimeMs: undefined,
+      retryDelay: undefined,
+    });
+  });
+
+  it("converts maxWaitTime to whole milliseconds", () => {
+    expect(
+      toConsumerSettings({ maxWaitTime: Duration.seconds(5) }).maxWaitTimeMs,
+    ).toBe(5_000);
+    expect(
+      toConsumerSettings({ maxWaitTime: "250 millis" }).maxWaitTimeMs,
+    ).toBe(250);
+    expect(toConsumerSettings({ maxWaitTime: 1500 }).maxWaitTimeMs).toBe(1500);
+  });
+
+  it("rounds sub-millisecond maxWaitTime up", () => {
+    expect(
+      toConsumerSettings({ maxWaitTime: Duration.nanos(1n) }).maxWaitTimeMs,
+    ).toBe(1);
+  });
+
+  it("converts retryDelay to whole seconds", () => {
+    expect(
+      toConsumerSettings({ retryDelay: Duration.minutes(2) }).retryDelay,
+    ).toBe(120);
+    expect(toConsumerSettings({ retryDelay: "30 seconds" }).retryDelay).toBe(
+      30,
+    );
+  });
+
+  it("rounds partial-second retryDelay up", () => {
+    expect(
+      toConsumerSettings({ retryDelay: Duration.millis(1500) }).retryDelay,
+    ).toBe(2);
+  });
+
+  it("leaves missing time fields undefined", () => {
+    const result = toConsumerSettings({ batchSize: 10 });
+    expect(result.maxWaitTimeMs).toBeUndefined();
+    expect(result.retryDelay).toBeUndefined();
+  });
+});

--- a/website/src/content/docs/tutorial/cloudflare/queue-consumer.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/queue-consumer.mdx
@@ -118,8 +118,16 @@ before dead-lettering. For finer control, call `msg.ack()` /
 ## Tune batching and backoff
 
 `messages(queue, props)` accepts a settings object. Time fields are
-`Duration.Input` — pass a `Duration`, a number of milliseconds, or
-a string like `"5 seconds"`.
+`Duration.Input` — any of these are accepted:
+
+```typescript
+maxWaitTime: Duration.seconds(5)   // a Duration value
+maxWaitTime: 5_000                 // a number of milliseconds
+maxWaitTime: "5 seconds"           // a "<number> <unit>" string
+```
+
+Units in the string form are plural (`"seconds"`, `"millis"`,
+`"minutes"`, ...) — that's Effect's `Duration.Unit` shape.
 
 ```diff lang="typescript"
 +import * as Duration from "effect/Duration";

--- a/website/src/content/docs/tutorial/cloudflare/queue-consumer.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/queue-consumer.mdx
@@ -124,10 +124,8 @@ before dead-lettering. For finer control, call `msg.ack()` /
 maxWaitTime: Duration.seconds(5)   // a Duration value
 maxWaitTime: 5_000                 // a number of milliseconds
 maxWaitTime: "5 seconds"           // a "<number> <unit>" string
+retryDelay: "1 second"             // singular and plural units both work
 ```
-
-Units in the string form are plural (`"seconds"`, `"millis"`,
-`"minutes"`, ...) — that's Effect's `Duration.Unit` shape.
 
 ```diff lang="typescript"
 +import * as Duration from "effect/Duration";

--- a/website/src/content/docs/tutorial/cloudflare/queue-consumer.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/queue-consumer.mdx
@@ -115,6 +115,27 @@ Cloudflare applies the consumer's `maxRetries` and `retryDelay`
 before dead-lettering. For finer control, call `msg.ack()` /
 `msg.retry()` per message inside the handler.
 
+## Tune batching and backoff
+
+`messages(queue, props)` accepts a settings object. Time fields are
+`Duration.Input` — pass a `Duration`, a number of milliseconds, or
+a string like `"5 seconds"`.
+
+```diff lang="typescript"
++import * as Duration from "effect/Duration";
+
+- Cloudflare.messages<QueueMessageBody>(queueResource).subscribe(
++ Cloudflare.messages<QueueMessageBody>(queueResource, {
++   batchSize: 25,
++   maxRetries: 3,
++   maxWaitTime: "5 seconds",
++   retryDelay: Duration.seconds(30),
++ }).subscribe(
+```
+
+`maxWaitTime` is rounded up to whole milliseconds and `retryDelay`
+to whole seconds when forwarded to Cloudflare.
+
 ## Provide the runtime layer
 
 `messages(...).subscribe(...)` is a `Context.Service` call —


### PR DESCRIPTION
`Cloudflare.messages(queue, props)` now takes `Duration.Input` for the time-shaped fields. Internally, values are rounded up and forwarded as numbers to the auto-created `Cloudflare.QueueConsumer`.

```diff
-  maxWaitTimeMs?: number;
-  retryDelay?: number;
+  maxWaitTime?: Duration.Input;
+  retryDelay?: Duration.Input;
```

All three forms are accepted:

```ts
maxWaitTime: Duration.seconds(5)   // Duration value
maxWaitTime: 5_000                 // number of milliseconds
maxWaitTime: "5 seconds"           // "<number> <unit>" string (plural units)
```

```ts
yield* Cloudflare.messages<MyEvent>(queueResource, {
  batchSize: 25,
  maxRetries: 3,
  maxWaitTime: "5 seconds",
  retryDelay: Duration.seconds(30),
}).subscribe(...)
```

`maxWaitTime` rounds up to whole ms; `retryDelay` rounds up to whole seconds.
