### PR TITLE
feat(cloudflare/workers): yieldable DynamicWorkerLoader marker

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/DynamicWorkerLoader.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DynamicWorkerLoader.ts
@@ -1,4 +1,5 @@
 import * as Effect from "effect/Effect";
+import { SingleShotGen } from "effect/Utils";
 import { ALCHEMY_PHASE } from "../../Phase.ts";
 import { fromCloudflareFetcher, type Fetcher } from "../Fetcher.ts";
 import { makeRpcStub } from "./Rpc.ts";
@@ -56,10 +57,10 @@ export interface DynamicWorkerInstance extends Fetcher {
 }
 
 /**
- * The handle returned by `DynamicWorker(name)`. Provides a `.load()` method
- * for spinning up isolated dynamic workers at runtime.
+ * The runtime handle obtained by `yield* Cloudflare.DynamicWorkerLoader(name)`.
+ * Provides a `.load()` method for spinning up isolated dynamic workers.
  */
-export type DynamicWorkerLoader = {
+export interface DynamicWorkerLoaderHandle {
   Type: DynamicWorkerTypeId;
   name: string;
   /**
@@ -67,7 +68,57 @@ export type DynamicWorkerLoader = {
    * exposes `.getEntrypoint()` and `.fetch()` for calling into the worker.
    */
   load(options: DynamicWorkerLoadOptions): DynamicWorkerInstance;
-};
+}
+
+/**
+ * The native `worker_loader` runtime binding shape, as seen by an async
+ * (non-Effect) Worker that declares the loader through `env`. `InferEnv` maps
+ * a `DynamicWorkerLoader` marker in `env` to this type.
+ */
+export interface DynamicWorkerLoaderBinding {
+  load(options: DynamicWorkerLoadOptions): {
+    getEntrypoint(name?: string): {
+      fetch(request: Request): Promise<Response>;
+      [method: string]: unknown;
+    };
+  };
+}
+
+/**
+ * The Effect yielded when a `DynamicWorkerLoader` marker is used inside a
+ * Worker init phase: it registers the `worker_loader` binding on the
+ * surrounding Worker and resolves to a {@link DynamicWorkerLoaderHandle}.
+ */
+type BindEffect = ReturnType<typeof bindLoader>;
+
+/**
+ * Marker for a Cloudflare Worker Loader binding.
+ *
+ * It is a plain data structure (so it can be declared directly on a Worker's
+ * `env`) that is **also** yieldable inside an Effect-native Worker. Yielding it
+ * (`yield* Cloudflare.DynamicWorkerLoader(name)`) registers the binding on the
+ * surrounding Worker and returns a {@link DynamicWorkerLoaderHandle} with
+ * `.load()` — no separate `.bind(...)` step required.
+ *
+ * The divergence is achieved via `[Symbol.iterator]`: the object is not an
+ * `Effect` (so `InferEnv` resolves it to the native
+ * {@link DynamicWorkerLoaderBinding} in the `env` position), but it is iterable
+ * as one when `yield*`-ed.
+ */
+export interface DynamicWorkerLoader {
+  kind: DynamicWorkerTypeId;
+  name: string;
+  asEffect(): BindEffect;
+  [Symbol.iterator](): SingleShotGen<BindEffect, DynamicWorkerLoaderHandle>;
+}
+
+export const isDynamicWorkerLoader = (
+  value: unknown,
+): value is DynamicWorkerLoader =>
+  typeof value === "object" &&
+  value !== null &&
+  "kind" in value &&
+  (value as DynamicWorkerLoader).kind === DynamicWorkerTypeId;
 
 /**
  * Load and run ephemeral Workers at runtime from inline JavaScript
@@ -86,14 +137,79 @@ export type DynamicWorkerLoader = {
  * @resource
  *
  * @section Creating a Loader
- * Yield `Cloudflare.DynamicWorkerLoader` in your Worker's init
- * phase to register the binding. The string argument becomes the
- * binding name on the deployed Worker.
+ * Yield `Cloudflare.DynamicWorkerLoader(name)` in your Worker's init
+ * phase to register the binding and get back a runtime handle. The
+ * string argument becomes the binding name on the deployed Worker.
  *
- * @example Registering a loader
+ * @example Registering a loader (effect-native Worker)
  * ```typescript
- * // init
- * const loader = yield* Cloudflare.DynamicWorkerLoader("Loader");
+ * import * as Cloudflare from "alchemy/Cloudflare";
+ * import * as Effect from "effect/Effect";
+ * import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+ * import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+ * import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+ *
+ * export default class EvalWorker extends Cloudflare.Worker<EvalWorker>()(
+ *   "EvalWorker",
+ *   { main: import.meta.filename },
+ *   Effect.gen(function* () {
+ *     // Registers the `worker_loader` binding on this Worker and returns the
+ *     // runtime handle in one step — no separate `.bind(...)`.
+ *     const loader = yield* Cloudflare.DynamicWorkerLoader("LOADER");
+ *
+ *     return {
+ *       fetch: Effect.gen(function* () {
+ *         const request = yield* HttpServerRequest;
+ *         const code = yield* request.text;
+ *
+ *         // Spin up an isolated, sandboxed Worker from inline source.
+ *         const worker = loader.load({
+ *           compatibilityDate: "2026-01-28",
+ *           mainModule: "worker.js",
+ *           modules: {
+ *             "worker.js": `export default {
+ *               async fetch(req) {
+ *                 const result = (0, eval)(await req.text());
+ *                 return new Response(String(result));
+ *               }
+ *             }`,
+ *           },
+ *           globalOutbound: null, // block outbound network access
+ *         });
+ *
+ *         // Call the loaded Worker over Effect-native HTTP.
+ *         const response = yield* worker.fetch(
+ *           HttpClientRequest.post("https://worker/").pipe(
+ *             HttpClientRequest.bodyText(code),
+ *           ),
+ *         );
+ *         return HttpServerResponse.fromClientResponse(response);
+ *       }),
+ *     };
+ *   }),
+ * ) {}
+ * ```
+ *
+ * @example Declaring on env (async Worker)
+ * ```typescript
+ * export const Worker = Cloudflare.Worker("Worker", {
+ *   main: "./src/worker.ts",
+ *   env: { LOADER: Cloudflare.DynamicWorkerLoader() },
+ * });
+ *
+ * export type WorkerEnv = Cloudflare.InferEnv<typeof Worker>;
+ *
+ * // worker.ts
+ * export default {
+ *   async fetch(req: Request, env: WorkerEnv) {
+ *     const worker = env.LOADER.load({
+ *       compatibilityDate: "2026-01-28",
+ *       mainModule: "worker.js",
+ *       modules: { "worker.js": "export default { fetch: () => new Response('ok') }" },
+ *     });
+ *     return worker.getEntrypoint().fetch(req);
+ *   },
+ * };
  * ```
  *
  * @section Loading a Worker
@@ -155,7 +271,17 @@ export type DynamicWorkerLoader = {
  * const greeting = yield* api.greet("world");
  * ```
  */
