### PR TITLE
chore(website): remove dead Providers reference link from getting started

### DIFF
--- a/website/src/content/docs/getting-started.mdx
+++ b/website/src/content/docs/getting-started.mdx
@@ -133,11 +133,6 @@ See [Profiles](/concepts/profiles) for the full picture.
   <span>Adds a Worker to this Stack and covers the core concepts.</span>
 </a>
 
-<a href="/providers" class="next-card">
-  <strong>Providers reference</strong>
-  <span>Every supported Resource with copy-pasteable examples.</span>
-</a>
-
 <a href="/guides/migrating-from-v1" class="next-card">
   <strong>Migrating from v1</strong>
   <span>Upgrading from async/await Alchemy? Start here.</span>


### PR DESCRIPTION
The `/providers` route doesn't exist, so the "Providers reference" card on the Getting Started page is a dead link. Remove it.
