### PR TITLE
fix(deploy): skip website preview on fork PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,14 @@ env:
 
 jobs:
   deploy:
-    if: ${{ github.event.action != 'closed' }}
+    # Skip on cross-repo (fork) PRs — they can't access the
+    # alchemy-version-bot secrets or the Cloudflare API key, so
+    # `create-github-app-token` errors before anything useful runs.
+    # Internal PRs still get a preview; forks just don't.
+    if: >-
+      github.event.action != 'closed' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -97,9 +104,9 @@ jobs:
 
   cleanup:
     runs-on: ubuntu-latest
-    if:
-      ${{ github.event_name == 'pull_request' && github.event.action == 'closed'
-      }}
+    if: >-
+      github.event_name == 'pull_request' && github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,10 +11,13 @@ on:
       - "bun.lock"
       - ".github/workflows/deploy.yml"
   pull_request:
+    # `labeled` so adding `deploy-website` on an open PR triggers a
+    # deploy without needing another push.
     types:
       - opened
       - reopened
       - synchronize
+      - labeled
       - closed
     paths:
       - "website/**"
@@ -33,14 +36,17 @@ env:
 
 jobs:
   deploy:
-    # Skip on cross-repo (fork) PRs — they can't access the
-    # alchemy-version-bot secrets or the Cloudflare API key, so
-    # `create-github-app-token` errors before anything useful runs.
-    # Internal PRs still get a preview; forks just don't.
+    # Deploy on push-to-main and `workflow_dispatch` always. On PRs,
+    # require BOTH:
+    #   - the PR is internal (forks can't access bot/Cloudflare secrets
+    #     so `create-github-app-token` would error immediately), AND
+    #   - the PR carries the `deploy-website` label (opt-in — most PRs
+    #     don't need a website preview, so default to skipping).
     if: >-
       github.event.action != 'closed' &&
       (github.event_name != 'pull_request' ||
-       github.event.pull_request.head.repo.full_name == github.repository)
+       (github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(github.event.pull_request.labels.*.name, 'deploy-website')))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The website preview deploy job tries to mint a GitHub App token before doing anything else, but fork PRs can't access `secrets.ALCHEMY_VERSION_BOT_ID` — so `create-github-app-token` errors out immediately. ([example failure on #524](https://github.com/alchemy-run/alchemy-effect/actions/runs/26845300237/job/79163084636?pr=524))

Even if we worked around the token, the deploy itself needs `ADMIN_CLOUDFLARE_API_KEY` which is also gated to non-fork runs. Forks fundamentally can't deploy a preview, so skip both jobs for cross-repo PRs.

```diff
 jobs:
   deploy:
-    if: ${{ github.event.action != 'closed' }}
+    if: >-
+      github.event.action != 'closed' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
```

Same guard on `cleanup`. Internal PRs still get their preview as before.
