### PR TITLE
fix(cli): disable --experimental-transform-types on node.js 26

### DIFF
--- a/packages/alchemy/src/Cli/commands/dev.ts
+++ b/packages/alchemy/src/Cli/commands/dev.ts
@@ -40,7 +40,12 @@ export const devCommand = Command.make(
           : [
               "node",
               ...process.execArgv,
-              "--experimental-transform-types",
+              ...(isTransformTypesSupported()
+                ? [
+                    "--experimental-transform-types",
+                    "--no-warnings=ExperimentalWarning",
+                  ]
+                : []),
               "--watch",
               "--watch-preserve-output",
               fileURLToPath(import.meta.resolve("alchemy/bin/exec.js")),
@@ -67,3 +72,10 @@ export const devCommand = Command.make(
       )(effect),
   ),
 );
+
+const isTransformTypesSupported = (
+  version = process.versions.node,
+): boolean => {
+  const [major, minor] = version.split(".").map(Number);
+  return (major === 22 && minor >= 7) || (major >= 23 && major < 26);
+};


### PR DESCRIPTION
Closes #343.

Context: the `--experimental-transform-types` option was removed in Node.js 26. When we use it, Node.js exits immediately.

This PR detects if you are between Node.js 22.7 (minimum, inclusive) and 26.0 (maximum, exclusive), and applies the flag if it's available.

This doesn't support non-erasable syntax or other transpiler tricks, so whether we should use `tsx` or our own Rolldown-based transpiler step is an open question — but shouldn't stop us from shipping this patch for now.