### PR TITLE
fix(core): trigger updates when a Redacted config/secret value changes

### DIFF
--- a/examples/cloudflare-dev/src/EffectWorker.ts
+++ b/examples/cloudflare-dev/src/EffectWorker.ts
@@ -1,5 +1,4 @@
 import * as Cloudflare from "alchemy/Cloudflare";
-import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
@@ -18,18 +17,12 @@ export default class EffectWorker extends Cloudflare.Worker<EffectWorker>()(
     main: import.meta.filename,
   },
   Effect.gen(function* () {
-    const myVariable = yield* Config.string("MY_EFFECT_VARIABLE");
     const kv = yield* Cloudflare.KVNamespace.bind(KV);
     const workflow = yield* NotifyWorkflow;
     return {
       fetch: Effect.gen(function* () {
         const request = yield* HttpServerRequest.HttpServerRequest;
         const url = new URL(request.url, "http://internal");
-        if (url.pathname === "/env") {
-          return yield* HttpServerResponse.json({
-            myVariable,
-          });
-        }
         if (url.pathname === "/wasm") {
           const instance = yield* Effect.promise(async () => {
             // This is dynamically imported so that the WASM import doesn't occur at deploy-time, which works in Bun but fails in Node.

--- a/examples/cloudflare-dev/src/EffectWorker.ts
+++ b/examples/cloudflare-dev/src/EffectWorker.ts
@@ -1,4 +1,5 @@
 import * as Cloudflare from "alchemy/Cloudflare";
+import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
@@ -17,12 +18,18 @@ export default class EffectWorker extends Cloudflare.Worker<EffectWorker>()(
     main: import.meta.filename,
   },
   Effect.gen(function* () {
+    const myVariable = yield* Config.string("MY_EFFECT_VARIABLE");
     const kv = yield* Cloudflare.KVNamespace.bind(KV);
     const workflow = yield* NotifyWorkflow;
     return {
       fetch: Effect.gen(function* () {
         const request = yield* HttpServerRequest.HttpServerRequest;
         const url = new URL(request.url, "http://internal");
+        if (url.pathname === "/env") {
+          return yield* HttpServerResponse.json({
+            myVariable,
+          });
+        }
         if (url.pathname === "/wasm") {
           const instance = yield* Effect.promise(async () => {
             // This is dynamically imported so that the WASM import doesn't occur at deploy-time, which works in Bun but fails in Node.

--- a/packages/alchemy/src/Diff.ts
+++ b/packages/alchemy/src/Diff.ts
@@ -1,4 +1,5 @@
 import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
 import type { Input } from "./Input.ts";
 import * as Output from "./Output.ts";
 import type { BindingNode } from "./Plan.ts";
@@ -119,6 +120,12 @@ export const deepEqual = (
 
 const canonicalize = (value: unknown, stripNullish: boolean): unknown => {
   if (stripNullish && value == null) return undefined;
+  if (Redacted.isRedacted(value)) {
+    return {
+      _tag: "Redacted",
+      value: Redacted.value(value),
+    };
+  }
   if (Array.isArray(value)) {
     return value.map((v) => canonicalize(v, stripNullish));
   }

--- a/packages/alchemy/test/Diff.test.ts
+++ b/packages/alchemy/test/Diff.test.ts
@@ -5,19 +5,19 @@ import * as Redacted from "effect/Redacted";
 describe("Diff", () => {
   describe("havePropsChanged with Redacted values", () => {
     // Config values yielded in a Worker's init phase (e.g.
-    // `yield* Config.string("MY_EFFECT_VARIABLE")`) land in `props.env`
+    // `yield* Config.string("MY_VARIABLE")`) land in `props.env`
     // as `Redacted<string>`. Before unwrapping, every Redacted serialized
     // to the constant mask `"<redacted>"`, so a changed secret was
     // invisible to the diff and the Worker never redeployed.
     test("detects a changed yielded config value in env", () => {
       const olds = {
         env: {
-          MY_EFFECT_VARIABLE: Redacted.make("my-effect-variable-abc1234"),
+          MY_VARIABLE: Redacted.make("my-variable-abc1234"),
         },
       };
       const news = {
         env: {
-          MY_EFFECT_VARIABLE: Redacted.make("my-effect-variable-CHANGED"),
+          MY_VARIABLE: Redacted.make("my-variable-CHANGED"),
         },
       };
       expect(havePropsChanged(olds, news)).toBe(true);
@@ -26,12 +26,12 @@ describe("Diff", () => {
     test("does not flag an unchanged yielded config value", () => {
       const olds = {
         env: {
-          MY_EFFECT_VARIABLE: Redacted.make("my-effect-variable-abc1234"),
+          MY_VARIABLE: Redacted.make("my-variable-abc1234"),
         },
       };
       const news = {
         env: {
-          MY_EFFECT_VARIABLE: Redacted.make("my-effect-variable-abc1234"),
+          MY_VARIABLE: Redacted.make("my-variable-abc1234"),
         },
       };
       expect(havePropsChanged(olds, news)).toBe(false);

--- a/packages/alchemy/test/Diff.test.ts
+++ b/packages/alchemy/test/Diff.test.ts
@@ -1,0 +1,111 @@
+import { deepEqual, havePropsChanged } from "@/Diff";
+import { describe, expect, test } from "@effect/vitest";
+import * as Redacted from "effect/Redacted";
+
+describe("Diff", () => {
+  describe("havePropsChanged with Redacted values", () => {
+    // Config values yielded in a Worker's init phase (e.g.
+    // `yield* Config.string("MY_EFFECT_VARIABLE")`) land in `props.env`
+    // as `Redacted<string>`. Before unwrapping, every Redacted serialized
+    // to the constant mask `"<redacted>"`, so a changed secret was
+    // invisible to the diff and the Worker never redeployed.
+    test("detects a changed yielded config value in env", () => {
+      const olds = {
+        env: {
+          MY_EFFECT_VARIABLE: Redacted.make("my-effect-variable-abc1234"),
+        },
+      };
+      const news = {
+        env: {
+          MY_EFFECT_VARIABLE: Redacted.make("my-effect-variable-CHANGED"),
+        },
+      };
+      expect(havePropsChanged(olds, news)).toBe(true);
+    });
+
+    test("does not flag an unchanged yielded config value", () => {
+      const olds = {
+        env: {
+          MY_EFFECT_VARIABLE: Redacted.make("my-effect-variable-abc1234"),
+        },
+      };
+      const news = {
+        env: {
+          MY_EFFECT_VARIABLE: Redacted.make("my-effect-variable-abc1234"),
+        },
+      };
+      expect(havePropsChanged(olds, news)).toBe(false);
+    });
+
+    test("detects a changed top-level Redacted value", () => {
+      expect(
+        havePropsChanged(
+          { secret: Redacted.make("a") },
+          { secret: Redacted.make("b") },
+        ),
+      ).toBe(true);
+    });
+
+    test("detects a Redacted value changing to a different inner type", () => {
+      expect(
+        havePropsChanged(
+          { secret: Redacted.make("123") },
+          { secret: Redacted.make(123) },
+        ),
+      ).toBe(true);
+    });
+
+    test("detects a changed Redacted value nested in arrays", () => {
+      expect(
+        havePropsChanged(
+          { secrets: [Redacted.make("a"), Redacted.make("b")] },
+          { secrets: [Redacted.make("a"), Redacted.make("c")] },
+        ),
+      ).toBe(true);
+    });
+
+    test("does not flag unchanged plain env values", () => {
+      expect(
+        havePropsChanged(
+          { env: { MY_VARIABLE: "value" } },
+          { env: { MY_VARIABLE: "value" } },
+        ),
+      ).toBe(false);
+    });
+
+    test("detects changed env when a Redacted value sits alongside plain values", () => {
+      const olds = {
+        env: {
+          MY_VARIABLE: "value",
+          MY_SECRET: Redacted.make("secret-1"),
+        },
+      };
+      const news = {
+        env: {
+          MY_VARIABLE: "value",
+          MY_SECRET: Redacted.make("secret-2"),
+        },
+      };
+      expect(havePropsChanged(olds, news)).toBe(true);
+    });
+  });
+
+  describe("deepEqual with Redacted values", () => {
+    test("distinguishes Redacted values with different inner values", () => {
+      expect(deepEqual(Redacted.make("a"), Redacted.make("b"))).toBe(false);
+    });
+
+    test("equates Redacted values with the same inner value", () => {
+      expect(deepEqual(Redacted.make("a"), Redacted.make("a"))).toBe(true);
+    });
+
+    test("distinguishes Redacted values nested in objects", () => {
+      expect(
+        deepEqual(
+          { secret: Redacted.make("a") },
+          { secret: Redacted.make("b") },
+        ),
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
A `Config` value yielded in a Worker's init phase (e.g. `yield* Config.string("MY_EFFECT_VARIABLE")`) lands in `props.env` as a `Redacted<string>` and is deployed as `secret_text`. Changing that value in the underlying env never redeployed the Worker.

The Worker `diff` falls through to the engine's structural `havePropsChanged`, which canonicalizes + `JSON.stringify`s props. Every `Redacted` serializes to the constant mask `"<redacted>"`, so two different secrets compared equal → `noop` → no update.

`canonicalize` now unwraps `Redacted` so the actual value participates in the comparison:

```diff
 const canonicalize = (value: unknown, stripNullish: boolean): unknown => {
   if (stripNullish && value == null) return undefined;
+  if (Redacted.isRedacted(value)) {
+    return { _tag: "Redacted", value: Redacted.value(value) };
+  }
```

This fixes `havePropsChanged` and `deepEqual` for any `Redacted` env value (`Config.string`, `Config.redacted`, literal `Redacted`, …), not just the yielded-config case.

- Adds `packages/alchemy/test/Diff.test.ts` covering changed/unchanged redacted env values, nested redacted in arrays/objects, and `deepEqual`.