### PR TITLE
fix(cloudflare): two vite fixes (draft)

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -288,7 +288,7 @@ export const LocalWorkerProvider = () =>
           dev: {
             ...props.dev,
             // This is the default. Vite and cloudflare-runtime will retry if unavailable, unless `strictPort` is true.
-            port: props.dev?.port ?? 1337,
+            port: props.dev?.port ?? (props.vite ? 5173 : 1337),
           },
         };
       });

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -296,7 +296,7 @@ export interface WorkerProps<
     /**
      * Port the local dev server listens on. If the port is unavailable, the
      * next free port is used unless {@link strictPort} is `true`.
-     * @default 1337
+     * @default 5173 for Vite, 1337 for non-Vite
      */
     port?: number;
     /**

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -38,9 +38,11 @@ export const bindWorkerAsyncBindings = Effect.fnUntraced(function* (
       // Bindings can be passed as a plain resource value, an Effect that
       // yields a resource, or an effect-class (e.g. a `Cloudflare.Worker`
       // class). Resolve the yieldable forms before deriving binding metadata.
-      const binding = isYieldableEffectLike(bindingEff)
-        ? ((yield* bindingEff as Effect.Effect<unknown>) as WorkerBindingResource)
-        : bindingEff;
+      const binding = (
+        isYieldableEffectLike(bindingEff) && !Output.isOutput(bindingEff)
+          ? yield* bindingEff as Effect.Effect<unknown>
+          : bindingEff
+      ) as WorkerBindingResource;
 
       const bindingMeta: InputProps<WorkerBinding> | undefined =
         yield* asEffect(toBinding(bindingName, binding));


### PR DESCRIPTION
Two bugs in this PR. I'll split these out into a separate PR, but I'm grouping them here to test against a user repro: https://github.com/lucasthevenet/repro-alchemy

1. `vite dev` listens on port 1337 instead of 5173, which is non-default behavior for Vite, and can cause conflicts with our server (need to figure out why the retry logic doesn't apply here, but this should work as a patch)
2. When binding an `Output` value to an external Worker, we `yield*` the output in `bindWorkerAsyncBindings`, which calls `.bind()` on it prematurely, causing a crash because `bind()` requires `RuntimeContext` which is not available at deploy-time. To fix this, I added a check to see if it's an `Output` before yielding.