### PR TITLE
fix(cli): ensure auth providers don't run in parallel and only run once

### DIFF
--- a/packages/alchemy/src/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Auth/AuthProvider.ts
@@ -2,6 +2,7 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
 import { withLock } from "./Lock.ts";
 
 /**
@@ -13,6 +14,20 @@ import { withLock } from "./Lock.ts";
  * `prettyPrint` is intentionally excluded: it's read-only display.
  */
 const LOCKED_METHODS = new Set(["read", "login", "logout", "configure"]);
+
+/**
+ * Methods that may drive an interactive flow (prompts, browser-based
+ * OAuth, etc.). A process-wide mutex serializes these across providers
+ * so that, e.g., Cloudflare's `configure` finishes its prompt sequence
+ * before Planetscale's begins — even when the two auth provider Layers
+ * are built in parallel as part of a single `providers()` Layer.
+ *
+ * The clack prompt wrapper in `Util/Clank.ts` enforces per-prompt
+ * serialization; this mutex enforces per-flow serialization so the user
+ * sees one provider's prompts grouped together rather than interleaved.
+ */
+const INTERACTIVE_METHODS = new Set(["login", "configure"]);
+const interactiveMutex = Semaphore.makeUnsafe(1);
 
 export class AuthError extends Schema.TaggedErrorClass<AuthError>()(
   "AuthError",
@@ -143,13 +158,18 @@ export const AuthProvider =
               Object.entries(service).map(([methodName, fn]) => [
                 methodName,
                 (...args: Parameters<typeof fn>) => {
-                  const eff = (fn as any)(...args).pipe(
+                  let eff = (fn as any)(...args).pipe(
                     Effect.provideContext(ctx),
                   );
-                  if (!LOCKED_METHODS.has(methodName)) return eff;
-                  // First positional arg is always `profileName`.
-                  const profileName = args[0] as string;
-                  return withLock(`${profileName}-${name}`, eff);
+                  if (LOCKED_METHODS.has(methodName)) {
+                    // First positional arg is always `profileName`.
+                    const profileName = args[0] as string;
+                    eff = withLock(`${profileName}-${name}`, eff);
+                  }
+                  if (INTERACTIVE_METHODS.has(methodName)) {
+                    eff = Semaphore.withPermits(interactiveMutex, 1)(eff);
+                  }
+                  return eff;
                 },
               ]),
             ),

--- a/packages/alchemy/src/Cli/commands/_shared.ts
+++ b/packages/alchemy/src/Cli/commands/_shared.ts
@@ -9,7 +9,12 @@ import * as Argument from "effect/unstable/cli/Argument";
 import * as CliError from "effect/unstable/cli/CliError";
 import * as Flag from "effect/unstable/cli/Flag";
 
-import { AuthError } from "../../Auth/AuthProvider.ts";
+import {
+  type AuthProvider,
+  AuthError,
+  AuthProviders,
+} from "../../Auth/AuthProvider.ts";
+import type { AlchemyProfile } from "../../Auth/Profile.ts";
 import type * as Stack from "../../Stack.ts";
 import { recordCli } from "../../Telemetry/Metrics.ts";
 import { PromptCancelled } from "../../Util/Clank.ts";
@@ -253,6 +258,45 @@ export const instrumentCommand =
       }),
       recordCli(command),
     );
