### PR TITLE
Add GitHub Repository resource

### DIFF
--- a/packages/alchemy/src/GitHub/Providers.ts
+++ b/packages/alchemy/src/GitHub/Providers.ts
@@ -5,6 +5,7 @@ import * as Provider from "../Provider.ts";
 import { GitHubAuth } from "./AuthProvider.ts";
 import { Comment, CommentProvider } from "./Comment.ts";
 import * as Credentials from "./Credentials.ts";
+import { Repository, RepositoryProvider } from "./Repository.ts";
 import { Secret, SecretProvider } from "./Secret.ts";
 import { Variable, VariableProvider } from "./Variable.ts";
 
@@ -17,16 +18,21 @@ export class Providers extends Provider.ProviderCollection<Providers>()(
 export type ProviderRequirements = Layer.Services<ReturnType<typeof providers>>;
 
 /**
- * GitHub providers (Secret, Variable) plus the GitHub AuthProvider that
- * `alchemy login` discovers.
+ * GitHub providers (Comment, Repository, Secret, Variable) plus the GitHub
+ * AuthProvider that `alchemy login` discovers.
  */
 export const providers = () =>
   Layer.effect(
     Providers,
-    Provider.collection([Comment, Secret, Variable]),
+    Provider.collection([Comment, Repository, Secret, Variable]),
   ).pipe(
     Layer.provide(
-      Layer.mergeAll(CommentProvider(), SecretProvider(), VariableProvider()),
+      Layer.mergeAll(
+        CommentProvider(),
+        RepositoryProvider(),
+        SecretProvider(),
+        VariableProvider(),
+      ),
     ),
     Layer.provideMerge(Credentials.fromAuthProvider()),
     Layer.provideMerge(GitHubAuth),

--- a/packages/alchemy/src/GitHub/Repository.ts
+++ b/packages/alchemy/src/GitHub/Repository.ts
@@ -135,15 +135,6 @@ export interface RepositoryProps {
    * Only used at create time.
    */
   licenseTemplate?: string;
-
-  /**
-   * Whether to delete the repository when the resource is destroyed. By
-   * default the repository is preserved on destroy to protect its history
-   * (issues, pull requests, commits). Set to `true` to opt in to deletion —
-   * the token must have the `delete_repo` scope.
-   * @default false
-   */
-  allowDelete?: boolean;
 }
 
 export interface Repository extends Resource<
@@ -209,12 +200,17 @@ export interface Repository extends Resource<
  *
  * `Repository` manages the lifecycle of a repository owned by a user or
  * organization. The repository is created on first deploy and its settings are
- * converged on every subsequent deploy. To protect irreplaceable history,
- * destroy preserves the repository by default — opt in with `allowDelete: true`.
+ * converged on every subsequent deploy.
+ *
+ * Repositories default to **retain** on removal — destroying the stack does
+ * NOT delete the repository on GitHub, protecting its irreplaceable history
+ * (issues, pull requests, commits). Opt in to actual deletion by wrapping the
+ * resource (or the whole stack) in {@link destroy}() from
+ * `alchemy/RemovalPolicy`.
  *
  * Authentication is resolved via the `GitHubCredentials` service supplied by
  * `GitHub.providers()` (env, stored PAT, `gh` CLI, or OAuth). The token needs
- * `repo` scope (and `delete_repo` when `allowDelete` is set).
+ * `repo` scope (and `delete_repo` when deletion is opted in via `destroy()`).
  *
  * @section Creating a Repository
  * @example Basic Repository
@@ -276,37 +272,16 @@ export interface Repository extends Resource<
  * @section Deleting a Repository
  * @example Allow Repository Deletion
  * ```typescript
- * const repo = yield* GitHub.Repository("ephemeral", {
+ * import { destroy } from "alchemy/RemovalPolicy";
+ *
+ * yield* GitHub.Repository("ephemeral", {
  *   owner: "my-org",
  *   name: "ephemeral-preview",
- *   allowDelete: true,
- * });
+ * }).pipe(destroy());
  * ```
  */
-export const Repository = Resource<Repository>("GitHub.Repository");
-
-const attrsOf = (data: {
-  id: number;
-  node_id: string;
-  full_name: string;
-  html_url: string;
-  git_url: string;
-  ssh_url: string;
-  clone_url: string;
-  default_branch: string;
-  created_at: string | null;
-  updated_at: string | null;
-}) => ({
-  repoId: data.id,
-  nodeId: data.node_id,
-  fullName: data.full_name,
-  htmlUrl: data.html_url,
-  gitUrl: data.git_url,
-  sshUrl: data.ssh_url,
-  cloneUrl: data.clone_url,
-  defaultBranch: data.default_branch,
-  createdAt: data.created_at ?? new Date().toISOString(),
-  updatedAt: data.updated_at ?? new Date().toISOString(),
+export const Repository = Resource<Repository>("GitHub.Repository", {
+  defaultRemovalPolicy: "retain",
 });
 
 export const RepositoryProvider = () =>
@@ -561,10 +536,6 @@ export const RepositoryProvider = () =>
     }),
 
     delete: Effect.fn(function* ({ olds, output }) {
-      if (!olds.allowDelete) {
-        return;
-      }
-
       const octokit = yield* Octokit;
 
       // Resolve the current repository name via the stable numeric ID. A rename
@@ -608,3 +579,27 @@ export const RepositoryProvider = () =>
       });
     }),
   });
