### PR TITLE
chore(local): provide stack/lifecycle services in RpcProvider

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -47,11 +47,9 @@ import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import { AlchemyContext } from "../../AlchemyContext.ts";
 import type * as Bundle from "../../Bundle/Bundle.ts";
-import { InstanceId } from "../../InstanceId.ts";
 import * as RpcProvider from "../../Local/RpcProvider.ts";
 import type { ResourceBinding } from "../../Resource.ts";
 import { Stack } from "../../Stack.ts";
-import { Stage } from "../../Stage.ts";
 import { CloudflareEnvironment } from "../CloudflareEnvironment.ts";
 import type { WorkerAssetsConfig, WorkerProps } from "../Workers/Worker.ts";
 import { getCompatibility } from "./Compatibility.ts";
@@ -182,18 +180,12 @@ export const LocalWorkerProvider = () =>
         id,
         props,
         bindings,
-        instanceId,
       }: {
         id: string;
         props: WorkerProps;
         bindings: ResourceBinding<Worker["Binding"]>[];
-        instanceId: string;
       }) {
-        const name = yield* createWorkerName(id, props.name).pipe(
-          Effect.provideService(Stack, stack),
-          Effect.provideService(Stage, stack.stage),
-          Effect.provideService(InstanceId, instanceId),
-        );
+        const name = yield* createWorkerName(id, props.name);
         const compatibility = getCompatibility(props);
         const workerBindings: BindingHook<BindingServices>[] = [];
         const durableObjectNamespaces: Record<string, string> = {};
@@ -341,7 +333,6 @@ export const LocalWorkerProvider = () =>
         id: string;
         props: WorkerProps;
         bindings: ResourceBinding<Worker["Binding"]>[];
-        instanceId: string;
       }) {
         const { id, props, bindings } = options;
         const config = yield* buildConfig(options);
@@ -387,12 +378,11 @@ export const LocalWorkerProvider = () =>
       });
 
       return {
-        diff: Effect.fn(function* ({ id, news, newBindings, instanceId }) {
+        diff: Effect.fn(function* ({ id, news, newBindings }) {
           const options = {
             id,
             props: news,
             bindings: newBindings,
-            instanceId,
           };
           const hash = Hash.structure(options);
           return {
@@ -400,8 +390,8 @@ export const LocalWorkerProvider = () =>
               instances.get(options.id)?.hash === hash ? "noop" : "update",
           };
         }),
-        reconcile: Effect.fn(function* ({ id, news, bindings, instanceId }) {
-          const options = { id, props: news, bindings, instanceId };
+        reconcile: Effect.fn(function* ({ id, news, bindings }) {
+          const options = { id, props: news, bindings };
           const hash = Hash.structure(options);
           const existing = instances.get(options.id);
           if (existing) {

--- a/packages/alchemy/src/Local/RpcProvider.ts
+++ b/packages/alchemy/src/Local/RpcProvider.ts
@@ -1,9 +1,16 @@
+import type * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Predicate from "effect/Predicate";
 import type { Scope } from "effect/Scope";
+import * as Stream from "effect/Stream";
+import { InstanceId } from "../InstanceId.ts";
 import type { Platform } from "../Platform.ts";
 import * as Provider from "../Provider.ts";
 import type { ResourceClass, ResourceLike } from "../Resource.ts";
+import { Stack } from "../Stack.ts";
+import { Stage } from "../Stage.ts";
 import { RpcProviderProxy } from "./RpcProviderProxy.ts";
 
 /**
@@ -69,9 +76,46 @@ export const effect = <
     cls,
     Effect.gen(function* () {
       const client = yield* Effect.serviceOption(RpcProviderProxy);
-      if (client._tag === "None") return yield* eff;
+      const stack = yield* Stack;
+
+      if (client._tag === "None") {
+        const provider = yield* eff;
+        return new Proxy(provider, {
+          get: (target, prop) => {
+            const value = (target as any)[prop];
+            if (!Predicate.isFunction(value)) return value;
+            return (...args: any[]) => {
+              const result = value(...args);
+              const services = Layer.mergeAll(
+                layerFallback(Stack, stack),
+                layerFallback(Stage, stack.stage),
+                Predicate.hasProperty(args[0], "instanceId") &&
+                  Predicate.isString(args[0].instanceId)
+                  ? layerFallback(InstanceId, args[0].instanceId)
+                  : Layer.empty,
+              );
+              return result.pipe(
+                Stream.isStream(result)
+                  ? Stream.provide(services)
+                  : Effect.provide(services),
+              );
+            };
+          },
+        });
+      }
       return yield* client.value.get(serverEntryUrl, cls.Type);
     }),
+  );
+
+const layerFallback = <I, S>(
+  service: Context.Key<I, S>,
+  defaultValue: NoInfer<S>,
+) =>
+  Layer.effect(
+    service,
+    Effect.serviceOption(service).pipe(
+      Effect.map(Option.getOrElse(() => defaultValue)),
+    ),
   );
 
 /**

--- a/packages/alchemy/test/Local/RpcProvider.test.ts
+++ b/packages/alchemy/test/Local/RpcProvider.test.ts
@@ -1,0 +1,180 @@
+import { AlchemyContext } from "@/AlchemyContext.ts";
+import { InstanceId } from "@/InstanceId.ts";
+import * as RpcProvider from "@/Local/RpcProvider.ts";
+import type { ProviderService } from "@/Provider.ts";
+import { Resource } from "@/Resource.ts";
+import { Stack, type StackSpec } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Stream from "effect/Stream";
+
+interface TestResource extends Resource<
+  "Local.RpcProvider.Test",
+  {},
+  { ok: boolean }
+> {}
+const TestResource = Resource<TestResource>("Local.RpcProvider.Test");
+
+type StackShape = Omit<StackSpec, "output">;
+
+interface Capture {
+  stack?: StackShape;
+  stage?: string;
+  instanceId?: string;
+}
+
+const defaultStack: StackShape = {
+  name: "default-stack",
+  stage: "default-stage",
+  resources: {},
+  bindings: {},
+  actions: {},
+};
+
+describe("Local.RpcProvider.effect", () => {
+  it.effect(
+    "provides default Stack, Stage, and InstanceId to lifecycle effects",
+    () =>
+      Effect.gen(function* () {
+        const [capture, result] = yield* useProvider((provider) =>
+          provider.reconcile({
+            id: "r",
+            instanceId: "inst-from-arg",
+            news: {},
+            olds: undefined,
+            output: undefined,
+            session: undefined as any,
+            bindings: [],
+          }),
+        );
+        expect(result).toEqual({ ok: true });
+        expect(capture.stack).toBe(defaultStack);
+        expect(capture.stage).toBe(defaultStack.stage);
+        expect(capture.instanceId).toBe("inst-from-arg");
+      }),
+  );
+
+  it.effect(
+    "does not override Stack, Stage, or InstanceId when already provided",
+    () =>
+      Effect.gen(function* () {
+        const overrideStack: StackShape = {
+          name: "override-stack",
+          stage: "ignored-stage-on-stack",
+          resources: {},
+          bindings: {},
+          actions: {},
+        };
+        const [capture] = yield* useProvider((provider) =>
+          provider
+            .reconcile({
+              id: "r",
+              instanceId: "inst-from-arg",
+              news: {},
+              olds: undefined,
+              output: undefined,
+              session: undefined as any,
+              bindings: [],
+            })
+            .pipe(
+              Effect.provideService(Stack, overrideStack),
+              Effect.provideService(Stage, "override-stage"),
+              Effect.provideService(InstanceId, "override-instance-id"),
+            ),
+        );
+        expect(capture.stack).toBe(overrideStack);
+        expect(capture.stage).toBe("override-stage");
+        expect(capture.instanceId).toBe("override-instance-id");
+      }),
+  );
+
+  it.effect("provides defaults to Stream-returning lifecycle methods", () =>
+    Effect.gen(function* () {
+      const [capture, items] = yield* useProvider((provider) =>
+        provider.tail!({
+          id: "r",
+          instanceId: "inst-from-arg",
+          props: {},
+          output: { ok: true },
+        }).pipe(Stream.runCollect),
+      );
+      expect(items.length).toBe(1);
+      expect(capture.stack).toBe(defaultStack);
+      expect(capture.stage).toBe(defaultStack.stage);
+      expect(capture.instanceId).toBe("inst-from-arg");
+    }),
+  );
+
+  it.effect("omits InstanceId fallback when input has no instanceId", () =>
+    Effect.gen(function* () {
+      const [capture, exit] = yield* useProvider((provider) =>
+        provider
+          .reconcile({
+            id: "r",
+            news: {},
+            olds: undefined,
+            output: undefined,
+            session: undefined!,
+            instanceId: undefined!,
+            bindings: [],
+          })
+          .pipe(Effect.exit),
+      );
+      expect(exit._tag).toBe("Failure");
+      expect(capture.stack).toBe(defaultStack);
+      expect(capture.stage).toBe(defaultStack.stage);
+      expect(capture.instanceId).toBeUndefined();
+    }),
+  );
+});
+
+const TestResourceProvider = (capture: Capture) =>
+  RpcProvider.effect(
+    TestResource,
+    "ignored://entry",
+    Effect.succeed({
+      reconcile: Effect.fn(function* (_input: any) {
+        capture.stack = yield* Stack;
+        capture.stage = yield* Stage;
+        capture.instanceId = yield* InstanceId;
+        return { ok: true };
+      }),
+      tail: (_input: any) =>
+        Stream.fromEffect(
+          Effect.gen(function* () {
+            capture.stack = yield* Stack;
+            capture.stage = yield* Stage;
+            capture.instanceId = yield* InstanceId;
+            return { timestamp: new Date(0), message: "ok" };
+          }),
+        ),
+      delete: Effect.fn(function* () {}),
+    }),
+  );
+
+const useProvider = <A, E, R>(
+  callback: (provider: ProviderService<TestResource>) => Effect.Effect<A, E, R>,
+) => {
+  const capture: Capture = {};
+  return TestResource.Provider.pipe(
+    Effect.flatMap(callback),
+    Effect.map((result) => [capture, result] as const),
+    Effect.provide(
+      Layer.provide(
+        TestResourceProvider(capture),
+        Layer.mergeAll(
+          Layer.succeed(Stack, defaultStack),
+          Layer.succeed(Stage, defaultStack.stage),
+          Layer.succeed(AlchemyContext, {
+            dotAlchemy: "/tmp/.alchemy",
+            updateStateStore: false,
+            dev: false,
+            adopt: false,
+          }),
+        ),
+      ),
+    ),
+  );
+};


### PR DESCRIPTION
Wanted to call `createWorkerName` in `LocalWorkerProvider.diff` and found myself duplicating. Added this as a fix.