### PR TITLE
refactor: rename Init phase to Construct, Action init to constructor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,7 +420,7 @@ export class GetItem extends Binding.Service<
 
 Rules:
 
-- **Outer Effect** (the `bind(resource)` setup) runs at the Function's init phase. It does NOT require `RuntimeContext`.
+- **Outer Effect** (the `bind(resource)` setup) runs during the Function's Construct phase. It does NOT require `RuntimeContext`.
 - **Inner Effect** (the actual SDK invocation) only makes sense inside a running Function. It MUST require `RuntimeContext`.
 - Resolve cloud-environment services (`WorkerEnvironment`, AWS SDK clients, etc.) once during Layer construction and close over them. Do NOT leak `WorkerEnvironment` / `Lambda.FunctionEnvironment` onto the runtime callable — that couples downstream service code to a specific cloud and breaks Layer encapsulation. The Function/Worker runtime satisfies `RuntimeContext` automatically.
 - The implementation can return `Effect.Effect<A, E>` without explicitly providing `RuntimeContext` (it's contravariant in `R`); just declare it on the interface.

--- a/examples/cloudflare-dev/src/NotifyWorkflow.ts
+++ b/examples/cloudflare-dev/src/NotifyWorkflow.ts
@@ -6,14 +6,14 @@ import { KV } from "./KV.ts";
 
 /**
  * Hard-coded value the integ test asserts on to prove the secret was
- * bound at plantime and read at runtime through the `Redacted` accessor.
+ * bound during Construct and read at runtime through the `Redacted` accessor.
  */
 export const WORKFLOW_SECRET_VALUE = "wf-secret-abc123";
 
 export default class NotifyWorkflow extends Cloudflare.Workflow<NotifyWorkflow>()(
   "Notifier",
   Effect.gen(function* () {
-    // Bind a `secret_text` on the workflow at plantime. Using a literal
+    // Bind a `secret_text` on the workflow during Construct. Using a literal
     // (instead of `Config.redacted("WORKFLOW_SECRET")`) keeps the integ
     // test self-contained — no `.env` setup required.
     const secret = yield* Config.redacted("WORKFLOW_SECRET").pipe(

--- a/examples/cloudflare-dev/test/integ.test.ts
+++ b/examples/cloudflare-dev/test/integ.test.ts
@@ -138,7 +138,7 @@ interface WorkflowStatus {
 /**
  * Start a `NotifyWorkflow` instance through `workerUrl` and poll its status
  * until the instance reaches a terminal state. Asserts the workflow ran the
- * KV roundtrip task (`Processed: <message>`) and resolved the plantime-bound
+ * KV roundtrip task (`Processed: <message>`) and resolved the Construct-bound
  * `Alchemy.Secret` at runtime (`output.secret === WORKFLOW_SECRET_VALUE`).
  */
 const exerciseWorkflow = (workerUrl: string, label: string) =>

--- a/examples/cloudflare-worker/src/Api.ts
+++ b/examples/cloudflare-worker/src/Api.ts
@@ -355,7 +355,7 @@ export default class Api extends Cloudflare.Worker<Api>()(
         //
         // Producer side: `Cloudflare.QueueBinding`. Consumer side:
         // `Cloudflare.messages(Queue).subscribe(...)` registered in
-        // the init phase (above), with `QueueEventSourceLive` on the
+        // the construct phase (above), with `QueueEventSourceLive` on the
         // worker layer.
         // AI Gateway smoke test — POST /ai with { prompt }.
         //

--- a/examples/cloudflare-worker/src/NotifyWorkflow.ts
+++ b/examples/cloudflare-worker/src/NotifyWorkflow.ts
@@ -7,7 +7,7 @@ import Room from "./Room.ts";
 
 /**
  * Hard-coded value the integ test asserts on to prove the secret was
- * bound at plantime and read at runtime through the `Redacted` accessor.
+ * bound during Construct and read at runtime through the `Redacted` accessor.
  */
 export const WORKFLOW_SECRET_VALUE = Redacted.make("wf-secret-abc123");
 

--- a/examples/cloudflare-worker/src/SecondaryApi.ts
+++ b/examples/cloudflare-worker/src/SecondaryApi.ts
@@ -4,7 +4,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import Agent from "./Agent.ts";
 
 // A second Worker that binds the same `Agent` Durable Object as `Api`. Each
-// `yield* Agent` runs the DO's outer init, which calls
+// `yield* Agent` runs the DO's Construct phase, which calls
 // `Cloudflare.Container.bind(Sandbox)` and pushes a binding onto the Sandbox
 // ContainerApplication carrying the Agent namespace. With two Workers binding
 // the same DO, the Sandbox ends up with two bindings that share a single

--- a/examples/cloudflare-worker/test/integ.test.ts
+++ b/examples/cloudflare-worker/test/integ.test.ts
@@ -38,7 +38,7 @@ test(
  *
  * The stack now includes two Workers (`Api` and `SecondaryApi`) that both
  * bind the same `Agent` Durable Object, which in turn binds the `Sandbox`
- * Container. Each `yield* Agent` runs the DO's outer init, calling
+ * Container. Each `yield* Agent` runs the DO's Construct phase, calling
  * `Cloudflare.Container.bind(Sandbox)` once per Worker, so the Sandbox
  * ContainerApplication receives two bindings sharing one `namespaceId`.
  *
@@ -126,7 +126,7 @@ test(
     expect(lastStatus!.status).toBe("complete");
     expect(lastStatus!.error).toBeFalsy();
 
-    // Prove the `Alchemy.Secret(...)` bound at plantime made it all the
+    // Prove the `Alchemy.Secret(...)` bound during Construct made it all the
     // way through to the workflow body's runtime read. The workflow body
     // unwraps `Redacted.value(secret)` and embeds it in the returned
     // `processed` payload.

--- a/packages/alchemy/src/AWS/DynamoDB/Table.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/Table.ts
@@ -166,13 +166,13 @@ export interface Table extends Resource<
  * ```
  *
  * @section Runtime Operations
- * Bind DynamoDB operations in the init phase and use them in runtime
+ * Bind DynamoDB operations in the construct phase and use them in runtime
  * handlers. Bindings inject the table name and grant scoped IAM
  * permissions automatically.
  *
  * @example Read and write items
  * ```typescript
- * // init
+ * // construct
  * const getItem = yield* DynamoDB.GetItem.bind(table);
  * const putItem = yield* DynamoDB.PutItem.bind(table);
  *
@@ -197,7 +197,7 @@ export interface Table extends Resource<
  *
  * @example Process table changes
  * ```typescript
- * // init
+ * // construct
  * yield* DynamoDB.streams(table, {
  *   StreamViewType: "NEW_AND_OLD_IMAGES",
  * }).process(

--- a/packages/alchemy/src/AWS/EC2/hosted.ts
+++ b/packages/alchemy/src/AWS/EC2/hosted.ts
@@ -70,7 +70,7 @@ export interface Ec2HostedCleanupState {
 }
 
 /**
- * Deploy-time / plan-time host context for EC2-backed platforms that bundle a
+ * Deploy-time / Construct-phase host context for EC2-backed platforms that bundle a
  * long-lived program (`exports.program`) and collect background work via `run`.
  */
 export interface Ec2HostRuntimeContext extends ProcessContext {

--- a/packages/alchemy/src/AWS/Kinesis/Stream.ts
+++ b/packages/alchemy/src/AWS/Kinesis/Stream.ts
@@ -200,12 +200,12 @@ export interface Stream extends Resource<
  * ```
  *
  * @section Runtime Producers
- * Bind producer operations in the init phase and use them in runtime
+ * Bind producer operations in the construct phase and use them in runtime
  * handlers.
  *
  * @example Put a record from a handler
  * ```typescript
- * // init
+ * // construct
  * const putRecord = yield* Kinesis.PutRecord.bind(stream);
  *
  * return {
@@ -226,7 +226,7 @@ export interface Stream extends Resource<
  *
  * @example Process stream records
  * ```typescript
- * // init
+ * // construct
  * yield* Kinesis.records(stream).process(
  *   Effect.fn(function* (record) {
  *     const data = new TextDecoder().decode(record.data);

--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -214,7 +214,7 @@ export type FunctionShape = Main<FunctionServices>;
  *   "ApiFunction",
  *   { main: import.meta.filename, url: true },
  *   Effect.gen(function* () {
- *     // init: bind resources
+ *     // construct: bind resources
  *     const getItem = yield* DynamoDB.GetItem.bind(table);
  *
  *     return {
@@ -252,12 +252,12 @@ export type FunctionShape = Main<FunctionServices>;
  * ```
  *
  * @section S3 Bindings
- * Bind S3 operations in the init phase to give the function IAM
+ * Bind S3 operations in the construct phase to give the function IAM
  * permissions and inject the bucket name as an environment variable.
  *
  * @example Read and write S3 objects
  * ```typescript
- * // init
+ * // construct
  * const getObject = yield* S3.GetObject.bind(bucket);
  * const putObject = yield* S3.PutObject.bind(bucket);
  *
@@ -272,12 +272,12 @@ export type FunctionShape = Main<FunctionServices>;
  * ```
  *
  * @section DynamoDB Bindings
- * Bind DynamoDB operations in the init phase to grant table-scoped
+ * Bind DynamoDB operations in the construct phase to grant table-scoped
  * IAM permissions.
  *
  * @example Get and put items
  * ```typescript
- * // init
+ * // construct
  * const getItem = yield* DynamoDB.GetItem.bind(table);
  * const putItem = yield* DynamoDB.PutItem.bind(table);
  *
@@ -292,11 +292,11 @@ export type FunctionShape = Main<FunctionServices>;
  * ```
  *
  * @section SQS Bindings
- * Bind SQS operations in the init phase to send messages to a queue.
+ * Bind SQS operations in the construct phase to send messages to a queue.
  *
  * @example Send a message
  * ```typescript
- * // init
+ * // construct
  * const sendMessage = yield* SQS.SendMessage.bind(queue);
  *
  * return {
@@ -311,12 +311,12 @@ export type FunctionShape = Main<FunctionServices>;
  * ```
  *
  * @section SNS Bindings
- * Bind SNS operations in the init phase to publish messages to a
+ * Bind SNS operations in the construct phase to publish messages to a
  * topic.
  *
  * @example Publish a notification
  * ```typescript
- * // init
+ * // construct
  * const publish = yield* SNS.Publish.bind(topic);
  *
  * return {
@@ -332,12 +332,12 @@ export type FunctionShape = Main<FunctionServices>;
  * ```
  *
  * @section Kinesis Bindings
- * Bind Kinesis operations in the init phase to put records into a
+ * Bind Kinesis operations in the construct phase to put records into a
  * stream.
  *
  * @example Put a record
  * ```typescript
- * // init
+ * // construct
  * const putRecord = yield* Kinesis.PutRecord.bind(stream);
  *
  * return {

--- a/packages/alchemy/src/AWS/S3/Bucket.ts
+++ b/packages/alchemy/src/AWS/S3/Bucket.ts
@@ -111,13 +111,13 @@ export interface Bucket extends Resource<
  * ```
  *
  * @section Runtime Operations
- * Bind S3 operations in the init phase and use them in runtime
+ * Bind S3 operations in the construct phase and use them in runtime
  * handlers. Bindings inject the bucket name and grant scoped IAM
  * permissions automatically.
  *
  * @example Read and write objects
  * ```typescript
- * // init
+ * // construct
  * const getObject = yield* S3.GetObject.bind(bucket);
  * const putObject = yield* S3.PutObject.bind(bucket);
  *
@@ -137,17 +137,17 @@ export interface Bucket extends Resource<
  *
  * @example Delete an object
  * ```typescript
- * // init
+ * // construct
  * const deleteObject = yield* S3.DeleteObject.bind(bucket);
  * ```
  *
  * @section Event Notifications
- * Subscribe to bucket events from the init phase. The subscription
+ * Subscribe to bucket events from the construct phase. The subscription
  * and Lambda invoke permissions are created automatically.
  *
  * @example Process object creation events
  * ```typescript
- * // init
+ * // construct
  * yield* S3.notifications(bucket, {
  *   events: ["s3:ObjectCreated:*"],
  * }).subscribe((stream) =>

--- a/packages/alchemy/src/AWS/SNS/Topic.ts
+++ b/packages/alchemy/src/AWS/SNS/Topic.ts
@@ -93,12 +93,12 @@ export interface Topic extends Resource<
  * ```
  *
  * @section Runtime Publishing
- * Bind publish operations in the init phase and use them in runtime
+ * Bind publish operations in the construct phase and use them in runtime
  * handlers.
  *
  * @example Publish from a handler
  * ```typescript
- * // init
+ * // construct
  * const publish = yield* SNS.Publish.bind(topic);
  *
  * return {
@@ -120,7 +120,7 @@ export interface Topic extends Resource<
  *
  * @example Process topic notifications
  * ```typescript
- * // init
+ * // construct
  * yield* SNS.notifications(topic).subscribe((stream) =>
  *   stream.pipe(
  *     Stream.runForEach((message) =>

--- a/packages/alchemy/src/AWS/SQS/Queue.ts
+++ b/packages/alchemy/src/AWS/SQS/Queue.ts
@@ -122,12 +122,12 @@ export interface Queue extends Resource<
  * ```
  *
  * @section Sending Messages
- * Bind send operations in the init phase and use them in runtime
+ * Bind send operations in the construct phase and use them in runtime
  * handlers.
  *
  * @example Send a message from a handler
  * ```typescript
- * // init
+ * // construct
  * const sendMessage = yield* SQS.SendMessage.bind(queue);
  *
  * return {
@@ -147,7 +147,7 @@ export interface Queue extends Resource<
  *
  * @example Process queue messages
  * ```typescript
- * // init
+ * // construct
  * yield* SQS.messages(queue).process(
  *   Effect.fn(function* (message) {
  *     yield* Effect.log(`Received: ${message.body}`);

--- a/packages/alchemy/src/Action.ts
+++ b/packages/alchemy/src/Action.ts
@@ -17,7 +17,7 @@ import { Stack } from "./Stack.ts";
  *   - The body Effect is called when input changes (diff) or `--force` is set.
  *   - There is no replace/precreate/read/delete: removing an Action from the
  *     stack simply drops its persisted state without invoking the body.
- *   - Dependencies pulled in by the init Effect surface as `Req` on the
+ *   - Dependencies pulled in by the constructor Effect surface as `Req` on the
  *     call site, exactly like a Resource's provider services.
  *
  * Actions are recorded on {@link Stack.actions} and produce a single output
@@ -35,7 +35,7 @@ export interface ActionLike<
   readonly Type: Type;
   readonly LogicalId: string;
   readonly Input: In;
-  /** Resolved runner — populated by the init effect (if any). */
+  /** Resolved runner — populated by the constructor effect (if any). */
   readonly Run: (input: In) => Effect.Effect<Out, any, any>;
   /** @internal phantom */
   Output: Out;
@@ -50,14 +50,14 @@ export type ActionRunner<In extends object | undefined, Out, Req = any> = (
 ) => Effect.Effect<Out, any, Req>;
 
 /**
- * Init Effect — declares dependencies via `yield*` and returns the runner.
- * Lets multiple Action definitions share resolved services.
+ * Constructor Effect — declares dependencies via `yield*` and returns the
+ * runner. Lets multiple Action definitions share resolved services.
  */
-export type ActionInit<In extends object | undefined, Out, Req> = Effect.Effect<
-  ActionRunner<In, Out, any>,
-  any,
-  Req
->;
+export type ActionConstructor<
+  In extends object | undefined,
+  Out,
+  Req,
+> = Effect.Effect<ActionRunner<In, Out, any>, any, Req>;
 
 // ── Public API ─────────────────────────────────────────────────────────────
 //
@@ -67,7 +67,7 @@ export type ActionInit<In extends object | undefined, Out, Req> = Effect.Effect<
 //     return { rows: 42 };
 //   }));
 //
-// Init constructor — pulls in dependencies, returns the runner. The init
+// Constructor — pulls in dependencies, returns the runner. The constructor
 // Effect's `Req` channel bubbles up to the call site:
 //
 //   const Sync = Action("Sync", Effect.gen(function* () {
@@ -95,7 +95,9 @@ export function Action<
   Req = never,
 >(
   type: Type,
-  initOrRun: ActionRunner<In, Out, Req> | ActionInit<In, Out, Req>,
+  runnerOrConstructor:
+    | ActionRunner<In, Out, Req>
+    | ActionConstructor<In, Out, Req>,
 ): ActionClass<never, Type, In, Out, Req>;
 
 export function Action<Self, In extends object | undefined, Out>(): <
@@ -109,12 +111,12 @@ export function Action(...args: any[]): any {
     // Tagged form: Action<Self, In, Out>()(type)
     return (type: string) => makeActionClass(type, undefined);
   }
-  // Inline form: Action(type, runnerOrInit)
-  const [type, initOrRun] = args as [
+  // Inline form: Action(type, runnerOrConstructor)
+  const [type, runnerOrConstructor] = args as [
     string,
-    ActionRunner<any, any, any> | ActionInit<any, any, any>,
+    ActionRunner<any, any, any> | ActionConstructor<any, any, any>,
   ];
-  return makeActionClass(type, initOrRun);
+  return makeActionClass(type, runnerOrConstructor);
 }
 
 export interface ActionClass<
@@ -144,13 +146,15 @@ export interface ActionClass<
     input: { [k in keyof In]: Input<In[k]> },
   ): Effect.Effect<Output.ToOutput<Out, never>, never, Req | Stack>;
   /**
-   * Tagged-only: bind an init Effect to this Action's Self tag. Add the
+   * Tagged-only: bind a constructor Effect to this Action's Self tag. Add the
    * returned Layer to the stack's `providers`.
    */
   make: [Self] extends [never]
     ? never
     : <R = never>(
-        init: ActionRunner<In, Out, R> | ActionInit<In, Out, R>,
+        runnerOrConstructor:
+          | ActionRunner<In, Out, R>
+          | ActionConstructor<In, Out, R>,
       ) => Layer.Layer<Self, never, R>;
   /** Tagged-only: the Context tag holding the resolved runner. */
   readonly Self: [Self] extends [never]
@@ -159,17 +163,20 @@ export interface ActionClass<
 }
 
 const isRunnerEffect = (
-  v: ActionRunner<any, any, any> | ActionInit<any, any, any>,
-): v is ActionInit<any, any, any> => Effect.isEffect(v as any);
+  v: ActionRunner<any, any, any> | ActionConstructor<any, any, any>,
+): v is ActionConstructor<any, any, any> => Effect.isEffect(v as any);
 
 const makeActionClass = (
   type: string,
-  baked: ActionRunner<any, any, any> | ActionInit<any, any, any> | undefined,
+  baked:
+    | ActionRunner<any, any, any>
+    | ActionConstructor<any, any, any>
+    | undefined,
 ): any => {
-  // Pre-resolve baked init/runner into a single Effect<Runner, _, Req>. Use
-  // Effect.cached so the init's body runs at most once per process — every
+  // Pre-resolve baked constructor/runner into a single Effect<Runner, _, Req>. Use
+  // Effect.cached so the constructor's body runs at most once per process — every
   // action instance after the first reuses the resolved runner without paying
-  // the init cost (or re-yielding its dependencies).
+  // the constructor cost (or re-yielding its dependencies).
   let resolveRunner:
     | Effect.Effect<ActionRunner<any, any, any>, any, any>
     | undefined;
@@ -201,15 +208,20 @@ const makeActionClass = (
   const extra: Record<string, any> = { Type: type };
   if (SelfTag) {
     extra.Self = SelfTag;
-    // `.make(initOrRun)` — accepts either a direct runner or an init Effect.
-    // For init form we use `Layer.effect` so the init's Req surfaces on the
+    // `.make(runnerOrConstructor)` — accepts either a direct runner or a constructor Effect.
+    // For constructor form we use `Layer.effect` so the constructor's Req surfaces on the
     // Layer; for runners we use `Layer.succeed`.
     extra.make = <R>(
-      initOrRun: ActionRunner<any, any, R> | ActionInit<any, any, R>,
+      runnerOrConstructor:
+        | ActionRunner<any, any, R>
+        | ActionConstructor<any, any, R>,
     ) =>
-      isRunnerEffect(initOrRun)
-        ? Layer.effect(SelfTag, initOrRun as any)
-        : Layer.succeed(SelfTag, initOrRun as ActionRunner<any, any, any>);
+      isRunnerEffect(runnerOrConstructor)
+        ? Layer.effect(SelfTag, runnerOrConstructor as any)
+        : Layer.succeed(
+            SelfTag,
+            runnerOrConstructor as ActionRunner<any, any, any>,
+          );
   }
   return Object.assign(constructor, extra);
 };

--- a/packages/alchemy/src/Binding.ts
+++ b/packages/alchemy/src/Binding.ts
@@ -143,9 +143,9 @@ export const Policy =
           ? Effect.succeed(service)
           : Effect.all([CurrentStack, ALCHEMY_PHASE]).pipe(
               Effect.flatMap(([stack, phase]) =>
-                stack && phase === "plan"
+                stack && phase === "construct"
                   ? Effect.die(
-                      `Binding.Policy provider 'Policy<${Identifier}>' was not provided at Plan Time in Stack '${stack.name}'`,
+                      `Binding.Policy provider 'Policy<${Identifier}>' was not provided during the Construct phase in Stack '${stack.name}'`,
                     )
                   : Effect.succeed((() => Effect.void) as any as Shape),
               ),

--- a/packages/alchemy/src/Cloudflare/AiGateway/AiGateway.ts
+++ b/packages/alchemy/src/Cloudflare/AiGateway/AiGateway.ts
@@ -268,8 +268,8 @@ export const isAiGateway = (value: unknown): value is AiGateway =>
  * @section Binding into a Worker
  * @example Bind the gateway and provide the runtime layer
  * `AiGateway.bind(gateway)` returns a typed, Effect-native client during the
- * Worker's Init phase. Provide `Cloudflare.AiGatewayBindingLive` once at the
- * bottom of the Init layer chain so every `bind(...)` resolves at runtime.
+ * Worker's Construct phase. Provide `Cloudflare.AiGatewayBindingLive` once at the
+ * bottom of the Construct layer chain so every `bind(...)` resolves at runtime.
  * ```typescript
  * import * as Cloudflare from "alchemy/Cloudflare";
  * import * as Effect from "effect/Effect";
@@ -295,7 +295,7 @@ export const isAiGateway = (value: unknown): value is AiGateway =>
  * Call `aiGateway.model({...})` with a Workers AI model id. It returns a
  * `Layer<LanguageModel, never, RuntimeContext>` directly — no API key and no
  * `Layer.unwrap`, since the binding handles auth and the gateway URL. Build it
- * in the Init phase; construction is pure.
+ * in the Construct phase; construction is pure.
  * ```typescript
  * const aiGateway = yield* Cloudflare.AiGateway.bind(Gateway);
  *

--- a/packages/alchemy/src/Cloudflare/AiGateway/AiGatewayBinding.ts
+++ b/packages/alchemy/src/Cloudflare/AiGateway/AiGatewayBinding.ts
@@ -31,7 +31,7 @@ export class AiGatewayError extends Data.TaggedError("AiGatewayError")<{
  *
  * Wraps the runtime {@link AiGateway} binding so each operation returns an
  * Effect tagged with {@link AiGatewayError}. Use
- * `Cloudflare.AiGatewayBinding.bind(gateway)` inside a Worker's init phase.
+ * `Cloudflare.AiGatewayBinding.bind(gateway)` inside a Worker's construct phase.
  */
 export interface AiGatewayClient {
   /**
@@ -93,7 +93,7 @@ export interface AiGatewayClient {
  *
  * @section Calling AI Gateway
  * @example Run through a gateway
- * Bind the gateway during the Worker's init phase, then use `run` or
+ * Bind the gateway during the Worker's construct phase, then use `run` or
  * `getUrl` from request handlers.
  * ```typescript
  * const aiGateway = yield* Cloudflare.AiGatewayBinding.bind(gateway);

--- a/packages/alchemy/src/Cloudflare/Artifacts/ArtifactsBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Artifacts/ArtifactsBinding.ts
@@ -63,7 +63,7 @@ export interface ArtifactsRepoClient {
  *
  * Wraps the runtime {@link Artifacts} binding so each method returns an
  * Effect tagged with {@link ArtifactsError}. Use
- * `Cloudflare.ArtifactsBinding.bind(Repos)` inside a Worker's init phase.
+ * `Cloudflare.ArtifactsBinding.bind(Repos)` inside a Worker's construct phase.
  */
 export interface ArtifactsClient {
   /** Effect resolving to the raw Cloudflare runtime binding. */

--- a/packages/alchemy/src/Cloudflare/BrowserRendering/BrowserRendering.ts
+++ b/packages/alchemy/src/Cloudflare/BrowserRendering/BrowserRendering.ts
@@ -7,7 +7,7 @@ const BrowserRenderingTypeId = "Cloudflare.BrowserRendering" as const;
 export type BrowserRenderingProps = {
   /**
    * Binding name used when `Cloudflare.BrowserRendering.bind(browser)` attaches
-   * Browser Rendering from inside a Worker init phase. When Browser Rendering
+   * Browser Rendering from inside a Worker construct phase. When Browser Rendering
    * is passed through `Worker({ bindings: { ... } })`, the object key remains
    * the binding name.
    *

--- a/packages/alchemy/src/Cloudflare/Container/Container.ts
+++ b/packages/alchemy/src/Cloudflare/Container/Container.ts
@@ -157,7 +157,7 @@ export type Container = {
  * ```
  *
  * @section Calling from a Durable Object
- * Use `Cloudflare.Container.bind(Sandbox)` in the **outer** init
+ * Use `Cloudflare.Container.bind(Sandbox)` in the **outer** construct
  * phase of a Durable Object — only the class is imported, so the
  * DO bundle stays tiny. Then `Cloudflare.start(sandbox)` in the
  * **inner** per-instance phase ensures the container is running
@@ -169,7 +169,7 @@ export type Container = {
  * export default class Agent extends Cloudflare.DurableObjectNamespace<Agent>()(
  *   "Agents",
  *   Effect.gen(function* () {
- *     // OUTER (init): only the class is referenced — the runtime
+ *     // OUTER (construct): only the class is referenced — the runtime
  *     // implementation in `Sandbox.runtime.ts` is tree-shaken out
  *     // of this DO's bundle.
  *     const sandbox = yield* Cloudflare.Container.bind(Sandbox);
@@ -187,7 +187,7 @@ export type Container = {
  * ```
  *
  * @section Starting from a Durable Object
- * Use `Cloudflare.Container.bind` in the outer init phase to bind
+ * Use `Cloudflare.Container.bind` in the outer construct phase to bind
  * the container class, then `Cloudflare.start` in the inner
  * per-instance phase to start it. Because the DO only imports the
  * class, the runtime implementation is completely excluded from the
@@ -195,7 +195,7 @@ export type Container = {
  *
  * @example Binding and starting a container
  * ```typescript
- * // init (outer Effect) — only imports the class
+ * // construct (outer Effect) — only imports the class
  * const sandbox = yield* Cloudflare.Container.bind(Sandbox);
  *
  * // per-instance (inner Effect)
@@ -249,7 +249,7 @@ export const Container: Platform<
                 yield* httpServer.serve(handler);
                 yield* Effect.never;
               } else {
-                // this should only happen at plantime, validate?
+                // this should only happen during the Construct phase, validate?
               }
             }).pipe(Effect.orDie),
           );

--- a/packages/alchemy/src/Cloudflare/Images/Images.ts
+++ b/packages/alchemy/src/Cloudflare/Images/Images.ts
@@ -7,7 +7,7 @@ const ImagesTypeId = "Cloudflare.Images" as const;
 export type ImagesProps = {
   /**
    * Binding name used when `Cloudflare.Images.bind(images)` attaches Images
-   * from inside a Worker init phase. When Images is passed through
+   * from inside a Worker construct phase. When Images is passed through
    * `Worker({ bindings: { ... } })`, the object key remains the binding name.
    *
    * @default "IMAGES"

--- a/packages/alchemy/src/Cloudflare/Images/ImagesBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Images/ImagesBinding.ts
@@ -52,7 +52,7 @@ export interface ImageTransformerClient {
  *
  * Wraps the runtime {@link cf.ImagesBinding} so each method returns
  * an Effect tagged with {@link ImagesError}. Use
- * `Cloudflare.Images.bind(images)` inside a Worker's init phase.
+ * `Cloudflare.Images.bind(images)` inside a Worker's construct phase.
  */
 export interface ImagesClient {
   /** Effect resolving to the raw Cloudflare runtime binding. */

--- a/packages/alchemy/src/Cloudflare/Queue/Queue.ts
+++ b/packages/alchemy/src/Cloudflare/Queue/Queue.ts
@@ -55,7 +55,7 @@ export type Queue = Resource<
  *
  * @section Binding to a Worker
  * In an Effect-style Worker, use `Cloudflare.QueueBinding.bind` in
- * the init phase and provide `Cloudflare.QueueBindingLive` in the
+ * the construct phase and provide `Cloudflare.QueueBindingLive` in the
  * runtime layer. The returned `QueueSender` exposes `send` and
  * `sendBatch`.
  *

--- a/packages/alchemy/src/Cloudflare/Queue/QueueBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Queue/QueueBinding.ts
@@ -32,7 +32,7 @@ export class QueueSendError extends Data.TaggedError("QueueSendError")<{
  * {@link QueueSender} you can call from a Worker's runtime Effect.
  *
  * @section Sending Messages
- * Bind the queue in the Worker's init phase, then use `send` for
+ * Bind the queue in the Worker's construct phase, then use `send` for
  * single messages or `sendBatch` for many messages in one call.
  * Messages can be any JSON-serializable value.
  *

--- a/packages/alchemy/src/Cloudflare/Queue/QueueEventSource.ts
+++ b/packages/alchemy/src/Cloudflare/Queue/QueueEventSource.ts
@@ -121,7 +121,7 @@ export const messages = <Body = unknown>(
 // machinery provides bindings and `WorkerEnvironment` when the
 // dispatch fires — so the requirement is satisfied at handler
 // invocation, NOT at subscribe time. We drop `Req` from the return
-// to keep init effects clean (mirrors `AWS.SQS.QueueEventSourceService`).
+// to keep construct effects clean (mirrors `AWS.SQS.QueueEventSourceService`).
 export type QueueEventSourceService = <Body = unknown, Req = never>(
   queue: Queue,
   props: MessagesProps,
@@ -154,7 +154,7 @@ export class QueueEventSourcePolicy extends Binding.Policy<
 export const QueueEventSourcePolicyLive = QueueEventSourcePolicy.layer.succeed(
   // Cast: yielding `QueueConsumer(...)` requires the Cloudflare
   // `Providers` services, which the deploy-time stack provides
-  // when this policy runs (the worker's init scope inherits the
+  // when this policy runs (the worker's Construct scope inherits the
   // stack's services). `Binding.Policy.layer.succeed` types the
   // body as `Effect<void, never, never>` to keep most policies
   // simple; we step around that constraint here because we
@@ -188,7 +188,7 @@ export const QueueEventSourcePolicyLive = QueueEventSourcePolicy.layer.succeed(
 
 /**
  * Runtime layer for {@link messages}. Wires each
- * `messages(queue).subscribe(...)` call in the Worker init phase to
+ * `messages(queue).subscribe(...)` call in the Worker construct phase to
  * a `queue` event listener on the runtime context, and asks the
  * deploy-time policy ({@link QueueEventSourcePolicy}, provided in
  * `Cloudflare.providers()`) to yield the matching
@@ -217,7 +217,7 @@ export const QueueEventSourceLive = Layer.effect(
       // Resolve the runtime context per-call rather than at layer
       // construction. Capturing it on the layer would leak the
       // requirement past `PlatformServices` exclusion when the
-      // Worker typechecks its init effect.
+      // Worker typechecks its construct effect.
       const ctx = (yield* RuntimeContext) as unknown as FunctionContext;
       // Capture the queue-name accessor once; the listener body
       // re-resolves it per event via `yield* QueueName`. A worker

--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectNamespace.ts
@@ -239,7 +239,7 @@ export class DurableObjectNamespaceScope extends Context.Service<
  * export default class Counter extends Cloudflare.DurableObjectNamespace<Counter>()(
  *   "Counter",
  *   Effect.gen(function* () {
- *     // init: bind resources
+ *     // construct: bind resources
  *     const db = yield* Cloudflare.D1Connection.bind(MyDB);
  *
  *     return Effect.gen(function* () {
@@ -281,7 +281,7 @@ export class DurableObjectNamespaceScope extends Context.Service<
  *
  * export default Counter.make(
  *   Effect.gen(function* () {
- *     // init: bind resources
+ *     // construct: bind resources
  *     const db = yield* Cloudflare.D1Connection.bind(MyDB);
  *
  *     return Effect.gen(function* () {
@@ -309,7 +309,7 @@ export class DurableObjectNamespaceScope extends Context.Service<
  * // imports Counter; bundler tree-shakes .make()
  * import Counter from "./Counter.ts";
  *
- * // init
+ * // construct
  * const counters = yield* Counter;
  *
  * return {
@@ -607,13 +607,13 @@ export class DurableObjectNamespaceScope extends Context.Service<
  * ```
  *
  * @section Using from a Worker
- * Yield the DO class in your Worker's init phase to get a namespace
+ * Yield the DO class in your Worker's construct phase to get a namespace
  * handle. Call `getByName` or `getById` to get a typed stub, then
  * call any RPC method or forward an HTTP request with `fetch`.
  *
  * @example Calling RPC methods
  * ```typescript
- * // init
+ * // construct
  * const counters = yield* Counter;
  *
  * return {
@@ -628,7 +628,7 @@ export class DurableObjectNamespaceScope extends Context.Service<
  *
  * @example Forwarding an HTTP request
  * ```typescript
- * // init
+ * // construct
  * const rooms = yield* Room;
  *
  * return {
@@ -788,8 +788,8 @@ export const DurableObjectNamespace: DurableObjectNamespaceClass =
             ALCHEMY_PHASE,
           ]).pipe(
             Effect.flatMap(([env, phase]) => {
-              if (env === undefined || phase === "plan") {
-                // should be fine to return undefined here (it is only undefined at plantime)
+              if (env === undefined || phase === "construct") {
+                // should be fine to return undefined here (it is only undefined during the Construct phase)
                 return Effect.succeed(undefined);
               }
               const ns = env[namespace];

--- a/packages/alchemy/src/Cloudflare/Workers/DynamicWorkerLoader.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DynamicWorkerLoader.ts
@@ -86,13 +86,13 @@ export type DynamicWorkerLoader = {
  * @resource
  *
  * @section Creating a Loader
- * Yield `Cloudflare.DynamicWorkerLoader` in your Worker's init
+ * Yield `Cloudflare.DynamicWorkerLoader` in your Worker's Construct
  * phase to register the binding. The string argument becomes the
  * binding name on the deployed Worker.
  *
  * @example Registering a loader
  * ```typescript
- * // init
+ * // construct
  * const loader = yield* Cloudflare.DynamicWorkerLoader("Loader");
  * ```
  *
@@ -164,7 +164,7 @@ export const DynamicWorkerLoader = Effect.fnUntraced(function* (name: string) {
 
   const binding = yield* Effect.all([WorkerEnvironment, ALCHEMY_PHASE]).pipe(
     Effect.flatMap(([env, phase]) => {
-      if (env === undefined || phase === "plan") {
+      if (env === undefined || phase === "construct") {
         return Effect.succeed(undefined as any);
       }
       const loader = env[name];

--- a/packages/alchemy/src/Cloudflare/Workers/Rpc.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Rpc.ts
@@ -205,7 +205,7 @@ export const decodeRpcResult = (
  * stub is already resolved; everything else is treated as an RPC method
  * whose dispatch is deferred until call time, so the user effect runs in
  * the right runtime layer (which is what `bindWorker` actually wants —
- * its methods are called at exec, even though it's *defined* at init).
+ * its methods are called at runtime, even though it's *defined* during Construct).
  */
 export const makeRpcStub = <Shape>(
   stubSource: unknown | Effect.Effect<unknown, never, never>,

--- a/packages/alchemy/src/Cloudflare/Workers/RpcDurableObjectNamespace.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/RpcDurableObjectNamespace.ts
@@ -226,9 +226,9 @@ export interface RpcDurableObjectNamespaceClass extends Effect.Effect<
  *   "Counter",
  *   { schema: CounterRpcs },
  *   Effect.gen(function* () {
- *     // outer init: shared deps for all instances
+ *     // outer construct: shared deps for all instances
  *     return Effect.gen(function* () {
- *       // per-instance init: state + handlers
+ *       // per-instance setup: state + handlers
  *       const state = yield* Cloudflare.DurableObjectState;
  *       const handlers = CounterRpcs.toLayer({
  *         setTitle: ({ title }) => state.storage.put("title", title),

--- a/packages/alchemy/src/Cloudflare/Workers/RpcWorker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/RpcWorker.ts
@@ -90,7 +90,7 @@ export interface RpcWorkerClass extends Effect.Effect<
    * Yielding the class in a Stack returns the {@link Worker} resource
    * (so `worker.url`, `worker.workerName`, etc. work as usual). To get
    * a typed `RpcClient` for *this* worker's rpc group from inside
-   * another worker's init, call {@link RpcWorker.bind}.
+   * another worker's Construct phase, call {@link RpcWorker.bind}.
    */
   <Self, Deps = never>(): {
     /**
@@ -135,7 +135,7 @@ export interface RpcWorkerClass extends Effect.Effect<
    * worker's declared rpc {@link RpcGroup.RpcGroup} schema. Mirrors
    * `Cloudflare.R2Bucket.bind(MyBucket)` and friends.
    *
-   * Yield once at **init** — the result is a normal `RpcClient` you
+   * Yield once during **Construct** — the result is a normal `RpcClient` you
    * can call directly from any per-request handler. Internally each
    * method invocation builds a fresh underlying `RpcClient` (through
    * a Proxy) because Cloudflare rejects I/O objects created on a
@@ -146,7 +146,7 @@ export interface RpcWorkerClass extends Effect.Effect<
    *
    * @example
    * ```ts
-   * // INIT: register the binding once and get the typed client
+   * // CONSTRUCT: register the binding once and get the typed client
    * const tasks = yield* Cloudflare.RpcWorker.bind(TaskWorker);
    *
    * // PER-REQUEST: call methods directly
@@ -182,7 +182,7 @@ const bind = <Self, Rpcs extends Rpc.Any>(
       );
     }
     const worker = (yield* workerEff) as Worker;
-    // Register the service binding on the surrounding worker at INIT.
+    // Register the service binding on the surrounding worker during Construct.
     // Mirrors `Cloudflare.bindWorker` — yielding the class is *not*
     // enough; we need an explicit `self.bind\`${worker}\`(...)` so
     // workerd surfaces the stub on `env` at request time.
@@ -263,7 +263,7 @@ const bind = <Self, Rpcs extends Rpc.Any>(
  * `RpcWorker` is a thin sugar over {@link Worker} for the common case
  * where a worker's entire `fetch` surface is a typed Effect `RpcGroup`.
  * It takes the rpc `schema` directly in props alongside `main`, and
- * accepts an init Effect that returns the already-piped
+ * accepts a construct Effect that returns the already-piped
  * `RpcServer.toHttpEffect(...)`-producing Effect (no `{ fetch }`
  * wrapper) — the wrapper plugs it into the worker's `fetch` for you.
  *
@@ -303,7 +303,7 @@ const bind = <Self, Rpcs extends Rpc.Any>(
  * @section Implementing the worker
  * @example Class form (recommended)
  * Mirrors `Cloudflare.Worker<Self>()(...)` — `class X extends ...`
- * works the same. The init Effect builds a handlers `Layer` from the
+ * works the same. The construct Effect builds a handlers `Layer` from the
  * group and returns the `RpcServer.toHttpEffect(schema)`-piped Effect
  * directly.
  * ```typescript
@@ -385,7 +385,7 @@ const bind = <Self, Rpcs extends Rpc.Any>(
  *
  * @section Binding it from another worker
  * @example `Cloudflare.RpcWorker.bind(WorkerClass)`
- * Inside another worker's init, `RpcWorker.bind(WorkerClass)`
+ * Inside another worker's Construct phase, `RpcWorker.bind(WorkerClass)`
  * registers the service binding on the surrounding worker and returns
  * a typed `RpcClient` you can call directly from any per-request
  * handler. Internally each method invocation builds a fresh underlying
@@ -399,7 +399,7 @@ const bind = <Self, Rpcs extends Rpc.Any>(
  *   "Caller",
  *   { main: import.meta.filename, schema: CallerRpcs },
  *   Effect.gen(function* () {
- *     // INIT: register binding, get the typed client
+ *     // CONSTRUCT: register binding, get the typed client
  *     const tasks = yield* Cloudflare.RpcWorker.bind(TaskWorker);
  *
  *     const handlers = CallerRpcs.toLayer({
@@ -461,7 +461,7 @@ const bind = <Self, Rpcs extends Rpc.Any>(
  * ```
  *
  * @section Yielding the surrounding worker from inside the impl
- * @example `yield* RpcWorker` inside the init effect
+ * @example `yield* RpcWorker` inside the construct effect
  * Mirrors `yield* DurableObjectNamespace` — yield the tag to access
  * the surrounding worker.
  * ```typescript

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -262,7 +262,7 @@ export interface WorkerProps<
    *   `secret_text`, `string` → `plain_text`, anything else → `json`.
    *
    * In Effect-native Workers you can alternatively `yield*` a
-   * `Config` in the Init phase to register the binding implicitly;
+   * `Config` in the Construct phase to register the binding implicitly;
    * `env` is the only option for async (non-Effect) Workers.
    */
   env?: Bindings;
@@ -426,7 +426,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *   "MyWorker",
  *   { main: import.meta.filename },
  *   Effect.gen(function* () {
- *     // init: bind resources
+ *     // construct: bind resources
  *     const kv = yield* Cloudflare.KVNamespace.bind(MyKV);
  *
  *     return {
@@ -464,7 +464,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *
  * export default WorkerB.make(
  *   Effect.gen(function* () {
- *     // init: bind resources
+ *     // construct: bind resources
  *     const kv = yield* Cloudflare.KVNamespace.bind(MyKV);
  *
  *     return {
@@ -554,13 +554,13 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * ```
  *
  * @section R2 Bucket
- * Bind an R2 bucket in the init phase with `Cloudflare.R2Bucket.bind`.
+ * Bind an R2 bucket in the construct phase with `Cloudflare.R2Bucket.bind`.
  * The returned handle exposes `get`, `put`, `delete`, and `list`
  * methods you can call in your runtime handlers.
  *
  * @example Binding and using R2
  * ```typescript
- * // init
+ * // construct
  * const bucket = yield* Cloudflare.R2Bucket.bind(MyBucket);
  *
  * return {
@@ -588,7 +588,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *
  * @example Binding and using KV
  * ```typescript
- * // init
+ * // construct
  * const kv = yield* Cloudflare.KVNamespace.bind(MyKV);
  *
  * return {
@@ -606,7 +606,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *
  * @example Binding and querying D1
  * ```typescript
- * // init
+ * // construct
  * const db = yield* Cloudflare.D1Connection.bind(MyDB);
  *
  * return {
@@ -621,13 +621,13 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * ```
  *
  * @section Durable Objects
- * Yield a `DurableObjectNamespace` class in the init phase to get a
+ * Yield a `DurableObjectNamespace` class in the construct phase to get a
  * namespace handle. Call `getByName` or `getById` to get a typed RPC
  * stub, then call its methods from your runtime handlers.
  *
  * @example Using a Durable Object
  * ```typescript
- * // init
+ * // construct
  * const counters = yield* Counter;
  *
  * return {
@@ -647,7 +647,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *
  * @example Binding and starting a Container
  * ```typescript
- * // init (inside a DurableObjectNamespace)
+ * // construct (inside a DurableObjectNamespace)
  * const sandbox = yield* Cloudflare.Container.bind(Sandbox);
  *
  * return Effect.gen(function* () {
@@ -671,7 +671,7 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  *
  * @example Loading a dynamic Worker
  * ```typescript
- * // init
+ * // construct
  * const loader = yield* Cloudflare.DynamicWorkerLoader("Loader");
  *
  * return {

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
@@ -79,8 +79,8 @@ export const bindWorker = Effect.fnUntraced(function* <Shape, Req = never>(
     ],
   });
 
-  // `bindWorker` runs at *init* phase (both at plantime and at runtime
-  // cold-start). `WorkerEnvironment` only exists at exec phase on the
+  // `bindWorker` runs during the *Construct* phase (both locally and at
+  // cloud cold-start). `WorkerEnvironment` only exists at *Runtime* on the
   // deployed worker, so we hand `makeRpcStub` an `Effect<stub>` that
   // resolves the binding lazily on each method call.
   const stubEff = WorkerEnvironment.pipe(

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerRuntimeContext.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerRuntimeContext.ts
@@ -106,7 +106,7 @@ export const makeWorkerRuntimeContext = (id: string): WorkerRuntimeContext => {
       Effect.sync(() => {
         exports[name] = value;
       }),
-    planServices: Layer.succeed(WorkerEnvironment, {}),
+    constructServices: Layer.succeed(WorkerEnvironment, {}),
     exports: Effect.gen(function* () {
       const handlers = yield* Effect.all(listeners, {
         concurrency: "unbounded",

--- a/packages/alchemy/src/Cloudflare/Workers/Workflow.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Workflow.ts
@@ -254,7 +254,7 @@ export class WorkflowScope extends Context.Service<
  *
  * @example Accessing env bindings inside a task
  * Bind a resource (e.g. `KVNamespace`, `R2Bucket`) in the workflow's
- * outer init phase to get a typed Effect-native client, then use it
+ * outer construct phase to get a typed Effect-native client, then use it
  * directly inside `task`. `task` threads the binding's service
  * requirement (`WorkerEnvironment`) through automatically so the inner
  * Effect needs no extra plumbing.
@@ -395,7 +395,7 @@ export const Workflow: WorkflowClass = taggedFunction(WorkflowScope, ((
             ALCHEMY_PHASE,
           ]).pipe(
             Effect.flatMap(([env, phase]) => {
-              if (env === undefined || phase === "plan") {
+              if (env === undefined || phase === "construct") {
                 return Effect.succeed(undefined as any);
               }
               const wf = env[name];

--- a/packages/alchemy/src/Drizzle/Postgres.ts
+++ b/packages/alchemy/src/Drizzle/Postgres.ts
@@ -28,12 +28,12 @@ import { proxyChain } from "../Util/proxy-chain.ts";
  * Behind the scenes the actual connect work is wrapped in `Effect.cached`,
  * so the pool is built at most once per JS realm. Yielding the
  * connection string is also deferred until first query, so deploy /
- * plan-time invocations (where `WorkerEnvironment` isn't provided)
+ * Construct-phase invocations (where `WorkerEnvironment` isn't provided)
  * never trigger a real connection attempt.
  *
  * The PgClient pool is built against an isolated, never-closing `Scope`
  * so it outlives whatever scope this helper is yielded under. In a
- * Cloudflare Worker the surrounding `Cloudflare.Worker` runs init
+ * Cloudflare Worker the surrounding `Cloudflare.Worker` runs Construct
  * inside `Effect.scoped`, which closes after returning the exports
  * object — without an isolated scope, the pool's `end` finalizer
  * would fire there and every subsequent request would see "Cannot

--- a/packages/alchemy/src/Phase.ts
+++ b/packages/alchemy/src/Phase.ts
@@ -1,12 +1,21 @@
 import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 
-export type AlchemyPhase = "plan" | "runtime";
+/**
+ * The phase an alchemy program is currently executing in.
+ *
+ * - `construct` — builds the resource graph (Config, Bindings, Resources,
+ *   Layers). Runs both locally (`alchemy deploy`, `plan`, `dev`) and in the
+ *   cloud at cold start.
+ * - `runtime` — the deployed handler (API handlers, async/background jobs).
+ *   Only runs in the cloud, and references values declared during `construct`.
+ */
+export type AlchemyPhase = "construct" | "runtime";
 
 export const ALCHEMY_PHASE = Config.string("ALCHEMY_PHASE").pipe(
-  Config.withDefault("plan"),
+  Config.withDefault("construct"),
   Config.mapOrFail((value) => {
-    if (value !== "plan" && value !== "runtime") {
+    if (value !== "construct" && value !== "runtime") {
       return Effect.die(new Error(`Invalid ALCHEMY_PHASE: ${value}`));
     }
     return Effect.succeed(value as AlchemyPhase);

--- a/packages/alchemy/src/Platform.ts
+++ b/packages/alchemy/src/Platform.ts
@@ -372,8 +372,8 @@ export const Platform = <
                             path.map((p) => p.toString()).join("_"),
                           );
                           const node = yield* configProvider.get(path);
-                          if (phase === "plan" && node) {
-                            // bind it to the RuntimeContext if running in plan phase
+                          if (phase === "construct" && node) {
+                            // bind it to the RuntimeContext if running in construct phase
                             const output = Output.literal(node.value);
                             yield* ctx?.set(key, output) ?? Effect.void;
                             return node;
@@ -398,12 +398,12 @@ export const Platform = <
                         Layer.succeed(resource.Self, instance),
                         Layer.succeed(Platform.Self, instance),
                         Layer.succeed(Self, instance),
-                        runtimeContext.planServices
+                        runtimeContext.constructServices
                           ? Layer.unwrap(
                               ALCHEMY_PHASE.pipe(
                                 Effect.map((phase) =>
-                                  phase === "plan"
-                                    ? runtimeContext.planServices!
+                                  phase === "construct"
+                                    ? runtimeContext.constructServices!
                                     : Layer.empty,
                                 ),
                               ),

--- a/packages/alchemy/src/RuntimeContext.ts
+++ b/packages/alchemy/src/RuntimeContext.ts
@@ -25,8 +25,8 @@ export interface BaseRuntimeContext {
     options?: { shape?: Record<string, unknown> },
   ): Effect.Effect<void, never, Req>;
   shape?: () => Record<string, unknown>;
-  /** additional services to provide to the plan  */
-  planServices?: Layer.Layer<any>;
+  /** additional services to provide during the Construct phase  */
+  constructServices?: Layer.Layer<any>;
 }
 
 /**

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -51,7 +51,7 @@ Reference pages explaining what each primitive means and how they fit together. 
 - [Resource Lifecycle](https://v2.alchemy.run/concepts/resource-lifecycle) — How alchemy plans, applies, replaces, and destroys resources — and how to think about idempotency and recovery.
 - [Stack](https://v2.alchemy.run/concepts/stack) — A Stack is a collection of Resources deployed together as a unit.
 - [Stages](https://v2.alchemy.run/concepts/stages) — Stages are isolated instances of a Stack — dev_sam, staging, prod, pr-42 — each with their own state and physical names.
-- [Phases](https://v2.alchemy.run/concepts/phases) — Alchemy programs run in two phases — plantime/init drives the deploy, runtime handles requests. Knowing which is which is the key to using Platforms.
+- [Phases](https://v2.alchemy.run/concepts/phases) — Alchemy programs run in two phases — Construct builds the resource graph, Runtime handles requests. Knowing which is which is the key to using Platforms.
 - [Platform](https://v2.alchemy.run/concepts/platform) — A Platform bundles infrastructure with the runtime code that runs on it — Workers, Lambda Functions, Containers — so your handler ships with its bindings.
 - [Binding](https://v2.alchemy.run/concepts/binding) — A binding connects a resource to a Worker or Lambda. It generates IAM policies, env vars, and a typed SDK in one call.
 - [Inputs and Outputs](https://v2.alchemy.run/concepts/outputs) — Output<T> is alchemy's lazy reference type — the lazy values that flow between resources, get composed with .pipe, mapped, interpolated, and resolved during deploy.

--- a/website/src/content/docs/blog/2026-04-25-circular-references.md
+++ b/website/src/content/docs/blog/2026-04-25-circular-references.md
@@ -201,7 +201,7 @@ The runtime piece is a second file-level export:
 
 The `import { B }` here imports B's Tag only — its identity
 and binding contract. `Worker.bind(B)` returns a typed
-callable; at plan time the URL is an `Output<URL>`
+callable; during Construct the URL is an `Output<URL>`
 placeholder, at runtime it's a real `fetch` stub.
 
 `B.ts` mirrors the pattern: imports `A`'s Tag, binds it
@@ -238,7 +238,7 @@ scope — including the resource itself.
 
 ## How the two pieces compose
 
-At plan time, the engine builds a dependency graph from the
+During Construct, the engine builds a dependency graph from the
 Stack expression. When it sees a cycle, it routes the
 participating resources through a two-pass lifecycle:
 

--- a/website/src/content/docs/blog/2026-04-30-bindings.md
+++ b/website/src/content/docs/blog/2026-04-30-bindings.md
@@ -139,9 +139,9 @@ service
   ? Effect.succeed(service)
   : Effect.all([CurrentStack, ALCHEMY_PHASE]).pipe(
       Effect.flatMap(([stack, phase]) =>
-        stack && phase === "plan"
+        stack && phase === "construct"
           ? Effect.die(
-              `Binding.Policy provider 'Policy<${Identifier}>' was not provided at Plan Time in Stack '${stack.name}'`,
+              `Binding.Policy provider 'Policy<${Identifier}>' was not provided during the Construct phase in Stack '${stack.name}'`,
             )
           : Effect.succeed((() => Effect.void) as any as Shape),
       ),

--- a/website/src/content/docs/blog/2026-05-08-beta-35.md
+++ b/website/src/content/docs/blog/2026-05-08-beta-35.md
@@ -21,14 +21,14 @@ with `ack`/`retry` exposed per message. The handler returns
 when the batch is done; failed messages get retried up to
 `maxRetries`. Same Worker, same Effect runtime, same
 bindings — the queue consumer is just another `yield*` in
-the init phase.
+the construct phase.
 
 A real producer-and-consumer pair: a Worker accepts POSTs
 to `/queue/send`, the consumer writes each message to R2
 as JSON so the result is observable. Bindings already on
 the Worker (`bucket`, `queue`) are in scope inside the
 stream handler — the consumer is a peer to the Worker's
-init phase, not a separate file.
+construct phase, not a separate file.
 
 ```typescript
 import * as Cloudflare from "alchemy/Cloudflare";

--- a/website/src/content/docs/blog/2026-05-12-beta-37.md
+++ b/website/src/content/docs/blog/2026-05-12-beta-37.md
@@ -73,7 +73,7 @@ Three things to note:
   `Neon.Project` either way, so downstream
   (`Neon.Branch({ project })`) doesn't know or care
   whether it's real or referenced.
-- **Resolved at plan time.** Alchemy reads the project's
+- **Resolved during Construct.** Alchemy reads the project's
   attributes (id, host, etc.) out of `staging`'s persisted
   [state store](/concepts/state-store). If `staging`
   hasn't been deployed yet, plan fails loudly with
@@ -339,7 +339,7 @@ import Room from "./Room.ts";
 export default class NotifyWorkflow extends Cloudflare.Workflow<NotifyWorkflow>()(
   "Notifier",
   Effect.gen(function* () {
-    // Outer init phase: resolve shared dependencies once.
+    // Outer construct phase: resolve shared dependencies once.
     const rooms = yield* Room;
     const kv = yield* Cloudflare.KVNamespace.bind(KV);
     const secret = yield* Alchemy.Secret("WORKFLOW_SECRET");

--- a/website/src/content/docs/blog/2026-05-13-actions.md
+++ b/website/src/content/docs/blog/2026-05-13-actions.md
@@ -204,14 +204,14 @@ const Sync = Action("Sync", Effect.gen(function* () {
 }));
 ```
 
-The init Effect's `Req` bubbles to the call site:
+The constructor Effect's `Req` bubbles to the call site:
 
 ```typescript
 const rows = yield* Sync({ table: bucket.name });
 //          ^ Effect.Effect<Output<…>, never, Database | Logger | Stack>
 ```
 
-The init runs once per process — `Effect.cached` memoizes
+The constructor runs once per process — `Effect.cached` memoizes
 it — and every Action instance reuses the resolved runner.
 Dependencies show up in your stack's `R`, your stack's
 providers satisfy them, the body gets a fully-constructed
@@ -248,7 +248,7 @@ binds an implementation Layer that resolves the Tag. Stack
 providers include `SyncLive`, the constructor's `Req` picks
 up `Sync`, the planner has a runner to call.
 
-`.make()` accepts either a direct runner or an init Effect.
+`.make()` accepts either a direct runner or a constructor Effect.
 
 ## In the plan
 
@@ -307,7 +307,7 @@ among the others.
 ## Where to go next
 
 - [Concepts › Action](/concepts/action) — the full reference
-  for the inline, init-effect, and tagged forms, plus the
+  for the inline, constructor-effect, and tagged forms, plus the
   state model and lifecycle table.
 - [`packages/alchemy/src/Action.ts`](https://github.com/alchemy-run/alchemy-effect/blob/main/packages/alchemy/src/Action.ts)
   — the source. Around 270 lines including JSDoc.

--- a/website/src/content/docs/blog/2026-05-13-actions.md
+++ b/website/src/content/docs/blog/2026-05-13-actions.md
@@ -299,7 +299,7 @@ computed from resource outputs.
 
 The same graph means: upstream Outputs flow in as typed
 inputs, downstream resources can read outputs back, cycles
-are detected at plan time, `--force` works, removal drops
+are detected during Construct, `--force` works, removal drops
 state cleanly. The same graph means: Actions don't sit
 alongside your stack — they live *inside* it, one node
 among the others.

--- a/website/src/content/docs/blog/2026-05-13-beta-38.md
+++ b/website/src/content/docs/blog/2026-05-13-beta-38.md
@@ -125,7 +125,7 @@ Plan: 1 to create | 1 to update | 1 to run
 *input hash matches, skip*. `--force` flips skip→run for
 actions the same way it does for resources.
 
-Init-style construction works too, for the common case
+Constructor-style construction works too, for the common case
 where the body needs Effect Services from the stack's
 layers:
 
@@ -142,7 +142,7 @@ const Sync = Alchemy.Action("Sync",
 );
 ```
 
-The init Effect runs once per process (memoized), so the
+The constructor Effect runs once per process (memoized), so the
 runner is shared across every instance and every re-run.
 
 Actions also participate in the dependency graph in both

--- a/website/src/content/docs/blog/2026-05-20-beta-41.md
+++ b/website/src/content/docs/blog/2026-05-20-beta-41.md
@@ -170,7 +170,7 @@ export default Cloudflare.Worker(
 ```
 
 **3. Bind a Durable Object, get a typed fetcher per instance.**
-The DO's Init returns the same `{ fetch }` shape — an
+The DO's Construct phase returns the same `{ fetch }` shape — an
 `HttpEffect` from either `HttpApiBuilder` or
 `RpcServer.toHttpEffect`. Inside the Worker, bind the DO and use
 `Cloudflare.toHttpClient(stub)` to turn each instance into a

--- a/website/src/content/docs/concepts/action.mdx
+++ b/website/src/content/docs/concepts/action.mdx
@@ -120,7 +120,7 @@ differs means "run".
 alchemy deploy --force
 ```
 
-`--force` flips every `skip` to `run` at plan time, including actions.
+`--force` flips every `skip` to `run` during Construct, including actions.
 
 ### Dependencies
 
@@ -131,7 +131,7 @@ Actions live in the same FQN namespace as Resources. They can:
   waits for the action before reconciling)
 - Reference other Actions
 
-Cycles are rejected at plan time just like resource cycles.
+Cycles are rejected during Construct just like resource cycles.
 
 ## What Actions are not
 

--- a/website/src/content/docs/concepts/action.mdx
+++ b/website/src/content/docs/concepts/action.mdx
@@ -38,10 +38,10 @@ The body Effect receives the **resolved** input — any
 [Output](/concepts/outputs) references in the input are evaluated against the
 current tracker before the body runs.
 
-### Init constructor (pulling in dependencies)
+### Constructor (pulling in dependencies)
 
 Pass an Effect that yields the runner instead of the runner itself.
-The init Effect can `yield*` services, and those dependencies surface
+The constructor Effect can `yield*` services, and those dependencies surface
 as `Req` on the call site:
 
 ```typescript
@@ -57,7 +57,7 @@ const Sync = Action("Sync", Effect.gen(function* () {
 // `yield* Sync({...})` now requires `Database | Logger | Stack`.
 ```
 
-The init runs at most once per process and the resolved runner is
+The constructor runs at most once per process and the resolved runner is
 reused across every instance and re-run.
 
 ### Multiple instances
@@ -93,7 +93,7 @@ const rows = yield* Sync({ table: bucket.name });
 //          ^ requires `Sync` — add `SyncLive` to the stack's providers.
 ```
 
-`.make(...)` accepts either a direct runner or an init Effect.
+`.make(...)` accepts either a direct runner or a constructor Effect.
 
 ## Lifecycle
 

--- a/website/src/content/docs/concepts/binding.mdx
+++ b/website/src/content/docs/concepts/binding.mdx
@@ -33,7 +33,7 @@ the SDK.
 Bindings work in both handler styles a Platform supports. Pick
 whichever your Worker / Lambda is using.
 
-**Effect style** — `bind()` inside the init Effect, returns a typed
+**Effect style** — `bind()` inside the Construct phase, returns a typed
 handle:
 
 ```typescript
@@ -220,12 +220,12 @@ depends on the [phase](/concepts/phases):
   Worker bindings, and env vars. This is **not** included in the
   runtime bundle.
 
-At plantime the Policy layer is provided, so `bind()` records what
+At Construct the Policy layer is provided, so `bind()` records what
 the function needs. At runtime the Policy layer is absent, so the
 same call resolves to just the lightweight Service wrapper. The
 runtime bundle stays small because none of the planning code ships.
 
-See [Plantime and Runtime › `Binding.Service` vs
+See [Construct and Runtime › `Binding.Service` vs
 `Binding.Policy`](/concepts/phases#bindingservice-vs-bindingpolicy)
 for a deeper look.
 

--- a/website/src/content/docs/concepts/layers.mdx
+++ b/website/src/content/docs/concepts/layers.mdx
@@ -20,7 +20,7 @@ the rest.
 ## The encapsulation problem
 
 Say you want a Worker that serves jobs from a KV namespace. The
-straightforward thing is to bind the KV in the Worker's init
+straightforward thing is to bind the KV in the Worker's Construct
 closure and call it from `fetch`:
 
 ```typescript
@@ -186,17 +186,17 @@ type, not by convention.
 
 ## Runtime as a colored function
 
-A Platform program has two [phases](/concepts/phases): the **init**
-closure (outer) runs at both plantime and cold start, and the
+A Platform program has two [phases](/concepts/phases): the **Construct**
+closure (outer) runs both locally and at cold start, and the
 **runtime** closure (inner) runs only inside the deployed handler.
-Bindings live in init; the actual cloud calls live in runtime:
+Bindings live in Construct; the actual cloud calls live in runtime:
 
 ```typescript
 Cloudflare.Worker(
   "Api",
   { main: import.meta.filename },
   Effect.gen(function* () {
-    // ─── Init: declare dependencies ───
+    // ─── Construct: declare dependencies ───
     const kv = yield* Cloudflare.KVNamespaceBinding.bind(MyKV);
 
     return {
@@ -210,15 +210,15 @@ Cloudflare.Worker(
 ```
 
 `Alchemy.RuntimeContext` is the Effect service that exists *only*
-inside the runtime closure. It is not provided at plantime, cold
-start init, or anywhere else. So an Effect like:
+inside the runtime closure. It is not provided during Construct — neither locally nor at cold
+start — or anywhere else. So an Effect like:
 
 ```typescript
 kv.get(...): Effect.Effect<Job | null, KVNamespaceError, Alchemy.RuntimeContext>
 ```
 
 is one the type system *guarantees* can only run in the runtime
-phase. Move that call up into the init closure and the type checker
+phase. Move that call up into the Construct closure and the type checker
 rejects it — `RuntimeContext` is not satisfied there.
 
 You can think of it as a "color" in the sense of
@@ -230,7 +230,7 @@ runtime function getJob(id: string): Job
 
 TypeScript doesn't have keyword-level coloring, so Alchemy encodes
 the color as an Effect requirement. The compiler enforces the
-init/runtime boundary for you.
+construct/runtime boundary for you.
 
 ## What you compose with
 

--- a/website/src/content/docs/concepts/outputs.mdx
+++ b/website/src/content/docs/concepts/outputs.mdx
@@ -216,7 +216,7 @@ const sharedBucket = Output.ref<typeof Bucket>("Bucket", {
 sharedBucket.bucketName; // Output<string>
 ```
 
-Resolved at plan time against the persisted state store, fails
+Resolved during Construct against the persisted state store, fails
 with `InvalidReferenceError` when the target is missing. In
 day-to-day code prefer `Resource.ref` — same primitive, more
 ergonomic surface.

--- a/website/src/content/docs/concepts/phases.mdx
+++ b/website/src/content/docs/concepts/phases.mdx
@@ -1,6 +1,6 @@
 ---
 title: Phases
-description: Alchemy programs run in two phases — plantime/init drives the deploy, runtime handles requests. Knowing which is which is the key to using Platforms.
+description: Alchemy programs run in two phases — Construct builds the resource graph, Runtime handles requests. Knowing which is which is the key to using Platforms.
 sidebar:
   order: 6
 ---
@@ -8,28 +8,32 @@ sidebar:
 import DAG from "../../../components/DAG.astro";
 
 :::tip
-Read this after [Platform](/concepts/platform). The init/runtime
+Read this after [Platform](/concepts/platform). The Construct/Runtime
 pattern shown there is what this page explains in depth.
 :::
 
 Every alchemy program operates in two distinct phases:
 
-- **Plantime** — the deploy. Runs `alchemy deploy`, `plan`, or
-  `dev`. Produces the resource graph, runs providers, persists state.
-- **Runtime** — the deployed handler. Runs inside a Worker or Lambda
+- **Construct** — builds the resource graph. Config, Bindings, and
+  Resources are declared here by building all your Layers. Runs both
+  locally (`alchemy deploy`, `plan`, `dev`) **and** in the cloud at
+  cold start.
+- **Runtime** — the deployed handler. API handlers and
+  async/background jobs run here, pulling from values declared during
+  Construct. Only runs in the cloud, inside a Worker or Lambda
   Function whenever a request comes in.
 
 Platform resources express both in a single program by **returning
 an Effect from inside an Effect**.
 
-## Init vs Runtime
+## Construct vs Runtime
 
 ```typescript
 Cloudflare.Worker(
   "Worker",
   { main: import.meta.path },
   Effect.gen(function* () {
-    // ─── Init phase ───
+    // ─── Construct phase ───
     const bucket = yield* Cloudflare.R2Bucket.bind(Bucket);
 
     return {
@@ -43,16 +47,16 @@ Cloudflare.Worker(
 );
 ```
 
-| Phase   | Code   | When it runs                          |
-| ------- | ------ | ------------------------------------- |
-| Init    | outer  | At plantime **and** at cold start     |
-| Runtime | inner  | Only inside a deployed handler        |
+| Phase     | Code   | When it runs                          |
+| --------- | ------ | ------------------------------------- |
+| Construct | outer  | Locally at deploy **and** at cold start |
+| Runtime   | inner  | Only inside a deployed handler        |
 
-The `bucket` value is established once during init and captured by
-the runtime closure. Init runs at most once per cold start; the
-runtime body runs per request with everything already wired up.
+The `bucket` value is established once during Construct and captured
+by the runtime closure. Construct runs at most once per cold start;
+the runtime body runs per request with everything already wired up.
 
-The runtime phase is the *only* place where `Alchemy.RuntimeContext`
+The Runtime phase is the *only* place where `Alchemy.RuntimeContext`
 is available. Any Effect whose requirements include `RuntimeContext`
 can only execute inside the runtime closure — the type system
 rejects it everywhere else. See
@@ -61,14 +65,14 @@ rejects it everywhere else. See
 ## What runs when
 
 <DAG
-  caption="Plantime (top) records bindings and builds the plan. Runtime (bottom) starts on cold start and runs the handler per request."
+  caption="Construct (top) records bindings and builds the resource graph. Runtime (bottom) starts on cold start and runs the handler per request."
   nodes={[
-    { id: "Plan", label: "alchemy deploy", type: "plantime", tone: "accent" },
-    { id: "InitP", label: "init()", type: "records bindings" },
+    { id: "Plan", label: "alchemy deploy", type: "construct", tone: "accent" },
+    { id: "InitP", label: "construct()", type: "records bindings" },
     { id: "Apply", label: "apply", type: "create / update" },
     { id: "Deploy", label: "deployed", type: "Worker / Lambda" },
     { id: "Cold", label: "cold start", type: "runtime", tone: "accent", layer: 0 },
-    { id: "InitR", label: "init()", type: "builds SDK clients", layer: 1 },
+    { id: "InitR", label: "construct()", type: "builds SDK clients", layer: 1 },
     { id: "Runtime", label: "fetch()", type: "per request", layer: 2 },
   ]}
   edges={[
@@ -80,26 +84,26 @@ rejects it everywhere else. See
   ]}
 />
 
-- At **plantime**, init runs to discover bindings — alchemy needs
-  to know which resources the handler will use so it can wire
-  permissions, env vars, and references.
-- At **runtime cold start**, init runs again — this time inside the
-  deployed Worker, where the same `bind()` calls return live SDK
-  clients backed by the deployed resource.
+- **Locally during Construct**, the outer Effect runs to discover
+  bindings — alchemy needs to know which resources the handler will
+  use so it can wire permissions, env vars, and references.
+- **In the cloud at cold start**, Construct runs again — this time
+  inside the deployed Worker, where the same `bind()` calls return
+  live SDK clients backed by the deployed resource.
 - The **runtime body** only runs in the deployed handler. It never
-  executes at plantime, so you can put real per-request work there
-  without affecting deploy speed.
+  executes locally during Construct, so you can put real per-request
+  work there without affecting deploy speed.
 
 ## `ALCHEMY_PHASE`
 
 The current phase is exposed as the `ALCHEMY_PHASE` environment
 variable / config key:
 
-| Value     | Context                                                    |
-| --------- | ---------------------------------------------------------- |
-| `plan`    | Default. Running `alchemy deploy` or `alchemy plan`.       |
-| `dev`     | Running `alchemy dev` (local development with hot reload). |
-| `runtime` | Running inside a deployed Worker or Lambda Function.       |
+| Value       | Context                                                    |
+| ----------- | ---------------------------------------------------------- |
+| `construct` | Default. Running `alchemy deploy` or `alchemy plan`.       |
+| `dev`       | Running `alchemy dev` (local development with hot reload). |
+| `runtime`   | Running inside a deployed Worker or Lambda Function.       |
 
 Most user code never reads this directly — but providers and
 [bindings](/concepts/binding) use it internally to behave
@@ -110,15 +114,15 @@ differently across phases.
 A binding has two layers under the hood — and which one runs depends
 on the phase:
 
-| Layer              | Phase   | Job                                                   |
-| ------------------ | ------- | ----------------------------------------------------- |
-| `Binding.Service`  | Runtime | The lightweight typed SDK that ships with the bundle. |
-| `Binding.Policy`   | Plan    | The deploy-time logic that emits IAM / env / config.  |
+| Layer              | Phase     | Job                                                   |
+| ------------------ | --------- | ----------------------------------------------------- |
+| `Binding.Service`  | Runtime   | The lightweight typed SDK that ships with the bundle. |
+| `Binding.Policy`   | Construct | The deploy-time logic that emits IAM / env / config.  |
 
-At plantime the Policy layer is provided, so calling `bind()`
+During Construct the Policy layer is provided, so calling `bind()`
 records what the function will need. At runtime the Policy layer is
 absent — `bind()` returns just the Service wrapper. The runtime
-bundle stays small because none of the planning code is included.
+bundle stays small because none of the construction code is included.
 
 This is also how alchemy can let you write `bucket.get(...)` inside
 a Worker without bundling AWS / Cloudflare provisioning code:
@@ -126,9 +130,9 @@ provisioning lives in `Policy`, not `Service`.
 
 ## Why this matters
 
-The init/runtime split lets you write code that:
+The Construct/Runtime split lets you write code that:
 
-1. **Resolves infrastructure references at deploy time** — bindings
+1. **Resolves infrastructure references during Construct** — bindings
    know which bucket ARN, queue URL, etc. to inject.
 2. **Initializes SDK clients once at cold start** — not on every
    request.
@@ -138,7 +142,7 @@ The init/runtime split lets you write code that:
 
 ```typescript
 Effect.gen(function* () {
-  // Init: runs once per cold start
+  // Construct: runs once per cold start
   const bucket = yield* Cloudflare.R2Bucket.bind(Bucket);
   const kv = yield* Cloudflare.KVNamespace.bind(KV);
 

--- a/website/src/content/docs/concepts/platform.mdx
+++ b/website/src/content/docs/concepts/platform.mdx
@@ -29,7 +29,7 @@ export default Cloudflare.Worker(
   "Api",
   { main: import.meta.path },
   Effect.gen(function* () {
-    // Init: bind a resource. The binding is the typed SDK.
+    // Construct: bind a resource. The binding is the typed SDK.
     const bucket = yield* Cloudflare.R2Bucket.bind(Bucket);
 
     return {
@@ -183,5 +183,5 @@ Pick whichever fits your team. The Effect style unlocks
 testing; the async style integrates better with existing handler
 code.
 
-For a deeper look at when init code runs vs when exec code runs (and
-why), see [Plantime and Runtime](/concepts/phases).
+For a deeper look at when Construct code runs vs when Runtime code runs (and
+why), see [Construct and Runtime](/concepts/phases).

--- a/website/src/content/docs/concepts/references.mdx
+++ b/website/src/content/docs/concepts/references.mdx
@@ -1,6 +1,6 @@
 ---
 title: References
-description: Read values out of another stack or stage at plan time — typed, lazy, and resolved from persisted state.
+description: Read values out of another stack or stage during Construct — typed, lazy, and resolved from persisted state.
 sidebar:
   order: 3
 ---
@@ -13,7 +13,7 @@ without re-running prod's plan.
 
 A **reference** points at something **already deployed**
 somewhere else — a different stage, a different stack, or both —
-and resolves to that thing's live attributes at plan time by
+and resolves to that thing's live attributes during Construct by
 reading the persisted [state store](/concepts/state-store).
 
 References are lazy. They don't hit any cloud API at declaration
@@ -145,7 +145,7 @@ Every reference — resource or stack — carries a
 | `stage` | The current stage |
 | `id` | required for resource refs; equals the stack name for stack refs |
 
-At plan time Alchemy:
+During Construct Alchemy:
 
 1. Reads the upstream's persisted state under that triple
    (`state.get` for resource refs, `state.getOutput` for stack

--- a/website/src/content/docs/concepts/secrets.mdx
+++ b/website/src/content/docs/concepts/secrets.mdx
@@ -1,6 +1,6 @@
 ---
 title: Secrets and Config
-description: Use effect/Config to read env vars at init time and have Alchemy automatically bind them onto the deploy target.
+description: Use effect/Config to read env vars at construct time and have Alchemy automatically bind them onto the deploy target.
 sidebar:
   order: 8
 ---
@@ -10,7 +10,7 @@ to automatically bind env vars to your [Platform](/concepts/platform) environmen
 
 ## Bind a secret to your Worker
 
-Any `Config` value that is evaluated with `yield*` in the [Init phase](/concepts/phases)
+Any `Config` value that is evaluated with `yield*` in the [Construct phase](/concepts/phases)
 of (for example) a Worker, is automatically bound to its environment
 at deploy time.
 
@@ -25,7 +25,7 @@ export default Cloudflare.Worker(
   { main: import.meta.filename },
   Effect.gen(function* () {
     const apiKey = yield* Config.redacted("API_KEY"); 
-    // apiKey is Redacted<string> — usable here in Init AND captured as a binding
+    // apiKey is Redacted<string> — usable here in Construct AND captured as a binding
 
     return {
       fetch: Effect.gen(function* () {
@@ -37,13 +37,13 @@ export default Cloudflare.Worker(
 ```
 
 :::tip
-See [Phases](/concepts/phases) for why Init and Runtime run separately.
+See [Phases](/concepts/phases) for why Construct and Runtime run separately.
 :::
 
-## Use the value during Init
+## Use the value during Construct
 
 Unlike an [Output](/concepts/outputs), the value can be used immediately
-within the Init phase. For example, to initialize a client:
+within the Construct phase. For example, to initialize a client:
 
 ```typescript
 export default Cloudflare.Worker(
@@ -106,12 +106,12 @@ export default Cloudflare.Worker(
 );
 ```
 
-Always resolve the `Config` in the outer `Effect.gen` (Init) — even
+Always resolve the `Config` in the outer `Effect.gen` (Construct) — even
 if you only need the value inside `fetch`. Capture it in a `const`,
 and reference that `const` from the runtime body:
 
 ```typescript
-// ✅ bound in Init, used in Runtime
+// ✅ bound in Construct, used in Runtime
 Effect.gen(function* () {
   const apiKey = yield* Config.redacted("API_KEY");
   return {
@@ -124,7 +124,7 @@ Effect.gen(function* () {
 
 ## Async Workers — bind via `env`
 
-Async (non-Effect) Workers don't have an Init `Effect.gen` to
+Async (non-Effect) Workers don't have a Construct `Effect.gen` to
 `yield*` into, so you put the `Config` on the resource's `env`
 prop instead. Alchemy resolves each `Config` at deploy time and
 records the appropriate binding — same end result as the `yield*`

--- a/website/src/content/docs/concepts/stack.mdx
+++ b/website/src/content/docs/concepts/stack.mdx
@@ -130,13 +130,13 @@ export const Traces = Axiom.Dataset(
 );
 ```
 
-The function runs once at plan time, after the stage is resolved.
+The function runs once during Construct, after the stage is resolved.
 Use it anywhere a resource accepts a `props` object.
 
 ## Cross-stack references
 
 A typed `Alchemy.Stack` handle lets one stack read another's
-persisted outputs at plan time:
+persisted outputs during Construct:
 
 ```typescript
 // backend/src/Stack.ts — typed handle shared across packages

--- a/website/src/content/docs/guides/circular-bindings.mdx
+++ b/website/src/content/docs/guides/circular-bindings.mdx
@@ -75,7 +75,7 @@ triggers any runtime code by importing the other's class.
 
 ## Add A's runtime, binding B
 
-Attach A's implementation with `A.make(...)`. Inside the Init phase,
+Attach A's implementation with `A.make(...)`. Inside the Construct phase,
 `yield* Cloudflare.Worker.bind(B)` produces a typed callable that
 will dispatch to B's deployed URL at runtime.
 
@@ -102,7 +102,7 @@ will dispatch to B's deployed URL at runtime.
 ```
 
 The `import { B }` line pulls in B's Tag only. `Worker.bind(B)`
-returns a deferred reference — at plan time it's an `Output<URL>`
+returns a deferred reference — during Construct it's an `Output<URL>`
 placeholder; at runtime it's a real `fetch` stub.
 
 ## Add B's runtime, binding A

--- a/website/src/content/docs/guides/cli.mdx
+++ b/website/src/content/docs/guides/cli.mdx
@@ -137,7 +137,7 @@ yield* deploy(
 ).pipe(adopt(true));
 ```
 
-`AdoptPolicy` is consulted at plan time, so the combinator must
+`AdoptPolicy` is consulted during Construct, so the combinator must
 wrap the *deploy* (or test runner's `stack.deploy(...)`) — not the
 inner resource-declaration effect.
 

--- a/website/src/content/docs/guides/custom-provider.mdx
+++ b/website/src/content/docs/guides/custom-provider.mdx
@@ -54,8 +54,8 @@ export interface StripeProductAttributes {
 
 A `Resource<Type, Props, Attributes>` is a phantom type that ties a
 string `Type` to its props and attributes. The string `Type` (here
-`"Stripe.Product"`) is what Alchemy uses to look up the provider at
-plan time — it must be globally unique.
+`"Stripe.Product"`) is what Alchemy uses to look up the provider during
+Construct — it must be globally unique.
 
 ```diff lang="typescript"
 // src/stripe/Product.ts
@@ -358,7 +358,7 @@ products the `name` is mutable but (hypothetically) the
 product. Implement `diff` to tell Alchemy which kind of change to
 plan.
 
-`diff` runs at **plan time**, before `update`, and returns one of:
+`diff` runs during the **Construct** phase, before `update`, and returns one of:
 
 - `{ action: "noop" }` — change is trivial, skip `update`
 - `{ action: "update", stables?: [...] }` — apply in place

--- a/website/src/content/docs/guides/effect-ai.mdx
+++ b/website/src/content/docs/guides/effect-ai.mdx
@@ -30,12 +30,12 @@ Every Effect AI provider is two stacked layers:
 2. A **language model** Layer that picks the model and any defaults
    (`OpenAiLanguageModel.layer({ model: "gpt-4o-mini" })`, …).
 
-You build that stack once in the Platform's **init phase** and
+You build that stack once in the Platform's **construct phase** and
 `Effect.provide(...)` it on the handler:
 
 ```typescript
 Effect.gen(function* () {
-  // 1. Init: build the LanguageModel layer (deploy bindings happen here).
+  // 1. Construct: build the LanguageModel layer (deploy bindings happen here).
   const languageModel = ...;
 
   return {
@@ -57,14 +57,14 @@ procedure, a Workflow, or any other Effect.
 Every upstream provider's client Layer (`OpenAiClient.layer`,
 `AnthropicClient.layer`, …) takes an `apiKey: Redacted<string>`.
 [`Config.redacted`](/concepts/secrets) resolved in the Platform's
-Init phase gives you exactly that `Redacted<string>` — and Alchemy
+Construct phase gives you exactly that `Redacted<string>` — and Alchemy
 automatically binds the value as a `secret_text` binding
 (Cloudflare) or environment variable (Lambda) at deploy time:
 
 ```typescript
 import * as Config from "effect/Config";
 
-// outer init — resolves the value AND records the binding
+// Construct phase — resolves the value AND records the binding
 const apiKey = yield* Config.redacted("OPENAI_API_KEY");
 ```
 
@@ -72,9 +72,9 @@ const apiKey = yield* Config.redacted("OPENAI_API_KEY");
 `ConfigProvider` (e.g. `.env`) at deploy time, records the binding,
 and resolves from that binding again at runtime — one line, both
 phases. See [Concepts › Secrets and Config](/concepts/secrets) for
-the Init/Runtime split, `.env`, and transformations.
+the Construct/Runtime split, `.env`, and transformations.
 
-Because the value is in scope right in Init, the model Layer can be
+Because the value is in scope right in Construct, the model Layer can be
 built eagerly — no `Layer.unwrap` needed:
 
 ```typescript
@@ -167,7 +167,7 @@ Gateway as a resource and `.bind(Gateway).model({...})` returns a
 `LanguageModel` Layer that proxies Workers AI through the gateway —
 with caching, rate limiting, retries, and a unified request log.
 
-Bind the gateway in the Init phase and call `aiGateway.model({...})`
+Bind the gateway in the Construct phase and call `aiGateway.model({...})`
 with a Workers AI model id. It returns a `LanguageModel` Layer
 directly — no API key, no `Layer.unwrap`, since the gateway binding
 handles auth and the URL:
@@ -185,7 +185,7 @@ const languageModel = aiGateway.model({
 That `languageModel` Layer slots into the same `Effect.provide(...)`
 spot as any other provider — the rest of your handler doesn't
 change. Provide `Cloudflare.AiGatewayBindingLive` once at the
-bottom of the Init layer chain so the binding resolves at runtime:
+bottom of the Construct layer chain so the binding resolves at runtime:
 
 ```typescript
 Effect.gen(function* () {

--- a/website/src/content/docs/guides/effect-http-api.mdx
+++ b/website/src/content/docs/guides/effect-http-api.mdx
@@ -20,8 +20,8 @@ The mental model we'll follow is:
 
 1. **Define the schema and API outside the Worker.** Both are pure
    descriptions and can be imported by clients.
-2. **Construct the service inside the Worker's Init phase.**
-   The Init phase runs at plan time *and* runtime, so we only do
+2. **Construct the service inside the Worker's Construct phase.**
+   The Construct phase runs both locally and at runtime, so we only do
    pure construction here — we never `yield*` something that needs
    a request to exist.
 3. **Return `{ fetch }`** where `fetch` is an `HttpEffect`.
@@ -98,7 +98,7 @@ end of this guide.
 
 ## 3. Build the Worker
 
-Now we wire it up. Create `src/worker.ts` with an empty Init phase:
+Now we wire it up. Create `src/worker.ts` with an empty Construct phase:
 
 ```typescript
 // src/worker.ts
@@ -114,8 +114,8 @@ export default Cloudflare.Worker(
 );
 ```
 
-The generator inside `Cloudflare.Worker` is the **Init phase**. It
-runs both at *plan time* (when Alchemy builds the deployment graph)
+The generator inside `Cloudflare.Worker` is the **Construct phase**. It
+runs both locally (when Alchemy builds the resource graph)
 and at *runtime* (when the Worker boots a fresh isolate). Anything
 you `yield*` here must be safe in both contexts — typically resource
 binding factories like `R2Bucket.bind(...)`, never per-request work.
@@ -123,7 +123,7 @@ binding factories like `R2Bucket.bind(...)`, never per-request work.
 ### 3a. Bind an R2 bucket for storage
 
 Tasks need to live somewhere durable. Declare an `R2Bucket` resource
-and bind it inside Init — `bind()` returns a typed handle whose
+and bind it inside the Construct phase — `bind()` returns a typed handle whose
 `get` / `put` / `delete` / `list` methods we'll call from the
 handlers below.
 
@@ -153,15 +153,15 @@ We'll provide the runtime side of this binding
 (`Cloudflare.R2BucketBindingLive`) in step 3c when we wire up the
 `fetch` handler.
 
-### 3b. Construct the handler group inside Init
+### 3b. Construct the handler group inside the Construct phase
 
 `HttpApiBuilder.group` *constructs* a `Layer` that wires handlers
 into the API spec. It's pure — it doesn't run them. That makes it
-safe to call inside Init.
+safe to call inside the Construct phase.
 
 > Don't `yield*` `HttpApiBuilder.layer(TaskApi)` here — building the
 > layer is fine, but actually executing the server requires an
-> incoming request. Init only does construction; the work happens
+> incoming request. The Construct phase only does construction; the work happens
 > later, on each `fetch` call.
 
 ```typescript twoslash
@@ -209,7 +209,7 @@ keeping the typed error channel reserved for `TaskNotFound`.
 
 ### 3c. Return `{ fetch }`
 
-The return value of Init is the *Worker's surface* — for a
+The return value of the Construct phase is the *Worker's surface* — for a
 fetch-style Worker that means an object with a `fetch` field. The
 value of `fetch` must be an `HttpEffect`: an `Effect` that, given an
 `HttpServerRequest`, produces an `HttpServerResponse`.
@@ -452,7 +452,7 @@ export class TaskDOApi extends HttpApi.make("TaskDOApi").add(TasksDOGroup) {}
 
 ### Implement the DO
 
-The DO's Init returns `{ fetch }` — an `HttpEffect` produced exactly
+The DO's Construct phase returns `{ fetch }` — an `HttpEffect` produced exactly
 the same way the Worker produces one, just scoped to its own
 `TaskDOApi`. Storage is the DO's transactional `state.storage`
 instead of R2.
@@ -504,7 +504,7 @@ export default class TasksObject extends Cloudflare.DurableObjectNamespace<Tasks
 
 ### Bridge the DO into a typed client
 
-Inside the Worker's Init, `Cloudflare.toHttpClient(stub)` wraps a DO
+Inside the Worker's Construct phase, `Cloudflare.toHttpClient(stub)` wraps a DO
 stub as an `HttpClient`. Hand that client to `HttpApiClient.makeWith`
 and you get a fully typed client whose every call is a DO `fetch`
 under the hood:
@@ -559,7 +559,7 @@ backends behind the scenes.
 
 - The **schema** (`Task`, `TaskNotFound`) and the **API spec**
   (`TaskApi`) live outside the Worker — they're pure descriptions.
-- The **handlers** are constructed inside the Worker's Init phase
+- The **handlers** are constructed inside the Worker's Construct phase
   closure. We build a `Layer` with `HttpApiBuilder.group` but never
   `yield*` the running server — that only makes sense per-request.
 - The Worker's surface is `{ fetch }`, where `fetch` is an

--- a/website/src/content/docs/guides/effect-rpc.mdx
+++ b/website/src/content/docs/guides/effect-rpc.mdx
@@ -17,7 +17,7 @@ identical to the HTTP API guide:
 
 1. **Define schemas outside.** Domain types and tagged errors,
    importable by both server and client.
-2. **Construct the service inside the Worker's Init phase.**
+2. **Construct the service inside the Worker's Construct phase.**
    `RpcGroup.toLayer` is pure construction — safe to call at plan
    time. Don't `yield*` the running server; it can't run without a
    request.
@@ -85,7 +85,7 @@ export class TaskRpcs extends RpcGroup.make(getTask, createTask) {}
 
 ## 3. Build the Worker
 
-Create `src/worker.ts` with an empty Init phase:
+Create `src/worker.ts` with an empty Construct phase:
 
 ```typescript
 // src/worker.ts
@@ -101,15 +101,15 @@ export default Cloudflare.Worker(
 );
 ```
 
-The generator inside `Cloudflare.Worker` is the **Init phase** — it
-runs both at *plan time* and at *runtime*. Only do pure construction
+The generator inside `Cloudflare.Worker` is the **Construct phase** — it
+runs both locally and at *runtime*. Only do pure construction
 or resource-binding factories here; never `yield*` work that needs
 an incoming request.
 
 ### 3a. Bind an R2 bucket for storage
 
 Tasks need durable storage. Declare an `R2Bucket` resource and bind
-it inside Init — `bind()` returns a typed handle whose `get` /
+it inside the Construct phase — `bind()` returns a typed handle whose `get` /
 `put` / `delete` / `list` methods we'll call from the handlers
 below.
 
@@ -139,7 +139,7 @@ We'll provide the runtime side of this binding
 (`Cloudflare.R2BucketBindingLive`) in step 3c when we wire up the
 `fetch` handler.
 
-### 3b. Construct the handlers inside Init
+### 3b. Construct the handlers inside the Construct phase
 
 `TaskRpcs.toLayer` takes an `Effect` that returns one handler per
 procedure and produces a `Layer`. Like `HttpApiBuilder.group`, this
@@ -147,7 +147,7 @@ is pure construction — it builds a value, it doesn't run the server.
 
 > Don't `yield* TaskRpcs.toLayer(...)` here. Building a layer is
 > fine, but actually executing the procedures requires an incoming
-> request. Init only constructs; the work happens later, on each
+> request. The Construct phase only constructs; the work happens later, on each
 > `fetch` call.
 
 ```typescript twoslash
@@ -424,7 +424,7 @@ export class TaskRpcs extends InnerRpcs.merge(DoRpcs) {}
 
 ### Implement the DO
 
-The DO's Init returns `{ fetch }` produced by
+The DO's Construct phase returns `{ fetch }` produced by
 `RpcServer.toHttpEffect(InnerRpcs)`. State lives in
 `state.storage` instead of R2:
 
@@ -548,7 +548,7 @@ for external consumers and RPC for internal services.
 - **Schemas** (`Task`, `TaskNotFound`, `CreateTaskFailed`) and the
   **RPC group** (`TaskRpcs`) live outside the Worker — pure
   descriptions, importable by clients.
-- The **handlers** are constructed inside the Worker's Init phase
+- The **handlers** are constructed inside the Worker's Construct phase
   closure via `TaskRpcs.toLayer`. We build a `Layer` but never
   `yield*` the running server.
 - The Worker's surface is `{ fetch }`, where `fetch` is the
@@ -588,7 +588,7 @@ returns the same `Worker` resource — but `props.schema` lets a second
 Worker bind a typed client without re-importing `RpcClient`:
 
 ```typescript
-// INIT: register the binding, get the typed client
+// CONSTRUCT: register the binding, get the typed client
 const tasks = yield* Cloudflare.RpcWorker.bind(TaskWorker);
 
 // PER-REQUEST: just call methods directly

--- a/website/src/content/docs/guides/infrastructure-layers.mdx
+++ b/website/src/content/docs/guides/infrastructure-layers.mdx
@@ -134,7 +134,7 @@ Replace the TODO bodies with calls to the typed client:
 ## Scaffold the Worker
 
 Start with a minimal Worker that responds to every request with a
-placeholder. Init and runtime closures are both empty.
+placeholder. Construct and runtime closures are both empty.
 
 ```typescript
 // src/Api.ts
@@ -157,7 +157,7 @@ export default Cloudflare.Worker(
 
 ## Resolve the service
 
-Yield `JobService` in the init closure to get a typed handle, then
+Yield `JobService` in the Construct closure to get a typed handle, then
 call it from `fetch`:
 
 ```diff lang="typescript"
@@ -317,6 +317,6 @@ to talk to it.
 
 - [Layers](/concepts/layers) — the concept behind this guide
 - [Binding](/concepts/binding) — what `.bind(...)` does under the hood
-- [Phases](/concepts/phases) — when init vs runtime code runs
+- [Phases](/concepts/phases) — when Construct vs Runtime code runs
 - [Circular Bindings](/guides/circular-bindings) — two Layers
   referencing each other

--- a/website/src/content/docs/guides/migrating-from-v1.mdx
+++ b/website/src/content/docs/guides/migrating-from-v1.mdx
@@ -135,7 +135,7 @@ gives you typed errors, composable retries, and Effect's `HttpServer`
 integration.
 
 Instead of declaring `env` bindings on the resource props, you bind
-resources in the Worker's Init phase using `yield*`:
+resources in the Worker's Construct phase using `yield*`:
 
 ```typescript twoslash
 // @noErrors

--- a/website/src/content/docs/guides/monorepo.mdx
+++ b/website/src/content/docs/guides/monorepo.mdx
@@ -324,7 +324,7 @@ the one to reach for unless you have a reason not to.
 
 Each package owns its own `alchemy.run.ts`. The frontend reads
 the backend's deployed outputs through a **cross-stack
-reference** (`yield* Backend`), resolved at plan time against the
+reference** (`yield* Backend`), resolved during Construct against the
 state store. Each package can deploy and destroy independently.
 
 You pay for that with two extra moving parts:

--- a/website/src/content/docs/guides/secrets.mdx
+++ b/website/src/content/docs/guides/secrets.mdx
@@ -8,7 +8,7 @@ sidebar:
 Wire an `OPENAI_API_KEY` from your `.env` into a Cloudflare Worker
 as a `secret_text` binding.
 
-For the bigger picture — how this works, the Init/Runtime split,
+For the bigger picture — how this works, the Construct/Runtime split,
 trade-offs, and `Cloudflare.Secret` — see
 [Concepts › Secrets and Variables](/concepts/secrets).
 
@@ -19,7 +19,7 @@ trade-offs, and `Cloudflare.Secret` — see
 OPENAI_API_KEY=sk-proj-...
 ```
 
-## 2. Resolve it in the Worker's Init phase
+## 2. Resolve it in the Worker's Construct phase
 
 ```diff lang="typescript"
 // src/worker.ts
@@ -50,7 +50,7 @@ runtime, the same `Config.redacted("OPENAI_API_KEY")` resolves
 from that binding — one line, both phases.
 
 See [Concepts › Secrets and Variables](/concepts/secrets) for how
-the Init/Runtime hook-up works.
+the Construct/Runtime hook-up works.
 :::
 
 ## 3. Use it inside `fetch`

--- a/website/src/content/docs/guides/shared-database.mdx
+++ b/website/src/content/docs/guides/shared-database.mdx
@@ -14,7 +14,7 @@ shared instance instead.
 
 `Resource.ref(id, { stage })` reads a deployed resource's
 attributes from another stage of the same stack — typed, lazy,
-resolved at plan time against the persisted state store. See
+resolved during Construct against the persisted state store. See
 [References](/concepts/references) for the full reference surface
 (`Output.ref`, `Output.stackRef`, `Stack.stage`).
 
@@ -107,7 +107,7 @@ Three things to know about `Resource.ref`:
    attributes, same downstream API. The branch resource doesn't
    know or care that one stage's `project` is real and another's
    is a reference.
-3. **Resolved at plan time.** Alchemy reads the attributes (project
+3. **Resolved during Construct.** Alchemy reads the attributes (project
    id, host, etc.) from the staging stage's state file. If
    `staging` hasn't been deployed yet, plan fails with
    `InvalidReferenceError` — deploy `staging` first, then PR

--- a/website/src/content/docs/tutorial/aws/dynamodb.mdx
+++ b/website/src/content/docs/tutorial/aws/dynamodb.mdx
@@ -14,7 +14,7 @@ to the Lambda — same pattern as S3, different storage.
 
 DynamoDB tables need a partition key (and optionally a sort key)
 declared up-front. Yield the `Table` resource in the function's
-outer init, mirroring how you added the bucket:
+Construct phase, mirroring how you added the bucket:
 
 ```diff lang="typescript"
 // src/api.ts

--- a/website/src/content/docs/tutorial/aws/s3.mdx
+++ b/website/src/content/docs/tutorial/aws/s3.mdx
@@ -16,7 +16,7 @@ a least-privilege IAM policy from the bindings you actually use.
 S3 buckets are canonical Alchemy resources, so you create them
 the same way as the Lambda — yield the resource inside an Effect
 and the Stack captures it. Open `src/api.ts` and add a bucket in
-the outer init:
+the Construct phase:
 
 ```diff lang="typescript"
 // src/api.ts
@@ -58,7 +58,7 @@ as **bindings**. A binding is two things:
 2. An IAM policy statement that gets attached to the function
    role automatically — scoped to the exact bucket ARN.
 
-Bind them in the outer init, alongside the bucket:
+Bind them in the Construct phase, alongside the bucket:
 
 ```diff lang="typescript"
 Effect.gen(function* () {

--- a/website/src/content/docs/tutorial/aws/sqs.mdx
+++ b/website/src/content/docs/tutorial/aws/sqs.mdx
@@ -137,7 +137,7 @@ the shared handle instead of declaring the queue inline:
 
 ## Resolve the queue in the consumer
 
-Yield the same `Jobs` handle in the consumer's outer init to get
+Yield the same `Jobs` handle in the consumer's Construct phase to get
 a typed `Queue` resource:
 
 ```diff lang="typescript"

--- a/website/src/content/docs/tutorial/cloudflare/ai-gateway.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/ai-gateway.mdx
@@ -93,7 +93,7 @@ the gateway endpoint, `getLog`/`patchLog` for the request log, and
 ```
 
 `Cloudflare.AiGatewayBindingLive` is the runtime side of the
-binding. Provide it once at the bottom of the Init layer chain and
+binding. Provide it once at the bottom of the Construct layer chain and
 every `bind(...)` further up will resolve.
 
 ## Build a `LanguageModel` layer
@@ -121,7 +121,7 @@ that satisfies Effect's standard AI service.
 ```
 
 `parameters` is the per-call default; any individual call can still
-override it. The Init phase is the right place to build this layer —
+override it. The Construct phase is the right place to build this layer —
 construction is pure and the binding factory only exists here.
 
 ## Generate text on `/generate`

--- a/website/src/content/docs/tutorial/cloudflare/artifacts.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/artifacts.mdx
@@ -90,7 +90,7 @@ that becomes a discriminated union member on the client.
 ## Implement the Worker
 
 Create `src/Worker.ts`. The handler group is *constructed* with
-`HttpApiBuilder.group` (pure — safe inside the Worker's Init
+`HttpApiBuilder.group` (pure — safe inside the Worker's Construct
 phase), and the `fetch` field is the result of layering the API
 into an `HttpEffect`:
 
@@ -486,7 +486,7 @@ export default class Repo extends Cloudflare.DurableObjectNamespace<Repo>()(
 ## Persist the metadata
 
 Each DO instance has its own SQLite-backed key/value storage. Pull
-the current metadata out of storage in the inner init so it
+the current metadata out of storage in the inner Effect so it
 survives restarts and hibernation:
 
 ```diff lang="typescript"
@@ -572,7 +572,7 @@ export class RepoInfo extends Schema.Class<RepoInfo>("RepoInfo")({
 }) {}
 ```
 
-Yield the `Repo` class in the Worker's init phase. The handle is a
+Yield the `Repo` class in the Worker's construct phase. The handle is a
 DO namespace — `repos.getByName(name)` returns a typed RPC stub for
 that repo's instance:
 

--- a/website/src/content/docs/tutorial/cloudflare/containers.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/containers.mdx
@@ -255,7 +255,7 @@ that lives in `Sandbox.runtime.ts` and Rolldown tree-shakes it out.
 
 `Cloudflare.Container.bind(Sandbox)` registers the binding the
 same way `R2Bucket.bind` or `KVNamespace.bind` do. It belongs in
-the **outer** init phase — that runs once when the DO class is
+the **outer** construct phase — that runs once when the DO class is
 wired to its Worker. If you put it in the inner phase, every new
 DO instance would re-bind, which is wasteful and wrong.
 
@@ -280,7 +280,7 @@ phase, so each DO instance gets its own running container.
 
 `Cloudflare.start(sandbox)` ensures the container process is
 running for **this** DO instance, then hands you the typed shape
-you declared on the class. Add it to the **inner** init and wire
+you declared on the class. Add it to the **inner** Effect and wire
 the result up as an RPC method:
 
 ```diff lang="typescript"
@@ -298,7 +298,7 @@ Effect.gen(function* () {
 }),
 ```
 running for **this** DO instance, then hands you the typed shape
-you declared on the class. Add it to the **inner** init and wire
+you declared on the class. Add it to the **inner** Effect and wire
 the result up as an RPC method:
 
 ```diff lang="typescript"

--- a/website/src/content/docs/tutorial/cloudflare/cross-worker-durable-object.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/cross-worker-durable-object.mdx
@@ -146,7 +146,7 @@ WorkerA's bundle actually contains the DO class:
 +);
 ```
 
-`yield* Counter` inside WorkerA's init binds the DO _locally_ —
+`yield* Counter` inside WorkerA's Construct phase binds the DO _locally_ —
 WorkerA's `env.Counter` is wired up at deploy time and the class
 ships in the bundle.
 

--- a/website/src/content/docs/tutorial/cloudflare/drizzle.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/drizzle.mdx
@@ -149,7 +149,7 @@ No `drizzle-kit generate` step in your CI — the deploy owns it.
 
 `Drizzle.postgres` takes Hyperdrive's connection string and returns a
 typed `EffectPgDatabase` whose pool lives for the lifetime of the
-Worker isolate. Bind it once at init and use it directly inside
+Worker isolate. Bind it once during Construct and use it directly inside
 `fetch` — no per-request `Client` setup, no `Effect.promise(...)`
 wrappers around queries:
 

--- a/website/src/content/docs/tutorial/cloudflare/durable-objects.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/durable-objects.mdx
@@ -16,7 +16,7 @@ caller.
 
 A Durable Object is a globally-unique stateful instance addressed
 by name (or by id). Like Workers, it has two `Effect.gen` blocks:
-the outer one runs at init time, and the inner one runs every time
+the outer one runs during Construct, and the inner one runs every time
 a new instance starts up and returns the public API.
 
 Create `src/counter.ts` with the smallest possible DO — empty
@@ -30,7 +30,7 @@ import * as Effect from "effect/Effect";
 export default class Counter extends Cloudflare.DurableObjectNamespace<Counter>()(
   "Counter",
   Effect.gen(function* () {
-    // Outer (init): runs once when the DO class is bound to a
+    // Outer (construct): runs once when the DO class is bound to a
     // Worker. Resolve shared dependencies here.
     return Effect.gen(function* () {
       // Inner (per-instance): runs every time a new DO instance is
@@ -50,7 +50,7 @@ ceremony — the rest of your DO code looks completely normal.
 ## Persist the count
 
 Each DO instance has its own key/value storage, backed by SQLite.
-Pull the current count out of storage in the inner init so it
+Pull the current count out of storage in the inner Effect so it
 survives restarts and hibernation:
 
 ```diff lang="typescript"
@@ -94,7 +94,7 @@ fully type-checked through the Cloudflare RPC machinery.
 
 ## Bind the DO to the Worker
 
-Yield the `Counter` class in your Worker's init phase to get a
+Yield the `Counter` class in your Worker's construct phase to get a
 namespace handle:
 
 ```diff lang="typescript"
@@ -119,7 +119,7 @@ export default Cloudflare.Worker(
 );
 ```
 
-`yield* Counter` in init registers the DO with the Worker
+`yield* Counter` during Construct registers the DO with the Worker
 (binding + class-migration metadata) and hands you the namespace.
 
 ## Call the DO from `fetch`

--- a/website/src/content/docs/tutorial/cloudflare/hibernatable-websockets.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/hibernatable-websockets.mdx
@@ -12,7 +12,7 @@ messages between peers, and **survives hibernation**.
 
 Cloudflare can evict an idle Durable Object from memory while
 keeping its WebSocket connections open. When a message arrives the
-DO is reconstructed from scratch, your init Effect runs again, and
+DO is reconstructed from scratch, your Construct Effect runs again, and
 your `webSocketMessage` handler is invoked. Any per-instance state
 you held in JavaScript variables is gone — you have to put it back.
 
@@ -155,7 +155,7 @@ the DO is reconstructed: the inner `Effect.gen` runs again, and
 your `sessions` map starts empty — but the open sockets are still
 there.
 
-Rehydrate the map at the top of the inner init by reading every
+Rehydrate the map at the top of the inner Effect by reading every
 attached socket back from the runtime:
 
 ```diff lang="typescript"

--- a/website/src/content/docs/tutorial/cloudflare/queue-consumer.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/queue-consumer.mdx
@@ -46,7 +46,7 @@ test can read it back.
 
 ## Bind the Queue producer
 
-In the Worker init phase, yield the queue resource and ask
+In the Worker construct phase, yield the queue resource and ask
 `QueueBinding` for a typed sender. The sender exposes `send` /
 `sendBatch` that round-trip through Cloudflare's runtime.
 

--- a/website/src/content/docs/tutorial/cloudflare/rpc-worker.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/rpc-worker.mdx
@@ -133,7 +133,7 @@ and return type.
  ) {}
 ```
 
-The init returns the **piped `RpcServer.toHttpEffect` Effect
+The Construct phase returns the **piped `RpcServer.toHttpEffect` Effect
 directly** — no `{ fetch }` wrapper.
 
 ## Deploy the Worker
@@ -317,7 +317,7 @@ export default class Caller extends Cloudflare.Worker<Caller>()(
 
 A regular Worker — same shape as any other `Cloudflare.Worker`.
 
-## Bind the typed client at init
+## Bind the typed client during Construct
 
 ```diff lang="typescript"
  import * as Cloudflare from "alchemy/Cloudflare";
@@ -425,7 +425,7 @@ for the full cross-script pattern.
 
 - `Cloudflare.RpcWorker` keeps everything from
   [Effect RPC](/guides/effect-rpc) and removes the `{ fetch }`
-  wrapper. `props.schema` declares the served `RpcGroup`; the init
+  wrapper. `props.schema` declares the served `RpcGroup`; the Construct phase
   returns the piped `RpcServer.toHttpEffect(schema)` Effect directly.
 - Inline form `(id, props, impl)` bundles the runtime into the
   class; modular form `(id, props)` + `Class.make(impl)` keeps the

--- a/website/src/content/docs/tutorial/cloudflare/workflows.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/workflows.mdx
@@ -23,7 +23,7 @@ through:
 
 ```typescript
 Effect.gen(function* () {
-  // Phase 1: init — runs at deploy and once per workflow instance.
+  // Phase 1: construct — runs at deploy and once per workflow instance.
   const room = yield* Room;
 
   return Effect.fn(function* (input: { orderId: string }) {
@@ -65,7 +65,7 @@ export default class NotifyWorkflow extends Cloudflare.Workflow<NotifyWorkflow>(
 ) {}
 ```
 
-The outer init resolves shared dependencies — here, the `Room` DO
+The Construct phase resolves shared dependencies — here, the `Room` DO
 namespace from the previous tutorial so we can broadcast back to
 it. The inner `Effect.fn` is the workflow body that the Cloudflare
 runtime executes task by task.
@@ -89,7 +89,7 @@ something binds to it.
 ## Bind KV to the workflow
 
 `Cloudflare.KVNamespace.bind(KV)` belongs in the workflow's outer
-init phase. It registers the binding on the workflow's worker and
+construct phase. It registers the binding on the workflow's worker and
 returns a typed Effect-native client whose methods (`get`, `put`,
 `list`, `delete`) are Effects you can `yield*` directly:
 
@@ -114,7 +114,7 @@ export default class NotifyWorkflow extends Cloudflare.Workflow<NotifyWorkflow>(
 ) {}
 ```
 
-Yielding the binding in the outer init is a one-time setup — the
+Yielding the binding in the Construct phase is a one-time setup — the
 inner workflow body closes over `kv` and uses it on every run.
 
 ## Add a task
@@ -271,7 +271,7 @@ sleep → broadcast → return — is durable end to end.
 
 Most real workflows need credentials — an upstream API key, a
 signing token, etc. `Alchemy.Secret` registers a `secret_text`
-binding on the workflow at plantime and hands back an accessor
+binding on the workflow during Construct and hands back an accessor
 for use inside steps:
 
 ```diff lang="typescript"
@@ -288,7 +288,7 @@ for use inside steps:
 ```
 
 `Alchemy.Secret("API_KEY")` reads `API_KEY` from the active
-`Config` provider (env vars, `.env`, …) at plantime and binds it
+`Config` provider (env vars, `.env`, …) during Construct and binds it
 into the workflow as `secret_text`. Set it in your local `.env`:
 
 ```sh
@@ -301,7 +301,7 @@ input shapes (literals, `Effect`, `Config`, …).
 
 ## Use the secret in a task
 
-The accessor returned in init is yielded inside the Runtime phase to resolve a
+The accessor returned during Construct is yielded inside the Runtime phase to resolve a
 `Redacted<string>`. Unwrap with `Redacted.value` only at the call
 site that needs it (here, an `Authorization` header):
 
@@ -358,7 +358,7 @@ elsewhere the value stays redacted.
 ## Trigger from the Worker
 
 A Workflow becomes a typed handle when you `yield*` it in the
-Worker's init phase. Use `create()` to start an instance and
+Worker's construct phase. Use `create()` to start an instance and
 `get(id).status()` to poll it:
 
 ```diff lang="typescript"

--- a/website/src/content/docs/tutorial/part-2.mdx
+++ b/website/src/content/docs/tutorial/part-2.mdx
@@ -41,7 +41,7 @@ export default Cloudflare.Worker(
 
 :::note
 Notice the "Effect returning an Effect" pattern. The outer generator
-is the **Init phase** — it runs at both plan time and runtime. The
+is the **Construct phase** — it runs both locally and at runtime cold start. The
 inner `fetch` generator is the **Runtime phase** — it runs only when
 handling a request.
 :::
@@ -96,7 +96,7 @@ descriptions — they don't execute until you `yield*` them inside a
 Stack. You can safely import them from multiple files.
 :::
 
-Now the Worker can import `Bucket` and bind it in the Init phase:
+Now the Worker can import `Bucket` and bind it in the Construct phase:
 
 ```typescript twoslash errorReplace='.*::Type 'R2BucketBinding' is not assignable to type 'WorkerServices | PlatformServices'.'
 // src/worker.ts


### PR DESCRIPTION
Migrate the two-phase terminology to **Construct** and **Runtime** across docs and code, and standardize the Action's dependency-resolving Effect on **constructor**.

The phase model is now:

- **Construct** — builds the resource graph (Config, Bindings, Resources, Layers). Runs both locally (`alchemy deploy`/`plan`/`dev`) and in the cloud at cold start. Replaces the old "Init phase" and "plantime"/"plan time".
- **Runtime** — API handlers and async/background jobs; cloud-only, pulling from values declared during Construct.

### Phase rename

```diff
- export type AlchemyPhase = "plan" | "runtime";
+ export type AlchemyPhase = "construct" | "runtime";
```

- `ALCHEMY_PHASE` value `"plan"` → `"construct"` (type, default, validation, and all `phase === "construct"` checks).
- `RuntimeContext.planServices` → `constructServices`.
- `Binding.Policy` "not provided at Plan Time" error → "during the Construct phase".
- JSDoc, comments, `// init` example labels → `// construct`.
- website docs (concepts, guides, tutorials, blog), `llms.txt`, `AGENTS.md`.

### Action rename

```diff
- export type ActionInit<In, Out, Req> = ...
+ export type ActionConstructor<In, Out, Req> = ...
```

- `ActionInit` → `ActionConstructor` (not part of the public export surface).
- `initOrRun` params/vars → `runnerOrConstructor`.
- Docs (`action.mdx`, actions/beta-38 blog): "init Effect" / "Init constructor" → "constructor".

### Left untouched (different concepts)

- The Fetch API `RequestInit` options bag — a web-standard type we don't own.
- The `alchemy plan` command and the Plan/Diff engine internals ("the plan" / resource graph artifact).
- The git-style DO RPC method literally named `init` in the artifacts example.

`bun tsc -b` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_012GSktjP5rGoMa2xEXA3pBd)_