### PR TITLE
test(examples): cloudflare-worker-async fails due to incorrect type

### DIFF
--- a/examples/cloudflare-worker-async/alchemy.run.ts
+++ b/examples/cloudflare-worker-async/alchemy.run.ts
@@ -65,6 +65,6 @@ export default Alchemy.Stack(
       },
     });
 
-    return worker.url;
+    return { url: worker.url.as<string>() };
   }),
 );

--- a/examples/cloudflare-worker-async/test/integ.test.ts
+++ b/examples/cloudflare-worker-async/test/integ.test.ts
@@ -17,8 +17,7 @@ afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
 test(
   "deploys and exposes a url",
   Effect.gen(function* () {
-    const out = (yield* stack) as unknown;
-    const url = typeof out === "string" ? out : (out as { url: string }).url;
+    const { url } = yield* stack;
     expect(url).toBeString();
   }),
 );
@@ -26,8 +25,7 @@ test(
 test(
   "echoes env.API_KEY",
   Effect.gen(function* () {
-    const out = (yield* stack) as unknown;
-    const url = typeof out === "string" ? out : (out as { url: string }).url;
+    const { url } = yield* stack;
 
     const response = yield* HttpClient.get(`${url}/api-key`);
     expect(response.status).toBe(200);
@@ -49,8 +47,7 @@ test(
 test(
   "native queue() handler round-trip",
   Effect.gen(function* () {
-    const out = (yield* stack) as unknown;
-    const url = typeof out === "string" ? out : (out as { url: string }).url;
+    const { url } = yield* stack;
     const text = `hello-${Date.now()}`;
 
     const sendResponse = yield* HttpClient.execute(


### PR DESCRIPTION
The `cloudflare-worker-async` integration test was failing because it was expecting `{ url: string }` when the stack simply returns `string`. Quick fix.