### PR TITLE
fix(cloudflare/worker): normalize bundle entry path on windows

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
@@ -99,6 +99,8 @@ export const WorkerBundle = Effect.gen(function* () {
       }
     }).pipe(
       Effect.flatMap((path) => fs.realPath(path)),
+      //* fix windows paths
+      Effect.map((path) => path.replaceAll("\\", "/")),
       Effect.mapError(
         (cause) =>
           new Bundle.BundleError({


### PR DESCRIPTION
On Windows, `alchemy dev` failed with `Uncaught Error: No such module "."` because the bundled `worker.js` imported a mangled path:

```js
import*as e from"\0distilled:user-entry:D:worktempalchemywindows-is-brokensrcworker.ts"
```

`@distilled.cloud/cloudflare-rolldown-plugin` embeds the entry path into a JS string literal in its virtual worker-entry module without escaping. Backslash sequences (`\w`, `\a`, `\s`, ...) get eaten as invalid JS string escapes, so the resulting import specifier collapses to garbage and workerd resolves it to `.`.

Sidestep it by handing rolldown a forward-slash path — Node's filesystem APIs accept it on Windows and the string literal survives intact.

```diff
  Effect.flatMap((path) => fs.realPath(path)),
+ Effect.map((path) => path.replaceAll("\\", "/")),
```
