### PR TITLE
feat(cloudflare/worker): bundle: false — deploy prebuilt workers without re-bundling

### DIFF
--- a/packages/alchemy/src/Bundle/Bundle.ts
+++ b/packages/alchemy/src/Bundle/Bundle.ts
@@ -311,7 +311,7 @@ function bundleErrorFromUnknown(error: unknown): BundleError {
   });
 }
 
-function bundleOutputFromFiles(
+export function bundleOutputFromFiles(
   files: [BundleFile, ...BundleFile[]],
 ): Effect.Effect<BundleOutput> {
   return Effect.map(

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -225,39 +225,6 @@ export interface WorkerProps<
    */
   main?: string;
   /**
-   * Whether to bundle {@link main} with rolldown before upload.
-   *
-   * Set to `false` when `main` already points at a complete,
-   * runtime-ready ESM Worker produced by an external tool (OpenNext,
-   * a separate rolldown/esbuild pipeline, etc.). The entry and every
-   * file around it matching {@link rules} are uploaded byte-for-byte —
-   * no bundling, no minification, no transformation. Module names are
-   * the files' POSIX paths relative to the entry's directory, matching
-   * Wrangler's `no_bundle` contract.
-   *
-   * Re-bundling such artifacts is unsafe: dynamic `import()` calls the
-   * upstream tool relies on can be rewritten in ways that break runtime
-   * behavior.
-   *
-   * Durable Object and Workflow classes must be exported by the prebuilt
-   * entry itself — {@link exports} is not applied when `bundle` is
-   * `false`.
-   *
-   * @default true
-   */
-  bundle?: boolean;
-  /**
-   * Module rules selecting which files in the directory containing
-   * {@link main} are uploaded as additional modules when {@link bundle}
-   * is `false`. Each rule's globs are matched against POSIX-style paths
-   * relative to that directory, mirroring Wrangler's `rules`
-   * configuration. When provided, these rules replace
-   * {@link defaultModuleRules}.
-   *
-   * @default defaultModuleRules — ESModule (`**\/*.js`, `**\/*.mjs`), CompiledWasm (`**\/*.wasm`), Text (`**\/*.txt`, `**\/*.html`, `**\/*.sql`), Data (`**\/*.bin`)
-   */
-  rules?: ModuleRule[];
-  /**
    * Raw module source for the Worker. When provided, bundling is bypassed
    * entirely and this string is uploaded as a single ESM module
    * (`main.js`). Useful for tiny inline workers (tests, fixtures,
@@ -309,6 +276,39 @@ export interface WorkerProps<
    * options used to build this Worker. See {@link Bundle.BundleExtraOptions}.
    */
   build?: Bundle.BundleExtraOptions;
+  /**
+   * Whether to bundle {@link main} with rolldown before upload.
+   *
+   * Set to `false` when `main` already points at a complete,
+   * runtime-ready ESM Worker produced by an external tool (OpenNext,
+   * a separate rolldown/esbuild pipeline, etc.). The entry and every
+   * file around it matching {@link rules} are uploaded byte-for-byte —
+   * no bundling, no minification, no transformation. Module names are
+   * the files' POSIX paths relative to the entry's directory, matching
+   * Wrangler's `no_bundle` contract.
+   *
+   * Re-bundling such artifacts is unsafe: dynamic `import()` calls the
+   * upstream tool relies on can be rewritten in ways that break runtime
+   * behavior.
+   *
+   * Durable Object and Workflow classes must be exported by the prebuilt
+   * entry itself — {@link exports} is not applied when `bundle` is
+   * `false`.
+   *
+   * @default true
+   */
+  bundle?: boolean;
+  /**
+   * Module rules selecting which files in the directory containing
+   * {@link main} are uploaded as additional modules when {@link bundle}
+   * is `false`. Each rule's globs are matched against POSIX-style paths
+   * relative to that directory, mirroring Wrangler's `rules`
+   * configuration. When provided, these rules replace
+   * {@link defaultModuleRules}.
+   *
+   * @default defaultModuleRules — ESModule (`**\/*.js`, `**\/*.mjs`), CompiledWasm (`**\/*.wasm`), Text (`**\/*.txt`, `**\/*.html`, `**\/*.sql`), Data (`**\/*.bin`)
+   */
+  rules?: ModuleRule[];
   /**
    * Options for the local dev server that runs this Worker under `alchemy dev`.
    * Each Worker is served on its own port.

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -48,7 +48,11 @@ import type {
   WorkerBindings,
   WorkerSettingsBinding,
 } from "./WorkerBinding.ts";
-import { WorkerBundle } from "./WorkerBundle.ts";
+import {
+  readPrebuiltWorkerBundle,
+  WorkerBundle,
+  type ModuleRule,
+} from "./WorkerBundle.ts";
 import { createWorkerName } from "./WorkerName.ts";
 import {
   makeWorkerRuntimeContext,
@@ -220,6 +224,39 @@ export interface WorkerProps<
    * upload. Mutually exclusive with {@link script} — provide exactly one.
    */
   main?: string;
+  /**
+   * Whether to bundle {@link main} with rolldown before upload.
+   *
+   * Set to `false` when `main` already points at a complete,
+   * runtime-ready ESM Worker produced by an external tool (OpenNext,
+   * a separate rolldown/esbuild pipeline, etc.). The entry and every
+   * file around it matching {@link rules} are uploaded byte-for-byte —
+   * no bundling, no minification, no transformation. Module names are
+   * the files' POSIX paths relative to the entry's directory, matching
+   * Wrangler's `no_bundle` contract.
+   *
+   * Re-bundling such artifacts is unsafe: dynamic `import()` calls the
+   * upstream tool relies on can be rewritten in ways that break runtime
+   * behavior.
+   *
+   * Durable Object and Workflow classes must be exported by the prebuilt
+   * entry itself — {@link exports} is not applied when `bundle` is
+   * `false`.
+   *
+   * @default true
+   */
+  bundle?: boolean;
+  /**
+   * Module rules selecting which files in the directory containing
+   * {@link main} are uploaded as additional modules when {@link bundle}
+   * is `false`. Each rule's globs are matched against POSIX-style paths
+   * relative to that directory, mirroring Wrangler's `rules`
+   * configuration. When provided, these rules replace
+   * {@link defaultModuleRules}.
+   *
+   * @default defaultModuleRules — ESModule (`**\/*.js`, `**\/*.mjs`), CompiledWasm (`**\/*.wasm`), Text (`**\/*.txt`, `**\/*.html`, `**\/*.sql`), Data (`**\/*.bin`)
+   */
+  rules?: ModuleRule[];
   /**
    * Raw module source for the Worker. When provided, bundling is bypassed
    * entirely and this string is uploaded as a single ESM module
@@ -514,6 +551,21 @@ export type Worker<Bindings extends WorkerBindings = any> = Resource<
  * {
  *   main: import.meta.filename,
  *   assets: "./public",
+ * }
+ * ```
+ *
+ * @example Deploying a prebuilt Worker without bundling
+ * When `main` already points at a complete, runtime-ready ESM bundle
+ * produced by an external tool (e.g. OpenNext), set `bundle: false` to
+ * upload it byte-for-byte. The entry's directory is walked recursively
+ * and every file matching the module rules (by default `.js`, `.mjs`,
+ * `.wasm`, `.txt`, `.html`, `.sql`, and `.bin`) is uploaded as an
+ * additional module named by its path relative to that directory.
+ * ```typescript
+ * {
+ *   main: "./.open-next/worker.js",
+ *   bundle: false,
+ *   assets: "./.open-next/assets",
  * }
  * ```
  *
@@ -1144,23 +1196,27 @@ export const LiveWorkerProvider = () =>
       });
 
       const prepareBundle = (id: string, props: WorkerProps) =>
-        bundler
-          .build({
-            id,
-            main: props.main!,
-            compatibility: getCompatibility(props),
-            entry: props.isExternal
-              ? {
-                  kind: "external",
-                }
-              : {
-                  kind: "effect",
-                  exports: (props.exports ?? {}) as any,
-                },
-            stack: { name: stack.name, stage: stack.stage },
-            extraOptions: props.build,
-          })
-          .pipe(Artifacts.cached("build"));
+        (props.bundle === false
+          ? readPrebuiltWorkerBundle({
+              main: props.main!,
+              rules: props.rules,
+            })
+          : bundler.build({
+              id,
+              main: props.main!,
+              compatibility: getCompatibility(props),
+              entry: props.isExternal
+                ? {
+                    kind: "external",
+                  }
+                : {
+                    kind: "effect",
+                    exports: (props.exports ?? {}) as any,
+                  },
+              stack: { name: stack.name, stage: stack.stage },
+              extraOptions: props.build,
+            })
+        ).pipe(Artifacts.cached("build"));
 
       const hashScript = (script: string) =>
         Effect.sync(() =>

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
@@ -4,13 +4,13 @@ import * as FileSystem from "effect/FileSystem";
 import { flow } from "effect/Function";
 import type * as Path from "effect/Path";
 import * as Stream from "effect/Stream";
+import fg from "fast-glob";
 import { fileURLToPath } from "node:url";
 import path from "pathe";
-import picomatch from "picomatch";
 import type * as rolldown from "rolldown";
 import * as Bundle from "../../Bundle/Bundle.ts";
 import { findCwdForBundle } from "../../Bundle/TempRoot.ts";
-import { sha256, sha256Object } from "../../Util/sha256.ts";
+import { sha256 } from "../../Util/sha256.ts";
 import {
   isDurableObjectExport,
   type DurableObjectExport,
@@ -245,7 +245,8 @@ export const readPrebuiltWorkerBundle = Effect.fnUntraced(function* (
   options: PrebuiltWorkerBundleOptions,
 ) {
   const fs = yield* FileSystem.FileSystem;
-  const realMain = yield* Effect.sync(() => {
+
+  const main = yield* Effect.sync(() => {
     try {
       return fileURLToPath(options.main);
     } catch {
@@ -257,23 +258,8 @@ export const readPrebuiltWorkerBundle = Effect.fnUntraced(function* (
     // canonical location.
     Effect.map((p) => path.resolve(p)),
   );
-  yield* fs.stat(realMain).pipe(
-    Effect.mapError(
-      (cause) =>
-        new Bundle.BundleError({
-          message: `Failed to read prebuilt worker entry: ${options.main}`,
-          cause,
-        }),
-    ),
-  );
-  const root = path.dirname(realMain);
-  const entryName = path.basename(realMain);
-  const isMatch = picomatch(
-    (options.rules ?? defaultModuleRules).flatMap((rule) => rule.globs),
-    // Wrangler's glob matching does not special-case dotfiles, and
-    // prebuilt output dirs commonly contain hidden directories.
-    { dot: true },
-  );
+  const root = path.dirname(main);
+  const entryName = path.basename(main);
 
   const readModuleFile = Effect.fnUntraced(function* (name: string) {
     const file = path.join(root, name);
@@ -281,7 +267,7 @@ export const readPrebuiltWorkerBundle = Effect.fnUntraced(function* (
       Effect.mapError(
         (cause) =>
           new Bundle.BundleError({
-            message: `Failed to read prebuilt worker bundle module: ${file}`,
+            message: `Failed to read prebuilt worker bundle module "${file}"`,
             cause,
           }),
       ),
@@ -290,48 +276,41 @@ export const readPrebuiltWorkerBundle = Effect.fnUntraced(function* (
     return { path: name, content, hash } satisfies Bundle.BundleFile;
   });
 
-  const entries = yield* fs.readDirectory(root, { recursive: true }).pipe(
-    Effect.mapError(
-      (cause) =>
-        new Bundle.BundleError({
-          message: `Failed to read prebuilt worker bundle directory: ${root}`,
-          cause,
-        }),
-    ),
-  );
-  // Module names always use `/`, also required to match globs on Windows.
-  const candidates = entries
-    .map((entry) => entry.replaceAll("\\", "/"))
-    .filter((name) => name !== entryName && isMatch(name))
-    .sort((a, b) => a.localeCompare(b));
-  const additionalNames = yield* Effect.forEach(
-    candidates,
-    (name) =>
-      fs.stat(path.join(root, name)).pipe(
-        Effect.map((stat) => (stat.type === "File" ? name : undefined)),
-        Effect.mapError(
-          (cause) =>
-            new Bundle.BundleError({
-              message: `Failed to stat prebuilt worker bundle module: ${path.join(root, name)}`,
-              cause,
-            }),
+  return yield* readModuleFile(entryName).pipe(
+    Effect.zipWith(
+      Effect.tryPromise({
+        try: () =>
+          fg.glob(
+            (options.rules ?? defaultModuleRules).flatMap((rule) => rule.globs),
+            {
+              cwd: root,
+              onlyFiles: true,
+              dot: true,
+            },
+          ),
+        catch: (error) =>
+          new Bundle.BundleError({
+            message: `Failed to read additional modules in directory "${root}"`,
+            cause: error,
+          }),
+      }).pipe(
+        Effect.map((names) =>
+          names
+            .map((name) => name.replaceAll("\\", "/"))
+            .filter((name) => name !== entryName)
+            .sort(),
+        ),
+        Effect.flatMap(
+          Effect.forEach(readModuleFile, { concurrency: "unbounded" }),
         ),
       ),
-    { concurrency: 16 },
-  ).pipe(Effect.map((names) => names.filter((name) => name !== undefined)));
-
-  const entryFile = yield* readModuleFile(entryName);
-  const additionalFiles = yield* Effect.forEach(
-    additionalNames,
-    readModuleFile,
-    { concurrency: 16 },
+      (entryModule, additionalModules) =>
+        [entryModule, ...additionalModules] as [
+          Bundle.BundleFile,
+          ...Bundle.BundleFile[],
+        ],
+      { concurrent: true },
+    ),
+    Effect.flatMap(Bundle.bundleOutputFromFiles),
   );
-  const files: [Bundle.BundleFile, ...Bundle.BundleFile[]] = [
-    entryFile,
-    ...additionalFiles,
-  ];
-  const hash = yield* sha256Object(
-    files.map((file) => ({ path: file.path, hash: file.hash })),
-  );
-  return { files, hash } satisfies Bundle.BundleOutput;
 });

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBundle.ts
@@ -6,9 +6,11 @@ import type * as Path from "effect/Path";
 import * as Stream from "effect/Stream";
 import { fileURLToPath } from "node:url";
 import path from "pathe";
+import picomatch from "picomatch";
 import type * as rolldown from "rolldown";
 import * as Bundle from "../../Bundle/Bundle.ts";
 import { findCwdForBundle } from "../../Bundle/TempRoot.ts";
+import { sha256, sha256Object } from "../../Util/sha256.ts";
 import {
   isDurableObjectExport,
   type DurableObjectExport,
@@ -191,3 +193,145 @@ ${[
 ].join("\n")}
 `;
 };
+
+/**
+ * A rule selecting additional module files to upload alongside the entry
+ * of a prebuilt Worker (`bundle: false`). Globs are matched against
+ * POSIX-style paths relative to the directory containing the Worker's
+ * entry module, mirroring Wrangler's `rules` configuration.
+ */
+export interface ModuleRule {
+  readonly globs: readonly string[];
+}
+
+/**
+ * The default {@link ModuleRule | module rules} applied when
+ * `bundle: false` is set without explicit rules — the same set Wrangler
+ * applies to `no_bundle` Workers: ESModule (`**\/*.js`, `**\/*.mjs`),
+ * CompiledWasm (`**\/*.wasm`), Text (`**\/*.txt`, `**\/*.html`,
+ * `**\/*.sql`), and Data (`**\/*.bin`). Source maps (`.js.map`) are
+ * deliberately not uploaded.
+ */
+export const defaultModuleRules: ModuleRule[] = [
+  { globs: ["**/*.js", "**/*.mjs"] },
+  { globs: ["**/*.wasm"] },
+  { globs: ["**/*.txt", "**/*.html", "**/*.sql"] },
+  { globs: ["**/*.bin"] },
+];
+
+export interface PrebuiltWorkerBundleOptions {
+  /**
+   * Path (or `file://` URL) to the prebuilt, runtime-ready entry module.
+   */
+  main: string;
+  /**
+   * Module rules selecting additional files to upload alongside the
+   * entry. Defaults to {@link defaultModuleRules}.
+   */
+  rules?: readonly ModuleRule[] | undefined;
+}
+
+/**
+ * Read a prebuilt Worker bundle from disk without bundling.
+ *
+ * The entry's directory is walked recursively and every file matching the
+ * rule globs is uploaded byte-for-byte as an additional module, named by
+ * its POSIX path relative to that directory — the same contract as
+ * Wrangler's `find_additional_modules` and Alchemy v1's `noBundle`. The
+ * entry file is always first and never duplicated as an additional
+ * module.
+ */
+export const readPrebuiltWorkerBundle = Effect.fnUntraced(function* (
+  options: PrebuiltWorkerBundleOptions,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const realMain = yield* Effect.sync(() => {
+    try {
+      return fileURLToPath(options.main);
+    } catch {
+      return options.main;
+    }
+  }).pipe(
+    // Resolve without following symlinks (Alchemy v1 parity): the module
+    // walk happens in the directory the user pointed at, not the entry's
+    // canonical location.
+    Effect.map((p) => path.resolve(p)),
+  );
+  yield* fs.stat(realMain).pipe(
+    Effect.mapError(
+      (cause) =>
+        new Bundle.BundleError({
+          message: `Failed to read prebuilt worker entry: ${options.main}`,
+          cause,
+        }),
+    ),
+  );
+  const root = path.dirname(realMain);
+  const entryName = path.basename(realMain);
+  const isMatch = picomatch(
+    (options.rules ?? defaultModuleRules).flatMap((rule) => rule.globs),
+    // Wrangler's glob matching does not special-case dotfiles, and
+    // prebuilt output dirs commonly contain hidden directories.
+    { dot: true },
+  );
+
+  const readModuleFile = Effect.fnUntraced(function* (name: string) {
+    const file = path.join(root, name);
+    const content = yield* fs.readFile(file).pipe(
+      Effect.mapError(
+        (cause) =>
+          new Bundle.BundleError({
+            message: `Failed to read prebuilt worker bundle module: ${file}`,
+            cause,
+          }),
+      ),
+    );
+    const hash = yield* sha256(content);
+    return { path: name, content, hash } satisfies Bundle.BundleFile;
+  });
+
+  const entries = yield* fs.readDirectory(root, { recursive: true }).pipe(
+    Effect.mapError(
+      (cause) =>
+        new Bundle.BundleError({
+          message: `Failed to read prebuilt worker bundle directory: ${root}`,
+          cause,
+        }),
+    ),
+  );
+  // Module names always use `/`, also required to match globs on Windows.
+  const candidates = entries
+    .map((entry) => entry.replaceAll("\\", "/"))
+    .filter((name) => name !== entryName && isMatch(name))
+    .sort((a, b) => a.localeCompare(b));
+  const additionalNames = yield* Effect.forEach(
+    candidates,
+    (name) =>
+      fs.stat(path.join(root, name)).pipe(
+        Effect.map((stat) => (stat.type === "File" ? name : undefined)),
+        Effect.mapError(
+          (cause) =>
+            new Bundle.BundleError({
+              message: `Failed to stat prebuilt worker bundle module: ${path.join(root, name)}`,
+              cause,
+            }),
+        ),
+      ),
+    { concurrency: 16 },
+  ).pipe(Effect.map((names) => names.filter((name) => name !== undefined)));
+
+  const entryFile = yield* readModuleFile(entryName);
+  const additionalFiles = yield* Effect.forEach(
+    additionalNames,
+    readModuleFile,
+    { concurrency: 16 },
+  );
+  const files: [Bundle.BundleFile, ...Bundle.BundleFile[]] = [
+    entryFile,
+    ...additionalFiles,
+  ];
+  const hash = yield* sha256Object(
+    files.map((file) => ({ path: file.path, hash: file.hash })),
+  );
+  return { files, hash } satisfies Bundle.BundleOutput;
+});

--- a/packages/alchemy/test/Cloudflare/Workers/PrebuiltWorker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/PrebuiltWorker.test.ts
@@ -1,0 +1,88 @@
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import { readPrebuiltWorkerBundle } from "@/Cloudflare/Workers/WorkerBundle";
+import * as Test from "@/Test/Vitest";
+import { describe, expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as pathe from "pathe";
+import { expectUrlContains } from "../Utils/Http.ts";
+import { waitForWorkerToBeDeleted } from "../Utils/Worker.ts";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const main = pathe.resolve(import.meta.dirname, "fixtures/prebuilt/worker.mjs");
+
+describe.concurrent("Cloudflare.Worker with bundle: false", () => {
+  test.provider(
+    "uploads a prebuilt module graph byte-for-byte",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        // The bundle the provider must upload, computed from the source
+        // bytes on disk: entry first, additional modules named by their
+        // POSIX path relative to the entry's directory.
+        const expected = yield* readPrebuiltWorkerBundle({ main });
+        expect(expected.files.map((file) => file.path)).toEqual([
+          "worker.mjs",
+          "lib/format.mjs",
+          "lib/greeting.mjs",
+          "lib/notice.txt",
+        ]);
+
+        const worker = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Worker("PrebuiltWorker", {
+              main,
+              bundle: false,
+              subdomain: { enabled: true },
+              compatibility: {
+                date: "2024-01-01",
+              },
+            });
+          }),
+        );
+
+        // The stored bundle hash equals the hash of the source bytes
+        // only when no rolldown step ran — any re-bundling would
+        // minify the files and change every content hash.
+        expect(worker.hash?.bundle).toEqual(expected.hash);
+
+        // End-to-end: the response is assembled from values that flow
+        // through both nested ES modules and the nested text module, so
+        // it only renders if the module names survived the upload.
+        expect(worker.url).toBeDefined();
+        yield* expectUrlContains(
+          worker.url!,
+          "prebuilt-modules-survived alchemy-prebuilt-notice-4d2a!",
+        );
+
+        // Re-deploy with no changes: the prebuilt hash must be stable.
+        const redeployed = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* Cloudflare.Worker("PrebuiltWorker", {
+              main,
+              bundle: false,
+              subdomain: { enabled: true },
+              compatibility: {
+                date: "2024-01-01",
+              },
+            });
+          }),
+        );
+        expect(redeployed.hash?.bundle).toEqual(expected.hash);
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(worker.workerName, accountId);
+      }).pipe(logLevel),
+    { timeout: 360_000 },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Workers/PrebuiltWorkerBundle.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/PrebuiltWorkerBundle.test.ts
@@ -1,0 +1,196 @@
+import { readPrebuiltWorkerBundle } from "@/Cloudflare/Workers/WorkerBundle";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, layer } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+const decode = (content: string | Uint8Array<ArrayBufferLike>) =>
+  typeof content === "string"
+    ? content
+    : new TextDecoder().decode(content as Uint8Array);
+
+/**
+ * Write `files` (paths relative to a fresh temp directory) and return
+ * the temp directory's absolute path.
+ */
+const writeFixture = Effect.fnUntraced(function* (
+  files: Record<string, string | Uint8Array>,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const root = yield* fs.makeTempDirectory({ prefix: "alchemy-prebuilt-" });
+  for (const [name, content] of Object.entries(files)) {
+    const file = path.join(root, name);
+    yield* fs.makeDirectory(path.dirname(file), { recursive: true });
+    if (typeof content === "string") {
+      yield* fs.writeFileString(file, content);
+    } else {
+      yield* fs.writeFile(file, content);
+    }
+  }
+  return root;
+});
+
+layer(NodeServices.layer)("readPrebuiltWorkerBundle", (it) => {
+  it.effect(
+    "collects modules matching the default rules, entry first, names POSIX-relative to the entry's directory",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const root = yield* writeFixture({
+          "index.mjs": `import { greeting } from "./lib/greeting.mjs";\nexport default { fetch: () => new Response(greeting) };\n`,
+          "lib/greeting.mjs": `export const greeting = "hello";\n`,
+          "lib/deep/notice.txt": "NOTICE",
+          "add.wasm": new Uint8Array([0x00, 0x61, 0x73, 0x6d, 1, 0, 0, 0]),
+          "schema.sql": "select 1;",
+          "page.html": "<html></html>",
+          "blob.bin": new Uint8Array([1, 2, 3]),
+          // hidden directories are walked (wrangler glob parity)
+          ".chunks/extra.mjs": `export const extra = 1;\n`,
+          // not matched by any default rule
+          "README.md": "# not a module",
+          // source maps are never uploaded as modules
+          "index.mjs.map": "{}",
+          "lib/greeting.mjs.map": "{}",
+        });
+
+        const bundle = yield* readPrebuiltWorkerBundle({
+          main: path.join(root, "index.mjs"),
+        });
+
+        expect(bundle.files[0].path).toEqual("index.mjs");
+        expect(bundle.files.slice(1).map((file) => file.path)).toEqual([
+          ".chunks/extra.mjs",
+          "add.wasm",
+          "blob.bin",
+          "lib/deep/notice.txt",
+          "lib/greeting.mjs",
+          "page.html",
+          "schema.sql",
+        ]);
+
+        yield* fs.remove(root, { recursive: true });
+      }),
+  );
+
+  it.effect("uploads file contents byte-for-byte", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      // Comments and formatting that any bundler/minifier would strip.
+      const entrySource = `// SENTINEL: must survive byte-for-byte 7f1c\nconst kSentinel = "sentinel/7f1c";\nexport default { fetch: () => new Response(kSentinel) };\n`;
+      const wasmBytes = new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 1, 0, 0, 0, 42,
+      ]);
+      const root = yield* writeFixture({
+        "index.mjs": entrySource,
+        "add.wasm": wasmBytes,
+      });
+
+      const bundle = yield* readPrebuiltWorkerBundle({
+        main: path.join(root, "index.mjs"),
+      });
+
+      expect(decode(bundle.files[0].content)).toEqual(entrySource);
+      const wasm = bundle.files.find((file) => file.path === "add.wasm")!;
+      expect(new Uint8Array(wasm.content as Uint8Array)).toEqual(wasmBytes);
+
+      yield* fs.remove(root, { recursive: true });
+    }),
+  );
+
+  it.effect("does not walk outside the entry's directory", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* writeFixture({
+        "outside.mjs": `export const outside = true;\n`,
+        "dist/index.mjs": `export default { fetch: () => new Response("ok") };\n`,
+        "dist/chunk.mjs": `export const chunk = 1;\n`,
+      });
+
+      const bundle = yield* readPrebuiltWorkerBundle({
+        main: path.join(root, "dist/index.mjs"),
+      });
+
+      expect(bundle.files.map((file) => file.path)).toEqual([
+        "index.mjs",
+        "chunk.mjs",
+      ]);
+
+      yield* fs.remove(root, { recursive: true });
+    }),
+  );
+
+  it.effect("custom rules replace the defaults", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* writeFixture({
+        "index.mjs": `export default { fetch: () => new Response("ok") };\n`,
+        "data/weights.dat": "0101",
+        "data/skipped.txt": "skipped",
+        "skipped.mjs": `export const skipped = true;\n`,
+      });
+
+      const bundle = yield* readPrebuiltWorkerBundle({
+        main: path.join(root, "index.mjs"),
+        rules: [{ globs: ["**/*.dat"] }],
+      });
+
+      // The entry is always included, even when it matches no rule.
+      expect(bundle.files.map((file) => file.path)).toEqual([
+        "index.mjs",
+        "data/weights.dat",
+      ]);
+
+      yield* fs.remove(root, { recursive: true });
+    }),
+  );
+
+  it.effect("hash is stable across reads and sensitive to module changes", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* writeFixture({
+        "index.mjs": `import { x } from "./lib/x.mjs";\nexport default { fetch: () => new Response(String(x)) };\n`,
+        "lib/x.mjs": `export const x = 1;\n`,
+      });
+      const main = path.join(root, "index.mjs");
+
+      const first = yield* readPrebuiltWorkerBundle({ main });
+      const second = yield* readPrebuiltWorkerBundle({ main });
+      expect(second.hash).toEqual(first.hash);
+
+      yield* fs.writeFileString(
+        path.join(root, "lib/x.mjs"),
+        `export const x = 2;\n`,
+      );
+      const changed = yield* readPrebuiltWorkerBundle({ main });
+      expect(changed.hash).not.toEqual(first.hash);
+
+      yield* fs.remove(root, { recursive: true });
+    }),
+  );
+
+  it.effect("fails with BundleError when the entry does not exist", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectory({
+        prefix: "alchemy-prebuilt-",
+      });
+
+      const error = yield* readPrebuiltWorkerBundle({
+        main: path.join(root, "missing.mjs"),
+      }).pipe(Effect.flip);
+
+      expect(error._tag).toEqual("BundleError");
+      expect(error.message).toContain("missing.mjs");
+
+      yield* fs.remove(root, { recursive: true });
+    }),
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/prebuilt/lib/format.mjs
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/prebuilt/lib/format.mjs
@@ -1,0 +1,1 @@
+export const exclaim = (text) => `${text}!`;

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/prebuilt/lib/greeting.mjs
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/prebuilt/lib/greeting.mjs
@@ -1,0 +1,6 @@
+import notice from "./notice.txt";
+import { exclaim } from "./format.mjs";
+
+export const greeting = exclaim(
+  `prebuilt-modules-survived ${notice.trim()}`,
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/prebuilt/lib/notice.txt
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/prebuilt/lib/notice.txt
@@ -1,0 +1,1 @@
+alchemy-prebuilt-notice-4d2a

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/prebuilt/worker.mjs
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/prebuilt/worker.mjs
@@ -1,0 +1,15 @@
+// SENTINEL: alchemy-prebuilt-worker 7c2e
+//
+// This file is a hand-written, prebuilt ESM Worker deployed with
+// `bundle: false`. It must be uploaded byte-for-byte: re-bundling would
+// inline the imports below and collapse the module graph this test
+// asserts on.
+import { greeting } from "./lib/greeting.mjs";
+
+export default {
+  async fetch() {
+    return new Response(greeting, {
+      headers: { "x-alchemy-prebuilt": "7c2e" },
+    });
+  },
+};


### PR DESCRIPTION
Picks up #117 (thanks @czxtm for the original implementation and repro) with the review feedback applied. Adds `bundle?: boolean` to `Cloudflare.Worker`: when `false`, `main` is uploaded byte-for-byte — no rolldown, no minification, no pure-annotation pass.

```ts
Cloudflare.Worker("site", {
  main: "./.open-next/worker.js",
  bundle: false,
  assets: "./.open-next/assets",
});
```

Changes relative to #117, per review:

- **Pattern-based module resolution instead of regex import-scanning.** Additional modules are resolved from glob patterns the way Alchemy v1 (`WorkerBundleSource.FS`) and Wrangler (`findAdditionalModules`) do: the entry's directory is walked recursively, matching files are uploaded as modules named by their POSIX path relative to that directory. The entry is always first and never duplicated; `.js.map` files are not uploaded.
- **No Next.js example, no wrangler dependency.** The code path is exercised end-to-end by an integration test deploying a committed prebuilt fixture (nested ES modules + a text module) and asserting the response renders through the nested module graph — the bundle hash is derived from the verbatim source-byte hashes, so it cannot match a rolldown-processed output.
- Diffing needs no special casing: `prepareBundle` branches internally, so `hasChanged` compares the on-disk module-set hash against the stored `hash.bundle`.

Conscious decisions to sign off on:

- **`rules?: { globs: string[] }[]` replaces the defaults when provided** (Alchemy v1 semantics), rather than Wrangler's append-with-fallthrough-warnings.
- **Default rules are a superset of v1's** (`**/*.js`, `**/*.mjs`, `**/*.wasm`, plus Wrangler's `no_bundle` Text/Data rules: `**/*.txt`, `**/*.html`, `**/*.sql`, `**/*.bin`).
- **Glob matching includes dotfiles** (`dot: true`) — prebuilt output dirs commonly nest under hidden directories (`.open-next/`), and Wrangler's matching doesn't special-case them either.
- **No sourcemap upload**: v1 uploaded `.js.map` as modules; Wrangler routes sourcemaps through a separate upload channel that doesn't exist here yet, and maps-as-modules is arguably wrong. Omitted for now.
- **Durable Object / Workflow classes must be exported by the prebuilt entry itself** — `exports` is not applied when `bundle: false` (documented on the prop).

Also related:

- Users hitting #589 (re-bundle mangling a pre-built `main`) can now opt out entirely — `bundle: false` skips the bundler, including its pure-annotation pass. The default path's behavior there is unchanged.
- #590 — until `Cloudflare.Vite` captures multi-environment RSC builds, `bundle: false` is the working path for `@vitejs/plugin-rsc` apps: build with vite, deploy the emitted server directory as-is.

Not covered (same scope as #117): `alchemy dev` still rolldown-watches `main`; a no-bundle dev watcher (à la wrangler's `findAdditionalModuleWatchDirs`) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
