### PR TITLE
feat(planetscale): OAuth device flow as recommended auth method

### DIFF
--- a/packages/alchemy/src/Planetscale/AuthProvider.ts
+++ b/packages/alchemy/src/Planetscale/AuthProvider.ts
@@ -1,7 +1,17 @@
+import * as ops from "@distilled.cloud/planetscale/Operations";
 import * as Console from "effect/Console";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import * as Match from "effect/Match";
 import * as Redacted from "effect/Redacted";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import {
+  Credentials as PsCredentials,
+  DEFAULT_API_BASE_URL,
+} from "@distilled.cloud/planetscale/Credentials";
 import {
   AuthError,
   AuthProviderLayer,
@@ -14,6 +24,7 @@ import {
   retryOnce,
 } from "../Auth/Env.ts";
 import * as Clank from "../Util/Clank.ts";
+import * as OAuthClient from "./OAuthClient.ts";
 
 /**
  * Canonical name registered in {@link AuthProviders}. Use this key to look
@@ -21,11 +32,26 @@ import * as Clank from "../Util/Clank.ts";
  */
 export const PLANETSCALE_AUTH_PROVIDER_NAME = "Planetscale";
 
+/**
+ * Sentinel value placed in {@link PsCredentials} `tokenId` when OAuth is in
+ * use. The PlanetScale HttpClient middleware in `Credentials.ts` detects this
+ * sentinel and rewrites the Authorization header from `${tokenId}:${token}`
+ * to `Bearer ${token}` so requests authenticate as an OAuth user instead of
+ * a service token.
+ */
+export const PLANETSCALE_OAUTH_TOKEN_ID_MARKER =
+  "__alchemy_planetscale_oauth__";
+
 const options: Array<{
   value: PlanetscaleAuthConfig["method"];
   label: string;
   hint?: string;
 }> = [
+  {
+    value: "oauth",
+    label: "OAuth",
+    hint: "recommended — device-flow login with automatic token refresh",
+  },
   {
     value: "env",
     label: "Environment Variables",
@@ -36,24 +62,26 @@ const options: Array<{
     label: "Service Token",
     hint: "enter service token interactively, stored in ~/.alchemy/credentials",
   },
-  //todo(pear): add planetscale oauth
 ];
 
 /**
  * Auth configuration persisted in `~/.alchemy/profiles.json` for the
  * PlanetScale provider.
  *
+ * - `oauth`: PlanetScale OAuth device flow. Access and refresh tokens are
+ *   stored in `~/.alchemy/credentials/<profile>/planetscale-oauth.json` and
+ *   refreshed automatically on use.
  * - `env`: read credentials from environment variables at resolution time.
- * - `stored`: read credentials from `~/.alchemy/credentials/<profile>/planetscale-stored.json`.
- *
- * OAuth is intentionally not implemented because PlanetScale does not
- * publish a redirect-based OAuth client; service tokens are the canonical
- * credential.
+ * - `stored`: read service-token credentials from
+ *   `~/.alchemy/credentials/<profile>/planetscale-stored.json`.
  */
-export type PlanetscaleAuthConfig = { method: "env" } | { method: "stored" };
+export type PlanetscaleAuthConfig =
+  | { method: "env" }
+  | { method: "stored" }
+  | { method: "oauth"; scopes: string[]; organization: string };
 
 /**
- * apiToken credentials persisted to disk for `method: "stored"`.
+ * Service-token credentials persisted to disk for `method: "stored"`.
  * Stored under the file key `"planetscale-stored"`.
  */
 export interface PlanetscaleStoredCredentials {
@@ -67,16 +95,194 @@ export interface PlanetscaleStoredCredentials {
  * Resolved in-memory PlanetScale credentials returned by
  * {@link AuthProviderImpl.read}.
  */
-export interface PlanetscaleResolvedCredentials {
-  type: "apiToken";
-  tokenId: Redacted.Redacted<string>;
-  token: Redacted.Redacted<string>;
-  organization: string;
-  source: {
-    type: PlanetscaleAuthConfig["method"];
-    details?: string;
-  };
-}
+export type PlanetscaleResolvedCredentials =
+  | {
+      type: "apiToken";
+      tokenId: Redacted.Redacted<string>;
+      token: Redacted.Redacted<string>;
+      organization: string;
+      source: {
+        type: PlanetscaleAuthConfig["method"];
+        details?: string;
+      };
+    }
+  | {
+      type: "oauth";
+      accessToken: Redacted.Redacted<string>;
+      expires: number;
+      scopes: string[];
+      organization: string;
+      source: {
+        type: PlanetscaleAuthConfig["method"];
+        details?: string;
+      };
+    };
+
+/**
+ * Scopes alchemy requests by default. Cover the typical alchemy-managed
+ * resources: databases, branches, branch passwords, and postgres roles.
+ *
+ * @see https://planetscale.com/docs/api/reference/oauth-access-scopes
+ */
+export const DEFAULT_SCOPES = [
+  "read_user",
+  "read_organization",
+  "read_organizations",
+  "read_databases",
+  "create_databases",
+  "write_databases",
+  "delete_databases",
+  "read_branches",
+  "write_branches",
+  "delete_branches",
+  "promote_branches",
+  "delete_production_branches",
+  "manage_passwords",
+  "manage_production_branch_passwords",
+];
+
+/**
+ * Full set of OAuth scopes recognized by PlanetScale, grouped by what they
+ * grant access to. Used as the option list when the user customizes scopes
+ * during `alchemy login`.
+ */
+export const ALL_SCOPES: Record<string, string> = {
+  read_user: "Read user info",
+  write_user: "Write user info",
+  read_organizations: "List a user's organizations",
+  read_organization: "Read organization",
+  write_organization: "Write organization",
+  delete_organization: "Delete organization",
+  read_invoices: "Read organization invoices",
+  read_members: "Read organization members",
+  write_members: "Write organization members",
+  delete_members: "Delete organization members",
+  read_databases: "Read databases",
+  create_databases: "Create databases",
+  write_databases: "Write databases",
+  delete_databases: "Delete databases",
+  read_branches: "Read database branches",
+  write_branches: "Write database branches",
+  delete_branches: "Delete database branches",
+  promote_branches: "Promote database branches",
+  delete_production_branches: "Delete production branches",
+  manage_passwords: "Read, write, and delete branch passwords",
+  manage_production_branch_passwords:
+    "Read, write, and delete production branch passwords",
+  read_deploy_requests: "Read deploy requests",
+  write_deploy_requests: "Create and update deploy requests",
+  deploy_deploy_requests: "Deploy deploy requests",
+  approve_deploy_requests: "Approve deploy requests",
+  read_comments: "Read deploy request comments",
+  write_comments: "Create deploy request comments",
+  read_backups: "Read backups",
+  write_backups: "Create and update backups",
+  delete_backups: "Delete backups",
+  delete_production_branch_backups: "Delete production backups",
+  restore_backups: "Restore backups to new branches",
+  restore_production_branch_backups:
+    "Restore production branch backups to new branches",
+};
+
+/**
+ * Provide a Layer that lets the distilled SDK resolve PlanetScale calls
+ * authenticated with an OAuth access token. Sets the sentinel token id so
+ * the HttpClient middleware in `Credentials.ts` rewrites the Authorization
+ * header to `Bearer <access_token>`.
+ *
+ * Used during OAuth configuration to call `listOrganizations` before we
+ * have a persisted organization slug.
+ */
+const withOAuthCredentials = <A, E>(
+  accessToken: string,
+  effect: Effect.Effect<A, E, PsCredentials | HttpClient.HttpClient>,
+): Effect.Effect<A, E> => {
+  const credentialsLayer = Layer.succeed(PsCredentials, {
+    tokenId: Redacted.make(PLANETSCALE_OAUTH_TOKEN_ID_MARKER),
+    token: Redacted.make(accessToken),
+    organization: "",
+    apiBaseUrl: DEFAULT_API_BASE_URL,
+  });
+  const httpLayer = planetscaleHttpClientLayer.pipe(
+    Layer.provide(FetchHttpClient.layer),
+    Layer.provideMerge(credentialsLayer),
+  );
+  return Effect.provide(effect, httpLayer);
+};
+
+/**
+ * HttpClient layer that rewrites the Authorization header to `Bearer <token>`
+ * whenever the resolved PlanetScale credentials carry the OAuth sentinel
+ * token id. For service-token credentials the request passes through
+ * unchanged.
+ *
+ * Wired into `Planetscale.providers()` in place of the raw FetchHttpClient
+ * layer so every distilled-SDK call respects whichever auth method the
+ * resolved profile selected.
+ */
+export const planetscaleHttpClientLayer = Layer.effect(
+  HttpClient.HttpClient,
+  Effect.gen(function* () {
+    const inner = yield* HttpClient.HttpClient;
+    const creds = yield* PsCredentials;
+    if (Redacted.value(creds.tokenId) !== PLANETSCALE_OAUTH_TOKEN_ID_MARKER) {
+      return inner;
+    }
+    const bearer = `Bearer ${Redacted.value(creds.token)}`;
+    return HttpClient.mapRequest(inner, (req) =>
+      HttpClientRequest.setHeader(req, "Authorization", bearer),
+    );
+  }),
+);
+
+const selectOrganization = (accessToken: string) =>
+  Effect.gen(function* () {
+    const list = yield* ops.listOrganizations;
+    const response = yield* list({});
+    const orgs = response.data;
+    if (orgs.length === 0) {
+      yield* new AuthError({
+        message: "Planetscale: no organizations found for this account.",
+      });
+    }
+    if (orgs.length === 1) {
+      const org = orgs[0]!;
+      yield* Clank.info(`Planetscale: using organization: ${org.name}`);
+      return org.name;
+    }
+    return yield* Clank.select({
+      message: "Select a Planetscale organization",
+      options: orgs.map((o) => ({
+        value: o.name,
+        label: o.name,
+        hint: o.plan,
+      })),
+    }).pipe(retryOnce);
+  }).pipe((e) => withOAuthCredentials(accessToken, e));
+
+const promptOAuthScopes = () =>
+  Clank.confirm({
+    message: "Customize OAuth scopes? (default covers typical use cases)",
+    initialValue: false,
+  }).pipe(
+    retryOnce,
+    Effect.flatMap((customize) => {
+      if (!customize) return Effect.succeed([...DEFAULT_SCOPES]);
+      return Clank.multiselect({
+        message: "Select OAuth scopes",
+        initialValues: DEFAULT_SCOPES as string[],
+        options: Object.entries(ALL_SCOPES).map(([value, hint]) => ({
+          value: value as string,
+          label: value,
+          hint,
+        })),
+        required: true,
+      }).pipe(
+        Effect.map((s) => s as string[]),
+        retryOnce,
+      );
+    }),
+  );
 
 /**
  * Layer that registers the PlanetScale {@link AuthProvider} into the
@@ -84,6 +290,8 @@ export interface PlanetscaleResolvedCredentials {
  * PlanetScale `providers()` layer so `alchemy login` can discover it.
  *
  * Supported methods:
+ * - `oauth`: device-flow login. Opens the verification URL in a browser
+ *   and polls until the user authorizes. Access tokens refresh on use.
  * - `env`: reads `PLANETSCALE_API_TOKEN_ID`/`PLANETSCALE_API_TOKEN`/`PLANETSCALE_ORGANIZATION`.
  * - `stored`: prompts for a service token interactively and writes it to
  *   `~/.alchemy/credentials/<profile>/planetscale-stored.json`.
@@ -95,6 +303,33 @@ export const PlanetscaleAuth = AuthProviderLayer<
   PLANETSCALE_AUTH_PROVIDER_NAME,
   Effect.gen(function* () {
     const store = yield* CredentialsStore;
+
+    const oauthLogin = (profileName: string, scopes: string[]) =>
+      Effect.gen(function* () {
+        const verification = yield* OAuthClient.requestDevice(scopes);
+
+        yield* Clank.info(
+          `Planetscale: open ${verification.verificationUri} and enter the code:`,
+        );
+        yield* Clank.info(`  ${verification.userCode}`);
+        const target =
+          verification.verificationUriComplete ?? verification.verificationUri;
+        yield* Clank.openUrl(target).pipe(
+          Effect.catch(() =>
+            Clank.warn(
+              "Planetscale: could not open browser automatically. Please open the URL above manually.",
+            ),
+          ),
+        );
+        yield* Clank.info(
+          `Planetscale: waiting for authorization (up to ${Duration.format(Duration.seconds(verification.expiresIn))})...`,
+        );
+
+        const credentials = yield* OAuthClient.pollForToken(verification);
+        yield* store.write(profileName, "planetscale-oauth", credentials);
+        yield* Clank.success("Planetscale: OAuth credentials saved.");
+        return credentials;
+      });
 
     const loginStored = Effect.fnUntraced(function* (profileName: string) {
       const tokenId = yield* Clank.text({
@@ -126,6 +361,28 @@ export const PlanetscaleAuth = AuthProviderLayer<
       return { method: "stored" as const };
     });
 
+    const configureOAuth = Effect.fnUntraced(function* (profileName: string) {
+      const scopes = yield* promptOAuthScopes();
+
+      const oauthCreds = yield* oauthLogin(profileName, scopes);
+
+      const organization = yield* selectOrganization(oauthCreds.access).pipe(
+        Effect.mapError(
+          (e) =>
+            new AuthError({
+              message: "Planetscale: could not list organizations",
+              cause: e,
+            }),
+        ),
+      );
+
+      return {
+        method: "oauth" as const,
+        scopes,
+        organization,
+      };
+    });
+
     const configureInteractive = (profileName: string) =>
       Clank.select({
         message: "Planetscale authentication method",
@@ -134,6 +391,7 @@ export const PlanetscaleAuth = AuthProviderLayer<
         Effect.flatMap((method) =>
           Match.value(method).pipe(
             Match.when("env", () => Effect.succeed({ method: "env" as const })),
+            Match.when("oauth", () => configureOAuth(profileName)),
             Match.when("stored", () => loginStored(profileName)),
             Match.exhaustive,
           ),
@@ -214,6 +472,49 @@ export const PlanetscaleAuth = AuthProviderLayer<
               ),
             ),
         ),
+        Match.when({ method: "oauth" }, (cfg) =>
+          Effect.gen(function* () {
+            const creds = yield* store.read<OAuthClient.OAuthCredentials>(
+              profileName,
+              "planetscale-oauth",
+            );
+            if (creds == null || creds.type !== "oauth") {
+              return yield* Effect.fail(
+                new AuthError({
+                  message:
+                    "Planetscale OAuth credentials not found. Run: alchemy login",
+                }),
+              );
+            }
+            // Refresh proactively if the token has expired (or is within
+            // 10s of expiring). Persist the refreshed creds so subsequent
+            // resolves don't repeat the round-trip.
+            const fresh =
+              creds.expires > Date.now() + 10_000
+                ? creds
+                : yield* OAuthClient.refresh(creds).pipe(
+                    Effect.tap((refreshed) =>
+                      store.write(profileName, "planetscale-oauth", refreshed),
+                    ),
+                    Effect.mapError(
+                      (e) =>
+                        new AuthError({
+                          message:
+                            "Planetscale OAuth refresh failed. Run: alchemy login",
+                          cause: e,
+                        }),
+                    ),
+                  );
+            return {
+              type: "oauth" as const,
+              accessToken: Redacted.make(fresh.access),
+              expires: fresh.expires,
+              scopes: fresh.scopes,
+              organization: cfg.organization,
+              source: { type: "oauth" as const },
+            } satisfies PlanetscaleResolvedCredentials;
+          }),
+        ),
         Match.exhaustive,
       );
 
@@ -226,6 +527,30 @@ export const PlanetscaleAuth = AuthProviderLayer<
             .pipe(
               Effect.andThen(
                 Clank.success("Planetscale: stored credentials removed"),
+              ),
+            ),
+        ),
+        Match.when({ method: "oauth" }, () =>
+          store
+            .read<OAuthClient.OAuthCredentials>(
+              profileName,
+              "planetscale-oauth",
+            )
+            .pipe(
+              Effect.tap((creds) =>
+                creds?.type === "oauth"
+                  ? OAuthClient.revoke(creds).pipe(
+                      Effect.catchTag("OAuthError", (err) =>
+                        Clank.warn(
+                          `Planetscale: could not revoke OAuth token: ${err.errorDescription}`,
+                        ),
+                      ),
+                    )
+                  : Effect.void,
+              ),
+              Effect.andThen(store.delete(profileName, "planetscale-oauth")),
+              Effect.andThen(
+                Clank.success("Planetscale: OAuth credentials removed."),
               ),
             ),
         ),
@@ -248,6 +573,39 @@ export const PlanetscaleAuth = AuthProviderLayer<
                 ),
               ),
           ),
+          Match.when({ method: "oauth" }, (c) =>
+            Effect.gen(function* () {
+              const creds = yield* store.read<OAuthClient.OAuthCredentials>(
+                profileName,
+                "planetscale-oauth",
+              );
+
+              if (creds?.type === "oauth") {
+                yield* Clank.info(
+                  "Planetscale: refreshing OAuth credentials...",
+                );
+                yield* OAuthClient.refresh(creds).pipe(
+                  Effect.flatMap((refreshed) =>
+                    store
+                      .write(profileName, "planetscale-oauth", refreshed)
+                      .pipe(
+                        Effect.andThen(
+                          Clank.success(
+                            "Planetscale: OAuth credentials refreshed.",
+                          ),
+                        ),
+                      ),
+                  ),
+                  Effect.catchTag("OAuthError", () =>
+                    oauthLogin(profileName, c.scopes).pipe(Effect.asVoid),
+                  ),
+                );
+                return;
+              }
+
+              yield* oauthLogin(profileName, c.scopes);
+            }),
+          ),
           Match.exhaustive,
         )
         .pipe(
@@ -262,12 +620,32 @@ export const PlanetscaleAuth = AuthProviderLayer<
           const sourceStr = creds.source.details
             ? `${creds.source.type} - ${creds.source.details}`
             : creds.source.type;
-          return Effect.all([
-            Console.log(`  tokenId: ${displayRedacted(creds.token, 3)}`),
-            Console.log(`  token: ${displayRedacted(creds.token, 6)}`),
-            Console.log(`  organization: ${creds.organization}`),
-            Console.log(`  source: ${sourceStr}`),
-          ]);
+          return Match.value(creds).pipe(
+            Match.when({ type: "apiToken" }, (c) =>
+              Effect.all([
+                Console.log(`  tokenId: ${displayRedacted(c.tokenId, 3)}`),
+                Console.log(`  token: ${displayRedacted(c.token, 6)}`),
+                Console.log(`  organization: ${c.organization}`),
+                Console.log(`  source: ${sourceStr}`),
+              ]),
+            ),
+            Match.when({ type: "oauth" }, (c) => {
+              const remainingMs = c.expires - Date.now();
+              const expiresAt = new Date(c.expires).toISOString();
+              const expiresStr =
+                remainingMs <= 0
+                  ? `expired (${expiresAt})`
+                  : `in ${Duration.format(Duration.millis(remainingMs))} (${expiresAt})`;
+              return Effect.all([
+                Console.log(`  accessToken: ${displayRedacted(c.accessToken)}`),
+                Console.log(`  expires: ${expiresStr}`),
+                Console.log(`  scopes: ${c.scopes.join(", ")}`),
+                Console.log(`  organization: ${c.organization}`),
+                Console.log(`  source: ${sourceStr}`),
+              ]);
+            }),
+            Match.exhaustive,
+          );
         }),
         Effect.catch((e) =>
           Console.error(`  Failed to retrieve credentials: ${e}`),

--- a/packages/alchemy/src/Planetscale/AuthProvider.ts
+++ b/packages/alchemy/src/Planetscale/AuthProvider.ts
@@ -1,4 +1,8 @@
 import * as ops from "@distilled.cloud/planetscale/Operations";
+import {
+  Credentials as PsCredentials,
+  fromOAuth,
+} from "@distilled.cloud/planetscale/Credentials";
 import * as Console from "effect/Console";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -7,11 +11,6 @@ import * as Match from "effect/Match";
 import * as Redacted from "effect/Redacted";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as HttpClient from "effect/unstable/http/HttpClient";
-import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
-import {
-  Credentials as PsCredentials,
-  DEFAULT_API_BASE_URL,
-} from "@distilled.cloud/planetscale/Credentials";
 import {
   AuthError,
   AuthProviderLayer,
@@ -31,16 +30,6 @@ import * as OAuthClient from "./OAuthClient.ts";
  * up the PlanetScale {@link AuthProvider} from inside provider Layers.
  */
 export const PLANETSCALE_AUTH_PROVIDER_NAME = "Planetscale";
-
-/**
- * Sentinel value placed in {@link PsCredentials} `tokenId` when OAuth is in
- * use. The PlanetScale HttpClient middleware in `Credentials.ts` detects this
- * sentinel and rewrites the Authorization header from `${tokenId}:${token}`
- * to `Bearer ${token}` so requests authenticate as an OAuth user instead of
- * a service token.
- */
-export const PLANETSCALE_OAUTH_TOKEN_ID_MARKER =
-  "__alchemy_planetscale_oauth__";
 
 const options: Array<{
   value: PlanetscaleAuthConfig["method"];
@@ -185,55 +174,28 @@ export const ALL_SCOPES: Record<string, string> = {
 };
 
 /**
- * Provide a Layer that lets the distilled SDK resolve PlanetScale calls
- * authenticated with an OAuth access token. Sets the sentinel token id so
- * the HttpClient middleware in `Credentials.ts` rewrites the Authorization
- * header to `Bearer <access_token>`.
- *
- * Used during OAuth configuration to call `listOrganizations` before we
- * have a persisted organization slug.
+ * Build a one-off PlanetScale Credentials + HttpClient layer wrapping an
+ * OAuth access token. Used by `configureOAuth` to list the user's
+ * organizations after the device-flow login.
  */
 const withOAuthCredentials = <A, E>(
   accessToken: string,
   effect: Effect.Effect<A, E, PsCredentials | HttpClient.HttpClient>,
-): Effect.Effect<A, E> => {
-  const credentialsLayer = Layer.succeed(PsCredentials, {
-    tokenId: Redacted.make(PLANETSCALE_OAUTH_TOKEN_ID_MARKER),
-    token: Redacted.make(accessToken),
-    organization: "",
-    apiBaseUrl: DEFAULT_API_BASE_URL,
-  });
-  const httpLayer = planetscaleHttpClientLayer.pipe(
-    Layer.provide(FetchHttpClient.layer),
-    Layer.provideMerge(credentialsLayer),
+): Effect.Effect<A, E> =>
+  Effect.provide(
+    effect,
+    Layer.mergeAll(
+      fromOAuth({
+        load: Effect.succeed({
+          accessToken,
+          organization: "",
+        }),
+        refresh: () =>
+          Effect.die("refresh not expected during organization selection"),
+      }),
+      FetchHttpClient.layer,
+    ),
   );
-  return Effect.provide(effect, httpLayer);
-};
-
-/**
- * HttpClient layer that rewrites the Authorization header to `Bearer <token>`
- * whenever the resolved PlanetScale credentials carry the OAuth sentinel
- * token id. For service-token credentials the request passes through
- * unchanged.
- *
- * Wired into `Planetscale.providers()` in place of the raw FetchHttpClient
- * layer so every distilled-SDK call respects whichever auth method the
- * resolved profile selected.
- */
-export const planetscaleHttpClientLayer = Layer.effect(
-  HttpClient.HttpClient,
-  Effect.gen(function* () {
-    const inner = yield* HttpClient.HttpClient;
-    const creds = yield* PsCredentials;
-    if (Redacted.value(creds.tokenId) !== PLANETSCALE_OAUTH_TOKEN_ID_MARKER) {
-      return inner;
-    }
-    const bearer = `Bearer ${Redacted.value(creds.token)}`;
-    return HttpClient.mapRequest(inner, (req) =>
-      HttpClientRequest.setHeader(req, "Authorization", bearer),
-    );
-  }),
-);
 
 const selectOrganization = (accessToken: string) =>
   Effect.gen(function* () {

--- a/packages/alchemy/src/Planetscale/Branch.ts
+++ b/packages/alchemy/src/Planetscale/Branch.ts
@@ -244,7 +244,7 @@ export const makeBranchProvider = <R extends ResourceLike>(opts: {
           const dbInfo = output
             ? { name: output.database, organization: output.organization }
             : resolveDatabase(olds.database);
-          const { organization: envOrg } = yield* Credentials;
+          const { organization: envOrg } = yield* yield* Credentials;
           const organization =
             output?.organization ?? dbInfo.organization ?? envOrg;
           const databaseName = output?.database ?? dbInfo.name;
@@ -281,7 +281,7 @@ export const makeBranchProvider = <R extends ResourceLike>(opts: {
         }),
 
         reconcile: Effect.fn(function* ({ id, news, output, session }: any) {
-          const { organization: envOrg } = yield* Credentials;
+          const { organization: envOrg } = yield* yield* Credentials;
           const dbInfo = resolveDatabase(news.database);
           const organization =
             output?.organization ?? dbInfo.organization ?? envOrg;

--- a/packages/alchemy/src/Planetscale/Credentials.ts
+++ b/packages/alchemy/src/Planetscale/Credentials.ts
@@ -6,11 +6,13 @@ import { ConfigError } from "@distilled.cloud/core/errors";
 import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Match from "effect/Match";
 import * as Redacted from "effect/Redacted";
 import { getAuthProvider } from "../Auth/AuthProvider.ts";
 import { ALCHEMY_PROFILE, Profile } from "../Auth/Profile.ts";
 import {
   PLANETSCALE_AUTH_PROVIDER_NAME,
+  PLANETSCALE_OAUTH_TOKEN_ID_MARKER,
   type PlanetscaleAuthConfig,
   type PlanetscaleResolvedCredentials,
 } from "./AuthProvider.ts";
@@ -20,6 +22,8 @@ export {
   CredentialsFromEnv,
   DEFAULT_API_BASE_URL,
 } from "@distilled.cloud/planetscale/Credentials";
+
+export { planetscaleHttpClientLayer } from "./AuthProvider.ts";
 
 /**
  * Build a PlanetScale `Credentials` Layer from an explicit token. Useful for
@@ -44,9 +48,9 @@ export const fromToken = (input: {
 }) =>
   Layer.succeed(Credentials, {
     tokenId:
-      typeof input.token === "string"
-        ? Redacted.make(input.token)
-        : input.token,
+      typeof input.tokenId === "string"
+        ? Redacted.make(input.tokenId)
+        : input.tokenId,
     token:
       typeof input.token === "string"
         ? Redacted.make(input.token)
@@ -59,6 +63,10 @@ export const fromToken = (input: {
  * Build a PlanetScale `Credentials` Layer that resolves credentials via the
  * Alchemy AuthProvider using the configured profile (defaults to "default",
  * overridable with the `ALCHEMY_PROFILE` env/config value).
+ *
+ * For OAuth profiles the layer sets the sentinel token id
+ * {@link PLANETSCALE_OAUTH_TOKEN_ID_MARKER} so the PlanetScale HttpClient
+ * middleware rewrites the Authorization header to `Bearer <access_token>`.
  */
 export const fromAuthProvider = () =>
   Layer.effect(
@@ -79,12 +87,23 @@ export const fromAuthProvider = () =>
         Effect.flatMap((config) =>
           auth.read(profileName, config as PlanetscaleAuthConfig),
         ),
-        Effect.map((creds) => ({
-          tokenId: creds.tokenId,
-          token: creds.token,
-          organization: creds.organization,
-          apiBaseUrl,
-        })),
+        Effect.map((creds) =>
+          Match.value(creds).pipe(
+            Match.when({ type: "apiToken" }, (c) => ({
+              tokenId: c.tokenId,
+              token: c.token,
+              organization: c.organization,
+              apiBaseUrl,
+            })),
+            Match.when({ type: "oauth" }, (c) => ({
+              tokenId: Redacted.make(PLANETSCALE_OAUTH_TOKEN_ID_MARKER),
+              token: c.accessToken,
+              organization: c.organization,
+              apiBaseUrl,
+            })),
+            Match.exhaustive,
+          ),
+        ),
         Effect.mapError(
           (e) =>
             new ConfigError({

--- a/packages/alchemy/src/Planetscale/Credentials.ts
+++ b/packages/alchemy/src/Planetscale/Credentials.ts
@@ -1,21 +1,25 @@
+import { ConfigError } from "@distilled.cloud/core/errors";
 import {
   Credentials,
   DEFAULT_API_BASE_URL,
+  fromApiToken,
+  fromOAuth,
+  type OAuthConfig,
 } from "@distilled.cloud/planetscale/Credentials";
-import { ConfigError } from "@distilled.cloud/core/errors";
 import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Match from "effect/Match";
 import * as Redacted from "effect/Redacted";
 import { getAuthProvider } from "../Auth/AuthProvider.ts";
+import { CredentialsStore } from "../Auth/Credentials.ts";
 import { ALCHEMY_PROFILE, Profile } from "../Auth/Profile.ts";
 import {
   PLANETSCALE_AUTH_PROVIDER_NAME,
-  PLANETSCALE_OAUTH_TOKEN_ID_MARKER,
   type PlanetscaleAuthConfig,
   type PlanetscaleResolvedCredentials,
 } from "./AuthProvider.ts";
+import * as OAuthClient from "./OAuthClient.ts";
 
 export {
   Credentials,
@@ -23,11 +27,9 @@ export {
   DEFAULT_API_BASE_URL,
 } from "@distilled.cloud/planetscale/Credentials";
 
-export { planetscaleHttpClientLayer } from "./AuthProvider.ts";
-
 /**
- * Build a PlanetScale `Credentials` Layer from an explicit token. Useful for
- * tests or when the caller already has credentials in hand.
+ * Build a PlanetScale `Credentials` Layer from an explicit service token.
+ * Useful for tests or when the caller already has credentials in hand.
  *
  * @example
  * ```ts
@@ -46,69 +48,118 @@ export const fromToken = (input: {
   organization: string;
   apiBaseUrl?: string;
 }) =>
-  Layer.succeed(Credentials, {
+  fromApiToken({
     tokenId:
       typeof input.tokenId === "string"
-        ? Redacted.make(input.tokenId)
-        : input.tokenId,
+        ? input.tokenId
+        : Redacted.value(input.tokenId),
     token:
       typeof input.token === "string"
-        ? Redacted.make(input.token)
-        : input.token,
+        ? input.token
+        : Redacted.value(input.token),
     organization: input.organization,
     apiBaseUrl: input.apiBaseUrl ?? DEFAULT_API_BASE_URL,
   });
+
+const toOAuthConfig = (
+  creds: OAuthClient.OAuthCredentials,
+  organization: string,
+): OAuthConfig => ({
+  accessToken: creds.access,
+  refreshToken: creds.refresh,
+  expiresAt: creds.expires,
+  organization,
+});
 
 /**
  * Build a PlanetScale `Credentials` Layer that resolves credentials via the
  * Alchemy AuthProvider using the configured profile (defaults to "default",
  * overridable with the `ALCHEMY_PROFILE` env/config value).
  *
- * For OAuth profiles the layer sets the sentinel token id
- * {@link PLANETSCALE_OAUTH_TOKEN_ID_MARKER} so the PlanetScale HttpClient
- * middleware rewrites the Authorization header to `Bearer <access_token>`.
+ * For OAuth profiles, delegates to {@link fromOAuth} so the distilled SDK
+ * can refresh the access token transparently on every API call. For
+ * service-token profiles (env/stored), delegates to {@link fromApiToken}.
  */
 export const fromAuthProvider = () =>
-  Layer.effect(
-    Credentials,
+  Layer.unwrap(
     Effect.gen(function* () {
       const profile = yield* Profile;
       const auth = yield* getAuthProvider<
         PlanetscaleAuthConfig,
         PlanetscaleResolvedCredentials
       >(PLANETSCALE_AUTH_PROVIDER_NAME);
+      const store = yield* CredentialsStore;
       const profileName = yield* ALCHEMY_PROFILE;
       const ci = yield* Config.boolean("CI").pipe(Config.withDefault(false));
       const apiBaseUrl = yield* Config.string("PLANETSCALE_API_BASE_URL").pipe(
         Config.withDefault(DEFAULT_API_BASE_URL),
       );
 
-      return yield* profile.loadOrConfigure(auth, profileName, { ci }).pipe(
-        Effect.flatMap((config) =>
-          auth.read(profileName, config as PlanetscaleAuthConfig),
+      const config = (yield* profile.loadOrConfigure(auth, profileName, {
+        ci,
+      })) as PlanetscaleAuthConfig;
+
+      return Match.value(config).pipe(
+        Match.when({ method: "oauth" }, (cfg) =>
+          fromOAuth({
+            apiBaseUrl,
+            load: store
+              .read<OAuthClient.OAuthCredentials>(
+                profileName,
+                "planetscale-oauth",
+              )
+              .pipe(
+                Effect.flatMap((creds) =>
+                  creds == null || creds.type !== "oauth"
+                    ? Effect.fail(
+                        new ConfigError({
+                          message:
+                            "Planetscale OAuth credentials not found. Run: alchemy login",
+                        }),
+                      )
+                    : Effect.succeed(toOAuthConfig(creds, cfg.organization)),
+                ),
+              ),
+            refresh: (current) =>
+              OAuthClient.refresh({
+                type: "oauth",
+                access: current.accessToken,
+                refresh: current.refreshToken ?? "",
+                expires: current.expiresAt ?? 0,
+                scopes: cfg.scopes,
+              }).pipe(
+                Effect.tap((refreshed) =>
+                  store.write(profileName, "planetscale-oauth", refreshed),
+                ),
+                Effect.map((refreshed) =>
+                  toOAuthConfig(refreshed, cfg.organization),
+                ),
+              ),
+          }),
         ),
-        Effect.map((creds) =>
-          Match.value(creds).pipe(
-            Match.when({ type: "apiToken" }, (c) => ({
-              tokenId: c.tokenId,
-              token: c.token,
-              organization: c.organization,
-              apiBaseUrl,
-            })),
-            Match.when({ type: "oauth" }, (c) => ({
-              tokenId: Redacted.make(PLANETSCALE_OAUTH_TOKEN_ID_MARKER),
-              token: c.accessToken,
-              organization: c.organization,
-              apiBaseUrl,
-            })),
-            Match.exhaustive,
+        Match.orElse(() =>
+          Layer.unwrap(
+            auth.read(profileName, config).pipe(
+              Effect.map((resolved) => {
+                if (resolved.type !== "apiToken") {
+                  // The non-oauth branch only resolves apiToken-shaped creds.
+                  return Layer.empty as Layer.Layer<Credentials>;
+                }
+                return fromApiToken({
+                  tokenId: Redacted.value(resolved.tokenId),
+                  token: Redacted.value(resolved.token),
+                  organization: resolved.organization,
+                  apiBaseUrl,
+                });
+              }),
+              Effect.mapError(
+                (e) =>
+                  new ConfigError({
+                    message: `Failed to resolve Planetscale credentials for profile '${profileName}': ${(e as { message?: string }).message ?? String(e)}`,
+                  }),
+              ),
+            ),
           ),
-        ),
-        Effect.mapError(
-          (e) =>
-            new ConfigError({
-              message: `Failed to resolve Planetscale credentials for profile '${profileName}': ${(e as { message?: string }).message ?? String(e)}`,
-            }),
         ),
       );
     }),

--- a/packages/alchemy/src/Planetscale/MySQL/MySQLDatabase.ts
+++ b/packages/alchemy/src/Planetscale/MySQL/MySQLDatabase.ts
@@ -215,7 +215,7 @@ export const MySQLDatabaseProvider = () =>
         }),
 
         read: Effect.fn(function* ({ id, output, olds }) {
-          const { organization } = yield* Credentials;
+          const { organization } = yield* yield* Credentials;
           const databaseName =
             output?.name ?? (yield* createDatabaseName(id, olds?.name));
           return yield* getDb({
@@ -269,7 +269,7 @@ export const MySQLDatabaseProvider = () =>
         }),
 
         reconcile: Effect.fn(function* ({ id, news, output, session }) {
-          const { organization } = yield* Credentials;
+          const { organization } = yield* yield* Credentials;
           const newName = yield* createDatabaseName(id, news.name);
           const clusterSize = news.clusterSize;
 

--- a/packages/alchemy/src/Planetscale/MySQL/MySQLPassword.ts
+++ b/packages/alchemy/src/Planetscale/MySQL/MySQLPassword.ts
@@ -293,7 +293,7 @@ export const MySQLPasswordProvider = () =>
           // Identifiers — stable across update (diff replaces on
           // database/branch changes), so we can pull from `output` first
           // and fall back to `news` for greenfield.
-          const { organization: envOrg } = yield* Credentials;
+          const { organization: envOrg } = yield* yield* Credentials;
           const organization =
             output?.organization ?? resolveDatabaseOrg(news.database) ?? envOrg;
           const databaseName =

--- a/packages/alchemy/src/Planetscale/OAuthClient.ts
+++ b/packages/alchemy/src/Planetscale/OAuthClient.ts
@@ -1,0 +1,234 @@
+import * as Data from "effect/Data";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+
+/**
+ * PlanetScale's OAuth endpoints (RFC 8628 device authorization grant).
+ */
+export const OAUTH_ENDPOINTS = {
+  device: "https://auth.planetscale.com/oauth/authorize_device",
+  token: "https://auth.planetscale.com/oauth/token",
+  revoke: "https://auth.planetscale.com/oauth/revoke",
+};
+
+/**
+ * Public OAuth client id/secret shipped with the PlanetScale CLI. PlanetScale
+ * documents these as safe to embed in distributed binaries — they are not
+ * confidential and the actual user-facing authorization happens on the
+ * planetscale.com domain.
+ *
+ * @see https://github.com/planetscale/cli/blob/main/internal/auth/authenticator.go
+ */
+export const OAUTH_CLIENT_ID = "wzzkYKOfRcxFAiMgDgfbhO9yIikNIlt9-yhosmvPBQA";
+export const OAUTH_CLIENT_SECRET =
+  "eIDdgw21BYsovcrpC4iKZQ0o7ol9cN1LsSr8fuNyg5o";
+
+export class OAuthError extends Data.TaggedError("OAuthError")<{
+  error: string;
+  errorDescription: string;
+}> {}
+
+/**
+ * OAuth credentials persisted under `~/.alchemy/credentials/<profile>/planetscale-oauth.json`.
+ */
+export interface OAuthCredentials {
+  type: "oauth";
+  access: string;
+  refresh: string;
+  expires: number;
+  scopes: string[];
+}
+
+/**
+ * Response from the device authorization endpoint.
+ */
+export interface DeviceVerification {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  verificationUriComplete: string | undefined;
+  expiresIn: number;
+  interval: number;
+}
+
+const extractCredentials = (json: {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  scope: string;
+}): OAuthCredentials => ({
+  type: "oauth",
+  access: json.access_token,
+  refresh: json.refresh_token,
+  expires: Date.now() + json.expires_in * 1000,
+  scopes: json.scope.split(" "),
+});
+
+const formPost = (
+  url: string,
+  body: Record<string, string>,
+): Effect.Effect<Response, OAuthError> =>
+  Effect.tryPromise({
+    try: () =>
+      fetch(url, {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: new URLSearchParams(body).toString(),
+      }),
+    catch: (err) =>
+      new OAuthError({
+        error: "network_error",
+        errorDescription: `Request to ${url} failed: ${err}`,
+      }),
+  });
+
+const parseError = (
+  res: Response,
+): Effect.Effect<{ error: string; error_description?: string }, OAuthError> =>
+  Effect.tryPromise({
+    try: () =>
+      res.json() as Promise<{ error: string; error_description?: string }>,
+    catch: () =>
+      new OAuthError({
+        error: "parse_error",
+        errorDescription: `Token endpoint returned ${res.status}`,
+      }),
+  });
+
+const tokenRequest = (
+  body: Record<string, string>,
+): Effect.Effect<OAuthCredentials, OAuthError> =>
+  Effect.gen(function* () {
+    const res = yield* formPost(OAUTH_ENDPOINTS.token, body);
+
+    if (!res.ok) {
+      const json = yield* parseError(res);
+      return yield* new OAuthError({
+        error: json.error,
+        errorDescription:
+          json.error_description ?? `Token endpoint returned ${res.status}`,
+      });
+    }
+
+    const json = yield* Effect.tryPromise({
+      try: () =>
+        res.json() as Promise<{
+          access_token: string;
+          refresh_token: string;
+          expires_in: number;
+          scope: string;
+        }>,
+      catch: () =>
+        new OAuthError({
+          error: "parse_error",
+          errorDescription: "Failed to parse token response",
+        }),
+    });
+    return extractCredentials(json);
+  });
+
+/**
+ * Initiates the device authorization grant. Returns the user code and
+ * verification URL the user should visit, along with the device code we
+ * subsequently exchange for an access token.
+ */
+export const requestDevice = (
+  scopes: string[],
+): Effect.Effect<DeviceVerification, OAuthError> =>
+  Effect.gen(function* () {
+    const res = yield* formPost(OAUTH_ENDPOINTS.device, {
+      client_id: OAUTH_CLIENT_ID,
+      client_secret: OAUTH_CLIENT_SECRET,
+      scope: scopes.join(" "),
+    });
+
+    if (!res.ok) {
+      const json = yield* parseError(res);
+      return yield* new OAuthError({
+        error: json.error ?? "device_request_failed",
+        errorDescription:
+          json.error_description ??
+          `Device authorization returned ${res.status}`,
+      });
+    }
+
+    const json = yield* Effect.tryPromise({
+      try: () =>
+        res.json() as Promise<{
+          device_code: string;
+          user_code: string;
+          verification_uri: string;
+          verification_uri_complete?: string;
+          expires_in: number;
+          interval: number;
+        }>,
+      catch: () =>
+        new OAuthError({
+          error: "parse_error",
+          errorDescription: "Failed to parse device authorization response",
+        }),
+    });
+
+    return {
+      deviceCode: json.device_code,
+      userCode: json.user_code,
+      verificationUri: json.verification_uri,
+      verificationUriComplete: json.verification_uri_complete,
+      expiresIn: json.expires_in,
+      interval: json.interval,
+    };
+  });
+
+/**
+ * Poll the token endpoint until the user completes authorization, the device
+ * code expires, or an unrecoverable error is returned.
+ *
+ * The PlanetScale device flow returns `authorization_pending` while we wait
+ * and `slow_down` if we are polling too quickly; both are recoverable and
+ * trigger another wait cycle.
+ */
+export const pollForToken = (
+  verification: DeviceVerification,
+): Effect.Effect<OAuthCredentials, OAuthError> => {
+  const intervalMs = Math.max(1, verification.interval) * 1000;
+  const maxAttempts = Math.ceil(verification.expiresIn / verification.interval);
+
+  return tokenRequest({
+    grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+    device_code: verification.deviceCode,
+    client_id: OAUTH_CLIENT_ID,
+    client_secret: OAUTH_CLIENT_SECRET,
+  }).pipe(
+    Effect.retry({
+      schedule: Schedule.spaced(Duration.millis(intervalMs)),
+      while: (err) =>
+        err.error === "authorization_pending" || err.error === "slow_down",
+      times: maxAttempts,
+    }),
+  );
+};
+
+export const refresh = (
+  credentials: OAuthCredentials,
+): Effect.Effect<OAuthCredentials, OAuthError> =>
+  tokenRequest({
+    grant_type: "refresh_token",
+    refresh_token: credentials.refresh,
+    client_id: OAUTH_CLIENT_ID,
+    client_secret: OAUTH_CLIENT_SECRET,
+  });
+
+export const revoke = (
+  credentials: OAuthCredentials,
+): Effect.Effect<void, OAuthError> =>
+  Effect.gen(function* () {
+    yield* formPost(OAUTH_ENDPOINTS.revoke, {
+      token: credentials.refresh,
+      client_id: OAUTH_CLIENT_ID,
+      client_secret: OAUTH_CLIENT_SECRET,
+    });
+  });

--- a/packages/alchemy/src/Planetscale/Postgres/PostgresDatabase.ts
+++ b/packages/alchemy/src/Planetscale/Postgres/PostgresDatabase.ts
@@ -171,7 +171,7 @@ export const PostgresDatabaseProvider = () =>
         }),
 
         read: Effect.fn(function* ({ id, output, olds }) {
-          const { organization } = yield* Credentials;
+          const { organization } = yield* yield* Credentials;
           const databaseName =
             output?.name ?? (yield* createDatabaseName(id, olds?.name));
 
@@ -233,7 +233,7 @@ export const PostgresDatabaseProvider = () =>
         }),
 
         reconcile: Effect.fn(function* ({ id, news, output, session }) {
-          const { organization } = yield* Credentials;
+          const { organization } = yield* yield* Credentials;
           const newName = yield* createDatabaseName(id, news.name);
           const clusterSize = toPostgresClusterSku({
             size: news.clusterSize,

--- a/packages/alchemy/src/Planetscale/Postgres/PostgresDefaultRole.ts
+++ b/packages/alchemy/src/Planetscale/Postgres/PostgresDefaultRole.ts
@@ -177,7 +177,7 @@ export const PostgresDefaultRoleProvider = () =>
         }),
 
         reconcile: Effect.fn(function* ({ news, output }) {
-          const { organization: envOrg } = yield* Credentials;
+          const { organization: envOrg } = yield* yield* Credentials;
           const organization = resolveDatabaseOrg(news.database) ?? envOrg;
           const databaseName = resolveDatabaseName(news.database);
           const branchName = resolveBranchName(news.branch);

--- a/packages/alchemy/src/Planetscale/Postgres/PostgresRole.ts
+++ b/packages/alchemy/src/Planetscale/Postgres/PostgresRole.ts
@@ -347,7 +347,7 @@ export const PostgresRoleProvider = () =>
         }),
 
         reconcile: Effect.fn(function* ({ id, news, output }) {
-          const { organization: envOrg } = yield* Credentials;
+          const { organization: envOrg } = yield* yield* Credentials;
           const organization = resolveDatabaseOrg(news.database) ?? envOrg;
           const databaseName = resolveDatabaseName(news.database);
           const branchName = resolveBranchName(news.branch);

--- a/packages/alchemy/src/Planetscale/Providers.ts
+++ b/packages/alchemy/src/Planetscale/Providers.ts
@@ -4,7 +4,7 @@ import { CredentialsStoreLive } from "../Auth/Credentials.ts";
 import { ProfileLive } from "../Auth/Profile.ts";
 import * as Provider from "../Provider.ts";
 import type { StackServices } from "../Stack.ts";
-import { PlanetscaleAuth, planetscaleHttpClientLayer } from "./AuthProvider.ts";
+import { PlanetscaleAuth } from "./AuthProvider.ts";
 import * as Credentials from "./Credentials.ts";
 import { MySQLBranch, MySQLBranchProvider } from "./MySQL/MySQLBranch.ts";
 import { MySQLDatabase, MySQLDatabaseProvider } from "./MySQL/MySQLDatabase.ts";
@@ -71,11 +71,6 @@ export const providers = (): Layer.Layer<
         PostgresDefaultRoleProvider(),
       ),
     ),
-    // The HttpClient middleware reads the resolved Credentials to decide
-    // whether to rewrite the Authorization header for OAuth, so it must be
-    // composed AFTER `fromAuthProvider()` in the pipe — Layer.provideMerge
-    // resolves later entries first.
-    Layer.provideMerge(planetscaleHttpClientLayer),
     Layer.provideMerge(Credentials.fromAuthProvider()),
     Layer.provideMerge(FetchHttpClient.layer),
     Layer.provideMerge(PlanetscaleAuth),

--- a/packages/alchemy/src/Planetscale/Providers.ts
+++ b/packages/alchemy/src/Planetscale/Providers.ts
@@ -4,7 +4,7 @@ import { CredentialsStoreLive } from "../Auth/Credentials.ts";
 import { ProfileLive } from "../Auth/Profile.ts";
 import * as Provider from "../Provider.ts";
 import type { StackServices } from "../Stack.ts";
-import { PlanetscaleAuth } from "./AuthProvider.ts";
+import { PlanetscaleAuth, planetscaleHttpClientLayer } from "./AuthProvider.ts";
 import * as Credentials from "./Credentials.ts";
 import { MySQLBranch, MySQLBranchProvider } from "./MySQL/MySQLBranch.ts";
 import { MySQLDatabase, MySQLDatabaseProvider } from "./MySQL/MySQLDatabase.ts";
@@ -71,6 +71,11 @@ export const providers = (): Layer.Layer<
         PostgresDefaultRoleProvider(),
       ),
     ),
+    // The HttpClient middleware reads the resolved Credentials to decide
+    // whether to rewrite the Authorization header for OAuth, so it must be
+    // composed AFTER `fromAuthProvider()` in the pipe — Layer.provideMerge
+    // resolves later entries first.
+    Layer.provideMerge(planetscaleHttpClientLayer),
     Layer.provideMerge(Credentials.fromAuthProvider()),
     Layer.provideMerge(FetchHttpClient.layer),
     Layer.provideMerge(PlanetscaleAuth),

--- a/packages/alchemy/test/Planetscale/MySQL/MySQLPassword.test.ts
+++ b/packages/alchemy/test/Planetscale/MySQL/MySQLPassword.test.ts
@@ -250,7 +250,7 @@ describe.skipIf(!process.env.PLANETSCALE_TEST)(() => {
         // Destroy the stack — both retained, so neither should be removed.
         yield* stack.destroy();
 
-        const { organization } = yield* Planetscale.Credentials;
+        const { organization } = yield* yield* Planetscale.Credentials;
 
         // Database should still exist and be ready.
         const liveDb = yield* Planetscale.waitForDatabaseReady(

--- a/packages/alchemy/test/Planetscale/Postgres/PostgresRole.test.ts
+++ b/packages/alchemy/test/Planetscale/Postgres/PostgresRole.test.ts
@@ -263,7 +263,7 @@ describe.skipIf(!process.env.PLANETSCALE_TEST)(() => {
       Effect.gen(function* () {
         yield* stack.destroy();
 
-        const { organization } = yield* Planetscale.Credentials;
+        const { organization } = yield* yield* Planetscale.Credentials;
 
         const { database, role } = yield* stack.deploy(
           Effect.gen(function* () {


### PR DESCRIPTION
Adds PlanetScale OAuth (RFC 8628 device authorization grant) as the recommended option in `alchemy login`, alongside the existing env-var and service-token methods. Tokens persist to `~/.alchemy/credentials/<profile>/planetscale-oauth.json` and refresh transparently on every API call.

```ts
// new alchemy login flow
//   Planetscale authentication method
//   ❯ OAuth                  recommended — device-flow login with automatic token refresh
//     Environment Variables  PLANETSCALE_API_TOKEN_ID + PLANETSCALE_API_TOKEN + PLANETSCALE_ORGANIZATION
//     Service Token          enter service token interactively, stored in ~/.alchemy/credentials
```

`@distilled.cloud/planetscale` now models credentials the same way `@distilled.cloud/cloudflare` does: `Credentials` holds `Effect<ResolvedCredentials, ...>` and the SDK's `formatHeaders` picks the right `Authorization` shape (`Bearer …` for OAuth, `tokenId:token` for service tokens). Callsites that destructured the static config now resolve the inner Effect first:

```diff
-const { organization } = yield* Credentials;
+const { organization } = yield* (yield* Credentials);
```

### Distilled-side change

This branch consumes new APIs from `@distilled.cloud/planetscale`. The matching patch (`packages/planetscale/src/credentials.ts` + `client.ts`, mirroring the cloudflare package) is on branch `claude/planetscale-oauth-credentials` in `alchemy-run/distilled` and must land + release before this can be merged. The diff is identical to what's in `.vendor/distilled` locally (gitignored).


---
_Generated by [Claude Code](https://claude.ai/code/session_01XX38YtyXZpLs7G4TtbDaPS)_