### PR TITLE
fix(drizzle): preserve snapshot lineage

### DIFF
--- a/packages/alchemy/src/Drizzle/Schema.ts
+++ b/packages/alchemy/src/Drizzle/Schema.ts
@@ -9,6 +9,10 @@ import type { Providers } from "./Providers.ts";
 
 export type Dialect = "postgres" | "mysql" | "sqlite";
 
+type DrizzleSnapshot = {
+  id?: string;
+};
+
 export type SchemaProps = {
   /**
    * Path to the schema module, relative to the current working directory.
@@ -164,7 +168,10 @@ export const SchemaProvider = () =>
             const exists = yield* fs.exists(snapshotPath);
             if (!exists) continue;
             const text = yield* fs.readFileString(snapshotPath);
-            return { snapshot: JSON.parse(text) as unknown, hash: sha(text) };
+            return {
+              snapshot: JSON.parse(text) as DrizzleSnapshot,
+              hash: sha(text),
+            };
           }
           return undefined;
         });
@@ -181,13 +188,14 @@ export const SchemaProvider = () =>
           const dialect = props.dialect ?? "postgres";
           const kit = yield* loadKit(dialect);
           const schemaModule = yield* loadSchemaModule(props);
+          const prevEntry = yield* readLatestSnapshot(out);
           const cur = yield* Effect.tryPromise({
-            try: () => kit.generateDrizzleJson(schemaModule),
+            try: () =>
+              kit.generateDrizzleJson(schemaModule, prevEntry?.snapshot.id),
             catch: (cause) =>
               new Error(`drizzle-kit generateDrizzleJson failed: ${cause}`),
           });
 
-          const prevEntry = yield* readLatestSnapshot(out);
           // For the initial migration, drizzle-kit needs an *empty* snapshot
           // produced by `generateDrizzleJson({})`, not a bare `{}` — the
           // snapshot has internal fields (`ddl`, etc.) that the differ reads.

--- a/packages/alchemy/test/Drizzle/Schema.test.ts
+++ b/packages/alchemy/test/Drizzle/Schema.test.ts
@@ -9,6 +9,8 @@ import * as Path from "effect/Path";
 
 const { test } = Test.make({ providers: Drizzle.providers() });
 
+const DRIZZLE_ORIGIN_UUID = "00000000-0000-0000-0000-000000000000";
+
 // Minimal drizzle-orm schema source — enough for `generateDrizzleJson`
 // to produce a non-empty snapshot.
 const SCHEMA_SOURCE = `
@@ -37,12 +39,46 @@ const stageWorkspace = (initialSource: string) =>
     return { root, out, schemaPath };
   });
 
+const readSnapshots = (out: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const dirs = (yield* fs.readDirectory(out))
+      .filter((name) => /^\d+_/.test(name))
+      .sort();
+    const snapshots: Array<{ id: string; prevIds: string[] }> = [];
+    for (const dir of dirs) {
+      const text = yield* fs.readFileString(
+        path.join(out, dir, "snapshot.json"),
+      );
+      snapshots.push(JSON.parse(text) as { id: string; prevIds: string[] });
+    }
+    return snapshots;
+  });
+
 const getStatus = Effect.fn(function* (fqn: string) {
   const state = yield* yield* State;
   const stk = yield* Stack.Stack;
   const s = yield* state.get({ stack: stk.name, stage: stk.stage, fqn });
   return s?.status;
 });
+
+test.provider("initial snapshot starts from the Drizzle origin", (stack) =>
+  Effect.gen(function* () {
+    const ws = yield* stageWorkspace(SCHEMA_SOURCE);
+
+    yield* stack.deploy(
+      Drizzle.Schema("app-schema", {
+        schema: ws.schemaPath,
+        out: ws.out,
+      }),
+    );
+
+    const snapshots = yield* readSnapshots(ws.out);
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]?.prevIds).toEqual([DRIZZLE_ORIGIN_UUID]);
+  }),
+);
 
 test.provider(
   "repeated deploys with no schema drift produce noop, not update (regression: forced update cascaded into Neon.Branch)",
@@ -87,11 +123,13 @@ test.provider(
           out: ws.out,
         }),
       );
+      const [initialSnapshot] = yield* readSnapshots(ws.out);
 
       // Write the drifted schema as a *new* file so the dynamic import
       // cache doesn't hand us the original module.
       const driftedSchemaPath = path.join(ws.root, "schema-drifted.ts");
       yield* fs.writeFileString(driftedSchemaPath, DRIFTED_SCHEMA_SOURCE);
+      yield* Effect.sleep("1 second");
 
       const drifted = yield* stack.deploy(
         Drizzle.Schema("app-schema", {
@@ -102,5 +140,8 @@ test.provider(
 
       expect(yield* getStatus("app-schema")).toEqual("updated");
       expect(drifted.snapshotHash).not.toEqual(initial.snapshotHash);
+      const snapshots = yield* readSnapshots(ws.out);
+      expect(snapshots).toHaveLength(2);
+      expect(snapshots[1]?.prevIds).toEqual([initialSnapshot?.id]);
     }),
 );


### PR DESCRIPTION
Generate follow-up Drizzle snapshots with the latest stored snapshot as their lineage parent.

```ts
const prevEntry = yield* readLatestSnapshot(out);
const cur = yield* kit.generateDrizzleJson(
  schemaModule,
  prevEntry?.snapshot.id,
);
```

Previously `generateDrizzleJson(schemaModule)` ran before the latest snapshot was read, so every generated snapshot used Drizzle's origin UUID in `prevIds`. Initial snapshots still start from the origin UUID; follow-up snapshots now reference the preceding snapshot id.

The Drizzle schema regression suite now asserts both lineage cases.
