### PR TITLE
fix(aws): deliver S3 bucket notifications to Lambda event sources

### DIFF
--- a/packages/alchemy/src/AWS/Lambda/BucketEventSource.ts
+++ b/packages/alchemy/src/AWS/Lambda/BucketEventSource.ts
@@ -119,7 +119,7 @@ export const BucketEventSourcePolicyLive = BucketEventSourcePolicy.layer.effect(
     ) {
       if (Lambda.isFunction(host)) {
         yield* Permission(`AWS.Lambda.InvokeFunction(${bucket.LogicalId})`, {
-          action: "lambda.InvokeFunction",
+          action: "lambda:InvokeFunction",
           functionName: host.functionName,
           principal: "s3.amazonaws.com",
           sourceArn: bucket.bucketArn,

--- a/packages/alchemy/src/AWS/Lambda/BucketEventSource.ts
+++ b/packages/alchemy/src/AWS/Lambda/BucketEventSource.ts
@@ -113,11 +113,23 @@ export const BucketEventSourcePolicyLive = BucketEventSourcePolicy.layer.effect(
       bucket: Bucket,
       {
         events: Events = ["s3:ObjectCreated:*"],
+        prefix,
+        suffix,
       }: {
         events?: S3EventType[];
+        prefix?: string;
+        suffix?: string;
       } = {},
     ) {
       if (Lambda.isFunction(host)) {
+        const filterRules = [
+          ...(prefix !== undefined
+            ? [{ Name: "prefix" as const, Value: prefix }]
+            : []),
+          ...(suffix !== undefined
+            ? [{ Name: "suffix" as const, Value: suffix }]
+            : []),
+        ];
         yield* Permission(`AWS.Lambda.InvokeFunction(${bucket.LogicalId})`, {
           action: "lambda:InvokeFunction",
           functionName: host.functionName,
@@ -130,6 +142,9 @@ export const BucketEventSourcePolicyLive = BucketEventSourcePolicy.layer.effect(
               {
                 LambdaFunctionArn: host.functionArn,
                 Events,
+                ...(filterRules.length > 0
+                  ? { Filter: { Key: { FilterRules: filterRules } } }
+                  : {}),
               },
             ],
           },

--- a/packages/alchemy/src/AWS/S3/Bucket.ts
+++ b/packages/alchemy/src/AWS/S3/Bucket.ts
@@ -1,7 +1,9 @@
 import { Region } from "@distilled.cloud/aws/Region";
 import type { BucketLocationConstraint } from "@distilled.cloud/aws/s3";
 import * as s3 from "@distilled.cloud/aws/s3";
+import * as Arr from "effect/Array";
 import * as Effect from "effect/Effect";
+import * as Order from "effect/Order";
 import * as Schedule from "effect/Schedule";
 import type { ScopedPlanStatusSession } from "../../Cli/Cli.ts";
 import { isResolved } from "../../Diff.ts";
@@ -475,6 +477,75 @@ export const BucketProvider = () =>
         yield* session.note(`Removed bucket policy: ${bucketName}`);
       });
 
+      // Apply S3 event notification configuration declared via bindings
+      // (e.g. `S3.notifications(bucket).subscribe(...)`). Without this the
+      // binding is recorded in state but never reaches the bucket, so no
+      // events are ever delivered.
+      // Canonical form of the Lambda targets, ignoring S3-assigned `Id`s and
+      // event ordering, so drift detection doesn't churn across deploys.
+      const canonicalLambda = (
+        configs: readonly s3.LambdaFunctionConfiguration[],
+      ) =>
+        JSON.stringify(
+          Arr.map(configs, (c) => ({
+            arn: c.LambdaFunctionArn,
+            events: Arr.sort(c.Events ?? [], Order.String),
+            filter: c.Filter ?? null,
+          })),
+        );
+
+      const syncBucketNotifications = Effect.fnUntraced(function* ({
+        bucketName,
+        bindings,
+        session,
+        operation,
+      }: {
+        bucketName: string;
+        session: ScopedPlanStatusSession;
+        bindings: ResourceBinding<Bucket["Binding"]>[];
+        operation: "create" | "update";
+      }) {
+        const desired = Arr.flatMap(
+          bindings,
+          (binding) =>
+            binding.data.notificationConfiguration
+              ?.LambdaFunctionConfigurations ?? [],
+        );
+
+        // Nothing declared — leave any externally-managed config untouched.
+        if (Arr.isReadonlyArrayEmpty(desired)) return;
+
+        const existing = yield* s3.getBucketNotificationConfiguration({
+          Bucket: bucketName,
+        });
+
+        if (
+          canonicalLambda(existing.LambdaFunctionConfigurations ?? []) ===
+          canonicalLambda(desired)
+        ) {
+          return;
+        }
+
+        yield* Effect.logInfo(
+          `S3 Bucket ${operation}: applying notification configuration to ${bucketName}`,
+        );
+        yield* s3.putBucketNotificationConfiguration({
+          Bucket: bucketName,
+          // Preserve any Topic/Queue/EventBridge config already on the bucket;
+          // only manage the Lambda targets declared through bindings.
+          NotificationConfiguration: {
+            ...existing,
+            LambdaFunctionConfigurations: desired,
+          },
+          // The Lambda invoke permission is created as a separate resource
+          // that may be applied after this bucket reconcile. Skip S3's
+          // synchronous test-invoke so the PUT doesn't fail on ordering;
+          // the permission exists by the time events are delivered.
+          SkipDestinationValidation: true,
+        });
+        yield* session.note(`Updated bucket notifications: ${bucketName}`);
+      });
+
       return {
         stables: ["bucketName", "bucketArn", "region", "accountId"],
         // S3 bucket names are globally unique. `headBucket` succeeds only when
@@ -548,6 +619,13 @@ export const BucketProvider = () =>
           });
 
           yield* syncBucketPolicy({
+            bucketName: resolved.bucketName,
+            bindings,
+            session,
+            operation,
+          });
+
+          yield* syncBucketNotifications({
             bucketName: resolved.bucketName,
             bindings,
             session,

--- a/packages/alchemy/src/AWS/S3/BucketNotifications.ts
+++ b/packages/alchemy/src/AWS/S3/BucketNotifications.ts
@@ -24,6 +24,16 @@ export type BucketNotification = {
 export interface NotificationsProps<Events extends S3EventType[]> {
   /** S3 event types to subscribe to. Defaults to all event types. */
   events?: Events;
+  /**
+   * Only deliver events for object keys beginning with this prefix.
+   * Maps to an S3 `prefix` filter rule on the notification configuration.
+   */
+  prefix?: string;
+  /**
+   * Only deliver events for object keys ending with this suffix.
+   * Maps to an S3 `suffix` filter rule on the notification configuration.
+   */
+  suffix?: string;
 }
 
 /**

--- a/packages/alchemy/test/AWS/S3/EventSource.test.ts
+++ b/packages/alchemy/test/AWS/S3/EventSource.test.ts
@@ -1,0 +1,130 @@
+import * as AWS from "@/AWS";
+import * as Core from "@/Test/Core";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import { describe } from "vitest";
+
+import BucketEventSourceFunctionLive, {
+  BucketEventSourceFunction,
+} from "./fixtures/event-source-handler.ts";
+
+const testOptions = { providers: AWS.providers() };
+const { test, beforeAll, afterAll } = Test.make(testOptions);
+const sharedStack = Core.scratchStack(testOptions, "S3EventSource");
+
+// Lambda function URL cold-start (DNS, IAM propagation, init) can take well
+// over a minute on a fresh deploy under parallel-suite load. Budget ~150s.
+const readinessPolicy = Schedule.fixed("2 seconds").pipe(
+  Schedule.both(Schedule.recurs(75)),
+);
+
+let baseUrl: string;
+
+describe("S3 Bucket Event Source", () => {
+  beforeAll(
+    Effect.gen(function* () {
+      yield* Effect.logInfo(
+        "S3 EventSource test: destroying previous resources",
+      );
+      yield* sharedStack.destroy();
+
+      yield* Effect.logInfo("S3 EventSource test: deploying fixture");
+      const { functionUrl } = yield* sharedStack.deploy(
+        Effect.gen(function* () {
+          return yield* BucketEventSourceFunction;
+        }).pipe(Effect.provide(BucketEventSourceFunctionLive)),
+      );
+
+      expect(functionUrl).toBeTruthy();
+      baseUrl = functionUrl!.replace(/\/+$/, "");
+
+      yield* Effect.logInfo(
+        `S3 EventSource test: function URL ready (${functionUrl}), probing readiness`,
+      );
+
+      // A missing key returns 404 via the NoSuchKey path — that's the
+      // signal the handler is reachable.
+      yield* HttpClient.get(`${baseUrl}/processed?key=__ready__`).pipe(
+        Effect.flatMap((response) =>
+          response.status === 404 || response.status === 200
+            ? Effect.succeed(response)
+            : Effect.fail(new Error(`Function not ready: ${response.status}`)),
+        ),
+        Effect.tapError((error) =>
+          Effect.logWarning(
+            `S3 EventSource test: fixture not ready yet (${String(error)})`,
+          ),
+        ),
+        Effect.retry({ schedule: readinessPolicy }),
+      );
+      yield* Effect.logInfo(
+        "S3 EventSource test: fixture responded successfully",
+      );
+    }),
+    { timeout: 240_000 },
+  );
+
+  afterAll(sharedStack.destroy(), { timeout: 60_000 });
+
+  test.provider(
+    "object created under the watched prefix triggers the subscription to write derived state",
+    (_stack) =>
+      Effect.gen(function* () {
+        const key = "e2e-object";
+
+        // Trigger: write an object under `incoming/`, which the Lambda
+        // event-source subscription should observe.
+        const putResponse = yield* HttpClient.execute(
+          HttpClientRequest.bodyJsonUnsafe(
+            HttpClientRequest.post(`${baseUrl}/put`),
+            { key, value: "hello from s3 event source" },
+          ),
+        ).pipe(Effect.flatMap((r) => r.json));
+        expect(putResponse).toHaveProperty("ok", true);
+
+        // Poll the `/processed` route until the subscription has written the
+        // derived object. S3 -> Lambda notification delivery is eventually
+        // consistent, so retry with a generous budget.
+        const fetchProcessed = Effect.gen(function* () {
+          const response = yield* HttpClient.get(
+            `${baseUrl}/processed?key=${encodeURIComponent(key)}`,
+          );
+          if (response.status !== 200) {
+            return yield* Effect.fail(new ProcessedNotReady());
+          }
+          const body = (yield* response.json) as { processed: unknown };
+          if (!body.processed) {
+            return yield* Effect.fail(new ProcessedNotReady());
+          }
+          return body.processed as ProcessedRecord;
+        });
+
+        const processed = yield* fetchProcessed.pipe(
+          Effect.retry({
+            while: (error) => error._tag === "ProcessedNotReady",
+            schedule: Schedule.fixed("5 seconds").pipe(
+              Schedule.both(Schedule.recurs(48)), // ~4 min budget
+            ),
+          }),
+        );
+
+        expect(processed.key).toBe(`incoming/${key}`);
+        expect(processed.size).toBeGreaterThan(0);
+        expect(processed.eTag).toBeTruthy();
+      }),
+    { timeout: 600_000 },
+  );
+});
+
+interface ProcessedRecord {
+  key: string;
+  size: number;
+  eTag: string;
+}
+
+class ProcessedNotReady extends Data.TaggedError("ProcessedNotReady") {}

--- a/packages/alchemy/test/AWS/S3/fixtures/event-source-handler.ts
+++ b/packages/alchemy/test/AWS/S3/fixtures/event-source-handler.ts
@@ -1,0 +1,109 @@
+import * as Lambda from "@/AWS/Lambda";
+import * as S3 from "@/AWS/S3";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Stream from "effect/Stream";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+// Keys written by the `fetch` route live under `incoming/`; the subscription
+// only listens to that prefix and writes its derived object under `processed/`.
+// Without the prefix filter the `processed/` write would itself trigger the
+// subscription, which writes another object, and so on — a runaway train.
+const INCOMING_PREFIX = "incoming/";
+const PROCESSED_PREFIX = "processed/";
+
+export class BucketEventSourceFunction extends Lambda.Function<BucketEventSourceFunction>()(
+  "BucketEventSourceFunction",
+  {
+    main: import.meta.filename,
+    url: true,
+  },
+) {}
+
+export default BucketEventSourceFunction.make(
+  Effect.gen(function* () {
+    const bucket = yield* S3.Bucket("EventSourceBucket", {
+      forceDestroy: true,
+    });
+
+    const putObject = yield* S3.PutObject.bind(bucket);
+    const getObject = yield* S3.GetObject.bind(bucket);
+
+    // Subscribe to object-created events under `incoming/`. Each notification
+    // writes a derived object under `processed/<name>` recording the event.
+    yield* S3.notifications(bucket, {
+      events: ["s3:ObjectCreated:*"],
+      prefix: INCOMING_PREFIX,
+    }).subscribe((stream) =>
+      stream.pipe(
+        Stream.runForEach((event) =>
+          Effect.gen(function* () {
+            const name = event.key.slice(INCOMING_PREFIX.length);
+            yield* putObject({
+              Key: `${PROCESSED_PREFIX}${name}`,
+              Body: JSON.stringify({
+                key: event.key,
+                size: event.size,
+                eTag: event.eTag,
+              }),
+              ContentType: "application/json",
+            });
+          }).pipe(Effect.orDie),
+        ),
+      ),
+    );
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.originalUrl);
+        const pathname = url.pathname;
+
+        if (request.method === "POST" && pathname === "/put") {
+          const body = (yield* request.json) as { key: string; value: string };
+          yield* putObject({
+            Key: `${INCOMING_PREFIX}${body.key}`,
+            Body: body.value,
+            ContentType: "text/plain",
+          });
+          return yield* HttpServerResponse.json({ ok: true });
+        }
+
+        if (request.method === "GET" && pathname === "/processed") {
+          const key = url.searchParams.get("key");
+          if (!key) {
+            return HttpServerResponse.text("Missing key", { status: 400 });
+          }
+          return yield* getObject({ Key: `${PROCESSED_PREFIX}${key}` }).pipe(
+            Effect.flatMap((result) =>
+              Stream.mkString(Stream.decodeText(result.Body!)),
+            ),
+            Effect.flatMap((text) =>
+              HttpServerResponse.json({ processed: JSON.parse(text) }),
+            ),
+            // Object not written yet — the test polls until it appears.
+            Effect.catchTag("NoSuchKey", () =>
+              Effect.succeed(
+                HttpServerResponse.json({ processed: null }, { status: 404 }),
+              ),
+            ),
+          );
+        }
+
+        return HttpServerResponse.json(
+          { error: "Not found", pathname },
+          { status: 404 },
+        );
+      }).pipe(Effect.orDie),
+    };
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        Lambda.BucketEventSource,
+        S3.PutObjectLive,
+        S3.GetObjectLive,
+      ),
+    ),
+  ),
+);


### PR DESCRIPTION
Two fixes that together make `S3.notifications(bucket).subscribe(...)` actually deliver object events to a Lambda. Independently, each leaves the trigger broken; both are required for an end-to-end S3 → Lambda event source.

### `fix(aws/lambda)`: malformed invoke action

The S3 → Lambda invoke permission used `lambda.InvokeFunction` (dot) instead of `lambda:InvokeFunction` (colon). Lambda `AddPermission` requires the `service:Action` form, so AWS rejects the call with `ValidationException`.

```diff
  yield* Permission(`AWS.Lambda.InvokeFunction(${bucket.LogicalId})`, {
-   action: "lambda.InvokeFunction",
+   action: "lambda:InvokeFunction",
    functionName: host.functionName,
    principal: "s3.amazonaws.com",
    sourceArn: bucket.bucketArn,
  });
```

Every sibling call site already uses the colon form (`Function.ts`, `EventBridge/ToLambda.ts`, `Lambda/InvokeFunction.ts`, `Lambda/TopicEventSource.ts`).

### `fix(aws/s3)`: notification binding never applied

`subscribe(...)` records a bucket binding carrying `notificationConfiguration`, but the Bucket provider's `reconcile` only ran `ensureBucketExists → syncBucketTags → syncBucketPolicy`. Nothing ever read `binding.data.notificationConfiguration` or called `putBucketNotificationConfiguration`, so the permission was created, state said "configured", but the bucket's notification config stayed empty and no trigger ever existed.

A new `syncBucketNotifications` helper (mirroring `syncBucketPolicy`) is called from `reconcile` right after `syncBucketPolicy`. It:

- collects declared Lambda targets from bindings;
- canonicalizes them (ignoring S3-assigned `Id`s and event order) to avoid deploy churn;
- merges with any existing Topic/Queue/EventBridge config, managing only its own Lambda targets;
- PUTs with `SkipDestinationValidation: true`, since the invoke-permission resource may apply after the bucket reconcile — skipping S3's synchronous test-invoke avoids an ordering failure, and the permission exists by the time events are delivered.
