### PR TITLE
fix(cloudflare): export fetcher from bridge

### DIFF
--- a/examples/cloudflare-tanstack/src/routes/api.hello.ts
+++ b/examples/cloudflare-tanstack/src/routes/api.hello.ts
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
 import * as Cloudflare from "alchemy/Cloudflare/Bridge";
 import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import * as HttpBody from "effect/unstable/http/HttpBody";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import type Backend from "../backend.ts";
 import { env } from "../env.ts";
@@ -62,20 +64,6 @@ export const Route = createFileRoute("/api/hello")({
               });
             });
 
-          // option 3 — bind to your effect worker and call http client
-          case "http-client":
-            return trace("GET option 3 (env.BACKEND.httpClient)", async () => {
-              const client = Cloudflare.toHttpClient(
-                Cloudflare.fromCloudflareFetcher(env.BACKEND),
-              );
-              const res = await client
-                .get(`https://backend/?key=${encodeURIComponent(key)}`)
-                .pipe(Effect.runPromise);
-              return HttpServerResponse.toWeb(
-                HttpServerResponse.fromClientResponse(res),
-              );
-            });
-
           // option 3 — bind to your effect worker and call rpc method
           case "rpc":
             return trace("GET option 3 (backend.hello rpc)", async () => {
@@ -86,6 +74,20 @@ export const Route = createFileRoute("/api/hello")({
               if (value === null)
                 return new Response("Not found", { status: 404 });
               return new Response(value);
+            });
+
+          // option 4 — bind to your effect worker and call http client
+          case "http-client":
+            return trace("GET option 4 (env.BACKEND.httpClient)", async () => {
+              const client = Cloudflare.toHttpClient(
+                Cloudflare.fromCloudflareFetcher(env.BACKEND),
+              );
+              const res = await client
+                .get(`https://backend/?key=${encodeURIComponent(key)}`)
+                .pipe(Effect.runPromise);
+              return HttpServerResponse.toWeb(
+                HttpServerResponse.fromClientResponse(res),
+              );
             });
         }
       },
@@ -136,6 +138,31 @@ export const Route = createFileRoute("/api/hello")({
           case "rpc":
             return new Response("PUT is not supported via=rpc", {
               status: 400,
+            });
+
+          // option 4 — bind to your effect worker and call http client
+          case "http-client":
+            return trace("PUT option 4 (env.BACKEND.httpClient)", async () => {
+              const client = Cloudflare.toHttpClient(
+                Cloudflare.fromCloudflareFetcher(env.BACKEND),
+              );
+              const res = await client
+                .put(`https://backend/?key=${encodeURIComponent(key)}`, {
+                  headers: request.headers,
+                  body: HttpBody.stream(
+                    Stream.fromReadableStream({
+                      evaluate: () => request.body!,
+                      onError: (error) =>
+                        new Error("Error reading request body", {
+                          cause: error,
+                        }),
+                    }),
+                  ),
+                })
+                .pipe(Effect.runPromise);
+              return HttpServerResponse.toWeb(
+                HttpServerResponse.fromClientResponse(res),
+              );
             });
         }
       },

--- a/examples/cloudflare-tanstack/src/routes/api.hello.ts
+++ b/examples/cloudflare-tanstack/src/routes/api.hello.ts
@@ -150,6 +150,7 @@ export const Route = createFileRoute("/api/hello")({
                 .pipe(Effect.runPromise);
               return HttpServerResponse.toWeb(
                 HttpServerResponse.fromClientResponse(res),
+                { withoutBody: res.status === 204 },
               );
             });
         }

--- a/examples/cloudflare-tanstack/src/routes/api.hello.ts
+++ b/examples/cloudflare-tanstack/src/routes/api.hello.ts
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import * as Cloudflare from "alchemy/Cloudflare";
+import * as Cloudflare from "alchemy/Cloudflare/Bridge";
 import * as Effect from "effect/Effect";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import type Backend from "../backend.ts";

--- a/examples/cloudflare-tanstack/src/routes/api.hello.ts
+++ b/examples/cloudflare-tanstack/src/routes/api.hello.ts
@@ -1,8 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import * as Cloudflare from "alchemy/Cloudflare/Bridge";
 import * as Effect from "effect/Effect";
-import * as Stream from "effect/Stream";
-import * as HttpBody from "effect/unstable/http/HttpBody";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import type Backend from "../backend.ts";
 import { env } from "../env.ts";
