### PR TITLE
fix(website): remove broken /tutorial/cloudflare/agent links

### DIFF
--- a/website/src/content/docs/guides/effect-ai.mdx
+++ b/website/src/content/docs/guides/effect-ai.mdx
@@ -151,14 +151,12 @@ durable. Pick the one that matches your platform:
 
 | Platform | Backing |
 | --- | --- |
-| Cloudflare Worker + Durable Object | [`Cloudflare.DurableObjectChatPersistence`](/tutorial/cloudflare/agent) — bytes live in `state.storage`, one DO instance per session |
+| Cloudflare Worker + Durable Object | `Cloudflare.DurableObjectChatPersistence` — bytes live in `state.storage`, one DO instance per session |
 | Any platform, in-memory (tests) | `Persistence.layerBackingMemory` — lost on restart |
 | Anything else (KV, R2, DynamoDB, …) | Implement `BackingPersistence` against your store |
 
 The `Chat.Persistence` API and handler code never change — only the
-backing layer does. See the
-[Add a Chat Agent](/tutorial/cloudflare/agent) tutorial for the
-end-to-end DO setup.
+backing layer does.
 
 ## Cloudflare AI Gateway
 
@@ -232,7 +230,5 @@ model })` — is the same.
 - [Add an AI Gateway](/tutorial/cloudflare/ai-gateway) — wire
   Workers AI behind a Cloudflare AI Gateway with caching and
   streaming.
-- [Add a Chat Agent](/tutorial/cloudflare/agent) — persisted
-  chat sessions backed by a Durable Object's `state.storage`.
 - [Secrets and env vars](/guides/secrets) — how `Config.redacted`
   feeds the upstream providers' API keys at deploy and runtime.

--- a/website/src/content/docs/tutorial/cloudflare/ai-gateway.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/ai-gateway.mdx
@@ -265,10 +265,9 @@ in place.
   agnostic, so swapping Workers AI for OpenAI or Anthropic later is
   a layer-level change, not a code-level one.
 
-The natural next step is to give the model **memory**. The [Add a
-Chat Agent](/tutorial/cloudflare/agent) tutorial wraps the same
-`LanguageModel` with `Chat.Service` and stores the conversation in a
-Durable Object's `state.storage`, so every session is resumable
+The natural next step is to give the model **memory** — wrapping the
+same `LanguageModel` with `Chat.Service` and storing the conversation
+in a Durable Object's `state.storage`, so every session is resumable
 across requests, restarts, and hibernation.
 
 For the wider API surface — `generateObject`, `Toolkit`, structured


### PR DESCRIPTION
The AI Gateway PR (#389) linked to a "Chat Agent" tutorial that was
never written, breaking the website build's broken-links check. Drop
the four references to /tutorial/cloudflare/agent while keeping the
surrounding prose.

https://claude.ai/code/session_01VaSwzGsR113qQd2Aodpbvx