### PR TITLE
fix(cloudflare/dev): populate assets binding for vite websites

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -244,6 +244,7 @@ export const LocalWorkerProvider = () =>
               ? Text.local(key, unredacted)
               : Json.local(key, unredacted);
           }),
+          ...(props.assets ? [Assets.local("ASSETS")] : []),
         ];
         const durableObjectNamespaces: Record<string, string> = {};
         const hyperdrives: Record<string, Required<HyperdriveOrigin>> = {};

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -244,7 +244,7 @@ export const LocalWorkerProvider = () =>
               ? Text.local(key, unredacted)
               : Json.local(key, unredacted);
           }),
-          ...(props.assets ? [Assets.local("ASSETS")] : []),
+          ...(props.assets || props.vite ? [Assets.local("ASSETS")] : []),
         ];
         const durableObjectNamespaces: Record<string, string> = {};
         const hyperdrives: Record<string, Required<HyperdriveOrigin>> = {};


### PR DESCRIPTION
The `ASSETS` binding was not included automatically in `LocalWorkerProvider` the way it is in `LiveWorkerProvider`, so `env.ASSETS.fetch()` wouldn't work. This should fix that.