### PR TITLE
chore: build bin directory for preview packages

### DIFF
--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -21,7 +21,7 @@
   "sideEffects": false,
   "scripts": {
     "dev": "tsdown --watch",
-    "build": "tsc -b && tsc -b -p tsconfig.bin.json && bun bundle",
+    "build": "tsc -b && tsc -b tsconfig.bin.json && bun bundle",
     "bundle": "tsdown",
     "bundle:watch": "tsdown --watch",
     "publish:npm": "cp ../README.md . && bun publish && rm README.md",

--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -21,7 +21,7 @@
   "sideEffects": false,
   "scripts": {
     "dev": "tsdown --watch",
-    "build": "tsc -b && bun bundle",
+    "build": "tsc -b && tsc -b -p tsconfig.bin.json && bun bundle",
     "bundle": "tsdown",
     "bundle:watch": "tsdown --watch",
     "publish:npm": "cp ../README.md . && bun publish && rm README.md",


### PR DESCRIPTION
The `bin` directory wasn't built for preview packages, which meant that preview packages won't work if your runtime runs JS instead of TS. This should fix that.