### PR TITLE
docs: add missing permission from tutorial part 5

### DIFF
--- a/website/src/content/docs/tutorial/part-5.mdx
+++ b/website/src/content/docs/tutorial/part-5.mdx
@@ -136,6 +136,7 @@ in state — the raw token never touches your terminal.
 +       {
 +         effect: "allow",
 +         permissionGroups: [
++           "Secrets Store Write",
 +           "Workers Scripts Write",
 +           "Workers KV Storage Write",
 +           "Workers R2 Storage Write",


### PR DESCRIPTION
First of all, sorry for the 1 line docs only PR. 😓 

# Background

I think the intent of this tutorial was to show an end to end working setup. I was adopting this and had to pare down my resources to just the tutorial resources and it still failed. Adding "Secrets Store Write" permission allows the github CI/CD cli call to succeed.

Here's running without this permission (using "Secrets Store Read" instead -- having neither is the same error)
https://github.com/DavidJFelix/DavidJFelix/actions/runs/27049597691/job/79844885723

Here's running with this permission:
https://github.com/DavidJFelix/DavidJFelix/actions/runs/27049597691/job/79844946149

Ultimately I think that #559 would help improve this experience and make it so that the docs don't need to exactly track the necessary permissions, but having the important ones now will help.