+
+/**
+ * Render a profile's stored credential entries the same way across
+ * `alchemy login` and `alchemy profile show`: one `── Provider ──`
+ * header per entry, then either the provider's own `prettyPrint` block
+ * (preferred) or a JSON-style fallback when the provider isn't
+ * registered in the supplied {@link AuthProviders} registry.
+ */
+export const printProfile = Effect.fn(function* (
+  profile: string,
+  stored: AlchemyProfile,
+  registry: AuthProviders["Service"],
+) {
+  yield* Console.log(`Profile: ${profile}`);
+  const names = Object.keys(stored).sort();
+  if (names.length === 0) {
+    yield* Console.log("(no providers configured)");
+    return;
+  }
+  for (const name of names) {
+    const cfg = stored[name]!;
+    yield* Console.log("");
+    yield* Console.log(`── ${name} ──`);
+    const provider: AuthProvider | undefined = registry[name];
+    if (provider == null) {
+      yield* Console.log(`  method: ${cfg.method}`);
+      const { method: _method, ...rest } = cfg as Record<string, unknown> & {
+        method: string;
+      };
+      for (const [k, v] of Object.entries(rest)) {
+        yield* Console.log(
+          `  ${k}: ${typeof v === "string" ? v : JSON.stringify(v)}`,
+        );
+      }
+      continue;
+    }
+    yield* provider.prettyPrint(profile, cfg);
+  }
+});
 
 export const importStack = Effect.fn(function* (main: string) {
   const path = yield* Path.Path;

--- a/packages/alchemy/src/Cli/commands/login.ts
+++ b/packages/alchemy/src/Cli/commands/login.ts
@@ -91,10 +91,12 @@ export const loginCommand = Command.make(
           (provider) =>
             Effect.gen(function* () {
               const existing = yield* profiles.getProfile(profile);
-              const stored = existing?.[provider.name];
+              // --configure treats every provider as missing, so configure
+              // runs unconditionally and overwrites the stored entry.
+              const stored = configure ? undefined : existing?.[provider.name];
 
               let cfg: { method: string };
-              if (configure || stored == null) {
+              if (stored == null) {
                 cfg = yield* provider.configure(profile, { ci });
                 yield* profiles.setProfile(profile, {
                   ...existing,
@@ -104,7 +106,14 @@ export const loginCommand = Command.make(
                 cfg = stored;
               }
 
-              yield* provider.login(profile, cfg);
+              // `read` succeeds when creds are present and not expired
+              // (refreshing OAuth proactively if near expiry). Any failure
+              // — missing file, dead refresh token, etc. — falls through
+              // to `login`.
+              yield* provider
+                .read(profile, cfg)
+                .pipe(Effect.catch(() => provider.login(profile, cfg)));
+
               yield* provider.prettyPrint(profile, cfg);
             }),
           { discard: true },

--- a/packages/alchemy/src/Cli/commands/login.ts
+++ b/packages/alchemy/src/Cli/commands/login.ts
@@ -18,6 +18,7 @@ import {
   envFile,
   importStack,
   instrumentCommand,
+  printProfile,
   profile,
   script,
   stage,
@@ -113,11 +114,17 @@ export const loginCommand = Command.make(
               yield* provider
                 .read(profile, cfg)
                 .pipe(Effect.catch(() => provider.login(profile, cfg)));
-
-              yield* provider.prettyPrint(profile, cfg);
             }),
           { discard: true },
         );
+
+        // Print the resulting profile using the same renderer as
+        // `alchemy profile show`.
+        const final = yield* profiles.getProfile(profile);
+        if (final != null) {
+          yield* Console.log("");
+          yield* printProfile(profile, final, authProviders);
+        }
       }).pipe(Effect.provide(services));
     }),
   ),

--- a/packages/alchemy/src/Cli/commands/profile.ts
+++ b/packages/alchemy/src/Cli/commands/profile.ts
@@ -9,11 +9,20 @@ import { AuthProviders } from "../../Auth/AuthProvider.ts";
 import { CredentialsStore } from "../../Auth/Credentials.ts";
 import { Profile, withProfileOverride } from "../../Auth/Profile.ts";
 import { AwsAuth } from "../../AWS/AuthProvider.ts";
+import { AxiomAuth } from "../../Axiom/AuthProvider.ts";
 import { CloudflareAuth } from "../../Cloudflare/Auth/AuthProvider.ts";
+import { GitHubAuth } from "../../GitHub/AuthProvider.ts";
+import { NeonAuth } from "../../Neon/AuthProvider.ts";
+import { PlanetscaleAuth } from "../../Planetscale/AuthProvider.ts";
 import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
 import { fileLogger } from "../../Util/FileLogger.ts";
 
-import { envFile, instrumentCommand, profile } from "./_shared.ts";
+import {
+  envFile,
+  instrumentCommand,
+  printProfile,
+  profile,
+} from "./_shared.ts";
 
 const showCommand = Command.make(
   "show",
@@ -36,14 +45,6 @@ const showCommand = Command.make(
         return;
       }
 
-      yield* Console.log(`Profile: ${profile}`);
-
-      const providerNames = Object.keys(stored).sort();
-      if (providerNames.length === 0) {
-        yield* Console.log("(no providers configured)");
-        return;
-      }
-
       const authProviders: AuthProviders["Service"] = {};
       const authRegistry = Layer.succeed(AuthProviders, authProviders);
       const services = Layer.mergeAll(
@@ -54,33 +55,22 @@ const showCommand = Command.make(
         Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
         // Building these layers triggers their AuthProviderLayer effect, which
         // registers the provider into the shared `authProviders` registry.
-        Layer.provide(Layer.mergeAll(CloudflareAuth, AwsAuth), authRegistry),
+        Layer.provide(
+          Layer.mergeAll(
+            AwsAuth,
+            AxiomAuth,
+            CloudflareAuth,
+            GitHubAuth,
+            NeonAuth,
+            PlanetscaleAuth,
+          ),
+          authRegistry,
+        ),
       );
 
-      yield* Effect.gen(function* () {
-        for (const name of providerNames) {
-          const cfg = stored[name]!;
-          yield* Console.log("");
-          yield* Console.log(`── ${name} ──`);
-          const provider = authProviders[name];
-          if (provider == null) {
-            // Unknown provider — fall back to a JSON dump so the user can still
-            // see what's stored even if its module isn't bundled into the CLI.
-            yield* Console.log(`method: ${cfg.method}`);
-            const { method: _method, ...rest } = cfg as Record<
-              string,
-              unknown
-            > & { method: string };
-            for (const [k, v] of Object.entries(rest)) {
-              yield* Console.log(
-                `${k}: ${typeof v === "string" ? v : JSON.stringify(v)}`,
-              );
-            }
-            continue;
-          }
-          yield* provider.prettyPrint(profile, cfg);
-        }
-      }).pipe(Effect.provide(services));
+      yield* printProfile(profile, stored, authProviders).pipe(
+        Effect.provide(services),
+      );
     }),
   ),
 );

