### PR TITLE
chore: run docs:check on every PR

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,43 @@
+name: docs-check
+
+# Runs the website docs validator (`bun run docs:check`) on every PR
+# so broken links / missing API references fail fast before merge.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-check-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: "24"
+
+jobs:
+  docs-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - run: bun install
+
+      - run: bun run docs:check


### PR DESCRIPTION
Catch broken links / missing API references before merge by running the website docs validator on every PR.

\`\`\`yaml
on:
  pull_request:
    types: [opened, reopened, synchronize]
jobs:
  docs-check:
    steps:
      - checkout + setup-node + setup-bun + bun.lock cache
      - bun install
      - bun run docs:check
\`\`\`

\`bun run docs:check\` is the existing root-level script that delegates to \`bun run --filter ./website docs:check\` → \`bun run build:reference && DOCS_FAST=1 astro build\`. Concurrency-cancels prior runs on the same PR so a fresh push supersedes the older check.