-export const DynamicWorkerLoader = Effect.fnUntraced(function* (name: string) {
+export const DynamicWorkerLoader = (name = "LOADER"): DynamicWorkerLoader => {
+  const self: DynamicWorkerLoader = {
+    kind: DynamicWorkerTypeId,
+    name,
+    asEffect: () => bindLoader(name),
+    [Symbol.iterator]: () => new SingleShotGen(bindLoader(name)),
+  };
+  return self;
+};
+
+const bindLoader = Effect.fnUntraced(function* (name: string) {
   const worker = yield* Worker;
 
   yield* worker.bind`${name}`({
@@ -177,14 +303,14 @@ export const DynamicWorkerLoader = Effect.fnUntraced(function* (name: string) {
     }),
   );
 
-  const self: DynamicWorkerLoader = {
+  const handle: DynamicWorkerLoaderHandle = {
     Type: DynamicWorkerTypeId,
     name,
     load: (options: DynamicWorkerLoadOptions): DynamicWorkerInstance =>
       wrapLoadedWorker(binding.load(options)),
   };
 
-  return self;
+  return handle;
 });
 
 const wrapEntrypoint = <Shape>(raw: any): DynamicWorkerEntrypoint<Shape> =>

--- a/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
@@ -48,15 +48,17 @@ export type GetBindingType<T> =
                               ? Fetcher
                               : T extends Cloudflare.Hyperdrive
                                 ? Hyperdrive
-                                : T extends Cloudflare.DurableObjectNamespaceLike
-                                  ? DurableObjectNamespace<
-                                      Exclude<T["Shape"], undefined>
-                                    >
-                                  : T extends Redacted<any>
-                                    ? // redacteds are always stored as secret_text, so are always string
-                                      // we JSON.stringify when not a Redacted<string>
-                                      string
-                                    : T;
+                                : T extends Cloudflare.DynamicWorkerLoader
+                                  ? Cloudflare.DynamicWorkerLoaderBinding
+                                  : T extends Cloudflare.DurableObjectNamespaceLike
+                                    ? DurableObjectNamespace<
+                                        Exclude<T["Shape"], undefined>
+                                      >
+                                    : T extends Redacted<any>
+                                      ? // redacteds are always stored as secret_text, so are always string
+                                        // we JSON.stringify when not a Redacted<string>
+                                        string
+                                      : T;
 
 /**
  * Cloudflare service-binding wire shape for an Effect-native Worker.

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -23,6 +23,7 @@ import { isRateLimit } from "../RateLimit/RateLimit.ts";
 import { isVectorizeIndex } from "../Vectorize/VectorizeIndex.ts";
 import { isAssets } from "./Assets.ts";
 import { isDurableObjectNamespaceLike } from "./DurableObjectNamespace.ts";
+import { isDynamicWorkerLoader } from "./DynamicWorkerLoader.ts";
 import type { WorkerBindingProps } from "./Worker.ts";
 import { isWorker, type Worker, type WorkerProps } from "./Worker.ts";
 import type { WorkerBinding, WorkerBindingResource } from "./WorkerBinding.ts";
@@ -205,6 +206,11 @@ const toBinding = (
       name: bindingName,
       indexName: binding.indexName,
     };
+  } else if (isDynamicWorkerLoader(binding)) {
+    return {
+      type: "worker_loader",
+      name: bindingName,
+    } as any;
   } else {
     return {
       type: "json",

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
@@ -21,6 +21,7 @@ import type { RateLimit } from "../RateLimit/RateLimit.ts";
 import type { VectorizeIndex } from "../Vectorize/VectorizeIndex.ts";
 import type { Assets } from "./Assets.ts";
 import type { DurableObjectNamespaceLike } from "./DurableObjectNamespace.ts";
+import type { DynamicWorkerLoader } from "./DynamicWorkerLoader.ts";
 import { makeRpcStub } from "./Rpc.ts";
 import { isWorker, Worker, WorkerEnvironment } from "./Worker.ts";
 
@@ -55,6 +56,7 @@ export type WorkerBindingResource =
   | Hyperdrive
   | VectorizeIndex
   | Worker
+  | DynamicWorkerLoader
   | DurableObjectNamespaceLike<any>;
 
 export type WorkerBindings = {

--- a/packages/alchemy/test/Cloudflare/Workers/DynamicWorkerLoader.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DynamicWorkerLoader.test.ts
@@ -1,0 +1,63 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import Stack from "./fixtures/dynamic-worker-loader/stack.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+});
+
+class WorkerNotReady extends Data.TaggedError("WorkerNotReady")<{
+  status: number;
+  body: string;
+}> {}
+
+// Fresh workers.dev URLs serve Cloudflare's placeholder page for a few seconds
+// after deploy. Retry until the worker (and its dynamically-loaded child)
+// answer 200, surfacing the body if not so a real failure isn't masked.
+const readJson = (url: string) =>
+  HttpClient.HttpClient.pipe(
+    Effect.flatMap((client) => client.get(url)),
+    Effect.flatMap((res) =>
+      res.status === 200
+        ? res.json
+        : res.text.pipe(
+            Effect.flatMap((body) =>
+              Effect.fail(new WorkerNotReady({ status: res.status, body })),
+            ),
+          ),
+    ),
+    Effect.retry({
+      while: (e): e is WorkerNotReady => e instanceof WorkerNotReady,
+      schedule: Schedule.exponential("500 millis").pipe(
+        Schedule.both(Schedule.recurs(20)),
+      ),
+    }),
+  );
+
+const stack = beforeAll(deploy(Stack));
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
+
+test(
+  "async worker loads and proxies to a dynamic worker via env binding",
+  Effect.gen(function* () {
+    const { asyncWorkerUrl } = yield* stack;
+    const body = yield* readJson(asyncWorkerUrl);
+    expect(body).toMatchObject({ mode: "async", ok: true });
+  }),
+  { timeout: 180_000 },
+);
+
+test(
+  "effect worker loads and proxies to a dynamic worker via yield* loader",
+  Effect.gen(function* () {
+    const { effectWorkerUrl } = yield* stack;
+    const body = yield* readJson(effectWorkerUrl);
+    expect(body).toMatchObject({ mode: "effect", ok: true });
+  }),
+  { timeout: 180_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/dynamic-worker-loader/async-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/dynamic-worker-loader/async-worker.ts
@@ -1,0 +1,25 @@
+import type { AsyncWorkerEnv } from "./stack.ts";
+
+/**
+ * Async (non-Effect) Worker fixture for the Worker Loader binding declared via
+ * `env: { LOADER: Cloudflare.DynamicWorkerLoader() }`. `InferEnv` maps the
+ * marker to the native `worker_loader` binding, so the handler calls
+ * `env.LOADER.load(...).getEntrypoint().fetch(...)` directly.
+ */
+export default {
+  async fetch(request: Request, env: AsyncWorkerEnv): Promise<Response> {
+    const worker = env.LOADER.load({
+      compatibilityDate: "2026-01-28",
+      mainModule: "worker.js",
+      modules: {
+        "worker.js": `export default {
+          async fetch() {
+            return Response.json({ mode: "async", ok: true });
+          }
+        }`,
+      },
+    });
+
+    return worker.getEntrypoint().fetch(request);
+  },
+};

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/dynamic-worker-loader/effect-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/dynamic-worker-loader/effect-worker.ts
@@ -1,0 +1,41 @@
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+
+/**
+ * Effect-native Worker fixture for the Worker Loader binding. Yielding
+ * `Cloudflare.DynamicWorkerLoader(name)` during Init registers the
+ * `worker_loader` binding on this Worker and returns the runtime handle in one
+ * step — no separate `.bind(...)`. The fetch handler loads an isolated dynamic
+ * Worker from inline source and proxies the request to it over Effect-native
+ * HTTP.
+ */
+export default class DynamicLoaderEffectWorker extends Cloudflare.Worker<DynamicLoaderEffectWorker>()(
+  "DynamicLoaderEffectWorker",
+  {
+    main: import.meta.filename,
+  },
+  Effect.gen(function* () {
+    const loader = yield* Cloudflare.DynamicWorkerLoader("LOADER");
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+
+        const worker = loader.load({
+          compatibilityDate: "2026-01-28",
+          mainModule: "worker.js",
+          modules: {
+            "worker.js": `export default {
+              async fetch() {
+                return Response.json({ mode: "effect", ok: true });
+              }
+            }`,
+          },
+        });
+
+        return yield* worker.fetch(request).pipe(Effect.orDie);
+      }),
+    };
+  }),
+) {}

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/dynamic-worker-loader/stack.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/dynamic-worker-loader/stack.ts
@@ -1,0 +1,31 @@
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as pathe from "pathe";
+import DynamicLoaderEffectWorker from "./effect-worker.ts";
+
+export const AsyncWorker = Cloudflare.Worker("DynamicLoaderAsyncWorker", {
+  main: pathe.resolve(import.meta.dirname, "async-worker.ts"),
+  env: {
+    LOADER: Cloudflare.DynamicWorkerLoader(),
+  },
+});
+
+export type AsyncWorkerEnv = Cloudflare.InferEnv<typeof AsyncWorker>;
+
+export default Alchemy.Stack(
+  "DynamicWorkerLoaderStack",
+  {
+    providers: Cloudflare.providers(),
+    state: Cloudflare.state(),
+  },
+  Effect.gen(function* () {
+    const asyncWorker = yield* AsyncWorker;
+    const effectWorker = yield* DynamicLoaderEffectWorker;
+
+    return {
+      asyncWorkerUrl: asyncWorker.url.as<string>(),
+      effectWorkerUrl: effectWorker.url.as<string>(),
+    };
+  }),
+);


### PR DESCRIPTION
Closes https://github.com/alchemy-run/alchemy-effect/issues/463

Makes `Cloudflare.DynamicWorkerLoader(name)` a dual-purpose marker (mirrors the `RateLimit`/`Browser`/`Images` changes): declarable on a Worker's `env` **and** yieldable inside an effect-native Worker. Both resolve to the native `worker_loader` binding.

### Declare via `env` (async Worker)

`InferEnv` maps the marker to the native loader binding:

```ts
export const Worker = Cloudflare.Worker("Worker", {
  main: "./src/worker.ts",
  env: { LOADER: Cloudflare.DynamicWorkerLoader() },
});

// worker.ts
export default {
  async fetch(req: Request, env: Cloudflare.InferEnv<typeof Worker>) {
    const worker = env.LOADER.load({
      compatibilityDate: "2026-01-28",
      mainModule: "worker.js",
      modules: { "worker.js": "export default { fetch: () => new Response('ok') }" },
    });
    return worker.getEntrypoint().fetch(req);
  },
};
```

### Bind inside an effect-native Worker

`yield* Cloudflare.DynamicWorkerLoader(name)` registers the binding on the surrounding Worker **and** returns the `.load()` handle in one step:

```ts
Cloudflare.Worker("Worker", { main: "./src/worker.ts" },
  Effect.gen(function* () {
    const loader = yield* Cloudflare.DynamicWorkerLoader("LOADER");
    return {
      fetch: Effect.gen(function* () {
        const request = yield* HttpServerRequest;
        const worker = loader.load({ /* ...inline modules... */ });
        return yield* worker.fetch(request);
      }),
    };
  }),
);
```

The dual behavior comes from giving the marker a `[Symbol.iterator]` (wrapping the bind Effect) without branding it as an `Effect`: it stays a plain `DynamicWorkerLoader` value for `InferEnv` / `env`, but `yield*` registers the binding and returns the handle.

### Tests

New `DynamicWorkerLoader.test.ts` with `fixtures/dynamic-worker-loader/` — e2e for both styles. Each deploys a real Worker that loads an isolated dynamic Worker from inline source and proxies a request to it, asserting the round-trip.