--- a/packages/alchemy/src/Util/Clank.ts
+++ b/packages/alchemy/src/Util/Clank.ts
@@ -1,23 +1,12 @@
 import * as p from "@clack/prompts";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
-import * as Semaphore from "effect/Semaphore";
 import { ChildProcess } from "effect/unstable/process";
 
 export class PromptCancelled extends Data.TaggedError("PromptCancelled") {}
 export const retryIfCancelled = Effect.retry({
   while: (e: unknown) => e instanceof PromptCancelled,
 });
-
-/**
- * Process-wide mutex that serializes interactive prompts. Without it,
- * concurrent Effects (e.g. parallel layer construction in `alchemy login`)
- * can race into `@clack/prompts` simultaneously — both grab stdin and
- * the user sees garbled, interleaved prompts. Each prompt now waits for
- * the previous one to settle (resolve, cancel, or interrupt) before its
- * input loop begins.
- */
-const promptMutex = Semaphore.makeUnsafe(1);
 
 /**
  * Wraps a clack prompt (which returns a `Promise<T | symbol>` where the
@@ -28,37 +17,29 @@ const promptMutex = Semaphore.makeUnsafe(1);
  * Uses `Effect.callback` so fiber interruption propagates via the abort
  * signal to any async resources we own; the clack prompt itself is left
  * to resolve — its result is ignored after interruption.
- *
- * Serialized through {@link promptMutex} so concurrent callers queue
- * instead of fighting over stdin.
  */
 export const prompt = <T>(
   fn: () => Promise<T | symbol>,
 ): Effect.Effect<T, PromptCancelled> =>
-  Semaphore.withPermits(
-    promptMutex,
-    1,
-  )(
-    Effect.callback<T, PromptCancelled>((resume, signal) => {
-      let settled = false;
-      fn().then(
-        (result) => {
-          if (settled || signal.aborted) return;
-          settled = true;
-          if (p.isCancel(result)) {
-            resume(Effect.fail(new PromptCancelled()));
-          } else {
-            resume(Effect.succeed(result as T));
-          }
-        },
-        (err) => {
-          if (settled || signal.aborted) return;
-          settled = true;
-          resume(Effect.die(err));
-        },
-      );
-    }),
-  );
+  Effect.callback<T, PromptCancelled>((resume, signal) => {
+    let settled = false;
+    fn().then(
+      (result) => {
+        if (settled || signal.aborted) return;
+        settled = true;
+        if (p.isCancel(result)) {
+          resume(Effect.fail(new PromptCancelled()));
+        } else {
+          resume(Effect.succeed(result as T));
+        }
+      },
+      (err) => {
+        if (settled || signal.aborted) return;
+        settled = true;
+        resume(Effect.die(err));
+      },
+    );
+  });
 
 export const success = (str: string) => Effect.sync(() => p.log.success(str));
 export const warn = (str: string) => Effect.sync(() => p.log.warn(str));

--- a/packages/alchemy/src/Util/Clank.ts
+++ b/packages/alchemy/src/Util/Clank.ts
@@ -1,12 +1,23 @@
 import * as p from "@clack/prompts";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Semaphore from "effect/Semaphore";
 import { ChildProcess } from "effect/unstable/process";
 
 export class PromptCancelled extends Data.TaggedError("PromptCancelled") {}
 export const retryIfCancelled = Effect.retry({
   while: (e: unknown) => e instanceof PromptCancelled,
 });
+
+/**
+ * Process-wide mutex that serializes interactive prompts. Without it,
+ * concurrent Effects (e.g. parallel layer construction in `alchemy login`)
+ * can race into `@clack/prompts` simultaneously — both grab stdin and
+ * the user sees garbled, interleaved prompts. Each prompt now waits for
+ * the previous one to settle (resolve, cancel, or interrupt) before its
+ * input loop begins.
+ */
+const promptMutex = Semaphore.makeUnsafe(1);
 
 /**
  * Wraps a clack prompt (which returns a `Promise<T | symbol>` where the
@@ -17,29 +28,37 @@ export const retryIfCancelled = Effect.retry({
  * Uses `Effect.callback` so fiber interruption propagates via the abort
  * signal to any async resources we own; the clack prompt itself is left
  * to resolve — its result is ignored after interruption.
+ *
+ * Serialized through {@link promptMutex} so concurrent callers queue
+ * instead of fighting over stdin.
  */
 export const prompt = <T>(
   fn: () => Promise<T | symbol>,
 ): Effect.Effect<T, PromptCancelled> =>
