### PR TITLE
fix(engine): honor retain removal policy on replace

### DIFF
--- a/examples/cloudflare-tanstack/alchemy.run.ts
+++ b/examples/cloudflare-tanstack/alchemy.run.ts
@@ -1,5 +1,4 @@
 import * as Alchemy from "alchemy";
-import * as AdoptPolicy from "alchemy/AdoptPolicy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 import Backend, { Bucket } from "./src/backend.ts";
@@ -26,13 +25,9 @@ export default Alchemy.Stack(
     const backend = yield* Backend;
     const website = yield* Website;
 
-    const zone = yield* Cloudflare.Zone("MyZone", {
-      name: "johnroyal.dev",
-    }).pipe(AdoptPolicy.adopt(true));
     return {
       backendUrl: backend.url.as<string>(),
       websiteUrl: website.url.as<string>(),
-      zoneId: zone.zoneId,
     };
   }),
 );

--- a/examples/cloudflare-tanstack/alchemy.run.ts
+++ b/examples/cloudflare-tanstack/alchemy.run.ts
@@ -1,4 +1,5 @@
 import * as Alchemy from "alchemy";
+import * as AdoptPolicy from "alchemy/AdoptPolicy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 import Backend, { Bucket } from "./src/backend.ts";
@@ -24,9 +25,14 @@ export default Alchemy.Stack(
   Effect.gen(function* () {
     const backend = yield* Backend;
     const website = yield* Website;
+
+    const zone = yield* Cloudflare.Zone("MyZone", {
+      name: "johnroyal.dev",
+    }).pipe(AdoptPolicy.adopt(true));
     return {
       backendUrl: backend.url.as<string>(),
       websiteUrl: website.url.as<string>(),
+      zoneId: zone.zoneId,
     };
   }),
 );

--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -1586,7 +1586,9 @@ const collectGarbage = Effect.fnUntraced(function* (
               });
               yield* report("deleted");
             } else {
-              yield* scopedSession.note("Cleaning up replaced resource...");
+              if (!retainOldGeneration) {
+                yield* scopedSession.note("Cleaning up replaced resource...");
+              }
               if (
                 node.old.status === "replacing" ||
                 node.old.status === "replaced"
@@ -1626,7 +1628,11 @@ const collectGarbage = Effect.fnUntraced(function* (
                   removalPolicy: node.removalPolicy,
                 });
               }
-              yield* scopedSession.note("Replaced resource cleanup complete.");
+              yield* scopedSession.note(
+                retainOldGeneration
+                  ? "Replaced resource retained."
+                  : "Replaced resource cleanup complete.",
+              );
             }
           }),
         ));

--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -1544,7 +1544,20 @@ const collectGarbage = Effect.fnUntraced(function* (
               });
             }
 