+
+const attrsOf = (data: {
+  id: number;
+  node_id: string;
+  full_name: string;
+  html_url: string;
+  git_url: string;
+  ssh_url: string;
+  clone_url: string;
+  default_branch: string;
+  created_at: string | null;
+  updated_at: string | null;
+}) => ({
+  repoId: data.id,
+  nodeId: data.node_id,
+  fullName: data.full_name,
+  htmlUrl: data.html_url,
+  gitUrl: data.git_url,
+  sshUrl: data.ssh_url,
+  cloneUrl: data.clone_url,
+  defaultBranch: data.default_branch,
+  createdAt: data.created_at ?? new Date().toISOString(),
+  updatedAt: data.updated_at ?? new Date().toISOString(),
+});

--- a/packages/alchemy/src/GitHub/Repository.ts
+++ b/packages/alchemy/src/GitHub/Repository.ts
@@ -1,0 +1,610 @@
+import * as Effect from "effect/Effect";
+import { isResolved } from "../Diff.ts";
+import * as Provider from "../Provider.ts";
+import { Resource } from "../Resource.ts";
+import { Octokit } from "./Octokit.ts";
+import type * as GitHub from "./Providers.ts";
+
+export interface RepositoryProps {
+  /**
+   * Repository owner — a user or organization login.
+   *
+   * Changing the owner replaces the repository (the old one is deleted and a
+   * new one created under the new owner).
+   */
+  owner: string;
+
+  /**
+   * Repository name. Renaming (deploying with the same logical ID and a
+   * different `name`) renames the existing repository in place rather than
+   * replacing it.
+   */
+  name: string;
+
+  /**
+   * Short description shown on the repository page.
+   */
+  description?: string;
+
+  /**
+   * Homepage URL shown on the repository page.
+   */
+  homepage?: string;
+
+  /**
+   * Repository visibility. `internal` is only valid for repositories owned by
+   * an organization on GitHub Enterprise. When omitted, GitHub's default
+   * applies (`public`).
+   * @default "public"
+   */
+  visibility?: "public" | "private" | "internal";
+
+  /**
+   * Whether the Issues tab is enabled.
+   * @default true
+   */
+  hasIssues?: boolean;
+
+  /**
+   * Whether the Projects tab is enabled.
+   * @default true
+   */
+  hasProjects?: boolean;
+
+  /**
+   * Whether the Wiki tab is enabled.
+   * @default true
+   */
+  hasWiki?: boolean;
+
+  /**
+   * Whether GitHub Discussions are enabled.
+   * @default false
+   */
+  hasDiscussions?: boolean;
+
+  /**
+   * Whether the repository is a template repository.
+   * @default false
+   */
+  isTemplate?: boolean;
+
+  /**
+   * Whether the repository is archived (read-only).
+   * @default false
+   */
+  archived?: boolean;
+
+  /**
+   * The default branch name. Only applied to repositories that already have
+   * at least one branch — setting it on an empty repository has no effect.
+   */
+  defaultBranch?: string;
+
+  /**
+   * Whether squash merges are allowed.
+   * @default true
+   */
+  allowSquashMerge?: boolean;
+
+  /**
+   * Whether merge commits are allowed.
+   * @default true
+   */
+  allowMergeCommit?: boolean;
+
+  /**
+   * Whether rebase merges are allowed.
+   * @default true
+   */
+  allowRebaseMerge?: boolean;
+
+  /**
+   * Whether auto-merge is enabled for pull requests.
+   * @default false
+   */
+  allowAutoMerge?: boolean;
+
+  /**
+   * Whether head branches are automatically deleted after a pull request is
+   * merged.
+   * @default false
+   */
+  deleteBranchOnMerge?: boolean;
+
+  /**
+   * Repository topics. The provided list fully replaces the existing topics.
+   */
+  topics?: string[];
+
+  /**
+   * Initialize the repository with an empty README on creation. Only used at
+   * create time — ignored on subsequent updates.
+   * @default false
+   */
+  autoInit?: boolean;
+
+  /**
+   * Name of the `.gitignore` template to apply on creation (e.g. `"Node"`).
+   * Only used at create time.
+   */
+  gitignoreTemplate?: string;
+
+  /**
+   * Keyword of the license template to apply on creation (e.g. `"mit"`).
+   * Only used at create time.
+   */
+  licenseTemplate?: string;
+
+  /**
+   * Whether to delete the repository when the resource is destroyed. By
+   * default the repository is preserved on destroy to protect its history
+   * (issues, pull requests, commits). Set to `true` to opt in to deletion —
+   * the token must have the `delete_repo` scope.
+   * @default false
+   */
+  allowDelete?: boolean;
+}
+
+export interface Repository extends Resource<
+  "GitHub.Repository",
+  RepositoryProps,
+  {
+    /**
+     * Numeric GitHub repository ID.
+     */
+    repoId: number;
+
+    /**
+     * GraphQL node ID of the repository.
+     */
+    nodeId: string;
+
+    /**
+     * Full name in `owner/name` form.
+     */
+    fullName: string;
+
+    /**
+     * URL to view the repository in a browser.
+     */
+    htmlUrl: string;
+
+    /**
+     * Git protocol clone URL (`git://`).
+     */
+    gitUrl: string;
+
+    /**
+     * SSH clone URL (`git@github.com:owner/name.git`).
+     */
+    sshUrl: string;
+
+    /**
+     * HTTPS clone URL.
+     */
+    cloneUrl: string;
+
+    /**
+     * The resolved default branch name.
+     */
+    defaultBranch: string;
+
+    /**
+     * ISO-8601 timestamp of when the repository was created.
+     */
+    createdAt: string;
+
+    /**
+     * ISO-8601 timestamp of the last update.
+     */
+    updatedAt: string;
+  },
+  never,
+  GitHub.Providers
+> {}
+
+/**
+ * A GitHub repository.
+ *
+ * `Repository` manages the lifecycle of a repository owned by a user or
+ * organization. The repository is created on first deploy and its settings are
+ * converged on every subsequent deploy. To protect irreplaceable history,
+ * destroy preserves the repository by default — opt in with `allowDelete: true`.
+ *
+ * Authentication is resolved via the `GitHubCredentials` service supplied by
+ * `GitHub.providers()` (env, stored PAT, `gh` CLI, or OAuth). The token needs
+ * `repo` scope (and `delete_repo` when `allowDelete` is set).
+ *
+ * @section Creating a Repository
+ * @example Basic Repository
+ * ```typescript
+ * const repo = yield* GitHub.Repository("api", {
+ *   owner: "my-org",
+ *   name: "api",
+ *   description: "API service",
+ *   autoInit: true,
+ * });
+ * ```
+ *
+ * @example Private Repository with Settings
+ * ```typescript
+ * const repo = yield* GitHub.Repository("internal-tools", {
+ *   owner: "my-org",
+ *   name: "internal-tools",
+ *   visibility: "private",
+ *   hasWiki: false,
+ *   hasProjects: false,
+ *   deleteBranchOnMerge: true,
+ * });
+ * ```
+ *
+ * @section Topics and Merge Configuration
+ * @example Repository with Topics and Merge Policy
+ * ```typescript
+ * const repo = yield* GitHub.Repository("sdk", {
+ *   owner: "my-org",
+ *   name: "sdk",
+ *   topics: ["typescript", "effect", "sdk"],
+ *   allowMergeCommit: false,
+ *   allowRebaseMerge: false,
+ *   allowSquashMerge: true,
+ *   allowAutoMerge: true,
+ * });
+ * ```
+ *
+ * @section Wiring with Other Resources
+ * The repository's outputs can drive other GitHub resources so the whole
+ * repository configuration lives in one program.
+ *
+ * @example Seed a Variable into the Repository
+ * ```typescript
+ * const repo = yield* GitHub.Repository("api", {
+ *   owner: "my-org",
+ *   name: "api",
+ *   autoInit: true,
+ * });
+ *
+ * yield* GitHub.Variable("region", {
+ *   owner: "my-org",
+ *   repository: repo.name!,
+ *   name: "AWS_REGION",
+ *   value: "us-east-1",
+ * });
+ * ```
+ *
+ * @section Deleting a Repository
+ * @example Allow Repository Deletion
+ * ```typescript
+ * const repo = yield* GitHub.Repository("ephemeral", {
+ *   owner: "my-org",
+ *   name: "ephemeral-preview",
+ *   allowDelete: true,
+ * });
+ * ```
+ */
+export const Repository = Resource<Repository>("GitHub.Repository");
+
+const attrsOf = (data: {
+  id: number;
+  node_id: string;
+  full_name: string;
+  html_url: string;
+  git_url: string;
+  ssh_url: string;
+  clone_url: string;
+  default_branch: string;
+  created_at: string | null;
+  updated_at: string | null;
+}) => ({
+  repoId: data.id,
+  nodeId: data.node_id,
+  fullName: data.full_name,
+  htmlUrl: data.html_url,
+  gitUrl: data.git_url,
+  sshUrl: data.ssh_url,
+  cloneUrl: data.clone_url,
+  defaultBranch: data.default_branch,
+  createdAt: data.created_at ?? new Date().toISOString(),
+  updatedAt: data.updated_at ?? new Date().toISOString(),
+});
+
+export const RepositoryProvider = () =>
+  Provider.succeed(Repository, {
+    stables: ["repoId", "nodeId"],
+
+    // The only structural change is the owner: a repository cannot be moved
+    // between owners by an update, so changing it replaces the resource.
+    // A `name` change is a rename, handled in `reconcile`, not a replacement.
+    diff: Effect.fn(function* ({ news, olds }) {
+      if (!isResolved(news)) return;
+      if (olds !== undefined && news.owner !== olds.owner) {
+        return { action: "replace" };
+      }
+    }),
+
+    reconcile: Effect.fn(function* ({ news, olds }) {
+      const octokit = yield* Octokit;
+
+      const getRepo = (repo: string) =>
+        Effect.tryPromise({
+          try: async () => {
+            try {
+              const { data } = await octokit.rest.repos.get({
+                owner: news.owner,
+                repo,
+              });
+              return data;
+            } catch (error: any) {
+              if (error.status === 404) return undefined;
+              throw error;
+            }
+          },
+          catch: (e) => e as Error,
+        });
+
+      // Observe — probe for the live repository under the desired name. On a
+      // rename (name changed since last deploy) the desired name 404s, so fall
+      // back to the prior name so we converge by renaming rather than creating
+      // a duplicate.
+      let observed = yield* getRepo(news.name);
+      if (
+        observed === undefined &&
+        olds?.name !== undefined &&
+        olds.name !== news.name
+      ) {
+        observed = yield* getRepo(olds.name);
+      }
+
+      // Ensure — create the repository when it does not exist. The owner may be
+      // a user or an organization; pick the matching create endpoint.
+      if (observed === undefined) {
+        const ownerType = yield* Effect.tryPromise({
+          try: async () => {
+            const { data } = await octokit.rest.users.getByUsername({
+              username: news.owner,
+            });
+            return data.type;
+          },
+          catch: (e) => e as Error,
+        });
+
+        const createInput = {
+          name: news.name,
+          description: news.description,
+          homepage: news.homepage,
+          has_issues: news.hasIssues,
+          has_projects: news.hasProjects,
+          has_wiki: news.hasWiki,
+          is_template: news.isTemplate,
+          auto_init: news.autoInit,
+          gitignore_template: news.gitignoreTemplate,
+          license_template: news.licenseTemplate,
+          allow_squash_merge: news.allowSquashMerge,
+          allow_merge_commit: news.allowMergeCommit,
+          allow_rebase_merge: news.allowRebaseMerge,
+          allow_auto_merge: news.allowAutoMerge,
+          delete_branch_on_merge: news.deleteBranchOnMerge,
+        };
+
+        observed = yield* Effect.tryPromise({
+          try: async () => {
+            try {
+              const { data } =
+                ownerType === "Organization"
+                  ? // The org endpoint accepts `visibility` directly, which is
+                    // the sole authority over public/private/internal. `internal`
+                    // is only valid here.
+                    await octokit.rest.repos.createInOrg({
+                      org: news.owner,
+                      ...createInput,
+                      visibility: news.visibility,
+                    } as Parameters<typeof octokit.rest.repos.createInOrg>[0])
+                  : // A personal account is either a `User` or a `Bot`; both
+                    // create through the authenticated-user endpoint, which only
+                    // understands the boolean `private` flag.
+                    await octokit.rest.repos.createForAuthenticatedUser({
+                      ...createInput,
+                      private: news.visibility
+                        ? news.visibility !== "public"
+                        : undefined,
+                    } as Parameters<
+                      typeof octokit.rest.repos.createForAuthenticatedUser
+                    >[0]);
+              return data;
+            } catch (error: any) {
+              // A 422 means the name already exists — treat as a create race
+              // and re-observe so the sync step converges its settings.
+              if (error.status === 422) return undefined;
+              throw error;
+            }
+          },
+          catch: (e) => e as Error,
+        });
+
+        if (observed === undefined) {
+          observed = yield* getRepo(news.name);
+        }
+        if (observed === undefined) {
+          return yield* Effect.fail(
+            new Error(
+              `Failed to create or locate GitHub repository ${news.owner}/${news.name}`,
+            ),
+          );
+        }
+      }
+
+      // Sync — converge settings (and the name on a rename) against the live
+      // repository. GitHub's update is an idempotent PATCH, so we always issue
+      // it with the desired settings. `archived` is applied in a separate,
+      // later PATCH because an archived repository rejects any other settings
+      // change in the same call.
+      const repoName = observed.name;
+      const updateInput = {
+        owner: news.owner,
+        repo: repoName,
+        name: news.name,
+        description: news.description,
+        homepage: news.homepage,
+        private: news.visibility ? news.visibility !== "public" : undefined,
+        visibility: news.visibility,
+        has_issues: news.hasIssues,
+        has_projects: news.hasProjects,
+        has_wiki: news.hasWiki,
+        has_discussions: news.hasDiscussions,
+        is_template: news.isTemplate,
+        allow_squash_merge: news.allowSquashMerge,
+        allow_merge_commit: news.allowMergeCommit,
+        allow_rebase_merge: news.allowRebaseMerge,
+        allow_auto_merge: news.allowAutoMerge,
+        delete_branch_on_merge: news.deleteBranchOnMerge,
+        // Only set the default branch when it actually differs from the
+        // observed branch. GitHub returns 422 if the branch does not yet
+        // exist (e.g. an empty repo), so the 422 handler below strips it and
+        // retries rather than hard-failing — the branch may be created right
+        // after this deploy.
+        default_branch:
+          news.defaultBranch !== undefined &&
+          observed.default_branch !== news.defaultBranch
+            ? news.defaultBranch
+            : undefined,
+      };
+
+      const updated = yield* Effect.tryPromise({
+        // Octokit's typed params lag the REST API: `visibility: "internal"`
+        // and `has_discussions` are valid at runtime but missing from the
+        // generated types, so assert to the accepted parameter shape.
+        try: async () => {
+          try {
+            const { data } = await octokit.rest.repos.update(
+              updateInput as Parameters<typeof octokit.rest.repos.update>[0],
+            );
+            return data;
+          } catch (error: any) {
+            // A 422 on a default-branch update usually means the branch does
+            // not exist yet. Drop it and retry so the rest of the settings
+            // still converge.
+            if (error.status === 422 && updateInput.default_branch) {
+              const { default_branch, ...withoutBranch } = updateInput;
+              const { data } = await octokit.rest.repos.update(
+                withoutBranch as Parameters<
+                  typeof octokit.rest.repos.update
+                >[0],
+              );
+              return data;
+            }
+            throw error;
+          }
+        },
+        catch: (e) => e as Error,
+      });
+
+      // Sync — apply `archived` in its own PATCH. Use the confirmed
+      // post-rename name from the first update so the call targets the right
+      // repo. Archiving is one-directional in this PATCH: only send it when
+      // explicitly provided.
+      if (news.archived !== undefined) {
+        yield* Effect.tryPromise({
+          try: () =>
+            octokit.rest.repos.update({
+              owner: news.owner,
+              repo: updated.name,
+              archived: news.archived,
+            } as Parameters<typeof octokit.rest.repos.update>[0]),
+          catch: (e) => e as Error,
+        });
+      }
+
+      // Sync — topics are managed via a dedicated endpoint. The provided list
+      // fully replaces existing topics, so removing the field (defined -> undefined)
+      // must clear them. Use the confirmed post-rename name from the first PATCH.
+      if (news.topics !== undefined || olds?.topics !== undefined) {
+        yield* Effect.tryPromise({
+          try: () =>
+            octokit.rest.repos.replaceAllTopics({
+              owner: news.owner,
+              repo: updated.name,
+              names: news.topics ?? [],
+            }),
+          catch: (e) => e as Error,
+        });
+      }
+
+      return attrsOf(updated);
+    }),
+
+    // Read by the numeric repository ID, which is stable across renames. This
+    // refreshes the output attributes (including the current name) so that a
+    // subsequent delete targets the live repository even when a prior rename's
+    // state persistence failed.
+    read: Effect.fn(function* ({ output }) {
+      if (output === undefined) {
+        return undefined;
+      }
+
+      const octokit = yield* Octokit;
+
+      return yield* Effect.tryPromise({
+        try: async () => {
+          try {
+            const { data } = await octokit.request("GET /repositories/{id}", {
+              id: output.repoId,
+            });
+            return attrsOf(data as Parameters<typeof attrsOf>[0]);
+          } catch (error: any) {
+            if (error.status === 404) return undefined;
+            throw error;
+          }
+        },
+        catch: (e) => e as Error,
+      });
+    }),
+
+    delete: Effect.fn(function* ({ olds, output }) {
+      if (!olds.allowDelete) {
+        return;
+      }
+
+      const octokit = yield* Octokit;
+
+      // Resolve the current repository name via the stable numeric ID. A rename
+      // whose state persistence failed leaves `olds.name` stale; deleting by
+      // the stale name 404s and silently leaves the repo behind. Looking it up
+      // by `repoId` gives us the live name.
+      let owner = olds.owner;
+      let repo = olds.name;
+      if (output?.repoId !== undefined) {
+        const current = yield* Effect.tryPromise({
+          try: async () => {
+            try {
+              const { data } = await octokit.request("GET /repositories/{id}", {
+                id: output.repoId,
+              });
+              return data;
+            } catch (error: any) {
+              if (error.status === 404) return undefined;
+              throw error;
+            }
+          },
+          catch: (e) => e as Error,
+        });
+        if (current !== undefined) {
+          owner = current.owner.login;
+          repo = current.name;
+        }
+      }
+
+      yield* Effect.tryPromise({
+        try: async () => {
+          try {
+            await octokit.rest.repos.delete({ owner, repo });
+          } catch (error: any) {
+            if (error.status !== 404) {
+              throw error;
+            }
+          }
+        },
+        catch: (e) => e as Error,
+      });
+    }),
+  });

