### PR TITLE
fix: dangling process on alchemy deploy/destroy

### DIFF
--- a/packages/alchemy/src/Local/RpcProvider.ts
+++ b/packages/alchemy/src/Local/RpcProvider.ts
@@ -5,6 +5,7 @@ import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
 import type { Scope } from "effect/Scope";
 import * as Stream from "effect/Stream";
+import { AlchemyContext } from "../AlchemyContext.ts";
 import { InstanceId } from "../InstanceId.ts";
 import type { Platform } from "../Platform.ts";
 import * as Provider from "../Provider.ts";
@@ -129,7 +130,8 @@ const layerFallback = <I, S>(
  */
 export const providerServices = <ROut, E, RIn>(
   self: Layer.Layer<ROut, E, RIn>,
-): Layer.Layer<ROut, E, RIn> => providerServicesEffect(Effect.succeed(self));
+): Layer.Layer<ROut, E, RIn | AlchemyContext> =>
+  providerServicesEffect(Effect.succeed(self));
 
 /**
  * Conditionally constructs a layer for use by an RpcProvider.
@@ -139,10 +141,12 @@ export const providerServices = <ROut, E, RIn>(
  */
 export const providerServicesEffect = <A, E1, R1, E, R>(
   self: Effect.Effect<Layer.Layer<A, E1, R1>, E, R>,
-): Layer.Layer<A, E | E1, R1 | Exclude<R, Scope>> =>
-  Effect.serviceOption(RpcProviderProxy).pipe(
-    Effect.flatMap((client) =>
-      client._tag === "None" ? self : (Effect.succeed(Layer.empty) as never),
+): Layer.Layer<A, E | E1, R1 | Exclude<R, Scope> | AlchemyContext> =>
+  Effect.zip(AlchemyContext, Effect.serviceOption(RpcProviderProxy)).pipe(
+    Effect.flatMap(([context, client]) =>
+      context.dev && client._tag === "None"
+        ? self
+        : (Effect.succeed(Layer.empty) as never),
     ),
     Layer.unwrap,
   );


### PR DESCRIPTION
The process would hang after `alchemy deploy` and `alchemy destroy` because dev-only layers were being initialized when they shouldn't have been. This is a fix for that.