-            if (attr !== undefined) {
+            // Honor `retain` for the old generation of a replacement, mirroring
+            // the orphan-delete path above. Delete-node retain is already
+            // handled with an early return; this guards the replaced
+            // old-generation physical delete.
+            const retainOldGeneration =
+              !isDeleteNode(node) && node.removalPolicy === "retain";
+
+            if (retainOldGeneration) {
+              yield* scopedSession.note(
+                "Retaining replaced resource (removal policy: retain)...",
+              );
+            }
+
+            if (attr !== undefined && !retainOldGeneration) {
               yield* provider
                 .delete({
                   id: logicalId,

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -1,6 +1,7 @@
 import { Cli } from "@/Cli/Cli";
 import * as Construct from "@/Construct";
 import * as Output from "@/Output";
+import * as RemovalPolicy from "@/RemovalPolicy.ts";
 import { Stack } from "@/Stack";
 import {
   type ReplacedResourceState,
@@ -1831,6 +1832,166 @@ describe("from replaced state", () => {
         }).pipe(stack.deploy);
         expectConvergedStatus((yield* getState("A"))?.status);
         expect(output).toEqual("another-replacement");
+      }),
+  );
+});
+
+describe("retain removal policy on replace", () => {
+  test.provider(
+    "replace with retain does not delete the old generation",
+    (stack) =>
+      Effect.gen(function* () {
+        const deleted: string[] = [];
+
+        // 1. Create initial resource with a retain removal policy.
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", { replaceString: "v1" }).pipe(
+            RemovalPolicy.retain(true),
+          );
+        }).pipe(stack.deploy);
+
+        const before = yield* getState("A");
+        expect(before?.status).toEqual("created");
+        const oldInstanceId = before?.instanceId;
+
+        // 2. Trigger a replacement (replaceString change). The old generation
+        //    must NOT be deleted because the resource is retained.
+        const output = yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", { replaceString: "v2" }).pipe(
+            RemovalPolicy.retain(true),
+          );
+          return A.replaceString;
+        }).pipe(
+          stack.deploy,
+          hook({
+            delete: (id) =>
+              Effect.sync(() => {
+                deleted.push(id);
+              }),
+          }),
+        );
+
+        expect(output).toEqual("v2");
+        // provider.delete must never fire for the retained old generation.
+        expect(deleted).not.toContain("A");
+
+        const after = yield* getState("A");
+        // Resource was genuinely replaced (fresh instance id) and the old
+        // chain drained back to a terminal `created` state.
+        expect(after?.status).toEqual("created");
+        expect(after?.instanceId).not.toEqual(oldInstanceId);
+      }),
+  );
+
+  test.provider(
+    "replace without retain deletes the old generation exactly once",
+    (stack) =>
+      Effect.gen(function* () {
+        const deleted: string[] = [];
+
+        // 1. Create initial resource with the default (destroy) policy.
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", { replaceString: "v1" });
+        }).pipe(stack.deploy);
+        expect((yield* getState("A"))?.status).toEqual("created");
+
+        // 2. Trigger a replacement. The old generation must be deleted since
+        //    the resource is not retained — guards the retain patch against
+        //    disabling normal replacement GC.
+        const output = yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", { replaceString: "v2" });
+          return A.replaceString;
+        }).pipe(
+          stack.deploy,
+          hook({
+            delete: (id) =>
+              Effect.sync(() => {
+                deleted.push(id);
+              }),
+          }),
+        );
+
+        expect(output).toEqual("v2");
+        expect(deleted.filter((id) => id === "A")).toHaveLength(1);
+        expect((yield* getState("A"))?.status).toEqual("created");
+      }),
+  );
+
+  test.provider(
+    "nested replacement chain with retain never deletes old generations",
+    (stack) =>
+      Effect.gen(function* () {
+        const deleted: string[] = [];
+
+        // 1. Create with retain.
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", { replaceString: "v1" }).pipe(
+            RemovalPolicy.retain(true),
+          );
+        }).pipe(stack.deploy);
+        expect((yield* getState("A"))?.status).toEqual("created");
+
+        // 2. Trigger a replacement but fail mid-create so a replacement chain
+        //    forms (replacing, with old=created still live).
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", { replaceString: "v2" }).pipe(
+            RemovalPolicy.retain(true),
+          );
+        }).pipe(
+          stack.deploy,
+          hook({ create: () => Effect.fail(new ResourceFailure()) }),
+        );
+        expect((yield* getState("A"))?.status).toEqual("replacing");
+
+        // 3. Replace again — converges and drains the entire old chain. Every
+        //    old generation must be retained (no provider.delete calls).
+        const output = yield* Effect.gen(function* () {
+          const A = yield* TestResource("A", { replaceString: "v3" }).pipe(
+            RemovalPolicy.retain(true),
+          );
+          return A.replaceString;
+        }).pipe(
+          stack.deploy,
+          hook({
+            delete: (id) =>
+              Effect.sync(() => {
+                deleted.push(id);
+              }),
+          }),
+        );
+
+        expect(output).toEqual("v3");
+        expect(deleted).not.toContain("A");
+        expect((yield* getState("A"))?.status).toEqual("created");
+      }),
+  );
+
+  test.provider(
+    "orphan delete still honors retain (regression guard)",
+    (stack) =>
+      Effect.gen(function* () {
+        const deleted: string[] = [];
+
+        yield* Effect.gen(function* () {
+          yield* TestResource("A", { string: "v1" }).pipe(
+            RemovalPolicy.retain(true),
+          );
+        }).pipe(stack.deploy);
+        expect((yield* getState("A"))?.status).toEqual("created");
+
+        // Destroy removes the resource from the stack (orphan delete). Retain
+        // (persisted in state) must skip provider.delete and just drop state.
+        yield* stack.destroy().pipe(
+          hook({
+            delete: (id) =>
+              Effect.sync(() => {
+                deleted.push(id);
+              }),
+          }),
+        );
+
+        expect(deleted).not.toContain("A");
+        expect(yield* getState("A")).toBeUndefined();
       }),
   );
 });


### PR DESCRIPTION
`RemovalPolicy.retain` was only honored when a resource was removed from the stack (orphan delete / destroy), not when it was replaced. Replacement is create-new-then-delete-old, and the old generation's cleanup in `collectGarbage` called `provider.delete` unconditionally — so the previous physical resource was destroyed even though the user asked to retain it.

The fix guards the old-generation delete with the replaced node's removal policy (`ReplacedResourceState` already carries `removalPolicy`, set at replace time and preserved through chain pops). State cleanup (chain pop / collapse to `created`) still runs, so the resource converges normally; only the physical `provider.delete` is skipped.

```diff
-if (attr !== undefined) {
+const retainOldGeneration =
+  !isDeleteNode(node) && node.removalPolicy === "retain";
+
+if (attr !== undefined && !retainOldGeneration) {
   yield* provider.delete({ /* … */ });
 }
```

Behavior:

- Replace of a retained resource keeps the old physical instance (no `provider.delete`), still mints a fresh instance and converges to `created`.
- Nested replacement chains skip the delete on every pass while draining to `created`.
- A changed policy (`retain` → `destroy`) at replace time deletes the old generation, consistent with CloudFormation `UpdateReplacePolicy` reading current desired state.

Adds a `retain removal policy on replace` suite to `apply.test.ts` covering replace-with-retain, the destroy contrast (delete fires exactly once), nested chains, and an orphan-delete regression guard.