--- a/packages/alchemy/src/GitHub/index.ts
+++ b/packages/alchemy/src/GitHub/index.ts
@@ -2,6 +2,7 @@ export * as Auth from "./AuthProvider.ts";
 export * from "./Comment.ts";
 export { GitHubCredentials, fromEnv, fromToken } from "./Credentials.ts";
 export * from "./Providers.ts";
+export * from "./Repository.ts";
 export * from "./Secret.ts";
 export * from "./Secrets.ts";
 export * from "./Variable.ts";

--- a/packages/alchemy/test/GitHub/Repository.test.ts
+++ b/packages/alchemy/test/GitHub/Repository.test.ts
@@ -1,0 +1,122 @@
+import * as GitHub from "@/GitHub";
+import { Octokit } from "@/GitHub/Octokit.ts";
+import * as Test from "@/Test/Vitest";
+import { expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+
+const { test } = Test.make({ providers: GitHub.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+// These tests create, mutate, and delete a real repository, so they require an
+// owner (user login or org) the token can write to. Skip when unset.
+const owner = process.env.GITHUB_TEST_OWNER ?? "";
+
+const getRepo = (repo: string) =>
+  Effect.gen(function* () {
+    const octokit = yield* Octokit;
+    return yield* Effect.tryPromise({
+      try: async () => {
+        try {
+          const { data } = await octokit.rest.repos.get({ owner, repo });
+          return data;
+        } catch (error: any) {
+          if (error.status === 404) return undefined;
+          throw error;
+        }
+      },
+      catch: (e) => e as Error,
+    });
+  });
+
+test.provider.skipIf(!owner)(
+  "create, update, rename, and delete a repository",
+  (stack) =>
+    Effect.gen(function* () {
+      const name = "alchemy-effect-repo-test";
+      const renamed = "alchemy-effect-repo-test-renamed";
+
+      // Clean up any leftovers from a previous run before deploying.
+      yield* stack.destroy();
+
+      // Create
+      const created = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Repository("Repo", {
+            owner,
+            name,
+            description: "alchemy-effect integration test",
+            visibility: "private",
+            autoInit: true,
+            hasWiki: false,
+            topics: ["alchemy", "test"],
+            allowDelete: true,
+          });
+        }),
+      );
+
+      expect(created.repoId).toBeGreaterThan(0);
+      expect(created.fullName).toEqual(`${owner}/${name}`);
+      expect(created.defaultBranch).toBeDefined();
+
+      const fetched = yield* getRepo(name);
+      expect(fetched?.id).toEqual(created.repoId);
+      expect(fetched?.description).toEqual("alchemy-effect integration test");
+      expect(fetched?.private).toEqual(true);
+      expect(fetched?.has_wiki).toEqual(false);
+      expect(fetched?.topics).toEqual(
+        expect.arrayContaining(["alchemy", "test"]),
+      );
+
+      // Update — change settings and topics, same logical ID → same repoId.
+      const updated = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Repository("Repo", {
+            owner,
+            name,
+            description: "updated description",
+            visibility: "private",
+            hasWiki: true,
+            topics: ["alchemy"],
+            allowDelete: true,
+          });
+        }),
+      );
+
+      expect(updated.repoId).toEqual(created.repoId);
+      const afterUpdate = yield* getRepo(name);
+      expect(afterUpdate?.description).toEqual("updated description");
+      expect(afterUpdate?.has_wiki).toEqual(true);
+      expect(afterUpdate?.topics).toEqual(["alchemy"]);
+
+      // Rename — new `name`, same logical ID → in-place rename, same repoId.
+      const wasRenamed = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* GitHub.Repository("Repo", {
+            owner,
+            name: renamed,
+            description: "updated description",
+            visibility: "private",
+            allowDelete: true,
+          });
+        }),
+      );
+
+      expect(wasRenamed.repoId).toEqual(created.repoId);
+      expect(wasRenamed.fullName).toEqual(`${owner}/${renamed}`);
+      const afterRename = yield* getRepo(renamed);
+      expect(afterRename?.id).toEqual(created.repoId);
+      const oldName = yield* getRepo(name);
+      expect(oldName).toBeUndefined();
+
+      // Delete
+      yield* stack.destroy();
+      const afterDestroy = yield* getRepo(renamed);
+      expect(afterDestroy).toBeUndefined();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);

