### PR TITLE
chore(readme): tag install deps with @next

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ One `bind()` wires the binding, env var, and typed connection — at deploy time
 - **Same code, every stage.** Local dev, `plan` / `deploy`, smoke tests, and CI all share one mental model.
 
 ```sh
-bun add alchemy effect
+bun add alchemy@next effect@next
 ```
 
 ## Bootstrap with an AI coding agent


### PR DESCRIPTION
The README install command was missing the `@next` dist-tag.

```diff
-bun add alchemy effect
+bun add alchemy@next effect@next
```


---
_Generated by [Claude Code](https://claude.ai/code/session_016SPAdqmH9VyFMSaJyxXHPC)_