### PR TITLE
fix(pr-package): use the resolved value for Authentication

### DIFF
--- a/packages/pr-package/src/Worker.ts
+++ b/packages/pr-package/src/Worker.ts
@@ -2,6 +2,7 @@ import * as Cloudflare from "alchemy/Cloudflare";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
 import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import {
@@ -70,7 +71,10 @@ export const handler = (options: HandlerOptions = {}) =>
         const requireAuth = Effect.gen(function* () {
           const authHeader = request.headers.authorization;
           const expected = yield* authToken;
-          if (!authHeader || authHeader !== `Bearer ${expected}`) {
+          if (
+            !authHeader ||
+            authHeader !== `Bearer ${Redacted.value(expected)}`
+          ) {
             return yield* Effect.fail(new Unauthorized());
           }
         });


### PR DESCRIPTION
`pr-package` uses a `Cloudflare.Secret` to store the secret for `Authentication` header against which the incoming `PUT` and `POST` requests are checked. `Cloudflare.Secret` returns a `Redacted<string>` which needs to resolved before checking against the incoming header. Directly using the `expected` value matches the header against `<redacted>` which is not intended.