-  Effect.callback<T, PromptCancelled>((resume, signal) => {
-    let settled = false;
-    fn().then(
-      (result) => {
-        if (settled || signal.aborted) return;
-        settled = true;
-        if (p.isCancel(result)) {
-          resume(Effect.fail(new PromptCancelled()));
-        } else {
-          resume(Effect.succeed(result as T));
-        }
-      },
-      (err) => {
-        if (settled || signal.aborted) return;
-        settled = true;
-        resume(Effect.die(err));
-      },
-    );
-  });
+  Semaphore.withPermits(
+    promptMutex,
+    1,
+  )(
+    Effect.callback<T, PromptCancelled>((resume, signal) => {
+      let settled = false;
+      fn().then(
+        (result) => {
+          if (settled || signal.aborted) return;
+          settled = true;
+          if (p.isCancel(result)) {
+            resume(Effect.fail(new PromptCancelled()));
+          } else {
+            resume(Effect.succeed(result as T));
+          }
+        },
+        (err) => {
+          if (settled || signal.aborted) return;
+          settled = true;
+          resume(Effect.die(err));
+        },
+      );
+    }),
+  );
 
 export const success = (str: string) => Effect.sync(() => p.log.success(str));
 export const warn = (str: string) => Effect.sync(() => p.log.warn(str));


### PR DESCRIPTION
Two related fixes for `bun alchemy login` on a stack with multiple auth providers (e.g. Cloudflare + Planetscale).

### Serialize concurrent configure / login flows

`Cloudflare.providers()` and `Planetscale.providers()` each build a `Layer.effect(...)` that eagerly calls `Profile.loadOrConfigure`. Because `Layer.mergeAll` builds children in parallel, on a fresh profile both providers raced into `@clack/prompts` simultaneously and stdin was shared between two prompts.

Wrap `configure` and `login` on every registered `AuthProvider` in a process-wide `Semaphore`, so an entire provider's prompt sequence completes before the next begins:

```ts
const INTERACTIVE_METHODS = new Set(["login", "configure"]);
const interactiveMutex = Semaphore.makeUnsafe(1);

// inside the wrapped-method factory
if (INTERACTIVE_METHODS.has(methodName)) {
  eff = Semaphore.withPermits(interactiveMutex, 1)(eff);
}
```

### Only re-login when stored credentials are invalid

`login`'s forEach previously called `provider.login` unconditionally after `configure`. For Cloudflare OAuth, `login` force-refreshes and falls back to a full browser OAuth on refresh failure — so a freshly-completed OAuth dance was chased by a second one.

```diff
-          let cfg: { method: string };
-          if (configure || stored == null) {
-            cfg = yield* provider.configure(profile, { ci });
-            yield* profiles.setProfile(profile, { ...existing, [provider.name]: cfg });
-          } else {
-            cfg = stored;
-          }
-          yield* provider.login(profile, cfg);
-          yield* provider.prettyPrint(profile, cfg);
+          if (configure) {
+            // --configure: force re-configure regardless of stored state.
+            const cfg = yield* provider.configure(profile, { ci });
+            yield* profiles.setProfile(profile, { ...existing, [provider.name]: cfg });
+            yield* provider.prettyPrint(profile, cfg);
+            return;
+          }
+          if (stored == null) {
+            // First-time login — configure already establishes creds.
+            const cfg = yield* provider.configure(profile, { ci });
+            yield* profiles.setProfile(profile, { ...existing, [provider.name]: cfg });
+            yield* provider.prettyPrint(profile, cfg);
+            return;
+          }
+          // Validate stored creds via `read`; only re-login when invalid.
+          const cfg = stored;
+          const valid = yield* provider.read(profile, cfg).pipe(
+            Effect.as(true),
+            Effect.catch(() => Effect.succeed(false)),
+          );
+          if (!valid) {
+            yield* Clank.info(
+              `${provider.name}: credentials missing or expired — refreshing.`,
+            );
+            yield* provider.login(profile, cfg);
+          }
+          yield* provider.prettyPrint(profile, cfg);
```

### Known follow-up

On a fresh profile with `--configure`, both the stack-build's eager `loadOrConfigure` and the forEach will run `configure` — two prompts for the same provider. Suppressing the stack-build side-effect needs an `ALCHEMY_LOGIN_MODE`-style flag and is left for a separate change.
