### PR TITLE
feat(docs): add Bindings section and refocus Providers on lifecycle interface

### DIFF
--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -125,6 +125,36 @@ import { Bucket } from "./bucket.ts";
 const bucket = yield* Cloudflare.R2Bucket.bind(Bucket);
 ```
 
+## Bindings
+
+A **Binding** connects a resource to a Worker or Lambda. A single
+`bind()` call hands your handler a typed client and — at deploy time
+— wires up the permissions, environment variables, and platform
+bindings that client needs:
+
+```typescript
+const bucket = yield* Cloudflare.R2Bucket.bind(Bucket);
+
+// later, inside fetch:
+yield* bucket.put("hello.txt", "world");
+```
+
+`bucket` is the resource presented as a typed SDK. There's no
+`env.BUCKET`, no `BUCKET_NAME` lookup, and no hand-written IAM policy
+— the binding **is** the client.
+
+On AWS, `bind()` emits least-privilege IAM scoped to the exact
+resource ARN. On Cloudflare, it attaches the native Worker binding
+(R2, KV, D1, Durable Object). The runtime API is identical, so code
+written against one consumes the other.
+
+Bindings also enable **circular references** between resources —
+Worker A can hold a typed client to Worker B and vice versa — which
+plain props, a directed acyclic graph, can't express.
+
+See [Bindings](/concepts/binding) for event sources, sinks, and the
+deploy-time mechanics.
+
 ## Stacks and stages
 
 A **Stack** is a collection of resources deployed together. Every
@@ -141,29 +171,41 @@ environments never interfere with each other.
 
 ## Providers
 
-**Providers** tell Alchemy how to talk to a cloud platform. They're
-expressed as Effect Layers and checked by the type system:
+A **Provider** teaches Alchemy how to manage a resource type. Behind
+every resource is a provider implementing four lifecycle operations:
+
+- **`read`** — look up the resource's live state in the cloud. It
+  tells the engine whether the resource exists and whether we own
+  it.
+- **`diff`** — compare the desired props against the previous ones
+  and decide whether the change is a no-op, an in-place update, or a
+  full replacement.
+- **`reconcile`** — make the cloud match the desired state. One flow
+  handles first-time creation, updates, and adoption: observe the
+  live state, create the resource if it's missing, sync any drifted
+  fields, and return the output attributes.
+- **`delete`** — remove the resource. Idempotent, so "already gone"
+  counts as success.
+
+The engine drives these in a **plan → apply** loop: `read` and
+`diff` build the plan, then `reconcile` and `delete` apply it in
+dependency order.
+
+Providers are Effect Layers, wired into a Stack with
+`Cloudflare.providers()` or `AWS.providers()`:
 
 ```typescript
-// Cloudflare
 Alchemy.Stack(
   "App",
-  {
-    providers: Cloudflare.providers(),
-  } /* ... */,
-);
-
-// AWS
-Alchemy.Stack(
-  "App",
-  {
-    providers: AWS.providers(),
-  } /* ... */,
+  { providers: Cloudflare.providers() } /* ... */,
 );
 ```
 
-If your Stack uses Cloudflare resources but you provide AWS
-providers, TypeScript catches the mismatch at compile time.
+The type system checks the wiring — using a Cloudflare resource
+without `Cloudflare.providers()`, or providing the wrong cloud's
+providers, is a compile-time error. To support a new cloud or
+third-party API, see [Writing a Custom Resource
+Provider](/guides/custom-provider).
 
 ## Two styles: Effect and Async
 


### PR DESCRIPTION
Add a Bindings section after Resources covering typed clients, automatic
IAM/Worker bindings, and circular references. Rewrite the Providers
section to define the lifecycle interface (read, diff, reconcile,
delete) instead of just provider Layer wiring.