### PR TITLE
fix(planetscale): remove kind attribute that collides with output proxy discriminator

### DIFF
--- a/packages/alchemy/src/Planetscale/MySQL/MySQLDatabase.ts
+++ b/packages/alchemy/src/Planetscale/MySQL/MySQLDatabase.ts
@@ -66,9 +66,6 @@ export interface MySQLDatabaseProps extends BaseDatabaseProps {
  * Output attributes of a deployed MySQL PlanetScale database.
  */
 export interface MySQLDatabaseAttributes extends BaseDatabaseAttributes {
-  /** Engine kind discriminator. */
-  kind: "mysql";
-
   /**
    * Whether to copy migration data to new branches and in deploy requests.
    */
@@ -177,7 +174,7 @@ export const MySQLDatabaseProvider = () =>
       const createBr = yield* ops.createBranch;
 
       return {
-        stables: ["id", "organization", "kind", "region"],
+        stables: ["id", "organization", "region"],
 
         diff: Effect.fn(function* ({ news, olds, output }) {
           if (!isResolved(news)) return undefined;
@@ -249,7 +246,6 @@ export const MySQLDatabaseProvider = () =>
                   output?.migrationsTable ?? olds?.migrationsTable,
                 migrationsHashes: output?.migrationsHashes ?? {},
                 importHashes: output?.importHashes ?? {},
-                kind: "mysql" as const,
                 clusterSize: output?.clusterSize ?? "",
                 requireApprovalForDeploy:
                   data.require_approval_for_deploy ?? false,
@@ -415,7 +411,6 @@ export const MySQLDatabaseProvider = () =>
             updatedAt: updated.updated_at,
             htmlUrl: updated.html_url,
             region: { slug: updated.region.slug },
-            kind: "mysql" as const,
             clusterSize,
             migrationsDir: news.migrationsDir,
             migrationsTable: news.migrationsDir ? migrationsTable : undefined,

--- a/packages/alchemy/src/Planetscale/Postgres/PostgresDatabase.ts
+++ b/packages/alchemy/src/Planetscale/Postgres/PostgresDatabase.ts
@@ -53,8 +53,6 @@ export interface PostgresDatabaseProps extends BaseDatabaseProps {
  * Output attributes of a deployed PostgreSQL PlanetScale database.
  */
 export interface PostgresDatabaseAttributes extends BaseDatabaseAttributes {
-  /** Engine kind discriminator. */
-  kind: "postgresql";
   /** PostgreSQL CPU architecture. */
   arch: "x86" | "arm";
 }
@@ -125,7 +123,7 @@ export const PostgresDatabaseProvider = () =>
       const createBr = yield* ops.createBranch;
 
       return {
-        stables: ["id", "organization", "kind", "region"],
+        stables: ["id", "organization", "region"],
 
         diff: Effect.fn(function* ({ news, olds, output }) {
           if (!isResolved(news)) return undefined;
@@ -222,7 +220,6 @@ export const PostgresDatabaseProvider = () =>
             migrationsTable: output?.migrationsTable ?? olds?.migrationsTable,
             migrationsHashes: output?.migrationsHashes ?? {},
             importHashes: output?.importHashes ?? {},
-            kind: "postgresql" as const,
             clusterSize,
             arch,
             requireApprovalForDeploy: data.require_approval_for_deploy ?? false,
@@ -378,7 +375,6 @@ export const PostgresDatabaseProvider = () =>
             updatedAt: updated.updated_at,
             htmlUrl: updated.html_url,
             region: { slug: updated.region.slug },
-            kind: "postgresql" as const,
             clusterSize: clusterSize,
             migrationsDir: news.migrationsDir,
             migrationsTable: news.migrationsDir ? migrationsTable : undefined,

--- a/packages/alchemy/test/Planetscale/MySQL/MySQLDatabase.test.ts
+++ b/packages/alchemy/test/Planetscale/MySQL/MySQLDatabase.test.ts
@@ -40,7 +40,6 @@ describe.skipIf(!process.env.PLANETSCALE_TEST)(() => {
       );
 
       expect(database).toMatchObject({
-        kind: "mysql",
         id: expect.any(String),
         name: expect.any(String),
         organization: expect.any(String),
@@ -100,7 +99,6 @@ describe.skipIf(!process.env.PLANETSCALE_TEST)(() => {
       );
 
       expect(database).toMatchObject({
-        kind: "mysql",
         id: expect.any(String),
         name: expect.any(String),
         organization: expect.any(String),
@@ -197,7 +195,6 @@ describe.skipIf(!process.env.PLANETSCALE_TEST)(() => {
         );
 
         expect(database).toMatchObject({
-          kind: "mysql",
           defaultBranch: "custom",
         });
 

--- a/packages/alchemy/test/Planetscale/Postgres/PostgresDatabase.test.ts
+++ b/packages/alchemy/test/Planetscale/Postgres/PostgresDatabase.test.ts
@@ -42,7 +42,6 @@ describe.skipIf(!process.env.PLANETSCALE_TEST)(() => {
         );
 
         expect(database).toMatchObject({
-          kind: "postgresql",
           id: expect.any(String),
           name: expect.any(String),
           organization: expect.any(String),
@@ -103,7 +102,6 @@ describe.skipIf(!process.env.PLANETSCALE_TEST)(() => {
         );
 
         expect(database).toMatchObject({
-          kind: "postgresql",
           id: expect.any(String),
           name,
           organization: expect.any(String),
@@ -193,7 +191,6 @@ describe.skipIf(!process.env.PLANETSCALE_TEST)(() => {
 
         expect(database).toMatchObject({
           name,
-          kind: "postgresql",
           defaultBranch,
         });
 
@@ -239,7 +236,6 @@ describe.skipIf(!process.env.PLANETSCALE_TEST)(() => {
         );
 
         expect(database).toMatchObject({
-          kind: "postgresql",
           id: expect.any(String),
           name,
           arch: "arm",


### PR DESCRIPTION
The engine's output proxy uses `kind: "ResourceExpr"` as its discriminator. PlanetScale's database resources exposed `kind: "postgresql"` / `kind: "mysql"` as a stable output attribute, which shadowed the proxy discriminator and caused the planner to crash with `Not implemented yetpostgresql` when a database output was passed to another resource.

Removed the `kind` attribute from `PostgresDatabaseAttributes` / `MySQLDatabaseAttributes`, from each provider's `stables` list, and from `read` / `reconcile` return shapes. Internal guards still read `data.kind` / `observed.kind` straight from the PlanetScale API response, so the wrong-engine adoption error path is unchanged.

```diff
 export interface PostgresDatabaseAttributes extends BaseDatabaseAttributes {
-  /** Engine kind discriminator. */
-  kind: "postgresql";
   /** PostgreSQL CPU architecture. */
   arch: "x86" | "arm";
 }
```

Engine-side fix (use a non-colliding discriminator on the output proxy) is the proper long-term solution; this is the user-facing unblocker.
