### PR TITLE
[codex] Fix Effect beta pipe compatibility

### DIFF
--- a/packages/alchemy/src/Artifacts.ts
+++ b/packages/alchemy/src/Artifacts.ts
@@ -1,6 +1,7 @@
 import * as Context from "effect/Context";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import { pipe } from "effect/Function";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 
@@ -108,7 +109,8 @@ export const scopedArtifacts = (
 export const provideFreshArtifactStore = <A, E, R>(
   effect: Effect.Effect<A, E, R | ArtifactStore>,
 ): Effect.Effect<A, E, R> =>
-  effect.pipe(
+  pipe(
+    effect,
     Effect.provideServiceEffect(
       ArtifactStore,
       Effect.sync(createArtifactStore),
@@ -125,7 +127,8 @@ export const ensureArtifactStore = <A, E, R>(
   Effect.serviceOption(ArtifactStore).pipe(
     Effect.map(Option.getOrUndefined),
     Effect.flatMap((existing) =>
-      effect.pipe(
+      pipe(
+        effect,
         Effect.provideService(ArtifactStore, existing ?? createArtifactStore()),
       ),
     ),

--- a/packages/alchemy/src/Test/Core.ts
+++ b/packages/alchemy/src/Test/Core.ts
@@ -1,5 +1,6 @@
 import { ConfigProvider } from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
+import { pipe } from "effect/Function";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Scope from "effect/Scope";
@@ -105,7 +106,8 @@ export const toEffect = <A>(
   const base = Effect.gen(function* () {
     const cfg = yield* loadConfigProvider(Option.none());
     const configProvider = withProfileOverride(cfg, options.profile);
-    return yield* effect.pipe(
+    return yield* pipe(
+      effect,
       provideFreshArtifactStore,
       Effect.provide(Layer.succeed(ConfigProvider, configProvider)),
     );
@@ -143,7 +145,8 @@ export const withProviders = <A, E, R, ROut>(
   options: MakeOptions<ROut>,
   stackName: string,
 ): Effect.Effect<A, E, Exclude<R, ROut | Stack | Stage>> =>
-  effect.pipe(
+  pipe(
+    effect,
     Effect.provide(options.providers as Layer.Layer<any, never, any>),
     Effect.provide(
       Layer.succeed(Stack, {


### PR DESCRIPTION
Updates Test/Core and Artifacts usage from effect.pipe to pipe() for Effect beta compatibility.\n\nThis PR contains the existing local commit from this checkout after rebasing onto current upstream main. The dirty working tree was not staged or included.\n\nValidation: not run in this cleanup pass.