### PR TITLE
docs(concepts): simplify secrets intro

### DIFF
--- a/website/src/content/docs/concepts/secrets.mdx
+++ b/website/src/content/docs/concepts/secrets.mdx
@@ -5,18 +5,10 @@ sidebar:
   order: 8
 ---
 
-A **secret** is any sensitive value your Worker or Function needs
-at runtime — an API key, a database password, a signing key, an
-OAuth client secret. You don't want it in source code, you don't
-want it in plain-text env vars on disk, and you don't want it
-echoed in logs.
-
-Alchemy doesn't ship its own secret/variable primitives. Instead,
-it hooks into [`effect/Config`](https://effect.website/docs/configuration):
-any `Config` you `yield*` during a deploy target's **Init** phase
-is automatically bound to that target, and the same `yield*`
-resolves from the live binding at **Runtime** (see: [Phases](/concepts/phases)).
-One declaration, two phases, no accessor wrapper.
+Any [`effect/Config`](https://effect.website/docs/configuration) you
+`yield*` during a deploy target's **Init** phase is bound to that
+target. At **Runtime**, the same `yield*` resolves the value back from
+that binding (see [Phases](/concepts/phases)).
 
 ## Bind a secret to your Worker
 

--- a/website/src/content/docs/concepts/secrets.mdx
+++ b/website/src/content/docs/concepts/secrets.mdx
@@ -46,9 +46,9 @@ See [Phases](/concepts/phases) for why Init and Runtime run separately.
 
 ## Use the value in Init
 
-Because `Config` is resolved in Init, you can build clients,
-compute derived values, or branch on the value before the runtime
-ever starts:
+The value is resolved in Init, so it's the actual value — not an
+`Output` reference. It's known before deployment, so you can build
+clients, derive values, or branch on it:
 
 ```typescript
 export default Cloudflare.Worker(

--- a/website/src/content/docs/concepts/secrets.mdx
+++ b/website/src/content/docs/concepts/secrets.mdx
@@ -69,28 +69,27 @@ export default Cloudflare.Worker(
 ```
 
 :::caution
-The `apiKey` above is bound to the Worker as `secret_text`. If a
-nested service re-resolves the same `Config` at runtime, it reads
-back from that binding — but only if it was resolved in Init first:
+Resolve every `Config` in the Init phase (the outer `Effect.gen`) and
+reference the value from `fetch`. Init reads from your environment;
+runtime only reads back from the binding, so a `Config` you only
+`yield*` inside `fetch` was never bound.
 
 ```typescript
-// 🚫 nested service re-resolving Config at runtime
-const makeClient = Effect.gen(function* () {
+Effect.gen(function* () {
+  // Init: resolve Config and build the client once, at cold start
   const apiKey = yield* Config.redacted("OPENAI_API_KEY");
-  return createOpenAI(Redacted.value(apiKey));
+  const client = createOpenAI(Redacted.value(apiKey));
+
+  return {
+    // Runtime: reuse the captured client per request
+    fetch: Effect.gen(function* () {
+      return yield* Effect.tryPromise(() => client.chat(/* ... */));
+    }),
+  };
 });
 ```
 
-Resolve every `Config` in the Init phase and pass the value down
-instead. Init is the only phase that resolves from your environment;
-relying on runtime resolution couples the service to a bound value
-that may not exist:
-
-```typescript
-// ✅ resolve in Init, pass the value to the service
-const apiKey = yield* Config.redacted("OPENAI_API_KEY");
-const client = createOpenAI(Redacted.value(apiKey));
-```
+See [Phases](/concepts/phases) for the Init/Runtime split.
 :::
 
 ## Transformations

--- a/website/src/content/docs/concepts/secrets.mdx
+++ b/website/src/content/docs/concepts/secrets.mdx
@@ -95,22 +95,10 @@ const client = createOpenAI(Redacted.value(apiKey));
 
 ## Transformations
 
-Every Config combinator works — defaults, mapping, validation,
-alternative sources:
-
-```typescript
-const apiKey = yield* Config.redacted("API_KEY").pipe(
-  Config.withDefault(Redacted.make("sk-dev-fallback")),
-);
-
-const host = yield* Config.string("HOST").pipe(
-  Config.orElse(() => Config.string("LEGACY_HOST")),
-);
-```
-
-The bound value is whatever's at the *leaf* of the `Config` — the
-raw env var. Transformations (`withDefault`, `orElse`, `mapAttempt`,
-…) run against that source value, both at Init and at Runtime.
+Any combinator works — `withDefault`, `orElse`, `mapAttempt`, and so
+on. What gets bound is the *source* value (the raw env var), not the
+transformed result; the combinators run again at runtime against that
+source.
 
 ```typescript
 const port = yield* Config.number("PORT").pipe(
@@ -118,17 +106,13 @@ const port = yield* Config.number("PORT").pipe(
 );
 ```
 
-- If `PORT` **is set** at deploy time, the raw value is bound onto
-  the target. At runtime `Config.number("PORT")` resolves it from
-  the binding.
-- If `PORT` **is not set**, the leaf has no value — nothing is
-  bound. At runtime the leaf is still empty, and `Config.withDefault(3000)`
-  re-applies on each side to produce `3000`.
+- If `PORT` is set, its raw value is bound. At runtime `Config.number("PORT")`
+  reads it from the binding and the combinators re-apply.
+- If `PORT` is not set, nothing is bound. At runtime the source is
+  still empty and `Config.withDefault(3000)` produces `3000` again.
 
-This is fine for pure defaults (the same default code runs both at
-deploy and at runtime, so both phases agree), but it means the
-default value itself is never deployed — it has to be reachable
-from the Worker bundle.
+Because a default is never bound, its code runs in both phases — keep
+it pure so both phases evaluate to the same value.
 
 ## `Config` always binds as a secret
 

--- a/website/src/content/docs/concepts/secrets.mdx
+++ b/website/src/content/docs/concepts/secrets.mdx
@@ -68,10 +68,30 @@ export default Cloudflare.Worker(
 );
 ```
 
-The same `apiKey` is also bound to the Worker as `secret_text`, so
-if you reach for `Config.redacted("OPENAI_API_KEY")` again from a
-nested service, the runtime serves it from the binding — not from
-`process.env`.
+:::caution
+The `apiKey` above is bound to the Worker as `secret_text`. If a
+nested service re-resolves the same `Config` at runtime, it reads
+back from that binding — but only if it was resolved in Init first:
+
+```typescript
+// 🚫 nested service re-resolving Config at runtime
+const makeClient = Effect.gen(function* () {
+  const apiKey = yield* Config.redacted("OPENAI_API_KEY");
+  return createOpenAI(Redacted.value(apiKey));
+});
+```
+
+Resolve every `Config` in the Init phase and pass the value down
+instead. Init is the only phase that resolves from your environment;
+relying on runtime resolution couples the service to a bound value
+that may not exist:
+
+```typescript
+// ✅ resolve in Init, pass the value to the service
+const apiKey = yield* Config.redacted("OPENAI_API_KEY");
+const client = createOpenAI(Redacted.value(apiKey));
+```
+:::
 
 ## Transformations
 

--- a/website/src/content/docs/concepts/secrets.mdx
+++ b/website/src/content/docs/concepts/secrets.mdx
@@ -75,8 +75,8 @@ nested service, the runtime serves it from the binding — not from
 
 ## Transformations
 
-Because it's just `effect/Config`, every Config combinator works —
-defaults, mapping, validation, alternative sources:
+Every Config combinator works — defaults, mapping, validation,
+alternative sources:
 
 ```typescript
 const apiKey = yield* Config.redacted("API_KEY").pipe(


### PR DESCRIPTION
Cut the secrets-vs-env preamble. The intro now just states the mechanism: a `Config` yielded in Init is bound to the target, and the same `yield*` resolves it back at Runtime.

```diff
-A **secret** is any sensitive value your Worker or Function needs
-at runtime — an API key, a database password, ...
-
-Alchemy doesn't ship its own secret/variable primitives. Instead,
-it hooks into effect/Config: any Config you yield* during a deploy
-target's Init phase is automatically bound to that target, ...
-One declaration, two phases, no accessor wrapper.
+Any effect/Config you yield* during a deploy target's Init phase is
+bound to that target. At Runtime, the same yield* resolves the value
+back from that binding (see Phases).
```


---
_Generated by [Claude Code](https://claude.ai/code/session_018zLzr59CzfjE4YTNqA2LDL)_