### PR TITLE
fix(cloudflare): handle props.env in local workers

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -232,7 +232,19 @@ export const LocalWorkerProvider = () =>
       }) {
         const name = yield* createWorkerName(id, props.name);
         const compatibility = getCompatibility(props);
-        const workerBindings: BindingHook<BindingServices>[] = [];
+        const workerBindings: BindingHook<BindingServices>[] = [
+          Text.local("ALCHEMY_PHASE", "runtime"),
+          Text.local("ALCHEMY_STACK_NAME", stack.name),
+          Text.local("ALCHEMY_STAGE", stack.stage),
+          ...Object.entries(props.env ?? {}).map(([key, value]) => {
+            const unredacted = Redacted.isRedacted(value)
+              ? Redacted.value(value)
+              : value;
+            return typeof unredacted === "string"
+              ? Text.local(key, unredacted)
+              : Json.local(key, unredacted);
+          }),
+        ];
         const durableObjectNamespaces: Record<string, string> = {};
         const hyperdrives: Record<string, Required<HyperdriveOrigin>> = {};
         for (const { data } of bindings) {


### PR DESCRIPTION
Closes #471. We weren't handling `props.env` in `LocalWorkerProvider`; this slipped through the cracks in tests because while the `cloudflare-dev` example does test `Config`, it does so using a hard-coded value instead of from `.env`.