### PR TITLE
fix(core): honor resource-scoped adopt(...) in the planner

### DIFF
--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -714,7 +714,10 @@ export const make = <A>(
                 .pipe(providePlanScope(fqn, adoptInstanceId));
               if (readResult !== undefined) {
                 const isUnowned = Unowned.is(readResult);
-                if (isUnowned && !(yield* shouldAdopt)) {
+                // A resource-scoped `adopt(...)` (captured on the resource at
+                // registration) overrides the stack/CLI default.
+                const adoptThis = resource.Adopt ?? (yield* shouldAdopt);
+                if (isUnowned && !adoptThis) {
                   return yield* new OwnedBySomeoneElse({
                     message:
                       `Cannot adopt resource '${fqn}' (${resource.Type}): ` +
@@ -1229,6 +1232,7 @@ export const make = <A>(
                     Binding: undefined!,
                     Provider: Provider(resourceType),
                     RemovalPolicy: oldState.removalPolicy,
+                    Adopt: undefined,
                     RuntimeContext: undefined!,
                     Providers: undefined,
                   } as ResourceLike,

--- a/packages/alchemy/src/Resource.ts
+++ b/packages/alchemy/src/Resource.ts
@@ -2,6 +2,7 @@ import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import { pipeArguments, type Pipeable } from "effect/Pipeable";
 import { SingleShotGen } from "effect/Utils";
+import { AdoptPolicy } from "./AdoptPolicy.ts";
 import { toFqn } from "./FQN.ts";
 import type { Input, InputProps } from "./Input.ts";
 import { CurrentNamespace, type NamespaceNode } from "./Namespace.ts";
@@ -106,6 +107,12 @@ export interface ResourceLike<
    * Removal Policy of the Resource.
    */
   RemovalPolicy: RemovalPolicy["Service"];
+  /**
+   * Per-resource adoption policy captured from the ambient {@link AdoptPolicy}
+   * at registration time (e.g. via `.pipe(adopt(true))`). `undefined` means no
+   * resource-scoped override — the planner falls back to the stack/CLI default.
+   */
+  Adopt: boolean | undefined;
   /** @internal phantom */
   Attributes: Attributes;
   /** @internal phantom */
@@ -245,6 +252,9 @@ export function Resource<R extends ResourceLike>(
         Provider: ProviderTag as Provider<any>,
         RemovalPolicy: yield* Effect.serviceOption(RemovalPolicy).pipe(
           Effect.map(Option.getOrElse(() => defaultRemovalPolicy)),
+        ),
+        Adopt: yield* Effect.serviceOption(AdoptPolicy).pipe(
+          Effect.map(Option.getOrUndefined),
         ),
         bind,
         toString(this: typeof target) {

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -1,4 +1,4 @@
-import { AdoptPolicy, Unowned } from "@/AdoptPolicy";
+import { adopt, AdoptPolicy, Unowned } from "@/AdoptPolicy";
 import * as Construct from "@/Construct";
 import { dedupeBindings } from "@/Diff";
 import type { Input, InputProps } from "@/Input";
@@ -2720,6 +2720,57 @@ describe("engine-level adoption", () => {
 
       expect(plan.resources.Fresh!.action).toBe("create");
       expect(plan.resources.Fresh!.state).toBeUndefined();
+    }),
+  );
+
+  test(
+    "Unowned read result + resource-scoped adopt(true) -> takeover even when the stack default is disabled",
+    Effect.gen(function* () {
+      const plan = yield* makeAdoptPlan(
+        Effect.gen(function* () {
+          yield* TestResource("Adopted", { string: "hello" }).pipe(adopt(true));
+        }),
+        {
+          // Stack/CLI default is OFF — only the per-resource scope opts in.
+          adopt: false,
+          readHook: () => Effect.succeed(Unowned(ownedAttrs)),
+        },
+      );
+
+      expect(plan.resources.Adopted!.action).toBe("update");
+
+      const state = yield* yield* State;
+      const persisted = yield* state.get({
+        stack: TEST_STACK,
+        stage: TEST_STAGE,
+        fqn: "Adopted",
+      });
+      expect(persisted?.status).toBe("created");
+    }),
+  );
+
+  test(
+    "Unowned read result + resource-scoped adopt(false) -> OwnedBySomeoneElse even when the stack default is enabled",
+    Effect.gen(function* () {
+      const exit = yield* makeAdoptPlan(
+        Effect.gen(function* () {
+          yield* TestResource("Foreign", { string: "hello" }).pipe(
+            adopt(false),
+          );
+        }),
+        {
+          // Stack/CLI default is ON, but the resource opts out.
+          adopt: true,
+          readHook: () => Effect.succeed(Unowned(ownedAttrs)),
+        },
+      ).pipe(Effect.exit);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        const reason = exit.cause.reasons.find(Cause.isFailReason);
+        expect((reason?.error as any)?._tag).toBe("OwnedBySomeoneElse");
+        expect((reason?.error as any)?.resourceType).toBe("Test.TestResource");
+      }
     }),
   );
 


### PR DESCRIPTION
A `.pipe(adopt(...))` scoped onto a single resource was provided only to that resource's *registration* effect, but the planner read `AdoptPolicy` from the *ambient* context — so the per-resource scope was silently dropped and `Unowned` resources still failed with `OwnedBySomeoneElse`.

Capture the ambient `AdoptPolicy` on the resource at registration time (mirroring `RemovalPolicy`) and have the planner prefer that per-resource value over the stack/CLI default.

```ts
// Resource.ts — captured at registration, like RemovalPolicy
Adopt: yield* Effect.serviceOption(AdoptPolicy).pipe(
  Effect.map(Option.getOrUndefined),
),
```

```ts
// Plan.ts — resource scope overrides the stack/CLI default
const adoptThis = resource.Adopt ?? (yield* shouldAdopt);
if (isUnowned && !adoptThis) {
  return yield* new OwnedBySomeoneElse({ /* … */ });
}
```

This makes per-resource opt-in/opt-out work both ways:

```ts
// adopt this one even though the stack default is off
yield* Zone("MyZone", { name: "example.com" }).pipe(adopt(true));

// refuse to adopt this one even though the stack default is on
yield* Zone("MyZone", { name: "example.com" }).pipe(adopt(false));
```
