### PR TITLE
feat(output): add flatMap and method-style combinators

### DIFF
--- a/packages/alchemy/src/Output.ts
+++ b/packages/alchemy/src/Output.ts
@@ -81,6 +81,7 @@ export type Expr<A = any, Req = any> =
   | AllExpr<Expr<A, Req>[]>
   | ApplyExpr<any, A, Req>
   | EffectExpr<any, A, Req>
+  | FlatMapExpr<any, A, Req>
   | LiteralExpr<A>
   | NamedExpr<A, Req>
   | PropExpr<A, keyof A, Req>
@@ -237,6 +238,45 @@ export const mapEffect =
   <A, B, Req2>(fn: (value: A) => Effect.Effect<B, never, Req2>) =>
   <Req>(output: Output<A, Req>): ToOutput<B, Req | Req2> =>
     new EffectExpr(output as Expr<A, Req>, fn) as any;
+
+export const flatMap: {
+  <A, B, Req2>(
+    fn: (value: A) => Output<B, Req2>,
+  ): <Req>(output: Output<A, Req>) => ToOutput<B, Req | Req2>;
+  <A, B, Req, Req2>(
+    output: Output<A, Req>,
+    fn: (value: A) => Output<B, Req2>,
+  ): ToOutput<B, Req | Req2>;
+} = (<A, B, Req, Req2>(
+  ...args:
+    | [fn: (value: A) => Output<B, Req2>]
+    | [output: Output<A, Req>, fn: (value: A) => Output<B, Req2>]
+) =>
+  args.length === 1
+    ? <Req>(output: Output<A, Req>): ToOutput<B, Req | Req2> =>
+        new FlatMapExpr(output as Expr<A, Req>, args[0]) as any
+    : new FlatMapExpr(args[0] as any, args[1])) as any;
+
+export const isFlatMapExpr = <In = any, Out = any, Req = any, Req2 = any>(
+  node: any,
+): node is FlatMapExpr<In, Out, Req, Req2> => node?.kind === "FlatMapExpr";
+
+export class FlatMapExpr<A, B, Req = never, Req2 = never> extends BaseExpr<
+  B,
+  Req | Req2
+> {
+  readonly kind = "FlatMapExpr";
+  constructor(
+    public readonly expr: Expr<A, Req>,
+    public readonly f: (value: A) => Output<B, Req2>,
+  ) {
+    super();
+    return proxy(this);
+  }
+  [inspect](): string {
+    return `${this.expr[inspect]()}.flatMap(${this.f.toString()})`;
+  }
+}
 
 export const isEffectExpr = <In = any, Out = any, Req = any, Req2 = any>(
   node: any,
@@ -461,20 +501,26 @@ function proxy(self: any): any {
             ? target[inspect]
             : isResourceExpr(self) && self.stables && prop in self.stables
               ? self.stables[prop as keyof typeof self.stables]
-              : prop === "apply"
-                ? self[prop]
-                : prop in self
-                  ? typeof self[prop as keyof typeof self] === "function" &&
-                    !("kind" in self)
-                    ? new PropExpr(proxy, prop as never)
-                    : self[prop as keyof typeof self]
-                  : new PropExpr(proxy, prop as never),
+              : prop in self
+                ? typeof self[prop as keyof typeof self] === "function" &&
+                  !("kind" in self)
+                  ? new PropExpr(proxy, prop as never)
+                  : self[prop as keyof typeof self]
+                : new PropExpr(proxy, prop as never),
     apply: (_, thisArg, args) => {
       if (isPropExpr(self)) {
-        if (self.identifier === "apply") {
+        // Method-style combinators on an Output proxy. `map`/`apply` and
+        // `mapEffect`/`effect` are aliases that mirror the standalone
+        // `Output.map` / `Output.mapEffect` / `Output.flatMap` functions.
+        if (self.identifier === "map" || self.identifier === "apply") {
           return new ApplyExpr(self.expr, args[0]);
-        } else if (self.identifier === "effect") {
+        } else if (
+          self.identifier === "mapEffect" ||
+          self.identifier === "effect"
+        ) {
           return new EffectExpr(self.expr, args[0]);
+        } else if (self.identifier === "flatMap") {
+          return new FlatMapExpr(self.expr, args[0]);
         }
       }
       return undefined;
@@ -540,6 +586,11 @@ export const evaluate: <A, Req = never>(
       } else if (isEffectExpr(expr)) {
         // TODO(sam): the same effect shoudl be memoized so that it's not run multiple times
         return yield* expr.f(yield* evaluate(expr.expr, upstream));
+      } else if (isFlatMapExpr(expr)) {
+        // Resolve the source, hand it to `f` to produce a new Output, then
+        // recursively evaluate that Output (flattening one level).
+        const value = yield* evaluate(expr.expr, upstream);
+        return yield* evaluate(expr.f(value), upstream);
       } else if (isAllExpr(expr)) {
         return yield* Effect.all(
           expr.outs.map((out) => evaluate(out, upstream)),
@@ -648,7 +699,12 @@ export const upstream = <E extends Output<any, any>>(expr: E): any => {
     return upstream(expr.expr);
   } else if (isAllExpr(expr)) {
     return Object.assign({}, ...expr.outs.map((out) => upstream(out)));
-  } else if (isEffectExpr(expr) || isApplyExpr(expr) || isNamedExpr(expr)) {
+  } else if (
+    isEffectExpr(expr) ||
+    isApplyExpr(expr) ||
+    isFlatMapExpr(expr) ||
+    isNamedExpr(expr)
+  ) {
     return upstream(expr.expr);
   } else if (Array.isArray(expr)) {
     return expr.map(upstream).reduce(toObject, {});

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -424,6 +424,15 @@ export const make = <A>(
         } else if (Output.isEffectExpr(expr)) {
           const upstream = yield* resolveOutput(expr.expr);
           return Output.hasOutputs(upstream) ? expr : yield* expr.f(upstream);
+        } else if (Output.isFlatMapExpr(expr)) {
+          const upstream = yield* resolveOutput(expr.expr);
+          // Source still unresolved -> keep the flatMap intact for a later pass.
+          // Otherwise run `f` to produce the next Output and resolve into it.
+          return Output.hasOutputs(upstream)
+            ? expr
+            : yield* resolveOutput(
+                Output.asOutput(expr.f(upstream)) as Output.Expr<any>,
+              );
         } else if (Output.isAllExpr(expr)) {
           return yield* Effect.all(expr.outs.map(resolveOutput), {
             concurrency: "unbounded",

--- a/packages/alchemy/test/Output.test.ts
+++ b/packages/alchemy/test/Output.test.ts
@@ -283,6 +283,161 @@ describe("Output.evaluate", () => {
     );
   });
 
+  describe("FlatMapExpr (flatMap)", () => {
+    it.effect("flattens an Output returned from the function", () =>
+      provideState(
+        Effect.gen(function* () {
+          const expr = Output.literal(5).pipe(
+            Output.flatMap((n: number) => Output.literal(n * 2)),
+          );
+          expect(yield* Output.evaluate(expr, {})).toBe(10);
+        }),
+      ),
+    );
+
+    it.effect("supports the data-first form", () =>
+      provideState(
+        Effect.gen(function* () {
+          const expr = Output.flatMap(Output.literal("a"), (s: string) =>
+            Output.literal(s + "b"),
+          );
+          expect(yield* Output.evaluate(expr, {})).toBe("ab");
+        }),
+      ),
+    );
+
+    it.effect("chains multiple flatMaps", () =>
+      provideState(
+        Effect.gen(function* () {
+          const expr = Output.literal(1).pipe(
+            Output.flatMap((n: number) => Output.literal(n + 1)),
+            Output.flatMap((n: number) => Output.literal(n * 10)),
+          );
+          expect(yield* Output.evaluate(expr, {})).toBe(20);
+        }),
+      ),
+    );
+
+    it.effect("flatMaps into another resource's output", () =>
+      provideState(
+        Effect.gen(function* () {
+          const a = fakeResource("Test.A", "FA");
+          const b = fakeResource("Test.B", "FB");
+          const expr = (Output.of(a) as any).name.pipe(
+            Output.flatMap(() => (Output.of(b) as any).name),
+          );
+          const result = yield* Output.evaluate(expr, {
+            FA: { name: "a-name" },
+            FB: { name: "b-name" },
+          });
+          expect(result).toBe("b-name");
+        }),
+      ),
+    );
+
+    it.effect("can flatMap into a non-Output literal value", () =>
+      provideState(
+        Effect.gen(function* () {
+          const expr = Output.literal(3).pipe(
+            Output.flatMap((n: number) => Output.asOutput(n + 1)),
+          );
+          expect(yield* Output.evaluate(expr, {})).toBe(4);
+        }),
+      ),
+    );
+
+    it("tracks only the source expression as upstream", () => {
+      const a = fakeResource("Test.A", "UA");
+      const expr = (Output.of(a) as any).name.pipe(
+        Output.flatMap((s: string) => Output.literal(s)),
+      );
+      expect(Object.keys(Output.upstream(expr))).toEqual(["UA"]);
+    });
+  });
+
+  describe("method-style combinators on a proxied Output", () => {
+    // Resource outputs are Proxies, so `.map(fn)` / `.mapEffect(fn)` /
+    // `.flatMap(fn)` / `.apply(fn)` / `.effect(fn)` must be callable as
+    // methods (not just via `Output.map(output, fn)` / `.pipe(...)`).
+    const resourceOutput = () => {
+      const src = fakeResource<"Test.Bucket", { name: string }>(
+        "Test.Bucket",
+        "M",
+      );
+      return (Output.of(src) as any).name as Output.Output<string>;
+    };
+
+    it.effect(".map(fn) builds an ApplyExpr", () =>
+      provideState(
+        Effect.gen(function* () {
+          const expr = (resourceOutput() as any).map((s: string) =>
+            s.toUpperCase(),
+          );
+          expect(Output.isApplyExpr(expr)).toBe(true);
+          expect(yield* Output.evaluate(expr, { M: { name: "abc" } })).toBe(
+            "ABC",
+          );
+        }),
+      ),
+    );
+
+    it.effect(".apply(fn) builds an ApplyExpr", () =>
+      provideState(
+        Effect.gen(function* () {
+          const expr = (resourceOutput() as any).apply((s: string) =>
+            s.toUpperCase(),
+          );
+          expect(Output.isApplyExpr(expr)).toBe(true);
+          expect(yield* Output.evaluate(expr, { M: { name: "abc" } })).toBe(
+            "ABC",
+          );
+        }),
+      ),
+    );
+
+    it.effect(".mapEffect(fn) builds an EffectExpr", () =>
+      provideState(
+        Effect.gen(function* () {
+          const expr = (resourceOutput() as any).mapEffect((s: string) =>
+            Effect.succeed(s + "!"),
+          );
+          expect(Output.isEffectExpr(expr)).toBe(true);
+          expect(yield* Output.evaluate(expr, { M: { name: "abc" } })).toBe(
+            "abc!",
+          );
+        }),
+      ),
+    );
+
+    it.effect(".effect(fn) builds an EffectExpr", () =>
+      provideState(
+        Effect.gen(function* () {
+          const expr = (resourceOutput() as any).effect((s: string) =>
+            Effect.succeed(s + "!"),
+          );
+          expect(Output.isEffectExpr(expr)).toBe(true);
+          expect(yield* Output.evaluate(expr, { M: { name: "abc" } })).toBe(
+            "abc!",
+          );
+        }),
+      ),
+    );
+
+    it.effect(".flatMap(fn) builds a FlatMapExpr", () =>
+      provideState(
+        Effect.gen(function* () {
+          const expr = (resourceOutput() as any).flatMap((s: string) =>
+            Output.literal(s + "?"),
+          );
+          expect(Output.isFlatMapExpr(expr)).toBe(true);
+          expect(yield* Output.evaluate(expr, { M: { name: "abc" } })).toBe(
+            "abc?",
+          );
+        }),
+      ),
+    );
+  });
+
   describe("AllExpr", () => {
     it.effect("evaluates all wrapped outputs in parallel", () =>
       provideState(

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -213,6 +213,23 @@ describe("basic operations", () => {
           return B.string;
         }).pipe(stack.deploy),
       ).toEqual("TEST-STRING-NEW");
+
+      expect(
+        yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", {
+            string: "test-string",
+            stringArray: ["test-string-array"],
+          });
+          const B = yield* TestResource("B", {
+            string: A.string.pipe(
+              Output.flatMap((string) =>
+                Output.literal(string.toUpperCase() + "-FLAT"),
+              ),
+            ),
+          });
+          return B.string;
+        }).pipe(stack.deploy),
+      ).toEqual("TEST-STRING-FLAT");
     }),
   );
 

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -1977,6 +1977,32 @@ describe("Outputs should resolve to old values", () => {
   );
 
   subtest(
+    "string.flatMap(() => Output.literal(undefined))",
+    (A) => ({
+      string: A.string.pipe(Output.flatMap(() => Output.literal(undefined))),
+    }),
+    {
+      string: undefined,
+    },
+  );
+
+  subtest(
+    "string.flatMap(string => A.stringArray.map(([first]) => first))",
+    (A) => ({
+      string: A.string.pipe(
+        Output.flatMap(() =>
+          A.stringArray.pipe(
+            Output.map((stringArray) => stringArray[0]!.toUpperCase()),
+          ),
+        ),
+      ),
+    }),
+    {
+      string: "TEST-STRING",
+    },
+  );
+
+  subtest(
     "stringArray[0].toUpperCase()",
     (A) => ({
       string: A.stringArray.pipe(
@@ -2128,6 +2154,15 @@ describe("stable properties should not cause downstream changes", () => {
     (A) => ({
       string: A.stableString.pipe(
         Output.mapEffect((string) => Effect.succeed(string.toUpperCase())),
+      ),
+    }),
+  );
+
+  subtest(
+    "A.stableString.flatMap((string) => Output.literal(string.toUpperCase()))",
+    (A) => ({
+      string: A.stableString.pipe(
+        Output.flatMap((string) => Output.literal(string.toUpperCase())),
       ),
     }),
   );


### PR DESCRIPTION
Add `Output.flatMap` and make the proxy combinators (`map`/`mapEffect`/`flatMap`) callable as methods.

`flatMap` resolves an `Output<A>`, hands the value to `f`, and flattens the returned `Output<B>`:

```ts
const expr = A.string.pipe(
  Output.flatMap((zoneId) =>
    Output.interpolate`com.cloudflare.api.account.zone.${zoneId}`,
  ),
);
```

It mirrors `map`/`mapEffect`: new `FlatMapExpr` node, `evaluate` recurses into `f(value)`, `upstream` tracks only the source expression, and `Plan.resolveOutput` short-circuits while the source is unresolved.

### Proxy method fix

The proxy `apply` trap only recognized `apply`/`effect`/`flatMap`, and a `prop === "apply"` short-circuit in the `get` trap stopped `.apply()` from ever building an `ApplyExpr`. Now all combinators work as methods, with `apply`/`effect` kept as aliases:

```ts
output.map(fn)        // ApplyExpr
output.apply(fn)      // ApplyExpr (alias)
output.mapEffect(fn)  // EffectExpr
output.effect(fn)     // EffectExpr (alias)
output.flatMap(fn)    // FlatMapExpr
```
