### PR TITLE
feat(cloudflare): class form for Vite and StaticSite

### DIFF
--- a/examples/cloudflare-tanstack/alchemy.run.ts
+++ b/examples/cloudflare-tanstack/alchemy.run.ts
@@ -3,7 +3,7 @@ import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 import Backend, { Bucket } from "./src/backend.ts";
 
-export const Website = Cloudflare.Vite("Website", {
+export class Website extends Cloudflare.Vite<Website>()("Website", {
   compatibility: {
     flags: ["nodejs_compat"],
   },
@@ -11,7 +11,7 @@ export const Website = Cloudflare.Vite("Website", {
     BUCKET: Bucket,
     BACKEND: Backend,
   },
-});
+}) {}
 
 export type WebsiteEnv = Cloudflare.InferEnv<typeof Website>;
 

--- a/packages/alchemy/src/Cloudflare/Website/StaticSite.ts
+++ b/packages/alchemy/src/Cloudflare/Website/StaticSite.ts
@@ -3,9 +3,12 @@ import * as Redacted from "effect/Redacted";
 import { Command, type CommandProps } from "../../Build/Command.ts";
 import type { InputProps } from "../../Input.ts";
 import * as Namespace from "../../Namespace.ts";
+import { effectClass } from "../../Util/effect.ts";
+import type { Providers } from "../Providers.ts";
 import type { AssetsConfig } from "../Workers/Assets.ts";
 import {
   Worker,
+  type NormalizedBindings,
   type WorkerAssetsConfig,
   type WorkerBindingProps,
   type WorkerProps,
@@ -25,7 +28,12 @@ export interface StaticSiteProps<Bindings extends WorkerBindingProps = {}>
   };
 }
 
-export type StaticSite = ReturnType<typeof StaticSite>;
+type StaticSiteWorker<Bindings extends WorkerBindingProps> = Worker<{
+  [binding in keyof NormalizedBindings<
+    Bindings,
+    WorkerAssetsConfig
+  >]: NormalizedBindings<Bindings, WorkerAssetsConfig>[binding];
+}>;
 
 /**
  * A Cloudflare Worker that serves static assets built by a shell command.
@@ -113,8 +121,47 @@ export type StaticSite = ReturnType<typeof StaticSite>;
  *   },
  * });
  * ```
+ *
+ * @section Class Form
+ * Calling `StaticSite` with no arguments returns a constructor you can
+ * `extend` to declare the Worker as a named class. The class is both
+ * an `Effect` you can `yield*` to deploy and a type you can reference
+ * elsewhere — useful when other resources need to bind to this Worker.
+ *
+ * @example Declaring a Worker class
+ * ```typescript
+ * class Blog extends Cloudflare.StaticSite<Blog>()("Blog", {
+ *   command: "hugo --minify",
+ *   outdir: "public",
+ *   main: "./src/worker.ts",
+ * }) {}
+ *
+ * const site = yield* Blog;
+ * ```
  */
