### PR TITLE
fix(cli): skip evalStack in login and defer State store init to runtime

### DIFF
--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -138,7 +138,7 @@ export const apply = <P extends Plan>(
   Effect.gen(function* () {
     const cli = yield* Cli;
     const session = yield* cli.startApplySession(plan);
-    const state = yield* State;
+    const state = yield* yield* State;
     const stack = yield* Stack;
     const stage = yield* Stage;
     const stackName = stack.name;
@@ -1397,7 +1397,7 @@ const collectGarbage = Effect.fnUntraced(function* (
   plan: Plan,
   session: PlanStatusSession,
 ) {
-  const state = yield* State;
+  const state = yield* yield* State;
   const stack = yield* Stack;
   const stackName = stack.name;
   const stage = yield* Stage;

--- a/packages/alchemy/src/Cli/commands/_shared.ts
+++ b/packages/alchemy/src/Cli/commands/_shared.ts
@@ -2,6 +2,7 @@ import * as Cause from "effect/Cause";
 import * as Config from "effect/Config";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as S from "effect/Schema";
@@ -312,5 +313,10 @@ export const importStack = Effect.fn(function* (main: string) {
       ),
     );
   }
-  return stackEffect;
+  return stackEffect as typeof stackEffect & {
+    stackName: string;
+    stage: string;
+    providers: Layer.Layer<never>;
+    state: Layer.Layer<never>;
+  };
 });

--- a/packages/alchemy/src/Cli/commands/login.ts
+++ b/packages/alchemy/src/Cli/commands/login.ts
@@ -1,4 +1,3 @@
-import * as Cause from "effect/Cause";
 import * as Config from "effect/Config";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Console from "effect/Console";
@@ -10,10 +9,10 @@ import { Command, Flag } from "effect/unstable/cli";
 import { AuthProviders } from "../../Auth/AuthProvider.ts";
 import { Profile, withProfileOverride } from "../../Auth/Profile.ts";
 import { Stage } from "../../Stage.ts";
-import * as State from "../../State/index.ts";
 import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
 import { fileLogger } from "../../Util/FileLogger.ts";
 
+import { Stack } from "../../Stack.ts";
 import {
   envFile,
   importStack,
@@ -59,73 +58,83 @@ export const loginCommand = Command.make(
 
       const authProviders: AuthProviders["Service"] = {};
 
-      const services = Layer.mergeAll(
-        Layer.succeed(AuthProviders, authProviders),
-        ConfigProvider.layer(
-          withProfileOverride(yield* loadConfigProvider(envFile), profile),
+      // build the state + providers layer to capture the Auth Providers
+      yield* Layer.build(
+        (stackEffect.providers ?? Layer.empty).pipe(
+          Layer.provideMerge(stackEffect.state ?? Layer.empty),
+          Layer.provideMerge(
+            Layer.mergeAll(
+              Layer.succeed(AuthProviders, authProviders),
+              ConfigProvider.layer(
+                withProfileOverride(
+                  yield* loadConfigProvider(envFile),
+                  profile,
+                ),
+              ),
+              Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
+              Layer.succeed(Stage, stage),
+              Layer.succeed(Stack, {
+                actions: {},
+                bindings: {},
+                name: stackEffect.stackName,
+                resources: {},
+                stage,
+              }),
+            ),
+          ),
         ),
-        Logger.layer([fileLogger("out")], { mergeWithExisting: true }),
-        Layer.succeed(Stage, stage),
-        State.localState(),
       );
 
-      yield* Effect.gen(function* () {
-        const profiles = yield* Profile;
-        yield* Effect.catchCause(stackEffect, (cause) =>
-          Console.warn(
-            `Ignoring error while building stack for login (likely due to missing or broken credentials):\n${Cause.pretty(cause)}`,
-          ),
+      const profiles = yield* Profile;
+
+      const ci = yield* Config.boolean("CI").pipe(Config.withDefault(false));
+      const providers = Object.values(authProviders);
+
+      if (providers.length === 0) {
+        yield* Console.log(
+          "No AuthProviders registered. Make sure the stack's providers() layer includes AuthProviderLayer entries.",
         );
+        return;
+      }
 
-        const ci = yield* Config.boolean("CI").pipe(Config.withDefault(false));
-        const providers = Object.values(authProviders);
+      yield* Effect.forEach(
+        providers,
+        (provider) =>
+          Effect.gen(function* () {
+            const existing = yield* profiles.getProfile(profile);
+            // --configure treats every provider as missing, so configure
+            // runs unconditionally and overwrites the stored entry.
+            const stored = configure ? undefined : existing?.[provider.name];
 
-        if (providers.length === 0) {
-          yield* Console.log(
-            "No AuthProviders registered. Make sure the stack's providers() layer includes AuthProviderLayer entries.",
-          );
-          return;
-        }
+            let cfg: { method: string };
+            if (stored == null) {
+              cfg = yield* provider.configure(profile, { ci });
+              yield* profiles.setProfile(profile, {
+                ...existing,
+                [provider.name]: cfg,
+              });
+            } else {
+              cfg = stored;
+            }
 
-        yield* Effect.forEach(
-          providers,
-          (provider) =>
-            Effect.gen(function* () {
-              const existing = yield* profiles.getProfile(profile);
-              // --configure treats every provider as missing, so configure
-              // runs unconditionally and overwrites the stored entry.
-              const stored = configure ? undefined : existing?.[provider.name];
+            // `read` succeeds when creds are present and not expired
+            // (refreshing OAuth proactively if near expiry). Any failure
+            // — missing file, dead refresh token, etc. — falls through
+            // to `login`.
+            yield* provider
+              .read(profile, cfg)
+              .pipe(Effect.catch(() => provider.login(profile, cfg)));
+          }),
+        { discard: true },
+      );
 
-              let cfg: { method: string };
-              if (stored == null) {
-                cfg = yield* provider.configure(profile, { ci });
-                yield* profiles.setProfile(profile, {
-                  ...existing,
-                  [provider.name]: cfg,
-                });
-              } else {
-                cfg = stored;
-              }
-
-              // `read` succeeds when creds are present and not expired
-              // (refreshing OAuth proactively if near expiry). Any failure
-              // — missing file, dead refresh token, etc. — falls through
-              // to `login`.
-              yield* provider
-                .read(profile, cfg)
-                .pipe(Effect.catch(() => provider.login(profile, cfg)));
-            }),
-          { discard: true },
-        );
-
-        // Print the resulting profile using the same renderer as
-        // `alchemy profile show`.
-        const final = yield* profiles.getProfile(profile);
-        if (final != null) {
-          yield* Console.log("");
-          yield* printProfile(profile, final, authProviders);
-        }
-      }).pipe(Effect.provide(services));
+      // Print the resulting profile using the same renderer as
+      // `alchemy profile show`.
+      const final = yield* profiles.getProfile(profile);
+      if (final != null) {
+        yield* Console.log("");
+        yield* printProfile(profile, final, authProviders);
+      }
     }),
   ),
 );

--- a/packages/alchemy/src/Cli/commands/logs.ts
+++ b/packages/alchemy/src/Cli/commands/logs.ts
@@ -89,7 +89,7 @@ export const logsCommand = Command.make(
         const stack = yield* stackEffect;
 
         yield* Effect.gen(function* () {
-          const state = yield* State.State;
+          const state = yield* yield* State.State;
           const filterSet = parseResourceFilter(filter);
           const availableIds = [
             ...new Set(Object.values(stack.resources).map((r) => r.LogicalId)),

--- a/packages/alchemy/src/Cli/commands/state.ts
+++ b/packages/alchemy/src/Cli/commands/state.ts
@@ -90,7 +90,7 @@ const withStateService = <A, E>(
     return yield* Effect.gen(function* () {
       const stack = yield* stackEffect;
       return yield* Effect.gen(function* () {
-        const state = yield* State.State;
+        const state = yield* yield* State.State;
         return yield* body(state);
       }).pipe(Effect.provide(stack.services));
     }).pipe(Effect.provide(services));

--- a/packages/alchemy/src/Cli/commands/tail.ts
+++ b/packages/alchemy/src/Cli/commands/tail.ts
@@ -62,7 +62,7 @@ export const tailCommand = Command.make(
         const stack = yield* stackEffect;
 
         yield* Effect.gen(function* () {
-          const state = yield* State.State;
+          const state = yield* yield* State.State;
           const filterSet = parseResourceFilter(filter);
           const availableIds = [
             ...new Set(Object.values(stack.resources).map((r) => r.LogicalId)),

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -57,124 +57,130 @@ export const state = () =>
       const profileName = yield* ALCHEMY_PROFILE;
       const localStage = `${profileName}_${scriptName}`;
       const credStore = yield* CredentialsStore;
-      if (yield* hasLocalStack(localStage)) {
-        // if there's still a local stack, then we need to finish the bootstrap
-        // TODO(sam): what if the local stack was
-        return yield* deployWithLocalState({
-          scriptName,
-          profileName,
-          isCI,
-          force: false,
-        });
-      }
+      const context = yield* Effect.context<Effect.Services<typeof init>>();
 
-      const ensureLatest = ({
-        url,
-        authToken,
-      }: {
-        url: string;
-        authToken: string;
-      }) =>
-        Effect.gen(function* () {
-          const { matches, expected, observed } =
-            yield* checkStateStoreVersion(url);
+      const init = Effect.gen(function* () {
+        if (yield* hasLocalStack(localStage)) {
+          // if there's still a local stack, then we need to finish the bootstrap
+          // TODO(sam): what if the local stack was
+          return yield* deployWithLocalState({
+            scriptName,
+            profileName,
+            isCI,
+            force: false,
+          });
+        }
 
-          if (observed === undefined) {
-            const shouldDeploy = yield* Clank.confirm({
-              message: `Cloudflare State Store '${scriptName}' is not available. Do you want to deploy it?`,
-            });
-            if (shouldDeploy) {
-              return yield* bootstrap({
-                workerName: scriptName,
-                profile: profileName,
+        const ensureLatest = ({
+          url,
+          authToken,
+        }: {
+          url: string;
+          authToken: string;
+        }) =>
+          Effect.gen(function* () {
+            const { matches, expected, observed } =
+              yield* checkStateStoreVersion(url);
+
+            if (observed === undefined) {
+              const shouldDeploy = yield* Clank.confirm({
+                message: `Cloudflare State Store '${scriptName}' is not available. Do you want to deploy it?`,
               });
-            } else {
-              return yield* Effect.die(new Clank.PromptCancelled());
+              if (shouldDeploy) {
+                return yield* bootstrap({
+                  workerName: scriptName,
+                  profile: profileName,
+                });
+              } else {
+                return yield* Effect.die(new Clank.PromptCancelled());
+              }
             }
-          }
 
-          const httpState = yield* ensureAccess({ url, authToken });
-          if (matches) {
-            return httpState;
-          } else if (isCI) {
-            return yield* Effect.die(
-              new AuthError({
-                message: `Cloudflare State store not found. Run 'alchemy bootstrap cloudflare --profile <your-ci-profile>' to deploy it first.`,
-              }),
-            );
-          } else {
-            const shouldDeploy = yield* Clank.confirm({
-              message:
-                `Cloudflare State Store '${scriptName}' is out of date ` +
-                `(expected v${expected}, observed v${observed ?? "unknown"})`,
-            });
-            if (shouldDeploy) {
-              const stateStoreOptions = yield* deployStateStore({
-                stage: scriptName,
-                state: httpState,
-                force: false,
-              });
-              return yield* makeCloudflareStateStore(stateStoreOptions);
-            } else {
-              return yield* Effect.die(new Clank.PromptCancelled());
-            }
-          }
-        });
-
-      const ensureAccess = (credentials: HttpStateStoreCredentials) =>
-        Effect.gen(function* () {
-          const isAuth = yield* checkHttpStateStoreAuth(credentials);
-          if (!isAuth) {
-            // our token is wrong, force a refresh
-            yield* Clank.info(
-              `Cloudflare State store authentication failed, refreshing credentials...`,
-            );
-            const credentials = yield* loginWithCloudflare(profileName, true);
-            if (!(yield* checkHttpStateStoreAuth(credentials))) {
+            const httpState = yield* ensureAccess({ url, authToken });
+            if (matches) {
+              return httpState;
+            } else if (isCI) {
               return yield* Effect.die(
                 new AuthError({
-                  message: `Cloudflare State store authentication failed, after refreshing credentials.`,
+                  message: `Cloudflare State store not found. Run 'alchemy bootstrap cloudflare --profile <your-ci-profile>' to deploy it first.`,
                 }),
               );
+            } else {
+              const shouldDeploy = yield* Clank.confirm({
+                message:
+                  `Cloudflare State Store '${scriptName}' is out of date ` +
+                  `(expected v${expected}, observed v${observed ?? "unknown"})`,
+              });
+              if (shouldDeploy) {
+                const stateStoreOptions = yield* deployStateStore({
+                  stage: scriptName,
+                  state: httpState,
+                  force: false,
+                });
+                return yield* makeCloudflareStateStore(stateStoreOptions);
+              } else {
+                return yield* Effect.die(new Clank.PromptCancelled());
+              }
+            }
+          });
+
+        const ensureAccess = (credentials: HttpStateStoreCredentials) =>
+          Effect.gen(function* () {
+            const isAuth = yield* checkHttpStateStoreAuth(credentials);
+            if (!isAuth) {
+              // our token is wrong, force a refresh
+              yield* Clank.info(
+                `Cloudflare State store authentication failed, refreshing credentials...`,
+              );
+              const credentials = yield* loginWithCloudflare(profileName, true);
+              if (!(yield* checkHttpStateStoreAuth(credentials))) {
+                return yield* Effect.die(
+                  new AuthError({
+                    message: `Cloudflare State store authentication failed, after refreshing credentials.`,
+                  }),
+                );
+              }
+              return yield* makeCloudflareStateStore(credentials);
             }
             return yield* makeCloudflareStateStore(credentials);
-          }
-          return yield* makeCloudflareStateStore(credentials);
-        });
+          });
 
-      const credentials = yield* credStore.read<HttpStateStoreCredentials>(
-        profileName,
-        CREDENTIALS_FILE,
-      );
-      if (credentials) {
-        return yield* ensureLatest(credentials);
-      }
-      const workerExists = yield* isStateStoreAvailable(scriptName);
-      if (workerExists) {
-        return yield* ensureLatest(
-          yield* loginWithCloudflare(profileName, false),
+        const credentials = yield* credStore.read<HttpStateStoreCredentials>(
+          profileName,
+          CREDENTIALS_FILE,
         );
-      } else if (isCI) {
-        // TODO(sam): do we want to support bootstrapping the state store from CI?
-        // for now - just die here
-        return yield* Effect.die(
-          new AuthError({
-            message: `Cloudflare State store not found. Run 'alchemy bootstrap cloudflare --profile <your-ci-profile>' to deploy it first.`,
-          }),
-        );
-      } else {
-        return yield* Clank.confirm({
-          message:
-            "Cloudflare State Store not found. Do you want to deploy it?",
-        }).pipe(
-          Effect.flatMap((shouldDeploy) =>
-            shouldDeploy
-              ? bootstrap()
-              : Effect.die(new Clank.PromptCancelled()),
-          ),
-        );
-      }
-    }).pipe(recordStateStoreInit, Effect.orDie),
+        if (credentials) {
+          return yield* ensureLatest(credentials);
+        }
+        const workerExists = yield* isStateStoreAvailable(scriptName);
+        if (workerExists) {
+          return yield* ensureLatest(
+            yield* loginWithCloudflare(profileName, false),
+          );
+        } else if (isCI) {
+          // TODO(sam): do we want to support bootstrapping the state store from CI?
+          // for now - just die here
+          return yield* Effect.die(
+            new AuthError({
+              message: `Cloudflare State store not found. Run 'alchemy bootstrap cloudflare --profile <your-ci-profile>' to deploy it first.`,
+            }),
+          );
+        } else {
+          return yield* Clank.confirm({
+            message:
+              "Cloudflare State Store not found. Do you want to deploy it?",
+          }).pipe(
+            Effect.flatMap((shouldDeploy) =>
+              shouldDeploy
+                ? bootstrap()
+                : Effect.die(new Clank.PromptCancelled()),
+            ),
+          );
+        }
+      }).pipe(recordStateStoreInit, Effect.orDie);
+
+      return yield* Effect.cached(init.pipe(Effect.provideContext(context)));
+    }),
   ).pipe(
     Layer.provideMerge(Credentials.fromAuthProvider()),
     Layer.provideMerge(CloudflareEnvironment.fromProfile()),
@@ -311,7 +317,7 @@ const deployStateStore = ({
   Effect.gen(function* () {
     yield* annotateAccountHash();
     // deploy it with local state (which we will then hoist into the Cloudflare state store)
-    const stateLayer = Layer.succeed(State, state);
+    const stateLayer = Layer.succeed(State, Effect.succeed(state));
     const { url, authToken } = yield* deploy({
       // use the script name as the stage name (so the user can have multiple state stores)
       stage,

--- a/packages/alchemy/src/Output.ts
+++ b/packages/alchemy/src/Output.ts
@@ -549,7 +549,7 @@ export const evaluate: <A, Req = never>(
       } else if (isNamedExpr(expr)) {
         return yield* evaluate(expr.expr, upstream);
       } else if (isRefExpr(expr)) {
-        const state = yield* State.State;
+        const state = yield* yield* State.State;
         const stack = expr.stack ?? (yield* Stack).name;
         const stage = expr.stage ?? (yield* Stage);
         const resource = yield* state.get({
@@ -572,7 +572,7 @@ export const evaluate: <A, Req = never>(
         // task's output value, otherwise undefined.
         return (resource as any).attr ?? (resource as any).output;
       } else if (isStackRefExpr(expr)) {
-        const state = yield* State.State;
+        const state = yield* yield* State.State;
         const stack = expr.stack;
         const stage = expr.stage ?? (yield* Stage);
         const output = yield* state.getOutput({ stack, stage });

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import { asEffect } from ".//Util/types.ts";
+import { isAction, type ActionLike } from "./Action.ts";
 import {
   AdoptPolicy,
   OwnedBySomeoneElse,
@@ -41,19 +42,18 @@ import {
 } from "./Resource.ts";
 import { type StackSpec } from "./Stack.ts";
 import {
+  isActionState,
   State,
+  type ActionState,
   type CreatedResourceState,
   type CreatingResourceState,
-  isActionState,
   type RanActionState,
   type ReplacedResourceState,
   type ReplacingResourceState,
   type ResourceState,
-  type ActionState,
   type UpdatedResourceState,
   type UpdatingReourceState,
 } from "./State/index.ts";
-import { isAction, type ActionLike } from "./Action.ts";
 import { hashInput } from "./Util/hash.ts";
 import { findCycleMembers } from "./Util/scc.ts";
 
@@ -236,7 +236,7 @@ export const make = <A>(
 ): Effect.Effect<Plan<A>, never, State> =>
   // @ts-expect-error
   Effect.gen(function* () {
-    const state = yield* State;
+    const state = yield* yield* State;
 
     const resources = Object.values(stack.resources);
     const actions = Object.values(stack.actions ?? {});

--- a/packages/alchemy/src/Stack.ts
+++ b/packages/alchemy/src/Stack.ts
@@ -125,7 +125,10 @@ export const Stack: Context.ServiceClass<
             // by default, reference the stack at the "current" stage of the importer
             Output.stackRef<A>(stackName).pipe(effectClass),
             {
+              stackName,
               stage: createStageProxy(stackName),
+              state: options?.state,
+              providers: options?.providers,
               make: <Req = never>(
                 options: StackProps<NoInfer<Req>>,
                 eff: Effect.Effect<A, never, Req>,
@@ -140,7 +143,10 @@ export const Stack: Context.ServiceClass<
         }),
         (eff) =>
           Object.assign(eff, {
+            stackName,
             stage: createStageProxy(stackName),
+            state: options?.state,
+            providers: options?.providers,
           }),
       );
     },

--- a/packages/alchemy/src/State/InMemoryState.ts
+++ b/packages/alchemy/src/State/InMemoryState.ts
@@ -18,8 +18,8 @@ export const inMemoryState = (
 ) =>
   Layer.effect(
     State,
-    Effect.succeed(InMemoryService(initialState, initialOutputs)).pipe(
-      recordStateStoreInit,
+    Effect.cached(
+      InMemoryService(initialState, initialOutputs).pipe(recordStateStoreInit),
     ),
   );
 
@@ -27,87 +27,89 @@ export const InMemoryService = (
   state: Record<StackId, Record<StageId, Record<Fqn, ResourceState>>> = {},
   outputs: Record<StackId, Record<StageId, unknown>> = {},
 ) =>
-  State.of({
-    id: "inmemory",
-    getVersion: () => Effect.succeed(STATE_STORE_VERSION),
-    listStacks: () => Effect.succeed(Array.from(Object.keys(state))),
-    listStages: (stack: string) =>
-      Effect.succeed(
-        Array.from(stack in state ? Object.keys(state[stack]) : []),
-      ),
-    get: ({
-      stack,
-      stage,
-      fqn,
-    }: {
-      stack: string;
-      stage: string;
-      fqn: string;
-    }) => Effect.succeed(state[stack]?.[stage]?.[fqn]),
-    getReplacedResources: ({
-      stack,
-      stage,
-    }: {
-      stack: string;
-      stage: string;
-    }) =>
-      Effect.succeed(
-        Array.from(Object.values(state[stack]?.[stage] ?? {}) ?? []).filter(
-          (s) => s.status === "replaced",
+  State.of(
+    Effect.succeed({
+      id: "inmemory",
+      getVersion: () => Effect.succeed(STATE_STORE_VERSION),
+      listStacks: () => Effect.succeed(Array.from(Object.keys(state))),
+      listStages: (stack: string) =>
+        Effect.succeed(
+          Array.from(stack in state ? Object.keys(state[stack]) : []),
         ),
-      ),
-    set: <V extends PersistedState>({
-      stack,
-      stage,
-      fqn,
-      value,
-    }: {
-      stack: string;
-      stage: string;
-      fqn: string;
-      value: V;
-    }) =>
-      Effect.sync(() => {
-        const stackState = (state[stack] ??= {});
-        const stageState = (stackState[stage] ??= {});
-        stageState[fqn] = value as ResourceState;
-        return value;
-      }),
-    delete: ({
-      stack,
-      stage,
-      fqn,
-    }: {
-      stack: string;
-      stage: string;
-      fqn: string;
-    }) => Effect.sync(() => delete state[stack]?.[stage]?.[fqn]),
-    deleteStack: ({ stack, stage }: { stack: string; stage?: string }) =>
-      Effect.sync(() => {
-        if (stage === undefined) {
-          delete state[stack];
-        } else {
-          delete state[stack]?.[stage];
-        }
-      }),
-    list: ({ stack, stage }: { stack: string; stage: string }) =>
-      Effect.succeed(
-        Array.from(Object.keys(state[stack]?.[stage] ?? {}) ?? []),
-      ),
-    getOutput: ({ stack, stage }: { stack: string; stage: string }) =>
-      Effect.succeed(outputs[stack]?.[stage]),
-    setOutput: ({
-      stack,
-      stage,
-      value,
-    }: {
-      stack: string;
-      stage: string;
-      value: unknown;
-    }) =>
-      Effect.sync(() => {
-        const stackOutputs = (outputs[stack] ??= {});
-        stackOutputs[stage] = value;
-        return value;
-      }),
-  });
+      get: ({
+        stack,
+        stage,
+        fqn,
+      }: {
+        stack: string;
+        stage: string;
+        fqn: string;
+      }) => Effect.succeed(state[stack]?.[stage]?.[fqn]),
+      getReplacedResources: ({
+        stack,
+        stage,
+      }: {
+        stack: string;
+        stage: string;
+      }) =>
+        Effect.succeed(
+          Array.from(Object.values(state[stack]?.[stage] ?? {}) ?? []).filter(
+            (s) => s.status === "replaced",
+          ),
+        ),
+      set: <V extends PersistedState>({
+        stack,
+        stage,
+        fqn,
+        value,
+      }: {
+        stack: string;
+        stage: string;
+        fqn: string;
+        value: V;
+      }) =>
+        Effect.sync(() => {
+          const stackState = (state[stack] ??= {});
+          const stageState = (stackState[stage] ??= {});
+          stageState[fqn] = value as ResourceState;
+          return value;
+        }),
+      delete: ({
+        stack,
+        stage,
+        fqn,
+      }: {
+        stack: string;
+        stage: string;
+        fqn: string;
+      }) => Effect.sync(() => delete state[stack]?.[stage]?.[fqn]),
+      deleteStack: ({ stack, stage }: { stack: string; stage?: string }) =>
+        Effect.sync(() => {
+          if (stage === undefined) {
+            delete state[stack];
+          } else {
+            delete state[stack]?.[stage];
+          }
+        }),
+      list: ({ stack, stage }: { stack: string; stage: string }) =>
+        Effect.succeed(
+          Array.from(Object.keys(state[stack]?.[stage] ?? {}) ?? []),
+        ),
+      getOutput: ({ stack, stage }: { stack: string; stage: string }) =>
+        Effect.succeed(outputs[stack]?.[stage]),
+      setOutput: ({
+        stack,
+        stage,
+        value,
+      }: {
+        stack: string;
+        stage: string;
+        value: unknown;
+      }) =>
+        Effect.sync(() => {
+          const stackOutputs = (outputs[stack] ??= {});
+          stackOutputs[stage] = value;
+          return value;
+        }),
+    }),
+  );

--- a/packages/alchemy/src/State/LocalState.ts
+++ b/packages/alchemy/src/State/LocalState.ts
@@ -10,7 +10,21 @@ import { State, StateStoreError, type StateService } from "./State.ts";
 import { encodeState, reviveState } from "./StateEncoding.ts";
 
 export const localState = () =>
-  Layer.effect(State, makeLocalState().pipe(recordStateStoreInit));
+  Layer.effect(
+    State,
+    Effect.gen(function* () {
+      const context = yield* Effect.context<
+        FileSystem.FileSystem | Path.Path
+      >();
+
+      const make = makeLocalState().pipe(
+        recordStateStoreInit,
+        Effect.provideContext(context),
+      );
+
+      return yield* Effect.cached(make);
+    }),
+  );
 
 export const makeLocalState = () =>
   Effect.gen(function* () {

--- a/packages/alchemy/src/State/State.ts
+++ b/packages/alchemy/src/State/State.ts
@@ -1,8 +1,8 @@
 import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
-import type { ReplacedResourceState, ResourceState } from "./ResourceState.ts";
 import type { ActionState } from "./ActionState.ts";
+import type { ReplacedResourceState, ResourceState } from "./ResourceState.ts";
 
 /**
  * Anything persistable under an FQN. Resources are discriminated by status
@@ -23,9 +23,10 @@ export class StateStoreError extends Data.TaggedError("StateStoreError")<{
   cause?: Error;
 }> {}
 
-export class State extends Context.Service<State, StateService>()(
-  "alchemy/State",
-) {}
+export class State extends Context.Service<
+  State,
+  Effect.Effect<StateService>
+>()("alchemy/State") {}
 
 /**
  * State service interface.

--- a/packages/alchemy/test/AWS/DynamoDB/Table.test.ts
+++ b/packages/alchemy/test/AWS/DynamoDB/Table.test.ts
@@ -588,7 +588,7 @@ describe("AWS.DynamoDB.Table", () => {
 
         // Phase 2: wipe local state — the table stays in DynamoDB.
         yield* Effect.gen(function* () {
-          const state = yield* State;
+          const state = yield* yield* State;
           yield* state.delete({
             stack: stack.name,
             stage: "test",
@@ -642,7 +642,7 @@ describe("AWS.DynamoDB.Table", () => {
 
         // Wipe state for "Original"; table stays in DynamoDB.
         yield* Effect.gen(function* () {
-          const state = yield* State;
+          const state = yield* yield* State;
           yield* state.delete({
             stack: stack.name,
             stage: "test",

--- a/packages/alchemy/test/AWS/IAM/Role.test.ts
+++ b/packages/alchemy/test/AWS/IAM/Role.test.ts
@@ -127,7 +127,7 @@ test.provider(
 
       // Wipe state — the role stays in IAM.
       yield* Effect.gen(function* () {
-        const state = yield* State;
+        const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
           stage: "test",
@@ -177,7 +177,7 @@ test.provider(
       );
 
       yield* Effect.gen(function* () {
-        const state = yield* State;
+        const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
           stage: "test",

--- a/packages/alchemy/test/AWS/Kinesis/Stream.test.ts
+++ b/packages/alchemy/test/AWS/Kinesis/Stream.test.ts
@@ -570,7 +570,7 @@ describe("AWS.Kinesis.Stream", () => {
 
         // Wipe state — the stream stays in Kinesis.
         yield* Effect.gen(function* () {
-          const state = yield* State;
+          const state = yield* yield* State;
           yield* state.delete({
             stack: stack.name,
             stage: "test",
@@ -609,7 +609,7 @@ describe("AWS.Kinesis.Stream", () => {
         );
 
         yield* Effect.gen(function* () {
-          const state = yield* State;
+          const state = yield* yield* State;
           yield* state.delete({
             stack: stack.name,
             stage: "test",

--- a/packages/alchemy/test/AWS/S3/Bucket.test.ts
+++ b/packages/alchemy/test/AWS/S3/Bucket.test.ts
@@ -348,7 +348,7 @@ test.provider(
 
       // Wipe state — bucket stays in S3.
       yield* Effect.gen(function* () {
-        const state = yield* State;
+        const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
           stage: "test",

--- a/packages/alchemy/test/AWS/SNS/Topic.test.ts
+++ b/packages/alchemy/test/AWS/SNS/Topic.test.ts
@@ -135,7 +135,7 @@ describe("AWS.SNS.Topic", () => {
 
         // Wipe state — the topic stays in SNS.
         yield* Effect.gen(function* () {
-          const state = yield* State;
+          const state = yield* yield* State;
           yield* state.delete({
             stack: stack.name,
             stage: "test",
@@ -173,7 +173,7 @@ describe("AWS.SNS.Topic", () => {
         );
 
         yield* Effect.gen(function* () {
-          const state = yield* State;
+          const state = yield* yield* State;
           yield* state.delete({
             stack: stack.name,
             stage: "test",

--- a/packages/alchemy/test/AWS/SQS/Queue.test.ts
+++ b/packages/alchemy/test/AWS/SQS/Queue.test.ts
@@ -224,7 +224,7 @@ test.provider(
 
       // Wipe state — queue stays in SQS.
       yield* Effect.gen(function* () {
-        const state = yield* State;
+        const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
           stage: "test",
@@ -263,7 +263,7 @@ test.provider(
       );
 
       yield* Effect.gen(function* () {
-        const state = yield* State;
+        const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
           stage: "test",

--- a/packages/alchemy/test/Cloudflare/AiGateway/AiGateway.test.ts
+++ b/packages/alchemy/test/Cloudflare/AiGateway/AiGateway.test.ts
@@ -138,7 +138,7 @@ test.provider(
 
       // Phase 2: wipe local state — the gateway stays on Cloudflare.
       yield* Effect.gen(function* () {
-        const state = yield* State;
+        const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
           stage: "test",
@@ -160,7 +160,7 @@ test.provider(
       expect(adopted.gatewayId).toEqual(gatewayId);
 
       const persisted = yield* Effect.gen(function* () {
-        const state = yield* State;
+        const state = yield* yield* State;
         return yield* state.get({
           stack: stack.name,
           stage: "test",

--- a/packages/alchemy/test/Cloudflare/D1/Database.test.ts
+++ b/packages/alchemy/test/Cloudflare/D1/Database.test.ts
@@ -579,7 +579,7 @@ test.provider(
 
       // Phase 2: wipe local state — the database stays on Cloudflare.
       yield* Effect.gen(function* () {
-        const state = yield* State;
+        const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
           stage: "test",
@@ -603,7 +603,7 @@ test.provider(
       expect(adopted.databaseName).toEqual(databaseName);
 
       const persisted = yield* Effect.gen(function* () {
-        const state = yield* State;
+        const state = yield* yield* State;
         return yield* state.get({
           stack: stack.name,
           stage: "test",

--- a/packages/alchemy/test/Cloudflare/KV/Namespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/KV/Namespace.test.ts
@@ -115,7 +115,7 @@ test.provider(
 
       // Phase 2: wipe local state — the namespace stays on Cloudflare.
       yield* Effect.gen(function* () {
-        const state = yield* State;
+        const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
           stage: "test",
@@ -137,7 +137,7 @@ test.provider(
       expect(adopted.title).toEqual(title);
 
       const persisted = yield* Effect.gen(function* () {
-        const state = yield* State;
+        const state = yield* yield* State;
         return yield* state.get({
           stack: stack.name,
           stage: "test",

--- a/packages/alchemy/test/Cloudflare/Queue/QueueConsumer.test.ts
+++ b/packages/alchemy/test/Cloudflare/Queue/QueueConsumer.test.ts
@@ -258,7 +258,7 @@ test.provider("adopts existing consumer after local state loss", (stack) =>
     // Wipe just the QueueConsumer entry — Queue and Worker stay so the
     // redeploy reuses the same queueId / scriptName.
     yield* Effect.gen(function* () {
-      const state = yield* State;
+      const state = yield* yield* State;
       yield* state.delete({
         stack: stack.name,
         stage: "test",
@@ -335,7 +335,7 @@ test.provider(
       );
 
       yield* Effect.gen(function* () {
-        const state = yield* State;
+        const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
           stage: "test",

--- a/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
+++ b/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
@@ -115,7 +115,7 @@ test.provider(
 
       // Phase 2: wipe local state — the bucket stays on Cloudflare.
       yield* Effect.gen(function* () {
-        const state = yield* State;
+        const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
           stage: "test",
@@ -137,7 +137,7 @@ test.provider(
       expect(adopted.bucketName).toEqual(bucketName);
 
       const persisted = yield* Effect.gen(function* () {
-        const state = yield* State;
+        const state = yield* yield* State;
         return yield* state.get({
           stack: stack.name,
           stage: "test",

--- a/packages/alchemy/test/Cloudflare/StateStore/State.test.ts
+++ b/packages/alchemy/test/Cloudflare/StateStore/State.test.ts
@@ -73,7 +73,7 @@ const replacedState = (fqn: string) => ({
 test(
   "getVersion returns the current STATE_STORE_VERSION",
   Effect.gen(function* () {
-    const store = yield* State;
+    const store = yield* yield* State;
     const version = yield* store.getVersion();
     expect(version).toBe(STATE_STORE_VERSION);
   }),
@@ -83,7 +83,7 @@ test(
 test(
   "DELETE /state/stacks/:stack wipes the test namespace (cleanup)",
   Effect.gen(function* () {
-    const store = yield* State;
+    const store = yield* yield* State;
     yield* store.deleteStack({ stack: STACK });
     const fqns = yield* store.list({ stack: STACK, stage: STAGE });
     expect(fqns).toEqual([]);
@@ -94,7 +94,7 @@ test(
 test(
   "PUT /resources/:fqn (setState) persists a resource",
   Effect.gen(function* () {
-    const store = yield* State;
+    const store = yield* yield* State;
     const fqn = "stack/scope/resource-a";
     const value = sampleState(fqn, "inst-a");
     const echoed = yield* store.set({
@@ -112,7 +112,7 @@ test(
 test(
   "GET /resources/:fqn (getState) reads back the persisted value",
   Effect.gen(function* () {
-    const store = yield* State;
+    const store = yield* yield* State;
     const fqn = "stack/scope/resource-a";
     const got = yield* store.get({ stack: STACK, stage: STAGE, fqn });
     expect(got).toBeDefined();
@@ -125,7 +125,7 @@ test(
 test(
   "GET /resources/:fqn returns undefined for a missing fqn",
   Effect.gen(function* () {
-    const store = yield* State;
+    const store = yield* yield* State;
     const got = yield* store.get({
       stack: STACK,
       stage: STAGE,
@@ -139,7 +139,7 @@ test(
 test(
   "GET /resources (listResources) returns the FQNs in the stage",
   Effect.gen(function* () {
-    const store = yield* State;
+    const store = yield* yield* State;
     const fqnB = "stack/scope/resource-b";
     yield* store.set({
       stack: STACK,
@@ -159,7 +159,7 @@ test(
 test(
   "GET /stacks (listStacks) includes the registered test stack",
   Effect.gen(function* () {
-    const store = yield* State;
+    const store = yield* yield* State;
     const stacks = yield* store.listStacks();
     expect(stacks).toContain(STACK);
   }),
@@ -169,7 +169,7 @@ test(
 test(
   "GET /stacks/:stack/stages (listStages) includes the test stage",
   Effect.gen(function* () {
-    const store = yield* State;
+    const store = yield* yield* State;
     const stages = yield* store.listStages(STACK);
     expect([...stages]).toContain(STAGE);
   }),
@@ -179,7 +179,7 @@ test(
 test(
   "PUT /output (setStackOutput) persists a stack output",
   Effect.gen(function* () {
-    const store = yield* State;
+    const store = yield* yield* State;
     const out = yield* store.setOutput({
       stack: STACK,
       stage: STAGE,
@@ -193,7 +193,7 @@ test(
 test(
   "GET /output (getStackOutput) reads back the persisted output",
   Effect.gen(function* () {
-    const store = yield* State;
+    const store = yield* yield* State;
     const out = yield* store.getOutput({ stack: STACK, stage: STAGE });
     expect(out).toEqual({ url: "https://example.com", count: 42 });
   }),
@@ -203,7 +203,7 @@ test(
 test(
   "GET /output returns undefined for an un-deployed stage",
   Effect.gen(function* () {
-    const store = yield* State;
+    const store = yield* yield* State;
     const out = yield* store.getOutput({
       stack: STACK,
       stage: "never-deployed",
@@ -216,7 +216,7 @@ test(
 test(
   "GET /replaced-resources (getReplacedResources) returns status===replaced rows",
   Effect.gen(function* () {
-    const store = yield* State;
+    const store = yield* yield* State;
     const fqn = "stack/scope/resource-replaced";
     yield* store.set({
       stack: STACK,
@@ -237,7 +237,7 @@ test(
 test(
   "DELETE /resources/:fqn (deleteState) removes a single resource",
   Effect.gen(function* () {
-    const store = yield* State;
+    const store = yield* yield* State;
     const fqn = "stack/scope/resource-a";
     yield* store.delete({ stack: STACK, stage: STAGE, fqn });
     const got = yield* store.get({ stack: STACK, stage: STAGE, fqn });
@@ -251,7 +251,7 @@ test(
 test(
   "DELETE /stacks/:stack?stage=... clears one stage but leaves the stack registered",
   Effect.gen(function* () {
-    const store = yield* State;
+    const store = yield* yield* State;
     yield* store.deleteStack({ stack: STACK, stage: STAGE });
     const fqns = yield* store.list({ stack: STACK, stage: STAGE });
     expect(fqns).toEqual([]);
@@ -267,7 +267,7 @@ test(
 test(
   "DELETE /stacks/:stack (no stage) removes the stack from listStacks",
   Effect.gen(function* () {
-    const store = yield* State;
+    const store = yield* yield* State;
     yield* store.deleteStack({ stack: STACK });
     const stacks = yield* store.listStacks();
     expect(stacks).not.toContain(STACK);
@@ -285,7 +285,7 @@ test(
 test(
   "setState 100x sequential — surfaces transient failures",
   Effect.gen(function* () {
-    const store = yield* State;
+    const store = yield* yield* State;
     const stack = STACK;
     const stage = `${STAGE}-stress-seq`;
     const fqn = "stack/scope/stress-seq";
@@ -324,7 +324,7 @@ test(
 test(
   "setState 100x concurrent — surfaces racy transient failures",
   Effect.gen(function* () {
-    const store = yield* State;
+    const store = yield* yield* State;
     const stack = STACK;
     const stage = `${STAGE}-stress-par`;
 
@@ -369,7 +369,7 @@ test(
 test(
   "GET+PUT interleaved 30x5 — engine traffic pattern",
   Effect.gen(function* () {
-    const store = yield* State;
+    const store = yield* yield* State;
     const stack = STACK;
     const stage = `${STAGE}-interleaved`;
 

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -505,7 +505,7 @@ describe.concurrent("Cloudflare.Worker", () => {
         // Cloudflare. From the next deploy's perspective this looks like a
         // fresh state store that has never seen this resource.
         yield* Effect.gen(function* () {
-          const state = yield* State;
+          const state = yield* yield* State;
           yield* state.delete({
             stack: stack.name,
             stage: "test",
@@ -531,7 +531,7 @@ describe.concurrent("Cloudflare.Worker", () => {
         expect(adopted.workerName).toEqual(physicalName);
 
         const persisted = yield* Effect.gen(function* () {
-          const state = yield* State;
+          const state = yield* yield* State;
           return yield* state.get({
             stack: stack.name,
             stage: "test",
@@ -578,7 +578,7 @@ describe.concurrent("Cloudflare.Worker", () => {
 
       // Wipe state for the "Original" entry; the worker stays on Cloudflare.
       yield* Effect.gen(function* () {
-        const state = yield* State;
+        const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
           stage: "test",

--- a/packages/alchemy/test/Drizzle/Schema.test.ts
+++ b/packages/alchemy/test/Drizzle/Schema.test.ts
@@ -38,7 +38,7 @@ const stageWorkspace = (initialSource: string) =>
   });
 
 const getStatus = Effect.fn(function* (fqn: string) {
-  const state = yield* State;
+  const state = yield* yield* State;
   const stk = yield* Stack.Stack;
   const s = yield* state.get({ stack: stk.name, stage: stk.stage, fqn });
   return s?.status;

--- a/packages/alchemy/test/State/Sync.test.ts
+++ b/packages/alchemy/test/State/Sync.test.ts
@@ -16,7 +16,7 @@ describe("syncState", () => {
         const sourceB = resource("resource-b", { value: "source-b" });
         const destinationA = resource("resource-a", { value: "destination-a" });
 
-        const source = InMemoryService({
+        const source = yield* InMemoryService({
           app: {
             dev: {
               "resource-a": sourceA,
@@ -24,7 +24,7 @@ describe("syncState", () => {
             },
           },
         });
-        const destination = InMemoryService({
+        const destination = yield* InMemoryService({
           app: {
             dev: {
               "resource-a": destinationA,
@@ -45,14 +45,14 @@ describe("syncState", () => {
     "deletes resources from destination when they are absent from source",
     () =>
       Effect.gen(function* () {
-        const source = InMemoryService({
+        const source = yield* InMemoryService({
           app: {
             dev: {
               "resource-a": resource("resource-a", { value: "source-a" }),
             },
           },
         });
-        const destination = InMemoryService({
+        const destination = yield* InMemoryService({
           app: {
             dev: {
               "resource-a": resource("resource-a", { value: "destination-a" }),

--- a/packages/alchemy/test/action.test.ts
+++ b/packages/alchemy/test/action.test.ts
@@ -1,15 +1,14 @@
-import * as Output from "@/Output";
+import { Action } from "@/Action";
 import * as Plan from "@/Plan";
 import * as Stack from "@/Stack";
 import { Stage } from "@/Stage";
 import {
-  inMemoryState,
   InMemoryService,
+  inMemoryState,
   State,
-  type RanActionState,
   type ActionState,
+  type RanActionState,
 } from "@/State";
-import { Action } from "@/Action";
 import * as Test from "@/Test/Vitest";
 import { describe, expect } from "@effect/vitest";
 import * as Context from "effect/Context";
@@ -46,7 +45,7 @@ const resolveStackId = Effect.gen(function* () {
 const seed = (rows: Record<string, ActionState>) =>
   Effect.gen(function* () {
     const { name, stage } = yield* resolveStackId;
-    const state = yield* State;
+    const state = yield* yield* State;
     for (const [fqn, value] of Object.entries(rows)) {
       yield* state.set({ stack: name, stage, fqn, value });
     }
@@ -308,7 +307,7 @@ describe("Apply", () => {
       expect(yield* Ref.get(counter)).toBe(1);
 
       // Persisted state is `ran` with the materialized output.
-      const state = yield* State;
+      const state = yield* yield* State;
       const persisted = yield* state.get({
         stack: stack.name,
         stage: "test",
@@ -415,7 +414,7 @@ describe("Apply", () => {
           }),
         );
 
-        const state = yield* State;
+        const state = yield* yield* State;
         expect(
           yield* state.get({ stack: stack.name, stage: "test", fqn: "Sync" }),
         ).toMatchObject({ kind: "action", status: "ran" });

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -31,7 +31,7 @@ import {
 const { test } = Test.make({ providers: TestLayers() });
 
 const getState = Effect.fn(function* <S = ResourceState>(resourceId: string) {
-  const state = yield* State;
+  const state = yield* yield* State;
   const stk = yield* Stack;
   return (yield* state.get({
     stack: stk.name,
@@ -40,7 +40,7 @@ const getState = Effect.fn(function* <S = ResourceState>(resourceId: string) {
   })) as S;
 });
 const listState = Effect.fn(function* () {
-  const state = yield* State;
+  const state = yield* yield* State;
   const stk = yield* Stack;
   return yield* state.list({ stack: stk.name, stage: stk.stage });
 });
@@ -4307,7 +4307,7 @@ describe("Redacted props/outputs survive deploy", () => {
 describe("stack output persistence", () => {
   const getStackOutput = (stack: string, stage: string) =>
     Effect.gen(function* () {
-      const state = yield* State;
+      const state = yield* yield* State;
       return yield* state.getOutput({ stack, stage });
     });
 

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -4,8 +4,8 @@ import { dedupeBindings } from "@/Diff";
 import type { Input, InputProps } from "@/Input";
 import * as Output from "@/Output";
 import * as Plan from "@/Plan";
-import type { ResourceBinding } from "@/Resource";
 import { UnsatisfiedResourceCycle } from "@/Plan";
+import type { ResourceBinding } from "@/Resource";
 import * as Stack from "@/Stack";
 import { Stage } from "@/Stage";
 import {
@@ -64,7 +64,7 @@ const resolveStackId = Effect.gen(function* () {
 const seed = (resources: Record<string, ResourceState>) =>
   Effect.gen(function* () {
     const { name, stage } = yield* resolveStackId;
-    const state = yield* State;
+    const state = yield* yield* State;
     for (const [fqn, value] of Object.entries(resources)) {
       yield* state.set({ stack: name, stage, fqn, value });
     }
@@ -950,7 +950,7 @@ test.provider(
   "binding removals do not keep reappearing after apply",
   (scratch) =>
     Effect.gen(function* () {
-      const state = yield* State;
+      const state = yield* yield* State;
       yield* state.set({
         stack: scratch.name,
         stage: TEST_STAGE,
@@ -2561,7 +2561,7 @@ describe("engine-level adoption", () => {
       // can't detect from `props` alone.
       expect(plan.resources.Adopted!.action).toBe("update");
 
-      const state = yield* State;
+      const state = yield* yield* State;
       const persisted = yield* state.get({
         stack: TEST_STACK,
         stage: TEST_STAGE,
@@ -2591,7 +2591,7 @@ describe("engine-level adoption", () => {
       // foreign-owned to subsequent deploys).
       expect(plan.resources.Adopted!.action).toBe("update");
 
-      const state = yield* State;
+      const state = yield* yield* State;
       const persisted = yield* state.get({
         stack: TEST_STACK,
         stage: TEST_STAGE,
@@ -2671,7 +2671,7 @@ describe("RefExpr resolution", () => {
     resources: Record<string, ResourceState>,
   ) =>
     Effect.gen(function* () {
-      const state = yield* State;
+      const state = yield* yield* State;
       for (const [fqn, value] of Object.entries(resources)) {
         yield* state.set({ stack, stage, fqn, value });
       }
@@ -2776,7 +2776,7 @@ describe("RefExpr resolution", () => {
 describe("StackRefExpr resolution", () => {
   const setStackOutput = (stack: string, stage: string, value: unknown) =>
     Effect.gen(function* () {
-      const state = yield* State;
+      const state = yield* yield* State;
       yield* state.setOutput({ stack, stage, value });
     });
 

--- a/website/src/content/docs/concepts/state-store.mdx
+++ b/website/src/content/docs/concepts/state-store.mdx
@@ -144,6 +144,13 @@ A state store is just an Effect `Layer` that provides the `State`
 service. If the built-in stores don't fit, you can back one with
 Postgres, S3, Redis, DynamoDB, or any other backend.
 
+The `State` service holds an `Effect<StateService>` — a deferred
+initializer — rather than a `StateService` directly. Wrap your
+builder in `Effect.cached` so the backend is only contacted on first
+use and the result is reused afterwards. This keeps commands that
+provide the layer but never read state (like `alchemy login`) from
+connecting to your backend or prompting for credentials.
+
 See [Writing a Custom State Store](/guides/custom-state-store) for
 a walkthrough of the `StateService` interface, an end-to-end
 implementation, and references to the built-in stores you can copy

--- a/website/src/content/docs/guides/custom-state-store.mdx
+++ b/website/src/content/docs/guides/custom-state-store.mdx
@@ -336,7 +336,7 @@ const layer = postgresState({
 describe("postgresState", () => {
   it("round-trips a resource", () =>
     Effect.gen(function* () {
-      const state = yield* State;
+      const state = yield* yield* State;
 
       yield* state.set({
         stack: "Test",

--- a/website/src/content/docs/guides/custom-state-store.mdx
+++ b/website/src/content/docs/guides/custom-state-store.mdx
@@ -21,9 +21,26 @@ state Alchemy persists and why.
 ## Scaffold the layer
 
 A state store is a `Layer.Layer<State, never, R>` where `R` is any
-ambient services your implementation needs. Start with an empty
-`StateService` so the types compile, then fill it in one method at
-a time.
+ambient services your implementation needs. The `State` service does
+**not** hold a `StateService` directly — it holds an
+`Effect<StateService>` that lazily builds one:
+
+```typescript
+class State extends Context.Service<State, Effect.Effect<StateService>>()(
+  "alchemy/State",
+) {}
+```
+
+This indirection matters. Commands like `alchemy login` provide the
+state layer but never touch state, so a store must not connect to its
+backend (open a DB connection, deploy a worker, prompt for
+credentials) just because the layer was built. Wrapping the builder
+in [`Effect.cached`](https://effect.website/docs/getting-started/control-flow/#caching)
+**defers** initialization until the first `yield* State` and **caches**
+it so subsequent accesses reuse the same `StateService`.
+
+Start with an empty `StateService` so the types compile, then fill it
+in one method at a time.
 
 Create `src/postgres-state.ts`:
 
@@ -38,7 +55,10 @@ export interface PostgresStateProps {
 }
 
 export const postgresState = (props: PostgresStateProps) =>
-  Layer.effect(State, makePostgresState(props));
+  // `Effect.cached` returns an `Effect<Effect<StateService>>`; yielding
+  // it inside `Layer.effect` hands `State` the deferred, memoized
+  // initializer. The body below only runs on first `yield* State`.
+  Layer.effect(State, Effect.cached(makePostgresState(props)));
 
 const makePostgresState = (_props: PostgresStateProps) =>
   Effect.gen(function* () {
@@ -63,13 +83,20 @@ operation. Next we'll wire up the database.
 
 We'll use the [`postgres`](https://github.com/porsager/postgres)
 package and create one schema with a single `state` table keyed by
-`(stack, stage, fqn)`. Acquire the connection inside `Layer.scoped`
-so it's released when the stack tears down:
+`(stack, stage, fqn)`. Acquire the connection with `Effect.acquireRelease`
+so it's released when the stack tears down — this requires a `Scope`,
+so the layer becomes `Layer.scoped`.
+
+Because initialization is deferred, capture the scope at layer-build
+time and provide it to the cached initializer, so the connection's
+release is still tied to the stack's lifetime even though it opens
+lazily on first use:
 
 ```diff lang="typescript"
 // src/postgres-state.ts
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
++import * as Scope from "effect/Scope";
 +import postgres from "postgres";
 import { State, type StateService } from "alchemy/State";
 
@@ -78,8 +105,19 @@ export interface PostgresStateProps {
 }
 
 export const postgresState = (props: PostgresStateProps) =>
--  Layer.effect(State, makePostgresState(props));
-+  Layer.scoped(State, makePostgresState(props));
+-  Layer.effect(State, Effect.cached(makePostgresState(props)));
++  Layer.scoped(
++    State,
++    Effect.gen(function* () {
++      // Capture the layer's scope so the deferred initializer can
++      // register the connection's release on it.
++      const context = yield* Effect.context<Scope.Scope>();
++      const make = makePostgresState(props).pipe(
++        Effect.provideContext(context),
++      );
++      return yield* Effect.cached(make);
++    }),
++  );
 
 const makePostgresState = (props: PostgresStateProps) =>
   Effect.gen(function* () {
@@ -320,7 +358,10 @@ export default Alchemy.Stack(
 ## Test the round-trip
 
 Spin up a throwaway Postgres (Docker, Testcontainers, or a local
-instance) and verify a resource round-trips through your store:
+instance) and verify a resource round-trips through your store. Note
+the double `yield*`: the first resolves the `State` service to its
+`Effect<StateService>` initializer, the second runs it to get the
+`StateService`.
 
 ```typescript
 // test/postgres-state.test.ts


### PR DESCRIPTION
There were two problems with `login`:
1. it would evaluate the stack to get the providers and state layers provided by the user, which could break (e.g. missing Config) or missing auth. We now assign them to the Stack effect so that they can be retrieved statically.
2. it would build the State layer which attempts to auto-deploy the stack before allowing login to configure auth. This bricks the user. The State service is now an Effect.cached so that it is deferred until actual usage and skipped during login and other commands.