### PR TITLE
fix(cloudflare): stream RPC return values across durable object boundary

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectBridge.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectBridge.ts
@@ -6,6 +6,7 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
 
 import { HttpServerResponse } from "effect/unstable/http";
 import type {
@@ -89,7 +90,15 @@ export const makeDurableObjectBridge =
               this.#execute((instance) => {
                 const method = instance[prop as keyof DurableObjectShape];
                 if (typeof method === "function") {
-                  return (method as any)(...args);
+                  const result = (method as any)(...args);
+                  // A streaming RPC method returns a `Stream` directly rather
+                  // than an `Effect`. Lift it into the success channel so the
+                  // resulting `Exit.value` is the `Stream` and `handleRpcExit`
+                  // can encode it as a stream envelope instead of trying to run
+                  // it as an effect.
+                  return Stream.isStream(result)
+                    ? Effect.succeed(result)
+                    : result;
                 } else if (Effect.isEffect(method)) {
                   return method;
                 } else {

--- a/packages/alchemy/src/Cloudflare/Workers/Rpc.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Rpc.ts
@@ -223,17 +223,46 @@ export const makeRpcStub = <Shape>(
         return target[prop];
       }
       return (...args: any[]) =>
-        Effect.gen(function* () {
-          const stub = isLazy
-            ? yield* stubSource as Effect.Effect<any>
-            : stubSource;
-          return yield* Effect.tryPromise({
-            try: () => (stub as any)[prop](...args),
-            catch: (cause) => new RpcCallError({ method: String(prop), cause }),
-          }).pipe(Effect.flatMap(decodeRpcResult));
-        });
+        asEffectOrStream(
+          Effect.gen(function* () {
+            const stub = isLazy
+              ? yield* stubSource as Effect.Effect<any>
+              : stubSource;
+            return yield* Effect.tryPromise({
+              try: () => (stub as any)[prop](...args),
+              catch: (cause) =>
+                new RpcCallError({ method: String(prop), cause }),
+            }).pipe(Effect.flatMap(decodeRpcResult));
+          }),
+        );
     },
   }) as Shape;
+};
+
+// Effect's internal Stream brand. `Stream.isStream` recognises a value by
+// this property and reads its `channel`. A `makeRpcStub` method can't know
+// synchronously whether the remote method returns a value or a `Stream`
+// (the call is async), yet its declared type mirrors the DO `Shape`
+// verbatim — value methods are typed `Effect<A>`, streaming methods `Stream<A>`.
+// We satisfy BOTH by handing back the call `Effect` augmented with the Stream
+// brand + channel, so the single return value can be `yield*`-ed / `.pipe`d as
+// an Effect (value methods, e.g. `stub.put(k, v).pipe(Effect.orDie)`) AND piped
+// through `Stream.*` combinators (streaming methods, e.g.
+// `stub.tick(n).pipe(Stream.map(...))`).
+const StreamTypeId = "~effect/Stream";
+
+const asEffectOrStream = (
+  call: Effect.Effect<unknown, unknown>,
+): Effect.Effect<unknown, unknown> => {
+  const streamForm = Stream.unwrap(
+    Effect.map(call, (value) =>
+      Stream.isStream(value) ? value : Stream.succeed(value),
+    ),
+  );
+  return Object.assign(call, {
+    [StreamTypeId]: streamForm[StreamTypeId],
+    channel: streamForm.channel,
+  });
 };
 
 export const toRpcStream = (stream: Stream.Stream<any, any, any>) =>

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
@@ -141,8 +141,17 @@ export const makeWorkerBridge = (
                       ),
                     );
                   }
+                  const result = dispatcher(...args);
+                  // A streaming RPC method returns a `Stream` directly rather
+                  // than an `Effect`. Lift it into the success channel so the
+                  // inner effect resolves to the `Stream` and `handleRpcExit`
+                  // can encode it as a stream envelope. Anything else is the
+                  // `Effect` it claims to be (its resolved value may itself be
+                  // a `Stream`, which `handleRpcExit` also handles).
                   return Effect.succeed([
-                    dispatcher(...args) as Effect.Effect<any>,
+                    Stream.isStream(result)
+                      ? Effect.succeed(result)
+                      : (result as Effect.Effect<any>),
                     Context.empty(),
                   ] as const);
                 }),
@@ -274,7 +283,16 @@ export const makeRpcProxy = (
                   ),
                 );
               }