-export const StaticSite = <
+export const StaticSite: {
+  <Self>(): {
+    <const Bindings extends WorkerBindingProps = {}, Req = never>(
+      id: string,
+      propsEff:
+        | InputProps<StaticSiteProps<Bindings>>
+        | Effect.Effect<InputProps<StaticSiteProps<Bindings>>, never, Req>,
+    ): Effect.Effect<Self, never, Req | Providers> & {
+      new (): StaticSiteWorker<Bindings>;
+    };
+  };
+  <const Bindings extends WorkerBindingProps = {}, Req = never>(
+    id: string,
+    propsEff:
+      | InputProps<StaticSiteProps<Bindings>>
+      | Effect.Effect<InputProps<StaticSiteProps<Bindings>>, never, Req>,
+  ): Effect.Effect<StaticSiteWorker<Bindings>, never, Req | Providers>;
+} = ((id?: any, propsEff?: any) =>
+  id === undefined
+    ? (id: string, propsEff: any) => effectClass(makeStaticSite(id, propsEff))
+    : makeStaticSite(id, propsEff)) as any;
+
+const makeStaticSite = <
   const Bindings extends WorkerBindingProps = {},
   Req = never,
 >(

--- a/packages/alchemy/src/Cloudflare/Website/Vite.ts
+++ b/packages/alchemy/src/Cloudflare/Website/Vite.ts
@@ -1,13 +1,15 @@
 import * as Effect from "effect/Effect";
 import type { MemoOptions } from "../../Build/Memo.ts";
 import type { InputProps } from "../../Input.ts";
+import { effectClass } from "../../Util/effect.ts";
+import type { Providers } from "../Providers.ts";
 import {
   Worker,
+  type NormalizedBindings,
   type WorkerAssetsConfig,
   type WorkerBindingProps,
   type WorkerProps,
 } from "../Workers/Worker.ts";
-
 export interface ViteProps<
   Bindings extends WorkerBindingProps = {},
 > extends Omit<WorkerProps<Bindings>, "vite" | "main"> {
@@ -106,27 +108,67 @@ export interface ViteProps<
  *   },
  * });
  * ```
+ *
+ * @section Class Form
+ * Calling `Vite` with no arguments returns a constructor you can
+ * `extend` to declare the Worker as a named class. The class is both
+ * an `Effect` you can `yield*` to deploy and a type you can reference
+ * elsewhere — useful when other resources need to bind to this Worker.
+ *
+ * @example Declaring a Worker class
+ * ```typescript
+ * class Website extends Cloudflare.Vite<Website>()("Website", {
+ *   compatibility: { flags: ["nodejs_compat"] },
+ * }) {}
+ *
+ * const site = yield* Website;
+ * ```
  */
-export const Vite = <
-  const Bindings extends WorkerBindingProps = {},
-  Req = never,
->(
-  id: string,
-  propsEff?:
-    | InputProps<ViteProps<Bindings>>
-    | Effect.Effect<InputProps<ViteProps<Bindings>>, never, Req>,
-) =>
-  Worker<Bindings, WorkerAssetsConfig, Req>(
-    id,
-    Effect.map(
-      Effect.isEffect(propsEff) ? propsEff : Effect.succeed(propsEff),
-      (props) => ({
-        ...props,
-        main: undefined!,
-        vite: {
-          rootDir: props?.rootDir,
-          memo: props?.memo,
-        },
-      }),
-    ),
-  );
+export const Vite: {
+  <Self>(): {
+    <const Bindings extends WorkerBindingProps = {}, Req = never>(
+      id: string,
+      propsEff?:
+        | InputProps<ViteProps<Bindings>>
+        | Effect.Effect<InputProps<ViteProps<Bindings>>, never, Req>,
+    ): Effect.Effect<Self, never, Req | Providers> & {
+      new (): Worker<{
+        [binding in keyof NormalizedBindings<
+          Bindings,
+          WorkerAssetsConfig
+        >]: NormalizedBindings<Bindings, WorkerAssetsConfig>[binding];
+      }>;
+    };
+  };
+  <const Bindings extends WorkerBindingProps = {}, Req = never>(
+    id: string,
+    propsEff?:
+      | InputProps<ViteProps<Bindings>>
+      | Effect.Effect<InputProps<ViteProps<Bindings>>, never, Req>,
+  ): Effect.Effect<
+    Worker<{
+      [binding in keyof NormalizedBindings<
+        Bindings,
+        WorkerAssetsConfig
+      >]: NormalizedBindings<Bindings, WorkerAssetsConfig>[binding];
+    }>,
+    never,
+    Req | Providers
+  >;
+} = ((id?: any, propsEff?: any) =>
+  id === undefined
+    ? (id: string, propsEff: any) => effectClass(Vite(id, propsEff))
+    : Worker(
+        id,
+        Effect.map(
+          Effect.isEffect(propsEff) ? propsEff : Effect.succeed(propsEff),
+          (props) => ({
+            ...props,
+            main: undefined!,
+            vite: {
+              rootDir: props?.rootDir,
+              memo: props?.memo,
+            },
+          }),
+        ),
+      )) as any;

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -166,7 +166,7 @@ export type WorkerBindingProps = {
     | Effect.Effect<WorkerBindingResource, any, any>;
 };
 
-type NormalizedBindings<
+export type NormalizedBindings<
   Bindings extends WorkerBindingProps = {},
   AssetsConfig extends WorkerAssetsConfig | undefined = undefined,
 > = {

--- a/packages/alchemy/test/Cloudflare/Website/StaticSite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/StaticSite.test.ts
@@ -96,6 +96,48 @@ test.provider(
   { timeout: 360_000 },
 );
 
+test.provider(
+  "StaticSite: class form deploys and serves the built assets",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      yield* stack.destroy();
+
+      const cwd = yield* cloneFixture(fixtureDir, {
+        prefix: "alchemy-staticsite-class-",
+        entries: ["src", "build.sh"],
+      });
+      const indexPath = path.join(cwd, "src", "index.html");
+
+      const marker = `staticsite-class-${Date.now()}`;
+      yield* fs.writeFileString(indexPath, htmlPage(marker));
+
+      const site1 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* class FixSite extends Cloudflare.StaticSite<FixSite>()(
+            "FixSite",
+            staticSiteProps(cwd),
+          ) {};
+        }),
+      );
+
+      expect(site1.url).toBeDefined();
+      expect(site1.hash?.assets).toBeDefined();
+      yield* expectWorkerExists(site1.workerName, accountId);
+      yield* expectUrlContains(`${site1.url!}/index.html`, marker, {
+        timeout: "120 seconds",
+        label: "class form marker",
+      });
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+    }).pipe(logLevel),
+  { timeout: 360_000 },
+);
+
 // ─────────────────────────────────────────────────────────────────────
 // Path-relocation / cross-machine state behavior
 //

--- a/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
@@ -100,6 +100,50 @@ test.provider(
   { timeout: 360_000 },
 );
 
+test.provider(
+  "Vite: class form deploys and serves the built assets",
+  (stack) =>
+    Effect.gen(function* () {
+      const { accountId } = yield* CloudflareEnvironment;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      yield* stack.destroy();
+
+      const rootDir = yield* cloneFixture(fixtureDir, {
+        prefix: "alchemy-vite-class-",
+        tempRoot,
+        entries: ["index.html", "package.json", "vite.config.ts", "src"],
+      });
+      const indexPath = path.join(rootDir, "index.html");
+      const memoInclude = ["index.html", "src/**", "package.json"];
+
+      const marker = `vite-class-${Date.now()}`;
+      yield* fs.writeFileString(indexPath, htmlPage(marker));
+
+      const site1 = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* class FixVite extends Cloudflare.Vite<FixVite>()(
+            "FixVite",
+            viteProps(rootDir, memoInclude),
+          ) {};
+        }),
+      );
+
+      expect(site1.url).toBeDefined();
+      expect(site1.hash?.input).toBeDefined();
+      yield* expectWorkerExists(site1.workerName, accountId);
+      yield* expectUrlContains(`${site1.url!}/`, marker, {
+        timeout: "120 seconds",
+        label: "class form marker",
+      });
+
+      yield* stack.destroy();
+      yield* waitForWorkerToBeDeleted(site1.workerName, accountId);
+    }).pipe(logLevel),
+  { timeout: 360_000 },
+);
+
 // ─────────────────────────────────────────────────────────────────────
 // Path-relocation behavior for the vite path
 //


### PR DESCRIPTION
`Cloudflare.Vite` and `Cloudflare.StaticSite` now support a no-arg Self-tag overload, letting you declare a site as a named Worker class (matching the `Worker` class form).

```ts
class Website extends Cloudflare.Vite<Website>()("Website", {
  compatibility: { flags: ["nodejs_compat"] },
}) {}

const site = yield* Website;
```

- `StaticSite` reworked to the overloaded shape, mirroring `Vite`
- Export `NormalizedBindings` from `Worker.ts` for the class return type
- Class-form deploy tests for both `Vite` and `StaticSite`
- `cloudflare-tanstack` example updated to the class form
