### PR TITLE
chore: compile via tsc in each package's build script

### DIFF
--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -21,7 +21,7 @@
   "sideEffects": false,
   "scripts": {
     "dev": "tsdown --watch",
-    "build": "bun bundle",
+    "build": "tsc -b && bun bundle",
     "bundle": "tsdown",
     "bundle:watch": "tsdown --watch",
     "publish:npm": "cp ../README.md . && bun publish && rm README.md",

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -13,7 +13,7 @@
     "src"
   ],
   "scripts": {
-    "build": "bun pm pack"
+    "build": "tsc -b"
   },
   "exports": {
     ".": {

--- a/packages/pr-package/package.json
+++ b/packages/pr-package/package.json
@@ -14,7 +14,7 @@
     "src"
   ],
   "scripts": {
-    "build": "bun pm pack"
+    "build": "tsc -b"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
Preview-package tarballs were shipping with empty `lib/` — only `src/` made it in. Bun consumers (`exports.".".bun → ./src/index.ts`) were fine; pnpm/npm consumers hit `exports.".".import → ./lib/index.js` and got nothing.

Root cause: the per-package `build` scripts didn't actually compile TypeScript. The repo-level pipeline relied on `bun tsc -b` at the root to produce every package's `lib/`, but the shared pr-package workflow runs `bun run build` inside each package's dir.

```diff
// packages/alchemy/package.json
- "build": "bun bundle"
+ "build": "tsc -b && bun bundle"

// packages/better-auth/package.json
- "build": "bun pm pack"
+ "build": "tsc -b"

// packages/pr-package/package.json
- "build": "bun pm pack"
+ "build": "tsc -b"
```

`tsc -b` in each package's dir compiles that package against its `tsconfig.json` (`composite: true`, `outDir: ./lib`), following its `references` to populate sibling deps as needed. `bun pm pack` in the original scripts was a no-op for compilation — the actual `bun pm pack` already happens inside the pr-package workflow's publish step, so removing it here just leaves the build doing real work.

For `alchemy`, the existing `bun bundle` (tsdown → `bin/cli.js`) is kept; `tsc -b` now runs ahead of it to also populate `lib/`.

Root-level `bun run build:packages` is unchanged. `tsc -b` is incremental against `.tsbuildinfo`, so the per-package call after a root build is near-free.
