### PR TITLE
fix(drizzle): cache detectDrift so interactive prompt only runs once

### DIFF
--- a/packages/alchemy/src/Drizzle/Schema.ts
+++ b/packages/alchemy/src/Drizzle/Schema.ts
@@ -2,6 +2,7 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import * as crypto from "node:crypto";
+import * as Artifacts from "../Artifacts.ts";
 import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
@@ -220,7 +221,7 @@ export const SchemaProvider = () =>
               new Error(`drizzle-kit generateMigration failed: ${cause}`),
           });
           return { out, cur, prevEntry, sqlStatements };
-        });
+        }).pipe(Artifacts.cached("detectDrift"));
 
       /**
        * Generate a new migration directory if the schema has drifted from


### PR DESCRIPTION
`detectDrift` calls drizzle-kit's `generateMigration`, which can open an interactive prompt (e.g. "rename this column, or delete and recreate?"). It runs in both `diff` and `reconcile`.

In `alchemy dev` there's no approval gate, so `diff` and `reconcile` run back-to-back. The two interactive prompts collide on stdin: even after you answer once, drizzle-kit is still waiting on a second prompt that never gets an answer, so the process hangs at:

```
🔄 app-schema (Drizzle.Schema) updating
 • Regenerating drizzle migrations for
```

Wrap the drift detection in `Artifacts.cached("detectDrift")` so it runs once per plan/apply cycle:

```diff
-        });
+        }).pipe(Artifacts.cached("detectDrift"));
```

Now the prompt is answered once during `diff`, and `reconcile` reuses the cached result. This also matches the intended model: you make the migration decision at plan time, not again at apply time.