--- a/packages/alchemy/test/GitHub/Repository.test.ts
+++ b/packages/alchemy/test/GitHub/Repository.test.ts
@@ -1,5 +1,6 @@
 import * as GitHub from "@/GitHub";
 import { Octokit } from "@/GitHub/Octokit.ts";
+import { destroy } from "@/RemovalPolicy";
 import * as Test from "@/Test/Vitest";
 import { expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
@@ -54,8 +55,7 @@ test.provider.skipIf(!owner)(
             autoInit: true,
             hasWiki: false,
             topics: ["alchemy", "test"],
-            allowDelete: true,
-          });
+          }).pipe(destroy());
         }),
       );
 
@@ -82,8 +82,7 @@ test.provider.skipIf(!owner)(
             visibility: "private",
             hasWiki: true,
             topics: ["alchemy"],
-            allowDelete: true,
-          });
+          }).pipe(destroy());
         }),
       );
 
@@ -101,8 +100,7 @@ test.provider.skipIf(!owner)(
             name: renamed,
             description: "updated description",
             visibility: "private",
-            allowDelete: true,
-          });
+          }).pipe(destroy());
         }),
       );
 


### PR DESCRIPTION
I've been wanting to move my GitHub configuration over to an IaC solution for a bit now so I can stop continually flipping off merge commits and other random bits like that. Y'all don't have a GitHub resource, but I was hoping this would be useful. 

The implementation was agent driven, but I've done a review pass. I assume that eventually you'll actually just want coverage in distilled for GitHub and this'll be handled more like other providers. 

## AI Summary

Manages the full lifecycle of a GitHub repository — create, update, rename, and delete — with a reconciler that converges settings on every deploy.

- Split `archived` into its own PATCH (GitHub rejects other settings changes in the same archiving call)
- Guard `default_branch` against non-existent branches with a 422 retry that strips the field rather than hard-failing
- `topics` cleared when field is removed (was silently left behind)
- `read` implemented via stable numeric `repoId` so renames don't leave stale names in state
- `delete` resolves live owner/name by `repoId` before deleting, surviving state-persistence failures after a rename
- `createInOrg` uses `visibility` directly; `internal` repos now created with the correct visibility class
- `replaceAllTopics` uses `updated.name` (confirmed post-PATCH name)