### PR TITLE
fix(cli): keep alchemy dev alive when an apply fails

### DIFF
--- a/packages/alchemy/src/Cli/commands/deploy.ts
+++ b/packages/alchemy/src/Cli/commands/deploy.ts
@@ -152,19 +152,22 @@ export const execStack = Effect.fn(function* ({
         // `alchemy dev` runs under `bun --watch`, which cancels watch mode
         // entirely on a clean exit (oven-sh/bun#10983), so completing here
         // would tear down every healthy local resource along with the failed
-        // one. Log the full cause (the TUI renderer only shows the failure
-        // status) and keep the process alive so the rest of the stack keeps
-        // serving.
-        const outputs = dev
-          ? yield* apply(updatePlan).pipe(
-              Effect.tapCause((cause) =>
-                Console.error(
-                  `alchemy dev: apply failed; keeping dev alive so healthy resources keep serving.\n${Cause.pretty(cause)}`,
-                ),
+        // one. Swallow apply failures (logging the full cause, since the TUI
+        // renderer only shows the failure status) so the keep-alive engages
+        // and the rest of the stack keeps serving, but re-propagate a pure
+        // interruption (Ctrl-C / fiber kill) so dev still shuts down cleanly.
+        const applyPlan = dev
+          ? apply(updatePlan).pipe(
+              Effect.catchCause((cause) =>
+                Cause.hasInterruptsOnly(cause)
+                  ? Effect.failCause(cause)
+                  : Console.error(
+                      `alchemy dev: apply failed; keeping dev alive so healthy resources keep serving.\n${Cause.pretty(cause)}`,
+                    ).pipe(Effect.as(undefined)),
               ),
-              Effect.catchCause(() => Effect.succeed(undefined)),
             )
-          : yield* apply(updatePlan);
+          : apply(updatePlan);
+        const outputs = yield* applyPlan;
 
         if (outputs !== undefined) {
           yield* Console.log(outputs);

--- a/packages/alchemy/src/Cli/commands/deploy.ts
+++ b/packages/alchemy/src/Cli/commands/deploy.ts
@@ -1,3 +1,4 @@
+import * as Cause from "effect/Cause";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
@@ -147,7 +148,23 @@ export const execStack = Effect.fn(function* ({
             return;
           }
         }
-        const outputs = yield* apply(updatePlan);
+        // In dev, a failed apply must not drain the keep-alive below:
+        // `alchemy dev` runs under `bun --watch`, which cancels watch mode
+        // entirely on a clean exit (oven-sh/bun#10983), so completing here
+        // would tear down every healthy local resource along with the failed
+        // one. Log the full cause (the TUI renderer only shows the failure
+        // status) and keep the process alive so the rest of the stack keeps
+        // serving.
+        const outputs = dev
+          ? yield* apply(updatePlan).pipe(
+              Effect.tapCause((cause) =>
+                Console.error(
+                  `alchemy dev: apply failed; keeping dev alive so healthy resources keep serving.\n${Cause.pretty(cause)}`,
+                ),
+              ),
+              Effect.catchCause(() => Effect.succeed(undefined)),
+            )
+          : yield* apply(updatePlan);
 
         if (outputs !== undefined) {
           yield* Console.log(outputs);


### PR DESCRIPTION
In dev, a failed apply drains the main effect before the keep-alive (`if (dev) yield* Effect.never`) engages, so the CLI exits 0. `alchemy dev` runs under `bun --watch`, and bun cancels watch mode entirely on a clean exit ([oven-sh/bun#10983](https://github.com/oven-sh/bun/discussions/10983)), so one bad resource tears down every healthy local worker with it.

Wrap the dev-mode apply in `tapCause` + `catchCause` so the failure is logged in full and the process stays up:

```ts
const outputs = dev
  ? yield* apply(updatePlan).pipe(
      Effect.tapCause((cause) =>
        Console.error(
          `alchemy dev: apply failed; keeping dev alive so healthy resources keep serving.\n${Cause.pretty(cause)}`,
        ),
      ),
      Effect.catchCause(() => Effect.succeed(undefined)),
    )
  : yield* apply(updatePlan);
```

- `Effect.tapCause` prints the pretty-printed cause; the TUI renderer only shows the failure status, so this is the only place the actual error becomes visible
- `Effect.catchCause` lets the keep-alive engage: healthy resources keep serving, and deploy mode is unchanged

Hit in practice via site Workers failing to bundle in dev (#349 is one such trigger): the only signal was a silent `[Worker] fail`, then the whole local stack exited 0.