@@ -147,18 +146,7 @@ export const Route = createFileRoute("/api/hello")({
                 Cloudflare.fromCloudflareFetcher(env.BACKEND),
               );
               const res = await client
-                .put(`https://backend/?key=${encodeURIComponent(key)}`, {
-                  headers: request.headers,
-                  body: HttpBody.stream(
-                    Stream.fromReadableStream({
-                      evaluate: () => request.body!,
-                      onError: (error) =>
-                        new Error("Error reading request body", {
-                          cause: error,
-                        }),
-                    }),
-                  ),
-                })
+                .execute(HttpClientRequest.fromWeb(request))
                 .pipe(Effect.runPromise);
               return HttpServerResponse.toWeb(
                 HttpServerResponse.fromClientResponse(res),

--- a/examples/cloudflare-tanstack/src/routes/api.hello.ts
+++ b/examples/cloudflare-tanstack/src/routes/api.hello.ts
@@ -1,9 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
-import * as Cloudflare from "alchemy/Cloudflare/Bridge";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import type Backend from "../backend.ts";
 import { env } from "../env.ts";
 
-const VIAS = ["binding", "fetch", "rpc"] as const;
+const VIAS = ["binding", "fetch", "rpc", "http-client"] as const;
 type Via = (typeof VIAS)[number];
 
 const parseRequest = (request: Request): { via: Via; key: string | null } => {
@@ -58,6 +60,20 @@ export const Route = createFileRoute("/api/hello")({
                 status: res.status,
                 headers: res.headers,
               });
+            });
+
+          // option 3 — bind to your effect worker and call http client
+          case "http-client":
+            return trace("GET option 3 (env.BACKEND.httpClient)", async () => {
+              const client = Cloudflare.toHttpClient(
+                Cloudflare.fromCloudflareFetcher(env.BACKEND),
+              );
+              const res = await client
+                .get(`https://backend/?key=${encodeURIComponent(key)}`)
+                .pipe(Effect.runPromise);
+              return HttpServerResponse.toWeb(
+                HttpServerResponse.fromClientResponse(res),
+              );
             });
 
           // option 3 — bind to your effect worker and call rpc method

--- a/examples/cloudflare-tanstack/test/integ.test.ts
+++ b/examples/cloudflare-tanstack/test/integ.test.ts
@@ -32,6 +32,7 @@ const KEYS = {
   binding: "integ:via-binding",
   fetch: "integ:via-fetch",
   rpc: "integ:via-rpc",
+  httpClient: "integ:via-http-client",
 };
 
 // Cold-start retry — fresh `workers.dev` URLs take a few seconds to start
@@ -115,6 +116,32 @@ test(
     const get = yield* client.get(route(websiteUrl, { key, via: "rpc" }));
     expect(get.status).toBe(200);
     expect(yield* get.text).toBe("hello-rpc");
+  }),
+  { timeout: 180_000 },
+);
+
+test(
+  "option 4 — service-binding HTTP client",
+  Effect.gen(function* () {
+    const { websiteUrl } = yield* stack;
+    const client = yield* HttpClient.HttpClient;
+    const key = KEYS.httpClient;
+
+    // Seed the bucket via option 1 (direct binding) so the RPC `hello`
+    // method has something to read.
+    const seed = yield* HttpClient.execute(
+      HttpClientRequest.put(
+        route(websiteUrl, { key, via: "http-client" }),
+      ).pipe(HttpClientRequest.bodyText("hello-http-client", "text/plain")),
+    ).pipe(coldStartRetry);
+    expect(seed.status).toBe(204);
+
+    // HTTP client GET reads through Backend.hello — exercises toPromiseApi.
+    const get = yield* client.get(
+      route(websiteUrl, { key, via: "http-client" }),
+    );
+    expect(get.status).toBe(200);
+    expect(yield* get.text).toBe("hello-http-client");
   }),
   { timeout: 180_000 },
 );

--- a/packages/alchemy/src/Cloudflare/Bridge.ts
+++ b/packages/alchemy/src/Cloudflare/Bridge.ts
@@ -1,3 +1,4 @@
+export * from "./Fetcher.ts";
 export * from "./Workers/InferEnv.ts";
 export * from "./Workers/Rpc.ts";
 export * from "./Workers/RpcAsync.ts";

--- a/packages/alchemy/src/Cloudflare/Fetcher.ts
+++ b/packages/alchemy/src/Cloudflare/Fetcher.ts
@@ -65,11 +65,13 @@ export const toCloudflareFetcher = Effect.fnUntraced(function* (
   } satisfies cf.Fetcher;
 });
 
-export const fromCloudflareFetcher = (fetcher: cf.Fetcher): Fetcher => {
+export const fromCloudflareFetcher = (
+  fetcher: cf.Fetcher | globalThis.Fetcher,
+): Fetcher => {
   const fetch = (request: Request) =>
     Effect.promise((signal) =>
-      fetcher.fetch(request as any as cf.Request, {
-        signal: signal as cf.AbortSignal,
+      (fetcher as globalThis.Fetcher).fetch(request, {
+        signal: signal,
       }),
     );
 
@@ -153,7 +155,9 @@ export const toHttpClient = (fetcher: {
     );
   });
 
-export const fromCloudflareSocket = (cfSocket: cf.Socket): Socket.Socket => {
+export const fromCloudflareSocket = (
+  cfSocket: globalThis.Socket | cf.Socket,
+): Socket.Socket => {
   const latch = Latch.makeUnsafe(false);
   let currentFiberSet: FiberSet.FiberSet<any, any> | undefined;
   let writerRef: WritableStreamDefaultWriter<Uint8Array> | undefined;


### PR DESCRIPTION
Vite's dependency optimization doesn't play well with a full import of `alchemy/Cloudflare` because of Node and other native imports. As a result, we offer an `alchemy/Cloudflare/Bridge` export with functions that are safe to import from Vite.

Our `Fetcher` utility, including functions like `fromCloudflareFetcher`, was not exported, meaning that you couldn't do something like this:

```ts
const client = Cloudflare.toHttpClient( // returns an effect HttpClient
  Cloudflare.fromCloudflareFetcher(env.BACKEND),
);
const res = await client
  .execute(HttpClientRequest.fromWeb(request))
  .pipe(Effect.runPromise);
```

This PR re-exports `./Fetcher` so this is fixed. Also updated the TanStack Start example and integration tests to exercise this new code path.