-              return dispatcher(...args) as Effect.Effect<any>;
+              const result = dispatcher(...args);
+              // A streaming RPC method returns a `Stream` directly rather than
+              // an `Effect`. Lift it into the success channel so the resulting
+              // `Exit.value` is the `Stream` and `handleRpcExit` can encode it
+              // as a stream envelope. Anything else is the `Effect` it claims
+              // to be and is run normally (its resolved value may itself be a
+              // `Stream`, which `handleRpcExit` also handles).
+              return Stream.isStream(result)
+                ? Effect.succeed(result)
+                : (result as Effect.Effect<any>);
             }),
             processEvent,
           )

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
@@ -4,6 +4,7 @@ import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import Stack from "./fixtures/do-rpc/stack.ts";
@@ -60,6 +61,38 @@ test(
     expect(res.status).toBe(200);
     const body = (yield* res.json) as { value: string };
     expect(body.value).toBe("ok");
+  }).pipe(logLevel),
+  { timeout: 60_000 },
+);
+
+// Reproduces the `tick` streaming example from the Durable Objects tutorial:
+// https://v2.alchemy.run/tutorial/cloudflare/durable-objects/
+//
+// The DO exposes `tick(n): Stream<number>` and the Worker forwards it to the
+// HTTP response with `HttpServerResponse.stream`. The client reads the body as
+// newline-delimited integers. With `/tick/5` we expect ["0","1","2","3","4"].
+test(
+  "tick streams sequential values from a durable object (tutorial repro)",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    const client = freshConn(yield* HttpClient.HttpClient);
+
+    const lines = yield* client.get(`${url}/tick/5`).pipe(
+      Effect.flatMap((res) =>
+        res.status === 200
+          ? res.stream.pipe(
+              Stream.decodeText,
+              Stream.splitLines,
+              Stream.filter((line) => line.length > 0),
+              Stream.runCollect,
+              Effect.map((chunk) => [...chunk]),
+            )
+          : Effect.fail(new Error(`Worker not ready: ${res.status}`)),
+      ),
+      Effect.retry({ schedule: readinessSchedule, times: readinessRetries }),
+    );
+
+    expect(lines).toEqual(["0", "1", "2", "3", "4"]);
   }).pipe(logLevel),
   { timeout: 60_000 },
 );

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/do-rpc/object.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/do-rpc/object.ts
@@ -1,5 +1,7 @@
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
 
 const KV = Cloudflare.KVNamespace("DurableObjectWorkerEnvironmentKV", {
   title: "durable-object-worker-environment-kv",
@@ -14,6 +16,14 @@ export class WorkerEnvironmentKVObject extends Cloudflare.DurableObjectNamespace
       return {
         put: (key: string, value: string) => kv.put(key, value),
         get: (key: string) => kv.get(key),
+        // Mirrors the `tick` example from the tutorial:
+        // https://v2.alchemy.run/tutorial/cloudflare/durable-objects/
+        // An RPC method that returns a Stream of sequential numbers.
+        tick: (n: number) =>
+          Stream.iterate(0, (i) => i + 1).pipe(
+            Stream.take(n),
+            Stream.schedule(Schedule.spaced("100 millis")),
+          ),
       };
     });
   }).pipe(Effect.provide(Cloudflare.KVNamespaceBindingLive)),

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/do-rpc/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/do-rpc/worker.ts
@@ -1,5 +1,6 @@
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
 import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import { WorkerEnvironmentKVObject } from "./object.ts";
@@ -25,6 +26,24 @@ export default class DurableObjectWorkerEnvironmentWorker extends Cloudflare.Wor
           yield* object.put(key, "ok").pipe(Effect.orDie);
           const value = yield* object.get(key).pipe(Effect.orDie);
           return yield* HttpServerResponse.json({ value });
+        }
+
+        // Mirrors the tutorial's `/tick/:n` route verbatim — forwards the
+        // Stream returned by the DO's `tick` RPC method straight onto the
+        // HTTP response.
+        // https://v2.alchemy.run/tutorial/cloudflare/durable-objects/
+        if (request.method === "GET" && url.pathname.startsWith("/tick/")) {
+          const n = Number(url.pathname.split("/").pop()!);
+          const stream = objects
+            .getByName("tick")
+            .tick(n)
+            .pipe(
+              Stream.map((i) => `${i}\n`),
+              Stream.encodeText,
+            );
+          return HttpServerResponse.stream(stream, {
+            headers: { "content-type": "text/plain" },
+          });
         }
 
         return HttpServerResponse.text("Not Found", { status: 404 });


### PR DESCRIPTION
Streaming RPC methods on a Durable Object (methods that return a `Stream`) crashed with `Fiber.runLoop: Not a valid effect: [object Object]` and the caller received an empty body.

Two server-side dispatch paths assumed every RPC method returns an `Effect` and ran the result directly, so a `Stream` return value was fed into the Effect runtime. `handleRpcExit` already knows how to encode a `Stream` result — the fix is to lift a `Stream` into the success channel so the `Exit.value` is the `Stream` it expects:

```diff
-return dispatcher(...args) as Effect.Effect<any>;
+const result = dispatcher(...args);
+return Stream.isStream(result) ? Effect.succeed(result) : (result as Effect.Effect<any>);
```

Applied in both `WorkerBridge.ts` (worker entrypoint / worker→worker RPC) and `DurableObjectBridge.ts` (DO instance method dispatch).

On the client, `makeRpcStub` now returns a value that is usable as both an `Effect` and a `Stream`. The proxy is type-erased and can't tell synchronously whether a method returns a value or a `Stream`, but the stub's declared type mirrors the DO `Shape` verbatim (value methods `Effect<A>`, streaming methods `Stream<A>`). The returned `call` stays a genuine `Effect` and is additionally branded as a `Stream` (non-enumerable, brand copied off a real `Stream`'s prototype) so both of these work:

```ts
yield* stub.increment()                       // Effect → value
stub.tick(n).pipe(Stream.map(...))            // Stream → chunks
```

Verified end-to-end against a deployed worker (`tick` DO RPC streams `0..4`).
