### PR TITLE
docs(blog): beta.44 release notes

### DIFF
--- a/website/src/content/docs/blog/2026-05-22-beta-44.md
+++ b/website/src/content/docs/blog/2026-05-22-beta-44.md
@@ -101,6 +101,16 @@ Workers. No code change required; existing artifact bindings
 light up locally on upgrade.
 ([#419](https://github.com/alchemy-run/alchemy-effect/pull/419))
 
+## Worker entrypoint cleanup
+
+- `WorkerBridge` now uses namespace imports from `effect`
+  instead of barrel imports, which silences a noisy rolldown
+  warning and trims a small amount of bundle work
+  ([#420](https://github.com/alchemy-run/alchemy-effect/pull/420)).
+- Removed a noisy `DurableObjectBridge` log that fired on every
+  WebSocket message, plus a few other stray dev logs
+  ([#410](https://github.com/alchemy-run/alchemy-effect/pull/410)).
+
 ## Also in this release
 
 - **Vite-style `?raw` imports in the Worker bundler** —
@@ -111,9 +121,22 @@ light up locally on upgrade.
   child sidecars are cleaned up when the dev server is
   interrupted
   ([#382](https://github.com/alchemy-run/alchemy-effect/pull/382)).
-- **Local Durable Object handling hardened** — fixes a class of
-  crashes when DOs are recreated mid-dev-session
+- **Local Durable Objects hardened** — fixes swapped
+  `className`/`namespaceId` in the local provider output, makes
+  the local `namespaceId` deterministic and independent of the
+  binding name, and stops DOs declared on other Workers in the
+  stack from being registered against the current Worker
   ([#408](https://github.com/alchemy-run/alchemy-effect/pull/408)).
+- **`alchemy dev` now honors your Workers `assets` config** —
+  the configured asset behavior was previously ignored in local
+  dev
+  ([#403](https://github.com/alchemy-run/alchemy-effect/pull/403)).
+- **`mysql2` no longer errors at bundle time** in the Worker
+  bundler
+  ([#403](https://github.com/alchemy-run/alchemy-effect/pull/403)).
+- **`x-forwarded-for` and `x-forwarded-proto` headers** are now
+  forwarded on incoming requests in `alchemy dev`
+  ([#403](https://github.com/alchemy-run/alchemy-effect/pull/403)).
 - **Rolldown bumped to 1.0.1 stable** — out of pre-release
   ([#409](https://github.com/alchemy-run/alchemy-effect/pull/409)).
 - **`@alchemy.run/node-utils` import resolution fix** — resolves
@@ -123,12 +146,6 @@ light up locally on upgrade.
   no more spurious warnings during dev. Thanks
   **[Michael K](https://github.com/michaelkleene)**
   ([#124](https://github.com/alchemy-run/alchemy-effect/pull/124)).
-- **`cloudflare-tools` bumped to 0.6.3**, `WorkerBridge` imports
-  optimized, stray logs removed
-  ([#403](https://github.com/alchemy-run/alchemy-effect/pull/403),
-  [#410](https://github.com/alchemy-run/alchemy-effect/pull/410),
-  [#418](https://github.com/alchemy-run/alchemy-effect/pull/418),
-  [#420](https://github.com/alchemy-run/alchemy-effect/pull/420)).
 
 ## Contributors
 

--- a/website/src/content/docs/blog/2026-05-22-beta-44.md
+++ b/website/src/content/docs/blog/2026-05-22-beta-44.md
@@ -107,8 +107,8 @@ Until beta.43, local providers (the runtime that backs
 `Cloudflare.Worker`, `DurableObjectNamespace`, etc. under
 `alchemy dev`) ran inside an in-process "sidecar" tied to the
 dev server. That worked, but it leaked: when the dev process
-exited — Ctrl-C, crash, HMR restart — the child `workerd` /
-miniflare processes it had spawned could survive, holding ports
+exited — Ctrl-C, crash, HMR restart — the child `workerd`
+processes it had spawned could survive, holding ports
 open and consuming memory until you noticed and killed them by
 hand.
 

--- a/website/src/content/docs/blog/2026-05-22-beta-44.md
+++ b/website/src/content/docs/blog/2026-05-22-beta-44.md
@@ -64,8 +64,8 @@ Opt in via `build.bundleAnalyzer` on the Worker:
  ) {}
 ```
 
-By default this writes `analyze-data.md` next to the bundle.
-Pass an object to customise:
+By default this writes `analyze-data.md` next to the bundle in `.alchemy/bundles/<id>`.
+Pass an object to customize:
 
 ```typescript
 build: {

--- a/website/src/content/docs/blog/2026-05-22-beta-44.md
+++ b/website/src/content/docs/blog/2026-05-22-beta-44.md
@@ -1,0 +1,144 @@
+---
+title: alchemy@2.0.0-beta.44
+date: 2026-05-22T20:00:00Z
+category: release
+excerpt: v2.0.0-beta.44 adds a new `Cloudflare.ZarazConfig` resource, a bundle analyzer for Workers, and Artifacts binding support in dev, plus a handful of bundler and dev-server fixes.
+---
+
+`v2.0.0-beta.44` is a polish release. Two new things worth
+calling out — a new **`Cloudflare.ZarazConfig`** resource and a
+**bundle analyzer plugin** for the Worker bundler — plus a
+batch of bundler and dev-server fixes.
+
+## `Cloudflare.ZarazConfig`
+
+New resource for managing a zone's Zaraz config — tools,
+triggers, variables, consent, analytics, and workflow mode —
+declaratively alongside the rest of your Cloudflare stack.
+
+```typescript
+import * as Cloudflare from "alchemy/Cloudflare";
+
+const zaraz = yield* Cloudflare.ZarazConfig("analytics", {
+  zone: "example.com",
+  tools: {
+    "google-analytics": { /* tool config */ },
+  },
+  consent: { enabled: true },
+});
+```
+
+A couple of design notes worth knowing:
+
+- Fields you omit (`tools`, `triggers`, `variables`, `workflow`)
+  are **left alone** rather than wiped. This means you can adopt
+  a zone's existing Zaraz setup incrementally.
+- Destroy is **opt-in** via `delete: true`. By default,
+  destroying the resource removes it from Alchemy state and
+  leaves the zone's Zaraz config intact. With `delete: true`,
+  destroy restores Cloudflare's defaults (including resetting
+  `workflow` to real-time mode).
+- Typed Zaraz event helpers ship as `defineZarazEvents`.
+
+Thanks **[Alex](https://github.com/gogl-alex)** for the
+contribution.
+([#371](https://github.com/alchemy-run/alchemy-effect/pull/371))
+
+## Bundle analyzer for Workers
+
+The Worker bundler can now emit a per-build report describing
+exactly what ended up in your bundle: chunks, modules, the
+import graph reachable from each entry point, and which entry
+pulled in which module.
+
+Opt in via `build.bundleAnalyzer` on the Worker:
+
+```diff lang="typescript"
+ export default class Api extends Cloudflare.Worker<Api>()(
+   "Api",
+   {
+     main: import.meta.filename,
++    build: { bundleAnalyzer: true },
+   },
+   /* ... */
+ ) {}
+```
+
+By default this writes `analyze-data.md` next to the bundle.
+Pass an object to customise:
+
+```typescript
+build: {
+  bundleAnalyzer: { fileName: "bundle.json", format: "json" },
+}
+```
+
+Under the hood it wraps rolldown's experimental
+`bundleAnalyzerPlugin`, exported as `Bundle.bundleAnalyzerPlugin`
+for anyone composing their own bundles.
+([#405](https://github.com/alchemy-run/alchemy-effect/pull/405))
+
+### `WorkerProps.build` reshaped
+
+The `build` prop is now `Bundle.BundleExtraOptions` —
+`{ pure?, bundleAnalyzer? }`. If you were setting
+`build.metafile`, drop it; the field is gone. `build.pure` is
+unchanged.
+
+```diff lang="typescript"
+ build: {
+-  metafile: true,
+   pure: { include: ["effect", "@effect/*"] },
++  bundleAnalyzer: true,
+ },
+```
+
+## `Cloudflare.Artifacts` in dev
+
+The `Cloudflare.Artifacts` binding now works under
+`bun alchemy dev` — previously it was only wired up in deployed
+Workers. No code change required; existing artifact bindings
+light up locally on upgrade.
+([#419](https://github.com/alchemy-run/alchemy-effect/pull/419))
+
+## Also in this release
+
+- **Vite-style `?raw` imports in the Worker bundler** —
+  `import sql from "./schema.sql?raw"` now works, matching the
+  Vite convention for inlining a file as a string
+  ([#411](https://github.com/alchemy-run/alchemy-effect/pull/411)).
+- **Dev server no longer leaves dangling processes on exit** —
+  child sidecars are cleaned up when the dev server is
+  interrupted
+  ([#382](https://github.com/alchemy-run/alchemy-effect/pull/382)).
+- **Local Durable Object handling hardened** — fixes a class of
+  crashes when DOs are recreated mid-dev-session
+  ([#408](https://github.com/alchemy-run/alchemy-effect/pull/408)).
+- **Rolldown bumped to 1.0.1 stable** — out of pre-release
+  ([#409](https://github.com/alchemy-run/alchemy-effect/pull/409)).
+- **`@alchemy.run/node-utils` import resolution fix** — resolves
+  an ESM resolution error on Node
+  ([#406](https://github.com/alchemy-run/alchemy-effect/pull/406)).
+- **CLI filters Bun's "not in project directory" watcher warning** —
+  no more spurious warnings during dev. Thanks
+  **[Michael K](https://github.com/michaelkleene)**
+  ([#124](https://github.com/alchemy-run/alchemy-effect/pull/124)).
+- **`cloudflare-tools` bumped to 0.6.3**, `WorkerBridge` imports
+  optimized, stray logs removed
+  ([#403](https://github.com/alchemy-run/alchemy-effect/pull/403),
+  [#410](https://github.com/alchemy-run/alchemy-effect/pull/410),
+  [#418](https://github.com/alchemy-run/alchemy-effect/pull/418),
+  [#420](https://github.com/alchemy-run/alchemy-effect/pull/420)).
+
+## Contributors
+
+Thanks to everyone who shipped code in this beta:
+
+- **[Alex](https://github.com/gogl-alex)** — `Cloudflare.ZarazConfig` ([#371](https://github.com/alchemy-run/alchemy-effect/pull/371))
+- **[Michael K](https://github.com/michaelkleene)** — CLI watcher warning filter ([#124](https://github.com/alchemy-run/alchemy-effect/pull/124))
+- **[sam](https://github.com/samgoodwin)** — privacy page styling cleanup ([#398](https://github.com/alchemy-run/alchemy-effect/pull/398))
+
+## Where to go next
+
+- [CHANGELOG](https://github.com/alchemy-run/alchemy-effect/blob/main/CHANGELOG.md#v200-beta44)
+- [Compare v2.0.0-beta.43 → v2.0.0-beta.44](https://github.com/alchemy-run/alchemy-effect/compare/v2.0.0-beta.43...v2.0.0-beta.44)

--- a/website/src/content/docs/blog/2026-05-22-beta-44.md
+++ b/website/src/content/docs/blog/2026-05-22-beta-44.md
@@ -101,16 +101,6 @@ Workers. No code change required; existing artifact bindings
 light up locally on upgrade.
 ([#419](https://github.com/alchemy-run/alchemy-effect/pull/419))
 
-## Worker entrypoint cleanup
-
-- `WorkerBridge` now uses namespace imports from `effect`
-  instead of barrel imports, which silences a noisy rolldown
-  warning and trims a small amount of bundle work
-  ([#420](https://github.com/alchemy-run/alchemy-effect/pull/420)).
-- Removed a noisy `DurableObjectBridge` log that fired on every
-  WebSocket message, plus a few other stray dev logs
-  ([#410](https://github.com/alchemy-run/alchemy-effect/pull/410)).
-
 ## Also in this release
 
 - **Vite-style `?raw` imports in the Worker bundler** —

--- a/website/src/content/docs/blog/2026-05-22-beta-44.md
+++ b/website/src/content/docs/blog/2026-05-22-beta-44.md
@@ -78,20 +78,7 @@ Under the hood it wraps rolldown's experimental
 for anyone composing their own bundles.
 ([#405](https://github.com/alchemy-run/alchemy-effect/pull/405))
 
-### `WorkerProps.build` reshaped
-
-The `build` prop is now `Bundle.BundleExtraOptions` —
-`{ pure?, bundleAnalyzer? }`. If you were setting
-`build.metafile`, drop it; the field is gone. `build.pure` is
-unchanged.
-
-```diff lang="typescript"
- build: {
--  metafile: true,
-   pure: { include: ["effect", "@effect/*"] },
-+  bundleAnalyzer: true,
- },
-```
+This replaces the previous `build.metafile` option, which is now removed.
 
 ## `Cloudflare.Artifacts` in dev
 

--- a/website/src/content/docs/blog/2026-05-22-beta-44.md
+++ b/website/src/content/docs/blog/2026-05-22-beta-44.md
@@ -101,16 +101,50 @@ Workers. No code change required; existing artifact bindings
 light up locally on upgrade.
 ([#419](https://github.com/alchemy-run/alchemy-effect/pull/419))
 
+## `RpcProvider` for more reliable local development
+
+Until beta.43, local providers (the runtime that backs
+`Cloudflare.Worker`, `DurableObjectNamespace`, etc. under
+`alchemy dev`) ran inside an in-process "sidecar" tied to the
+dev server. That worked, but it leaked: when the dev process
+exited — Ctrl-C, crash, HMR restart — the child `workerd` /
+miniflare processes it had spawned could survive, holding ports
+open and consuming memory until you noticed and killed them by
+hand.
+
+beta.44 refactors this into a generic `Local/Rpc*` provider
+abstraction. Local providers now run in their own child process
+managed by a new `RpcSpawner`, and the parent talks to them
+over RPC. Concretely:
+
+- It registers an `exitHook` that `SIGKILL`s the entire process
+  group when the parent exits, plus a scoped finalizer for the
+  graceful path. Dangling `workerd` processes are gone.
+- Sessions are cached per
+  `(serverEntryUrl, alchemyContext, stack)` and respawned
+  automatically if the child dies mid-session.
+- `RpcProvider.providerServicesEffect` lets heavy provider-only
+  layers (e.g. the Cloudflare local runtime and proxy) build
+  lazily inside the child rather than eagerly in the parent —
+  the parent stays lean.
+
+The defining shape for a provider is now thin:
+
+```typescript
+export const LocalWorkerProvider = () =>
+  RpcProvider.effect(
+    Worker,
+    import.meta.resolve(/* ./Local.ts | ./Local.js */),
+    Effect.gen(function* () { /* … */ }),
+  );
+```
+
 ## Also in this release
 
 - **Vite-style `?raw` imports in the Worker bundler** —
   `import sql from "./schema.sql?raw"` now works, matching the
   Vite convention for inlining a file as a string
   ([#411](https://github.com/alchemy-run/alchemy-effect/pull/411)).
-- **Dev server no longer leaves dangling processes on exit** —
-  child sidecars are cleaned up when the dev server is
-  interrupted
-  ([#382](https://github.com/alchemy-run/alchemy-effect/pull/382)).
 - **Local Durable Objects hardened** — fixes swapped
   `className`/`namespaceId` in the local provider output, makes
   the local `namespaceId` deterministic and independent of the


### PR DESCRIPTION
Release blog for `v2.0.0-beta.44`. Leads with the new `Cloudflare.ZarazConfig` resource and the Worker bundle analyzer, plus a heads-up on the `WorkerProps.build` reshape (`build.metafile` removed) and a roll-up of the remaining bundler and dev-server fixes.

New file: `website/src/content/docs/blog/2026-05-22-beta-44.md`.