### PR TITLE
docs: make llms.txt exhaustive and serve docs as utf-8

### DIFF
--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -24,11 +24,19 @@ A linear five-part walkthrough from zero to a tested, locally-developed, CI-depl
 Standalone tutorials that extend the main tutorial's Worker with a specific Cloudflare feature. Pick the ones that match your use case.
 
 - [Add a Durable Object](https://v2.alchemy.run/tutorial/cloudflare/durable-objects) — Add a Durable Object to your Worker — persist state per key, expose RPC methods, and stream values back to the client.
+- [Bind to another Worker's Durable Object](https://v2.alchemy.run/tutorial/cloudflare/cross-worker-durable-object) — Share a Durable Object across multiple Workers — one Worker hosts the runtime, others bind to it by scriptName for a typed RPC stub.
 - [Accept WebSockets](https://v2.alchemy.run/tutorial/cloudflare/hibernatable-websockets) — Accept WebSocket connections in a Durable Object, broadcast between peers, and survive Cloudflare's hibernation.
+- [Add a Vite SPA](https://v2.alchemy.run/tutorial/cloudflare/vite-spa) — Ship a Vite single-page app from the same Stack as your Worker — built, bundled, and deployed to Cloudflare in one command.
 - [Run a Container](https://v2.alchemy.run/tutorial/cloudflare/containers) — Run a long-lived container alongside a Durable Object, expose RPC methods, and proxy HTTP requests to ports inside the container.
 - [Add a Workflow](https://v2.alchemy.run/tutorial/cloudflare/workflows) — Orchestrate durable, multi-step work with Cloudflare Workflows — automatic retries, replayable steps, and at-least-once delivery.
-- [Add a Vite SPA](https://v2.alchemy.run/tutorial/cloudflare/vite-spa) — Ship a Vite single-page app from the same Stack as your Worker — built, bundled, and deployed to Cloudflare in one command.
-- [Add an AI Gateway](https://v2.alchemy.run/tutorial/cloudflare/ai-gateway) — Route Workers AI calls through a Cloudflare AI Gateway for caching, rate limiting, and unified observability across providers.
+- [Add an AI Gateway](https://v2.alchemy.run/tutorial/cloudflare/ai-gateway) — Wire an AI Gateway into your Worker, turn it into a typed Effect LanguageModel, and run generations and streams through Workers AI with caching, rate limiting, and logs.
+- [Build a Git Repo API](https://v2.alchemy.run/tutorial/cloudflare/artifacts) — Build a mini-GitHub on Cloudflare — Artifacts for Git storage, a Durable Object per repo for metadata, fronted by a schema-typed HttpApi.
+- [Connect to a Database with Hyperdrive](https://v2.alchemy.run/tutorial/cloudflare/hyperdrive) — Provision a Postgres or MySQL database (Neon, PlanetScale Postgres, or PlanetScale MySQL) and front it with Cloudflare Hyperdrive so your Worker reaches the database with edge-pooled, low-latency connections.
+- [Add Drizzle ORM](https://v2.alchemy.run/tutorial/cloudflare/drizzle) — Replace raw pg with Drizzle's effect-postgres integration, manage your schema as a resource, and have alchemy generate and apply migrations on every deploy.
+- [Branch from a shared database](https://v2.alchemy.run/tutorial/cloudflare/branch-from-shared-database) — Have ephemeral PR-preview stages reference a long-lived Neon project from the staging stage instead of provisioning their own — fast previews, copy-on-write branches, no extra Postgres clusters.
+- [Consume from a Queue](https://v2.alchemy.run/tutorial/cloudflare/queue-consumer) — Receive messages from a Cloudflare Queue with Cloudflare.messages(queue).subscribe(...) — Effect-style stream handler with automatic ack/retry.
+- [Define an RPC Worker](https://v2.alchemy.run/tutorial/cloudflare/rpc-worker) — Define a typed Effect RPC group, serve it from `Cloudflare.RpcWorker`, drive it from an integration test, and (later) bind a typed client from another Worker.
+- [Add a typed RPC Durable Object](https://v2.alchemy.run/tutorial/cloudflare/rpc-durable-object) — Replace alchemy's built-in DO method bridge with `Cloudflare.RpcDurableObjectNamespace` — a typed RPC group served on the DO's `fetch`, with a class-instance-preserving wire format. Walk through a single DO, drive it from a test, then layer in a Worker.
 
 ## Tutorial — AWS
 
@@ -37,55 +45,258 @@ End-to-end AWS tutorials. Read the Lambda page first; the others bind storage an
 - [Deploy a Lambda Function](https://v2.alchemy.run/tutorial/aws/lambda) — Stand up an AWS Lambda Function from a single Effect, expose it over a Function URL, and call it from a test.
 - [Read & Write S3](https://v2.alchemy.run/tutorial/aws/s3) — Add an S3 Bucket to your Stack, bind PutObject and GetObject as runtime capabilities, and let Alchemy mint the IAM policy for you.
 - [React to S3 Events](https://v2.alchemy.run/tutorial/aws/s3-events) — Subscribe a Lambda Function to S3 bucket notifications, process them as an Effect Stream, and let Alchemy wire up the IAM and event-source plumbing.
-- [Send & Consume SQS Messages](https://v2.alchemy.run/tutorial/aws/sqs) — Add an SQS Queue, publish messages from your Lambda, and consume them from a second consumer Lambda — all wired through Alchemy bindings.
-- [Stream Records with Kinesis](https://v2.alchemy.run/tutorial/aws/kinesis) — Add a Kinesis Data Stream, publish records from one Lambda, and consume them in order from another — wired through the same Stream-shaped event source.
 - [Store Records in DynamoDB](https://v2.alchemy.run/tutorial/aws/dynamodb) — Add a DynamoDB Table, bind GetItem and PutItem to your Lambda, and serve a typed key/value HTTP API backed by DynamoDB.
 - [Process DynamoDB Streams](https://v2.alchemy.run/tutorial/aws/dynamodb-streams) — Enable a DynamoDB Stream on your table and consume change records as a typed Effect Stream from the same Lambda.
+- [Send & Consume SQS Messages](https://v2.alchemy.run/tutorial/aws/sqs) — Add an SQS Queue, publish messages from your Lambda, and consume them from a second consumer Lambda — all wired through Alchemy bindings.
+- [Stream Records with Kinesis](https://v2.alchemy.run/tutorial/aws/kinesis) — Add a Kinesis Data Stream, publish records from one Lambda, and consume them in order from another — wired through the same Stream-shaped event source.
+- [REST API (API Gateway v1)](https://v2.alchemy.run/tutorial/aws/api-gateway) — Expose a Lambda with a regional Amazon API Gateway REST API using RestApi, Resource, Method, Deployment, and Stage primitives.
 
 ## Concepts — the mental model
 
 Reference pages explaining what each primitive means and how they fit together. Read these when something in a tutorial feels magical, or before designing a new Stack.
 
-- [Resource](https://v2.alchemy.run/concepts/resource) — Resources are named cloud entities with input properties and output attributes.
-- [Provider](https://v2.alchemy.run/concepts/provider) — Providers implement the lifecycle operations for a resource type — reconcile, delete, diff, read, and more.
-- [Resource Lifecycle](https://v2.alchemy.run/concepts/resource-lifecycle) — How alchemy plans, applies, replaces, and destroys resources — and how to think about idempotency and recovery.
 - [Stack](https://v2.alchemy.run/concepts/stack) — A Stack is a collection of Resources deployed together as a unit.
-- [Stages](https://v2.alchemy.run/concepts/stages) — Stages are isolated instances of a Stack — dev_sam, staging, prod, pr-42 — each with their own state and physical names.
-- [Phases](https://v2.alchemy.run/concepts/phases) — Alchemy programs run in two phases — plantime/init drives the deploy, runtime handles requests. Knowing which is which is the key to using Platforms.
-- [Platform](https://v2.alchemy.run/concepts/platform) — A Platform bundles infrastructure with the runtime code that runs on it — Workers, Lambda Functions, Containers — so your handler ships with its bindings.
-- [Binding](https://v2.alchemy.run/concepts/binding) — A binding connects a resource to a Worker or Lambda. It generates IAM policies, env vars, and a typed SDK in one call.
+- [Resource](https://v2.alchemy.run/concepts/resource) — Resources are named cloud entities with input properties and output attributes.
+- [Action](https://v2.alchemy.run/concepts/action) — A node in the dependency graph that runs an Effect during apply when its inputs change.
 - [Inputs and Outputs](https://v2.alchemy.run/concepts/outputs) — Output<T> is alchemy's lazy reference type — the lazy values that flow between resources, get composed with .pipe, mapped, interpolated, and resolved during deploy.
+- [References](https://v2.alchemy.run/concepts/references) — Read values out of another stack or stage at plan time — typed, lazy, and resolved from persisted state.
+- [Resource Lifecycle](https://v2.alchemy.run/concepts/resource-lifecycle) — How alchemy plans, applies, replaces, and destroys resources — and how to think about idempotency and recovery.
+- [Provider](https://v2.alchemy.run/concepts/provider) — Providers implement the lifecycle operations for a resource type — reconcile, delete, diff, read, and more.
+- [Platform](https://v2.alchemy.run/concepts/platform) — A Platform bundles infrastructure with the runtime code that runs on it — Workers, Lambda Functions, Containers — so your handler ships with its bindings.
+- [Phases](https://v2.alchemy.run/concepts/phases) — Alchemy programs run in two phases — plantime/init drives the deploy, runtime handles requests. Knowing which is which is the key to using Platforms.
+- [Binding](https://v2.alchemy.run/concepts/binding) — A binding connects a resource to a Worker or Lambda. It generates IAM policies, env vars, and a typed SDK in one call.
+- [Secrets and Config](https://v2.alchemy.run/concepts/secrets) — Use effect/Config to read env vars at init time and have Alchemy automatically bind them onto the deploy target.
 - [Layers](https://v2.alchemy.run/concepts/layers) — A Layer encapsulates a slice of infrastructure (resources, bindings, runtime logic) behind a typed service interface. Code that depends on the interface stays cloud-agnostic; swapping the implementation swaps the underlying infrastructure.
 - [State Store](https://v2.alchemy.run/concepts/state-store) — How Alchemy persists resource state between deploys to compute diffs and track infrastructure.
-- [Profiles](https://v2.alchemy.run/concepts/profiles) — Profiles store cloud credentials per environment in ~/.alchemy/profiles.json — switch between work and personal accounts, or between staging and prod credentials.
+- [Testing](https://v2.alchemy.run/concepts/testing) — Reference for alchemy/Test — every helper, hook, and option exposed by Test.make for Bun and Vitest.
 - [Local Development](https://v2.alchemy.run/concepts/local-development) — How alchemy dev provides hot reloading, local workerd execution, and cloud-backed resources for fast iteration.
 - [Observability](https://v2.alchemy.run/concepts/observability) — Effect emits OpenTelemetry — ship traces, metrics, and logs to Axiom, Datadog, CloudWatch, or any OTLP endpoint. Declare dashboards and alarms in code.
-- [Testing](https://v2.alchemy.run/concepts/testing) — Reference for alchemy/Test — every helper, hook, and option exposed by Test.make for Bun and Vitest.
+- [Profiles](https://v2.alchemy.run/concepts/profiles) — Profiles store cloud credentials per environment in ~/.alchemy/profiles.json — switch between work and personal accounts, or between staging and prod credentials.
+- [Stages](https://v2.alchemy.run/concepts/stages) — Stages are isolated instances of a Stack — dev_sam, staging, prod, pr-42 — each with their own state and physical names.
 
 ## Guides — task-oriented
 
 Standalone how-to pages. Each solves a specific problem; read in any order.
 
-- [Continuous Integration](https://v2.alchemy.run/guides/ci) — Set up CI/CD pipelines for alchemy projects with GitHub Actions, automated deployments, and PR previews — with provider credentials managed as code.
-- [Circular Bindings](https://v2.alchemy.run/guides/circular-bindings) — How to model two services that reference each other (Worker A ↔ Worker B, Lambda ↔ Lambda) using tagged classes and Layers.
-- [CLI Reference](https://v2.alchemy.run/guides/cli) — All Alchemy CLI commands — deploy, destroy, plan, dev, tail, logs, aws, cloudflare, login, profile, and state.
-- [Writing a Custom Resource Provider](https://v2.alchemy.run/guides/custom-provider) — Add support for a new cloud or third-party API by declaring a Resource type and implementing its lifecycle as an Effect Layer.
-- [Writing a Custom State Store](https://v2.alchemy.run/guides/custom-state-store) — Build a Postgres-backed Alchemy state store step by step — implement the StateService interface, plug it into a stack, and test it end-to-end.
-- [Effect HTTP API](https://v2.alchemy.run/guides/effect-http-api) — Build a schema-validated HTTP API with Effect's HttpApi module and deploy it as a Cloudflare Worker.
-- [Effect RPC](https://v2.alchemy.run/guides/effect-rpc) — Build a typed RPC API with Effect's Rpc module and deploy it as a Cloudflare Worker.
-- [Frontend frameworks](https://v2.alchemy.run/guides/frontends) — Deploy Vite-based frameworks (TanStack Start, Astro, SolidStart, Nuxt, React) and any custom-built static site (Hugo, Eleventy) to Cloudflare with one declaration.
-- [Building Infrastructure Layers](https://v2.alchemy.run/guides/infrastructure-layers) — Package resources + bindings + runtime glue into a typed Effect Layer, then swap a KV-backed implementation for an R2-backed one without touching the consumer.
 - [Migrating from v1](https://v2.alchemy.run/guides/migrating-from-v1) — Migrate your Alchemy v1 (async/await) project to Alchemy v2.
+- [CLI Reference](https://v2.alchemy.run/guides/cli) — All Alchemy CLI commands — deploy, destroy, plan, dev, tail, logs, aws, cloudflare, login, profile, and state.
+- [Continuous Integration](https://v2.alchemy.run/guides/ci) — Set up CI/CD pipelines for alchemy projects with GitHub Actions, automated deployments, and PR previews — with provider credentials managed as code.
 - [Monorepos](https://v2.alchemy.run/guides/monorepo) — Two patterns for organizing an Alchemy monorepo with a backend API and a frontend website — one shared stack (recommended) or one stack per package — with the trade-offs and a working example for each.
 - [Secrets and env vars](https://v2.alchemy.run/guides/secrets) — Wire OPENAI_API_KEY from .env into a Cloudflare Worker as a secret_text binding.
+- [Effect HTTP API](https://v2.alchemy.run/guides/effect-http-api) — Build a schema-validated HTTP API with Effect's HttpApi module and deploy it as a Cloudflare Worker.
 - [Shared database across stages](https://v2.alchemy.run/guides/shared-database) — Have ephemeral PR-preview stages reference a long-lived Neon Postgres project from staging instead of provisioning their own — fast previews, copy-on-write branches, no extra Postgres clusters.
+- [Effect RPC](https://v2.alchemy.run/guides/effect-rpc) — Build a typed RPC API with Effect's Rpc module and deploy it as a Cloudflare Worker.
+- [Frontend frameworks](https://v2.alchemy.run/guides/frontends) — Deploy Vite-based frameworks (TanStack Start, Astro, SolidStart, Nuxt, React) and any custom-built static site (Hugo, Eleventy) to Cloudflare with one declaration.
+- [Circular Bindings](https://v2.alchemy.run/guides/circular-bindings) — How to model two services that reference each other (Worker A ↔ Worker B, Lambda ↔ Lambda) using tagged classes and Layers.
+- [Effect AI](https://v2.alchemy.run/guides/effect-ai) — Wire Effect's LanguageModel and Chat services into a Cloudflare Worker — read API keys with effect/Config, provide the model layer to your handler, plug in persistence.
+- [Building Infrastructure Layers](https://v2.alchemy.run/guides/infrastructure-layers) — Package resources + bindings + runtime glue into a typed Effect Layer, then swap a KV-backed implementation for an R2-backed one without touching the consumer.
+- [Writing a Custom State Store](https://v2.alchemy.run/guides/custom-state-store) — Build a Postgres-backed Alchemy state store step by step — implement the StateService interface, plug it into a stack, and test it end-to-end.
+- [Writing a Custom Resource Provider](https://v2.alchemy.run/guides/custom-provider) — Add support for a new cloud or third-party API by declaring a Resource type and implementing its lifecycle as an Effect Layer.
 
-## Providers — auto-generated API reference
+## Providers
 
-Per-resource API pages live under `https://v2.alchemy.run/providers/{Cloud}/{Resource}` (e.g. `/providers/AWS/Bucket`, `/providers/Cloudflare/Worker`). They are generated from JSDoc on the source `.ts` files via `bun generate:api-reference` and are not checked into git, so this index does not enumerate them. Each page documents:
+Per-resource API reference, generated from JSDoc on the source `.ts` files via `bun generate:api-reference`. Each page documents the resource's input properties (with types, defaults, and constraints), output attributes, and Quick Reference / Examples sections derived from `@section` / `@example` JSDoc tags. Grouped by cloud below.
 
-- The resource's input properties (props) with types, defaults, and constraints.
-- The resource's output attributes.
-- Quick Reference and Examples sections derived from `@section` / `@example` JSDoc tags.
+### AWS
 
-To find a specific resource, browse the Providers section in the sidebar at https://v2.alchemy.run, or read the source JSDoc at `packages/alchemy/src/{Cloud}/{Service}/{Resource}.ts` in [the repository](https://github.com/alchemy-run/alchemy-effect).
+- [AccessEntry](https://v2.alchemy.run/providers/aws/eks/accessentry) — An Amazon EKS access entry that grants an IAM principal access to a cluster.
+- [AccessKey](https://v2.alchemy.run/providers/aws/iam/accesskey) — An IAM access key for a user.
+- [Account](https://v2.alchemy.run/providers/aws/apigateway/account) — Account-level settings for Amazon API Gateway in the current region (CloudWatch logging role, etc.).
+- [Account](https://v2.alchemy.run/providers/aws/organizations/account) — A member account created and managed by AWS Organizations.
+- [AccountAlias](https://v2.alchemy.run/providers/aws/iam/accountalias) — The singleton IAM account alias for an AWS account.
+- [AccountAssignment](https://v2.alchemy.run/providers/aws/identitycenter/accountassignment) — Assigns an IAM Identity Center permission set to a user or group in an AWS account.
+- [AccountPasswordPolicy](https://v2.alchemy.run/providers/aws/iam/accountpasswordpolicy) — The singleton IAM account password policy.
+- [Addon](https://v2.alchemy.run/providers/aws/eks/addon) — An Amazon EKS managed add-on installed on a cluster.
+- [Alarm](https://v2.alchemy.run/providers/aws/cloudwatch/alarm) — A CloudWatch metric alarm.
+- [AlarmMuteRule](https://v2.alchemy.run/providers/aws/cloudwatch/alarmmuterule) — A CloudWatch alarm mute rule.
+- [AnomalyDetector](https://v2.alchemy.run/providers/aws/cloudwatch/anomalydetector) — A CloudWatch anomaly detector.
+- [ApiKey](https://v2.alchemy.run/providers/aws/apigateway/apikey) — API Gateway API key for usage plans and `apiKeyRequired` methods.
+- [AssetDeployment](https://v2.alchemy.run/providers/aws/website/assetdeployment) — Upload a local directory into S3 with website-friendly defaults.
+- [Authorizer](https://v2.alchemy.run/providers/aws/apigateway/authorizer) — REST API Lambda, Cognito, or gateway authorizer.
+- [AutoScalingGroup](https://v2.alchemy.run/providers/aws/autoscaling/autoscalinggroup) — An EC2 Auto Scaling Group that manages a fleet of instances from a launch template and can register that fleet with one or more load balancer target groups.
+- [BasePathMapping](https://v2.alchemy.run/providers/aws/apigateway/basepathmapping) — Maps a custom domain name path to a REST API stage.
+- [Bucket](https://v2.alchemy.run/providers/aws/s3/bucket) — An S3 bucket for storing objects in AWS.
+- [CachePolicy](https://v2.alchemy.run/providers/aws/cloudfront/cachepolicy) — A CloudFront cache policy.
+- [CapacityProvider](https://v2.alchemy.run/providers/aws/ecs/capacityprovider) — An Amazon ECS capacity provider backed by an EC2 Auto Scaling Group.
+- [Certificate](https://v2.alchemy.run/providers/aws/acm/certificate) — An ACM certificate for CloudFront and other AWS endpoints.
+- [Cluster](https://v2.alchemy.run/providers/aws/ecs/cluster) — An Amazon ECS cluster for running tasks and services.
+- [Cluster](https://v2.alchemy.run/providers/aws/eks/cluster) — An Amazon EKS cluster with support for EKS Auto Mode settings.
+- [CompositeAlarm](https://v2.alchemy.run/providers/aws/cloudwatch/compositealarm) — A CloudWatch composite alarm.
+- [Dashboard](https://v2.alchemy.run/providers/aws/cloudwatch/dashboard) — An Amazon CloudWatch dashboard.
+- [DBCluster](https://v2.alchemy.run/providers/aws/rds/dbcluster) — An Aurora DB cluster.
+- [DBClusterEndpoint](https://v2.alchemy.run/providers/aws/rds/dbclusterendpoint) — A custom Aurora cluster endpoint.
+- [DBClusterParameterGroup](https://v2.alchemy.run/providers/aws/rds/dbclusterparametergroup) — An Aurora cluster parameter group.
+- [DBInstance](https://v2.alchemy.run/providers/aws/rds/dbinstance) — An Aurora cluster instance.
+- [DBParameterGroup](https://v2.alchemy.run/providers/aws/rds/dbparametergroup) — An RDS DB parameter group, useful for Aurora cluster instances.
+- [DBProxy](https://v2.alchemy.run/providers/aws/rds/dbproxy) — An RDS Proxy for pooled Lambda-to-Aurora connectivity.
+- [DBProxyEndpoint](https://v2.alchemy.run/providers/aws/rds/dbproxyendpoint) — An additional RDS Proxy endpoint.
+- [DBProxyTargetGroup](https://v2.alchemy.run/providers/aws/rds/dbproxytargetgroup) — The proxy target group that registers Aurora clusters or instances behind an RDS Proxy.
+- [DBSubnetGroup](https://v2.alchemy.run/providers/aws/rds/dbsubnetgroup) — An RDS DB subnet group for Aurora clusters, instances, and proxies.
+- [DelegatedAdministrator](https://v2.alchemy.run/providers/aws/organizations/delegatedadministrator) — Registers a delegated administrator account for a trusted AWS service.
+- [Deployment](https://v2.alchemy.run/providers/aws/apigateway/deployment) — A point-in-time snapshot of a REST API, ready to be served through a `Stage`.
+- [Distribution](https://v2.alchemy.run/providers/aws/cloudfront/distribution) — A CloudFront distribution.
+- [DomainName](https://v2.alchemy.run/providers/aws/apigateway/domainname) — Custom domain name for an Amazon API Gateway REST API.
+- [EgressOnlyInternetGateway](https://v2.alchemy.run/providers/aws/ec2/egressonlyinternetgateway) — API reference for EgressOnlyInternetGateway
+- [EIP](https://v2.alchemy.run/providers/aws/ec2/eip) — API reference for EIP
+- [EventBus](https://v2.alchemy.run/providers/aws/eventbridge/eventbus) — An Amazon EventBridge event bus for receiving and routing events.
+- [EventSourceMapping](https://v2.alchemy.run/providers/aws/lambda/eventsourcemapping) — API reference for EventSourceMapping
+- [Function](https://v2.alchemy.run/providers/aws/cloudfront/function) — A CloudFront Function for viewer request and response customization.
+- [Function](https://v2.alchemy.run/providers/aws/lambda/function) — An AWS Lambda host resource that combines code bundling, IAM role provisioning, and runtime binding collection.
+- [GatewayResponse](https://v2.alchemy.run/providers/aws/apigateway/gatewayresponse) — Gateway response mapping for a REST API (e.g. DEFAULT_4XX, DEFAULT_5XX).
+- [Group](https://v2.alchemy.run/providers/aws/iam/group) — An IAM group that can own managed and inline policies.
+- [Group](https://v2.alchemy.run/providers/aws/identitycenter/group) — A group in the IAM Identity Center identity store.
+- [GroupMembership](https://v2.alchemy.run/providers/aws/iam/groupmembership) — An explicit IAM group membership resource that owns a group's managed users.
+- [InsightRule](https://v2.alchemy.run/providers/aws/cloudwatch/insightrule) — A CloudWatch Contributor Insights rule.
+- [Instance](https://v2.alchemy.run/providers/aws/ec2/instance) — An EC2 instance that can either act as a low-level compute primitive or run a bundled long-lived Effect program directly on the machine.
+- [Instance](https://v2.alchemy.run/providers/aws/identitycenter/instance) — An IAM Identity Center instance visible to the current account.
+- [InstanceProfile](https://v2.alchemy.run/providers/aws/iam/instanceprofile) — An IAM instance profile that can present a role to EC2 instances.
+- [InternetGateway](https://v2.alchemy.run/providers/aws/ec2/internetgateway) — API reference for InternetGateway
+- [Invalidation](https://v2.alchemy.run/providers/aws/cloudfront/invalidation) — A CloudFront cache invalidation request.
+- [KeyGroup](https://v2.alchemy.run/providers/aws/cloudfront/keygroup) — A CloudFront key group.
+- [KeyValueStore](https://v2.alchemy.run/providers/aws/cloudfront/keyvaluestore) — A CloudFront KeyValueStore for edge metadata.
+- [KvEntries](https://v2.alchemy.run/providers/aws/cloudfront/kventries) — Manages namespaced key-value entries in a CloudFront KeyValueStore.
+- [KvRoutesUpdate](https://v2.alchemy.run/providers/aws/cloudfront/kvroutesupdate) — Manages a single route entry in a JSON array stored in a CloudFront KeyValueStore.
+- [LaunchTemplate](https://v2.alchemy.run/providers/aws/autoscaling/launchtemplate) — A launch template that preserves the `Host` authoring model used by `AWS.EC2.Instance`, but packages that host configuration for use with an Auto Scaling Group.
+- [Listener](https://v2.alchemy.run/providers/aws/elbv2/listener) — API reference for Listener
+- [LoadBalancer](https://v2.alchemy.run/providers/aws/elbv2/loadbalancer) — API reference for LoadBalancer
+- [LogGroup](https://v2.alchemy.run/providers/aws/logs/loggroup) — A CloudWatch Logs log group.
+- [LoginProfile](https://v2.alchemy.run/providers/aws/iam/loginprofile) — An IAM console login profile for a user.
+- [Method](https://v2.alchemy.run/providers/aws/apigateway/method) — An HTTP method on an API Gateway Resource.
+- [MetricStream](https://v2.alchemy.run/providers/aws/cloudwatch/metricstream) — A CloudWatch metric stream.
+- [NatGateway](https://v2.alchemy.run/providers/aws/ec2/natgateway) — API reference for NatGateway
+- [NetworkAcl](https://v2.alchemy.run/providers/aws/ec2/networkacl) — API reference for NetworkAcl
+- [NetworkAclAssociation](https://v2.alchemy.run/providers/aws/ec2/networkaclassociation) — API reference for NetworkAclAssociation
+- [NetworkAclEntry](https://v2.alchemy.run/providers/aws/ec2/networkaclentry) — API reference for NetworkAclEntry
+- [OpenIDConnectProvider](https://v2.alchemy.run/providers/aws/iam/openidconnectprovider) — An IAM OpenID Connect provider for web identity federation.
+- [Organization](https://v2.alchemy.run/providers/aws/organizations/organization) — The AWS Organization for the current management account.
+- [OrganizationalUnit](https://v2.alchemy.run/providers/aws/organizations/organizationalunit) — An AWS Organizations organizational unit.
+- [OrganizationResourcePolicy](https://v2.alchemy.run/providers/aws/organizations/organizationresourcepolicy) — The singleton AWS Organizations resource policy.
+- [OriginAccessControl](https://v2.alchemy.run/providers/aws/cloudfront/originaccesscontrol) — A CloudFront Origin Access Control for private origins.
+- [OriginRequestPolicy](https://v2.alchemy.run/providers/aws/cloudfront/originrequestpolicy) — A CloudFront origin request policy.
+- [Permission](https://v2.alchemy.run/providers/aws/eventbridge/permission) — An EventBridge event bus permission statement.
+- [Permission](https://v2.alchemy.run/providers/aws/lambda/permission) — A Lambda permission that grants an AWS service or another account permission to invoke a function.
+- [PermissionSet](https://v2.alchemy.run/providers/aws/identitycenter/permissionset) — An IAM Identity Center permission set.
+- [PodIdentityAssociation](https://v2.alchemy.run/providers/aws/eks/podidentityassociation) — An Amazon EKS pod identity association that binds a service account to an IAM role.
+- [Policy](https://v2.alchemy.run/providers/aws/iam/policy) — A customer-managed IAM policy.
+- [Policy](https://v2.alchemy.run/providers/aws/organizations/policy) — An AWS Organizations policy such as an SCP or tag policy.
+- [PolicyAttachment](https://v2.alchemy.run/providers/aws/organizations/policyattachment) — Attaches an Organizations policy to a root, OU, or account.
+- [PublicKey](https://v2.alchemy.run/providers/aws/cloudfront/publickey) — A CloudFront public key.
+- [Queue](https://v2.alchemy.run/providers/aws/sqs/queue) — An Amazon SQS queue for reliable, decoupled message processing.
+- [Record](https://v2.alchemy.run/providers/aws/route53/record) — A Route 53 DNS record set.
+- [Repository](https://v2.alchemy.run/providers/aws/ecr/repository) — An Amazon ECR repository for container images.
+- [ResponseHeadersPolicy](https://v2.alchemy.run/providers/aws/cloudfront/responseheaderspolicy) — A CloudFront response headers policy.
+- [RestApi](https://v2.alchemy.run/providers/aws/apigateway/restapi) — An Amazon API Gateway REST API (v1).
+- [Role](https://v2.alchemy.run/providers/aws/iam/role) — An IAM role for AWS services and runtimes.
+- [Root](https://v2.alchemy.run/providers/aws/organizations/root) — The organization root.
+- [RootPolicyType](https://v2.alchemy.run/providers/aws/organizations/rootpolicytype) — Enables a policy type on an organization root.
+- [Route](https://v2.alchemy.run/providers/aws/ec2/route) — API reference for Route
+- [RouteTable](https://v2.alchemy.run/providers/aws/ec2/routetable) — API reference for RouteTable
+- [RouteTableAssociation](https://v2.alchemy.run/providers/aws/ec2/routetableassociation) — API reference for RouteTableAssociation
+- [Rule](https://v2.alchemy.run/providers/aws/eventbridge/rule) — An Amazon EventBridge rule that matches events and routes them to targets.
+- [SAMLProvider](https://v2.alchemy.run/providers/aws/iam/samlprovider) — An IAM SAML identity provider.
+- [ScalingPolicy](https://v2.alchemy.run/providers/aws/autoscaling/scalingpolicy) — A target-tracking scaling policy for an Auto Scaling Group.
+- [Schedule](https://v2.alchemy.run/providers/aws/scheduler/schedule) — An EventBridge Scheduler schedule.
+- [ScheduleGroup](https://v2.alchemy.run/providers/aws/scheduler/schedulegroup) — An EventBridge Scheduler schedule group.
+- [Secret](https://v2.alchemy.run/providers/aws/secretsmanager/secret) — An AWS Secrets Manager secret.
+- [SecurityGroup](https://v2.alchemy.run/providers/aws/ec2/securitygroup) — Ingress or egress rule for a security group.
+- [SecurityGroupRule](https://v2.alchemy.run/providers/aws/ec2/securitygrouprule) — API reference for SecurityGroupRule
+- [ServerCertificate](https://v2.alchemy.run/providers/aws/iam/servercertificate) — An IAM server certificate.
+- [Service](https://v2.alchemy.run/providers/aws/ecs/service) — An ECS Fargate service for running long-lived tasks.
+- [ServiceSpecificCredential](https://v2.alchemy.run/providers/aws/iam/servicespecificcredential) — A service-specific IAM credential.
+- [SigningCertificate](https://v2.alchemy.run/providers/aws/iam/signingcertificate) — An IAM signing certificate for a user.
+- [SSHPublicKey](https://v2.alchemy.run/providers/aws/iam/sshpublickey) — An IAM SSH public key for CodeCommit-compatible workflows.
+- [Stage](https://v2.alchemy.run/providers/aws/apigateway/stage) — A stage for a REST API deployment.
+- [Stream](https://v2.alchemy.run/providers/aws/kinesis/stream) — An Amazon Kinesis Data Stream.
+- [StreamConsumer](https://v2.alchemy.run/providers/aws/kinesis/streamconsumer) — A registered Kinesis enhanced fan-out consumer.
+- [Subnet](https://v2.alchemy.run/providers/aws/ec2/subnet) — API reference for Subnet
+- [Subscription](https://v2.alchemy.run/providers/aws/sns/subscription) — An Amazon SNS subscription that attaches an endpoint to a topic.
+- [Table](https://v2.alchemy.run/providers/aws/dynamodb/table) — An Amazon DynamoDB table with optional indexes, PITR, TTL, and stream-aware binding support.
+- [TargetGroup](https://v2.alchemy.run/providers/aws/elbv2/targetgroup) — API reference for TargetGroup
+- [Task](https://v2.alchemy.run/providers/aws/ecs/task) — API reference for Task
+- [Topic](https://v2.alchemy.run/providers/aws/sns/topic) — An Amazon SNS topic for fan-out messaging and notifications.
+- [TrustedServiceAccess](https://v2.alchemy.run/providers/aws/organizations/trustedserviceaccess) — Enables trusted access for an AWS service principal.
+- [UsagePlan](https://v2.alchemy.run/providers/aws/apigateway/usageplan) — Usage plan for API stages, throttling, and quotas.
+- [UsagePlanKey](https://v2.alchemy.run/providers/aws/apigateway/usageplankey) — Associates an API key with a usage plan.
+- [User](https://v2.alchemy.run/providers/aws/iam/user) — An IAM user with optional inline policies, managed policies, and tags.
+- [VirtualMFADevice](https://v2.alchemy.run/providers/aws/iam/virtualmfadevice) — An IAM virtual MFA device.
+- [Vpc](https://v2.alchemy.run/providers/aws/ec2/vpc) — API reference for Vpc
+- [VpcEndpoint](https://v2.alchemy.run/providers/aws/ec2/vpcendpoint) — API reference for VpcEndpoint
+- [VpcLink](https://v2.alchemy.run/providers/aws/apigateway/vpclink) — VPC link for private integrations (`connectionType: \"VPC_LINK\"` on a method integration).
+
+### Axiom
+
+- [Annotation](https://v2.alchemy.run/providers/axiom/annotation) — An Axiom annotation — a vertical marker overlaid on charts to flag a deploy, incident, feature flag flip, or any other point/range event you want correlated with telemetry.
+- [ApiToken](https://v2.alchemy.run/providers/axiom/apitoken) — An Axiom API token — a scoped bearer token used to authenticate API requests (ingest, query, admin). Capabilities are pinned at creation time; changing any field triggers a **replacement** because Axiom does not expose an update endpoint.
+- [Dashboard](https://v2.alchemy.run/providers/axiom/dashboard) — An Axiom dashboard — a named, layout-driven collection of charts. Each dashboard takes a full document (`charts` + `layout` array of grid cells + `timeWindow` + `refreshTime`) at version `schemaVersion: 2`.
+- [Dataset](https://v2.alchemy.run/providers/axiom/dataset) — An Axiom dataset — the top-level container that stores events, logs, traces, or metrics. Pick a `kind` up-front: it determines schema and how the data is shown in the UI, and **cannot be changed** after creation (changing it triggers a replacement, which deletes the data).
+- [Monitor](https://v2.alchemy.run/providers/axiom/monitor) — An Axiom monitor — a scheduled APL/MPL query that evaluates on a fixed cadence and fires alerts via {@link Notifier notifiers} when its condition is met.
+- [Notifier](https://v2.alchemy.run/providers/axiom/notifier) — An Axiom notifier — an alert destination (Slack, email, PagerDuty, Opsgenie, Discord, Microsoft Teams, generic webhook, or a fully custom webhook with templated body/headers) that {@link Monitor monitors} target via `notifierIds`. Exactly one channel under `properties` should be set.
+- [View](https://v2.alchemy.run/providers/axiom/view) — An Axiom saved view — a named, shareable APL query. Useful for building starter dashboards, providing canned \"open in Axiom\" links from your app, or pinning common investigations the team revisits.
+- [VirtualField](https://v2.alchemy.run/providers/axiom/virtualfield) — An Axiom virtual field — a saved APL expression that appears as a derived column on a dataset at query time. Use these to standardise common computations (status classes, latency buckets, parsed JSON paths) so dashboards and monitors don't have to redefine them.
+
+### Build
+
+- [Command](https://v2.alchemy.run/providers/build/command) — A Build resource that runs a shell command and produces an output asset. Input files are hashed using globs to avoid redundant rebuilds.
+
+### Cloudflare
+
+- [AccountApiToken](https://v2.alchemy.run/providers/cloudflare/accountapitoken) — A Cloudflare account-owned API token (`POST /accounts/{account_id}/tokens`).
+- [AiGateway](https://v2.alchemy.run/providers/cloudflare/aigateway) — A Cloudflare AI Gateway for observability, caching, rate limiting, and governance across AI provider requests.
+- [AiGatewayBinding](https://v2.alchemy.run/providers/cloudflare/aigatewaybinding) — Binding service that turns an {@link AiGatewayResource} resource into a typed {@link AiGatewayClient} for Worker runtime code. Wraps the Cloudflare AI Gateway runtime binding so each operation returns an Effect tagged with {@link AiGatewayError}, exposes the raw Workers AI handle for `ai.run(...)`, and provides a `model(options)` factory that produces an `effect/unstable/ai` `LanguageModel` `Layer`.
+- [AnalyticsEngineDataset](https://v2.alchemy.run/providers/cloudflare/analyticsenginedataset) — A Cloudflare Workers Analytics Engine dataset binding.
+- [BrowserRendering](https://v2.alchemy.run/providers/cloudflare/browserrendering) — A Cloudflare Browser Rendering binding for launching headless browser sessions from Workers via `@cloudflare/puppeteer`.
+- [Container](https://v2.alchemy.run/providers/cloudflare/container) — A Cloudflare Container that runs a long-lived process alongside a Durable Object.
+- [D1Database](https://v2.alchemy.run/providers/cloudflare/d1database) — A Cloudflare D1 serverless SQL database built on SQLite.
+- [DurableObjectNamespace](https://v2.alchemy.run/providers/cloudflare/durableobjectnamespace) — A Cloudflare Durable Object namespace that manages globally unique, stateful instances with WebSocket hibernation support.
+- [DynamicWorkerLoader](https://v2.alchemy.run/providers/cloudflare/dynamicworkerloader) — Load and run ephemeral Workers at runtime from inline JavaScript modules.
+- [EmailAddress](https://v2.alchemy.run/providers/cloudflare/emailaddress) — A verified destination email address on the account.
+- [EmailRouting](https://v2.alchemy.run/providers/cloudflare/emailrouting) — Enables Cloudflare Email Routing on a zone. This is the prerequisite for receiving mail at any address on the domain and for sending email from a Worker via `send_email` bindings.
+- [EmailRule](https://v2.alchemy.run/providers/cloudflare/emailrule) — A Cloudflare Email Routing rule.
+- [Hyperdrive](https://v2.alchemy.run/providers/cloudflare/hyperdrive) — A Cloudflare Hyperdrive configuration.
+- [HyperdriveBinding](https://v2.alchemy.run/providers/cloudflare/hyperdrivebinding) — A typed accessor for a Cloudflare Hyperdrive runtime binding inside a Worker. Provides the same shape as the raw `Hyperdrive` runtime object (connection string, host, port, user, password, database) plus a `raw` escape hatch for libraries that want direct access.
+- [KVNamespace](https://v2.alchemy.run/providers/cloudflare/kvnamespace) — A Cloudflare Workers KV namespace for key-value storage at the edge.
+- [Queue](https://v2.alchemy.run/providers/cloudflare/queue) — A Cloudflare Queue for reliable message passing between Workers.
+- [QueueConsumer](https://v2.alchemy.run/providers/cloudflare/queueconsumer) — A Cloudflare Queue Consumer that processes messages from a Queue.
+- [R2Bucket](https://v2.alchemy.run/providers/cloudflare/r2bucket) — A Cloudflare R2 object storage bucket with S3-compatible API.
+- [RpcDurableObjectNamespace](https://v2.alchemy.run/providers/cloudflare/rpcdurableobjectnamespace) — `RpcDurableObjectNamespace` is sugar over {@link DurableObjectNamespace} for Durable Objects whose surface is a typed Effect `RpcGroup`. The DO serves an `RpcServer.toHttpEffect(group)` on its own `fetch`, and consumers see `namespace.getByName(id)` as a typed `RpcClient` directly — no manual client wiring.
+- [RpcWorker](https://v2.alchemy.run/providers/cloudflare/rpcworker) — `RpcWorker` is a thin sugar over {@link Worker} for the common case where a worker's entire `fetch` surface is a typed Effect `RpcGroup`. It takes the rpc `schema` directly in props alongside `main`, and accepts an init Effect that returns the already-piped `RpcServer.toHttpEffect(...)`-producing Effect (no `{ fetch }` wrapper) — the wrapper plugs it into the worker's `fetch` for you.
+- [Secret](https://v2.alchemy.run/providers/cloudflare/secret) — A single secret stored inside a Cloudflare Secrets Store.
+- [SecretsStore](https://v2.alchemy.run/providers/cloudflare/secretsstore) — A Cloudflare Secrets Store, a per-account container for secrets that can be bound into Workers with full redaction and audit support.
+- [SendEmail](https://v2.alchemy.run/providers/cloudflare/sendemail) — A Cloudflare Workers `send_email` binding descriptor.
+- [SendEmailBinding](https://v2.alchemy.run/providers/cloudflare/sendemailbinding) — A typed runtime accessor for a Cloudflare `send_email` Worker binding.
+- [StaticSite](https://v2.alchemy.run/providers/cloudflare/staticsite) — A Cloudflare Worker that serves static assets built by a shell command.
+- [Tunnel](https://v2.alchemy.run/providers/cloudflare/tunnel) — A Cloudflare Tunnel that establishes a secure connection from your origin to Cloudflare's edge.
+- [UserApiToken](https://v2.alchemy.run/providers/cloudflare/userapitoken) — A Cloudflare user-owned API token (`POST /user/tokens`).
+- [VectorizeIndex](https://v2.alchemy.run/providers/cloudflare/vectorizeindex) — A Cloudflare Vectorize index for storing and querying vector embeddings.
+- [VectorizeMetadataIndex](https://v2.alchemy.run/providers/cloudflare/vectorizemetadataindex) — A metadata index on a Cloudflare Vectorize index.
+- [Vite](https://v2.alchemy.run/providers/cloudflare/vite) — A Cloudflare Worker deployed from a Vite project.
+- [VpcService](https://v2.alchemy.run/providers/cloudflare/vpcservice) — A Cloudflare VPC service that exposes a private host (IP or hostname) reachable through a Cloudflare Tunnel for Workers VPC.
+- [Worker](https://v2.alchemy.run/providers/cloudflare/worker) — A Cloudflare Worker host with deploy-time binding support and runtime export collection.
+- [Workflow](https://v2.alchemy.run/providers/cloudflare/workflow) — Service that carries the current workflow event payload. `yield* WorkflowEvent` inside a workflow body to access it.
+- [ZarazConfig](https://v2.alchemy.run/providers/cloudflare/zarazconfig) — A Cloudflare Zaraz zone configuration.
+
+### Drizzle
+
+- [Postgres](https://v2.alchemy.run/providers/drizzle/postgres) — Open a Drizzle/Postgres database from a connection URL using the `drizzle-orm/effect-postgres` integration.
+- [Schema](https://v2.alchemy.run/providers/drizzle/schema) — A Drizzle schema managed as an Alchemy resource.
+
+### GitHub
+
+- [Comment](https://v2.alchemy.run/providers/github/comment) — A GitHub issue or pull request comment.
+- [Secret](https://v2.alchemy.run/providers/github/secret) — A GitHub Actions repository or environment secret.
+- [Variable](https://v2.alchemy.run/providers/github/variable) — A GitHub Actions repository variable.
+
+### Neon
+
+- [Branch](https://v2.alchemy.run/providers/neon/branch) — A branch of a Neon project.
+- [Project](https://v2.alchemy.run/providers/neon/project) — A Neon serverless Postgres project.
+
+### Planetscale
+
+- [MySQLBranch](https://v2.alchemy.run/providers/planetscale/mysql/mysqlbranch) — A PlanetScale branch of a {@link MySQLDatabase}. For PostgreSQL branches use {@link PostgresBranch} instead.
+- [MySQLDatabase](https://v2.alchemy.run/providers/planetscale/mysql/mysqldatabase) — A MySQL PlanetScale database (powered by Vitess). For PostgreSQL use {@link PostgresDatabase} instead.
+- [MySQLPassword](https://v2.alchemy.run/providers/planetscale/mysql/mysqlpassword) — A PlanetScale password for accessing a MySQL database branch.
+- [PostgresBranch](https://v2.alchemy.run/providers/planetscale/postgres/postgresbranch) — A PlanetScale branch of a {@link PostgresDatabase}. For MySQL branches use {@link MySQLBranch} instead.
+- [PostgresDatabase](https://v2.alchemy.run/providers/planetscale/postgres/postgresdatabase) — A PostgreSQL PlanetScale database. For MySQL, use {@link MySQLDatabase} instead.
+- [PostgresDefaultRole](https://v2.alchemy.run/providers/planetscale/postgres/postgresdefaultrole) — The default PlanetScale PostgreSQL role for a database branch.
+- [PostgresRole](https://v2.alchemy.run/providers/planetscale/postgres/postgresrole) — A PlanetScale role for accessing a PostgreSQL database branch.

--- a/website/scripts/generate-llms-txt.ts
+++ b/website/scripts/generate-llms-txt.ts
@@ -27,6 +27,8 @@ interface Page {
   title: string;
   description: string;
   draft: boolean;
+  /** `sidebar.order` from frontmatter; `Infinity` when unset. */
+  order: number;
 }
 
 interface Section {
@@ -65,56 +67,19 @@ const SECTIONS: Section[] = [
     heading: "Tutorial — Cloudflare add-ons",
     intro:
       "Standalone tutorials that extend the main tutorial's Worker with a specific Cloudflare feature. Pick the ones that match your use case.",
-    pages: {
-      slugs: [
-        "tutorial/cloudflare/durable-objects",
-        "tutorial/cloudflare/hibernatable-websockets",
-        "tutorial/cloudflare/containers",
-        "tutorial/cloudflare/workflows",
-        "tutorial/cloudflare/vite-spa",
-        "tutorial/cloudflare/ai-gateway",
-      ],
-    },
+    pages: { directory: "tutorial/cloudflare" },
   },
   {
     heading: "Tutorial — AWS",
     intro:
       "End-to-end AWS tutorials. Read the Lambda page first; the others bind storage and event sources to that Lambda.",
-    pages: {
-      slugs: [
-        "tutorial/aws/lambda",
-        "tutorial/aws/s3",
-        "tutorial/aws/s3-events",
-        "tutorial/aws/sqs",
-        "tutorial/aws/kinesis",
-        "tutorial/aws/dynamodb",
-        "tutorial/aws/dynamodb-streams",
-      ],
-    },
+    pages: { directory: "tutorial/aws" },
   },
   {
     heading: "Concepts — the mental model",
     intro:
       "Reference pages explaining what each primitive means and how they fit together. Read these when something in a tutorial feels magical, or before designing a new Stack.",
-    pages: {
-      slugs: [
-        "concepts/resource",
-        "concepts/provider",
-        "concepts/resource-lifecycle",
-        "concepts/stack",
-        "concepts/stages",
-        "concepts/phases",
-        "concepts/platform",
-        "concepts/binding",
-        "concepts/outputs",
-        "concepts/layers",
-        "concepts/state-store",
-        "concepts/profiles",
-        "concepts/local-development",
-        "concepts/observability",
-        "concepts/testing",
-      ],
-    },
+    pages: { directory: "concepts" },
   },
   {
     heading: "Guides — task-oriented",
@@ -124,15 +89,43 @@ const SECTIONS: Section[] = [
   },
 ];
 
-const PROVIDERS_SECTION = `## Providers — auto-generated API reference
+const PROVIDERS_INTRO = `Per-resource API reference, generated from JSDoc on the source \`.ts\` files via \`bun generate:api-reference\`. Each page documents the resource's input properties (with types, defaults, and constraints), output attributes, and Quick Reference / Examples sections derived from \`@section\` / \`@example\` JSDoc tags. Grouped by cloud below.`;
 
-Per-resource API pages live under \`${siteUrl}/providers/{Cloud}/{Resource}\` (e.g. \`/providers/AWS/Bucket\`, \`/providers/Cloudflare/Worker\`). They are generated from JSDoc on the source \`.ts\` files via \`bun generate:api-reference\` and are not checked into git, so this index does not enumerate them. Each page documents:
+/**
+ * Enumerates every generated provider page under `providers/{Cloud}/...`,
+ * grouped by cloud. These pages are produced by `build:reference` (which runs
+ * before this script in the build), so they exist on disk at generation time
+ * even though they are gitignored.
+ */
+async function renderProvidersSection(): Promise<string> {
+  const providersDir = path.join(docsDir, "providers");
+  let clouds: string[];
+  try {
+    const entries = await readdir(providersDir, { withFileTypes: true });
+    clouds = entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+  } catch (err: any) {
+    if (err?.code === "ENOENT") return `## Providers\n\n${PROVIDERS_INTRO}`;
+    throw err;
+  }
 
-- The resource's input properties (props) with types, defaults, and constraints.
-- The resource's output attributes.
-- Quick Reference and Examples sections derived from \`@section\` / \`@example\` JSDoc tags.
-
-To find a specific resource, browse the Providers section in the sidebar at ${siteUrl}, or read the source JSDoc at \`packages/alchemy/src/{Cloud}/{Service}/{Resource}.ts\` in [the repository](https://github.com/alchemy-run/alchemy-effect).`;
+  const blocks: string[] = [`## Providers`, PROVIDERS_INTRO];
+  for (const cloud of clouds) {
+    const slugs = await listSlugs(`providers/${cloud}`);
+    const pages = (await Promise.all(slugs.map(loadPage)))
+      .filter((p) => !p.draft)
+      // Starlight serves provider routes lowercased (e.g. the CamelCase source
+      // `providers/AWS/S3/Bucket.md` is reachable at `/providers/aws/s3/bucket`).
+      .map((p) => ({ ...p, href: p.href.toLowerCase() }))
+      .sort((a, b) => a.title.localeCompare(b.title));
+    if (pages.length === 0) continue;
+    blocks.push(`### ${cloud}`);
+    blocks.push(pages.map(renderPage).join("\n"));
+  }
+  return blocks.join("\n\n");
+}
 
 const HEADER = `# Alchemy
 
@@ -162,6 +155,30 @@ function parseFrontmatter(source: string): Record<string, string> {
   return out;
 }
 
+/**
+ * Extracts the nested `sidebar.order` value from a frontmatter block.
+ * Starlight uses this to order autogenerated sidebar groups; we mirror it
+ * so llms.txt lists pages in the same order the sidebar shows them.
+ * Returns `Infinity` when unset, so unordered pages sort after ordered ones.
+ */
+function parseSidebarOrder(source: string): number {
+  if (!source.startsWith("---")) return Number.POSITIVE_INFINITY;
+  const end = source.indexOf("\n---", 3);
+  if (end === -1) return Number.POSITIVE_INFINITY;
+  const block = source.slice(3, end);
+  const lines = block.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^sidebar:\s*$/.test(lines[i])) continue;
+    for (let j = i + 1; j < lines.length; j++) {
+      if (/^\S/.test(lines[j])) break; // dedented out of the sidebar block
+      const m = lines[j].match(/^\s+order:\s*(-?[\d.]+)\s*$/);
+      if (m) return Number.parseFloat(m[1]);
+    }
+    break;
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
 async function loadPage(slug: string): Promise<Page> {
   const candidates = [`${slug}.mdx`, `${slug}.md`];
   for (const rel of candidates) {
@@ -180,6 +197,7 @@ async function loadPage(slug: string): Promise<Page> {
         title,
         description,
         draft: fm.draft === "true" || (fm.draft as unknown as boolean) === true,
+        order: parseSidebarOrder(source),
       };
     } catch (err: any) {
       if (err?.code !== "ENOENT") throw err;
@@ -196,6 +214,11 @@ async function listSlugs(
   const entries = await readdir(dir, { withFileTypes: true });
   const slugs: string[] = [];
   for (const entry of entries) {
+    const rel = `${directory}/${entry.name}`;
+    if (entry.isDirectory()) {
+      slugs.push(...(await listSlugs(rel, exclude)));
+      continue;
+    }
     if (!entry.isFile()) continue;
     const ext = path.extname(entry.name);
     if (ext !== ".md" && ext !== ".mdx") continue;
@@ -205,6 +228,11 @@ async function listSlugs(
   }
   slugs.sort();
   return slugs;
+}
+
+function byOrderThenTitle(a: Page, b: Page): number {
+  if (a.order !== b.order) return a.order - b.order;
+  return a.title.localeCompare(b.title);
 }
 
 function renderPage(page: Page): string {
@@ -217,6 +245,7 @@ async function main() {
   const parts: string[] = [HEADER];
 
   for (const section of SECTIONS) {
+    const isDirectory = !("slugs" in section.pages);
     const slugs =
       "slugs" in section.pages
         ? section.pages.slugs
@@ -224,13 +253,16 @@ async function main() {
     const pages = (await Promise.all(slugs.map(loadPage))).filter(
       (p) => !p.draft,
     );
+    // Directory sections mirror the sidebar's `sidebar.order` ordering; slug
+    // sections keep the curated order they were declared in.
+    if (isDirectory) pages.sort(byOrderThenTitle);
 
     parts.push(`## ${section.heading}`);
     if (section.intro) parts.push(section.intro);
     parts.push(pages.map(renderPage).join("\n"));
   }
 
-  parts.push(PROVIDERS_SECTION);
+  parts.push(await renderProvidersSection());
 
   const body = parts.join("\n\n") + "\n";
   await writeFile(outFile, body, "utf8");

--- a/website/src/worker.ts
+++ b/website/src/worker.ts
@@ -34,11 +34,25 @@ export default {
     if (request.method === "GET" && prefersMarkdown(request)) {
       const mdUrl = toMarkdownUrl(new URL(request.url)).toString();
       const res = await env.ASSETS.fetch(new Request(mdUrl, request));
-      if (res.status !== 404) return res;
+      if (res.status !== 404) return withUtf8Charset(res);
     }
     const res = await env.ASSETS.fetch(request);
-    return rewriteCanonicalHost(request, res);
+    return withUtf8Charset(rewriteCanonicalHost(request, res));
   },
+};
+
+/**
+ * Astro's static asset server labels `.txt`/`.md` as `text/plain` and
+ * `text/markdown` with no charset. UTF-8 bytes (em dashes, arrows in our docs
+ * and `llms.txt`) then get decoded as latin-1 by browsers and agents, showing
+ * up as mojibake (`â€"`). Stamp `charset=utf-8` on text responses that omit it.
+ */
+const withUtf8Charset = (res: Response): Response => {
+  const ct = res.headers.get("content-type");
+  if (!ct || !ct.startsWith("text/") || /charset=/i.test(ct)) return res;
+  const next = new Response(res.body, res);
+  next.headers.set("content-type", `${ct}; charset=utf-8`);
+  return next;
 };
 
 const rewriteCanonicalHost = (request: Request, res: Response): Response => {

--- a/website/src/worker.ts
+++ b/website/src/worker.ts
@@ -34,7 +34,11 @@ export default {
     if (request.method === "GET" && prefersMarkdown(request)) {
       const mdUrl = toMarkdownUrl(new URL(request.url)).toString();
       const res = await env.ASSETS.fetch(new Request(mdUrl, request));
-      if (res.status !== 404) return withUtf8Charset(res);
+      // Astro's asset server labels `.md` as `application/octet-stream`, which
+      // agents treat as a binary download instead of rendering. Force the
+      // correct text type + charset since this branch only ever serves markdown.
+      if (res.status !== 404)
+        return withContentType(res, "text/markdown; charset=utf-8");
     }
     const res = await env.ASSETS.fetch(request);
     return withUtf8Charset(rewriteCanonicalHost(request, res));
@@ -42,16 +46,20 @@ export default {
 };
 
 /**
- * Astro's static asset server labels `.txt`/`.md` as `text/plain` and
- * `text/markdown` with no charset. UTF-8 bytes (em dashes, arrows in our docs
- * and `llms.txt`) then get decoded as latin-1 by browsers and agents, showing
- * up as mojibake (`â€"`). Stamp `charset=utf-8` on text responses that omit it.
+ * Astro's static asset server labels `.txt` as `text/plain` with no charset.
+ * UTF-8 bytes (em dashes, arrows in our docs and `llms.txt`) then get decoded
+ * as latin-1 by browsers and agents, showing up as mojibake (`â€"`). Stamp
+ * `charset=utf-8` on text responses that omit it.
  */
 const withUtf8Charset = (res: Response): Response => {
   const ct = res.headers.get("content-type");
   if (!ct || !ct.startsWith("text/") || /charset=/i.test(ct)) return res;
+  return withContentType(res, `${ct}; charset=utf-8`);
+};
+
+const withContentType = (res: Response, contentType: string): Response => {
   const next = new Response(res.body, res);
-  next.headers.set("content-type", `${ct}; charset=utf-8`);
+  next.headers.set("content-type", contentType);
   return next;
 };
 


### PR DESCRIPTION
`llms.txt` only listed a curated subset of pages and omitted the Providers section entirely, so it drifted from the sidebar. It was also served as `text/plain` with no charset, so UTF-8 em dashes/arrows decoded as latin-1 mojibake (`â€"`) in agents and browsers.

### Exhaustive index

`generate-llms-txt.ts` now enumerates directories (sorted by `sidebar.order`, matching the sidebar) instead of hand-maintained slug lists, and lists all 180 provider pages grouped by cloud.

```diff
-  pages: { slugs: ["concepts/resource", "concepts/provider", ...curated 15] },
+  pages: { directory: "concepts" },
```

```diff
-const PROVIDERS_SECTION = `## Providers — ...prose, no enumeration...`;
+async function renderProvidersSection() { /* walks providers/{Cloud}/... */ }
```

Provider hrefs are lowercased since Starlight serves `providers/AWS/S3/Bucket.md` at `/providers/aws/s3/bucket`.

Result: ~70 → 241 doc links.

### UTF-8 charset

Astro serves `.txt` as `text/plain` with no charset, so UTF-8 bytes decode as latin-1 mojibake. `withUtf8Charset` stamps `charset=utf-8` on any `text/*` response missing one (fixes `llms.txt`).

The agent-facing markdown branch had a related issue: Astro labels `.md` as `application/octet-stream`, so agents got a binary download instead of rendered markdown. That branch only ever serves `.md`, so it now forces `text/markdown; charset=utf-8`.
