### PR TITLE
docs(website): document Vite SPA local dev workflow

### DIFF
--- a/website/src/content/docs/tutorial/cloudflare/vite-spa.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/vite-spa.mdx
@@ -298,7 +298,44 @@ const stack = beforeAll(deploy(Stack));
 
 ## Local dev
 
-Coming soon.
+```sh
+bun alchemy dev
+```
+
+`alchemy dev` runs the whole Stack locally with hot reloading.
+For a `Cloudflare.Vite` worker that means Alchemy boots Vite's dev
+server (HMR, instant module updates) and wires it into the same
+local proxy URL your Worker backend serves from — so the SPA and
+its API share one origin in dev, just like they do in production:
+
+```
+{
+  url: "http://localhost:1337",
+  webUrl: "http://localhost:1337",
+}
+```
+
+Edit `src/main.tsx`, save, and the browser updates without a full
+reload. Backend resources (R2 buckets, D1 databases, service
+bindings) are the **real** cloud resources — only your application
+code runs locally, so there's no emulation fidelity gap.
+
+The build-time env injection works the same in dev: `VITE_`-prefixed
+entries are inlined as `import.meta.env.<KEY>`, and `Output` values
+like `worker.url.as<string>()` resolve before the dev server starts.
+
+Set a fixed port with the worker's `dev` option if `1337` is taken:
+
+```diff lang="typescript"
+// alchemy.run.ts
+ const web = yield* Cloudflare.Vite("Website", {
++  dev: { port: 3000 },
+ });
+```
+
+See [Local Development](/concepts/local-development) for the full
+model — how Workers run in `workerd`, how to attach a debugger, and
+how `dev` differs from `deploy`.
 
 ## Use a different framework
 

--- a/website/src/content/docs/tutorial/cloudflare/vite-spa.mdx
+++ b/website/src/content/docs/tutorial/cloudflare/vite-spa.mdx
@@ -320,11 +320,21 @@ reload. Backend resources (R2 buckets, D1 databases, service
 bindings) are the **real** cloud resources — only your application
 code runs locally, so there's no emulation fidelity gap.
 
-The build-time env injection works the same in dev: `VITE_`-prefixed
+The build-time env injection works the same in dev — `VITE_`-prefixed
 entries are inlined as `import.meta.env.<KEY>`, and `Output` values
-like `worker.url.as<string>()` resolve before the dev server starts.
+like `worker.url.as<string>()` resolve before the dev server starts:
 
-Set a fixed port with the worker's `dev` option if `1337` is taken:
+```typescript
+// alchemy.run.ts
+const web = yield* Cloudflare.Vite("Website", {
+  env: {
+    VITE_API_URL: worker.url.as<string>(),
+  },
+});
+```
+
+By default the dev server picks an available port. Set `dev.port`
+only if you want the local URL to stay the same across runs:
 
 ```diff lang="typescript"
 // alchemy.run.ts


### PR DESCRIPTION
Replaces the "Coming soon" placeholder in the Vite SPA tutorial's local-dev section with the real `alchemy dev` workflow.

- `bun alchemy dev` boots the Stack with HMR; Vite's dev server is wired into the same local proxy URL the Worker backend serves from, so the SPA and its API share one origin in dev.
- Backend resources stay real cloud resources — only app code runs locally.
- Build-time env injection (`VITE_` keys, `Output` values) behaves the same in dev.
- Documents the `dev: { port }` override and links to the Local Development concept page.

```diff lang="typescript"
 const web = yield* Cloudflare.Vite("Website", {
+  dev: { port: 3000 },
 });
```
