### PR TITLE
docs: serve provider raw markdown at lowercased URLs

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -28,9 +28,10 @@ function copyMarkdownSources() {
 
         /**
          * @param {string} srcDir
-         * @param {string} relTo
+         * @param {{ lowercase?: boolean }} [opts]
+         * @param {string} [relTo]
          */
-        async function walk(srcDir, relTo = srcDir) {
+        async function walk(srcDir, opts = {}, relTo = srcDir) {
           let entries;
           try {
             entries = await fs.readdir(srcDir, { withFileTypes: true });
@@ -40,29 +41,34 @@ function copyMarkdownSources() {
           for (const entry of entries) {
             const full = path.join(srcDir, entry.name);
             if (entry.isDirectory()) {
-              await walk(full, relTo);
+              await walk(full, opts, relTo);
               continue;
             }
             if (!entry.isFile()) continue;
             const ext = path.extname(entry.name).toLowerCase();
             if (ext !== ".md" && ext !== ".mdx") continue;
-            const rel = path.relative(relTo, full);
-            const target = path.join(
-              outDir,
-              rel.slice(0, rel.length - ext.length) + ".md",
-            );
+            let rel = path.relative(relTo, full);
+            rel = rel.slice(0, rel.length - ext.length) + ".md";
+            // Starlight lowercases doc URLs (e.g. CamelCase source
+            // `providers/AWS/S3/Bucket.md` is served at `/providers/aws/s3/bucket`),
+            // so the raw-markdown copy must live at the lowercased path or the
+            // worker's `/providers/aws/s3/bucket.md` lookup 404s into HTML.
+            if (opts.lowercase) rel = rel.toLowerCase();
+            const target = path.join(outDir, rel);
             await fs.mkdir(path.dirname(target), { recursive: true });
             await fs.copyFile(full, target);
           }
         }
 
         // Docs (Starlight content collection) — preserves nested layout under
-        // /content/docs/ → /<path>.md
+        // /content/docs/ → /<path>.md, lowercased to match Starlight's URLs.
         await walk(
           fileURLToPath(new URL("./src/content/docs/", import.meta.url)),
+          { lowercase: true },
         );
         // Marketing pages (top-level Astro pages) — exposes /<page>.md so
-        // agents can fetch raw MDX via the worker's content negotiation.
+        // agents can fetch raw MDX via the worker's content negotiation. Astro
+        // page routing preserves case, so don't lowercase these.
         await walk(fileURLToPath(new URL("./src/pages/", import.meta.url)));
       },
     },


### PR DESCRIPTION
Agents requesting markdown of a **provider** page got HTML instead of the raw `.md`.

Starlight lowercases doc URLs (`providers/AWS/S3/Bucket.md` → `/providers/aws/s3/bucket`), but `copyMarkdownSources` copied the raw markdown at its CamelCase source path. The worker's content-negotiation lookup is for the lowercased URL + `.md`, so it 404'd and fell back to HTML:

```
served URL:        /providers/aws/s3/bucket
worker requests:   /providers/aws/s3/bucket.md   (404 — case mismatch)
copied file was:   /providers/AWS/S3/Bucket.md
```

Lowercase the copied doc paths so they match the served URLs:

```diff
+ if (opts.lowercase) rel = rel.toLowerCase();
  const target = path.join(outDir, rel);
```

Docs (Starlight, lowercased URLs) pass `{ lowercase: true }`; marketing pages under `src/pages` keep Astro's case-preserving routing.

Verified by running the exact `walk` logic over `src/content/docs`: all 255 `.md` files copy to fully-lowercased paths (0 uppercase remaining), and `toMarkdownUrl(servedURL)` lands on each copied file for providers and non-providers alike.
