### PR TITLE
chore(cloudflare): mark WorkerProps["exports"] as internal and correct type

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -311,7 +311,7 @@ export const LocalWorkerProvider = () =>
             compatibility,
             entry: props.isExternal
               ? { kind: "external" }
-              : { kind: "effect", exports: (props.exports ?? {}) as any },
+              : { kind: "effect", exports: props.exports ?? {} },
             stack: { name: stack.name, stage: stack.stage },
             extraOptions: props.build,
           } satisfies WorkerBundleOptions,

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -34,7 +34,10 @@ import {
   type AssetsProps,
 } from "./Assets.ts";
 import { getCompatibility } from "./Compatibility.ts";
-import { isDurableObjectExport } from "./DurableObjectNamespace.ts";
+import {
+  isDurableObjectExport,
+  type DurableObjectExport,
+} from "./DurableObjectNamespace.ts";
 import { LocalWorkerProvider } from "./LocalWorkerProvider.ts";
 import { Request } from "./Request.ts";
 import * as Vite from "./Vite.ts";
@@ -58,6 +61,7 @@ import {
   makeWorkerRuntimeContext,
   type WorkerRuntimeContext,
 } from "./WorkerRuntimeContext.ts";
+import type { WorkflowExport } from "./Workflow.ts";
 
 export const WorkerTypeId = "Cloudflare.Worker";
 export type WorkerTypeId = typeof WorkerTypeId;
@@ -238,7 +242,12 @@ export interface WorkerProps<
   };
   limits?: WorkerLimits;
   placement?: WorkerPlacement;
-  exports?: string[];
+  /**
+   * Tracks Durable Object and Workflow exports for Effect-native Workers only.
+   * Populated automatically from bindings; do not set manually.
+   * @internal
+   */
+  exports?: Record<string, DurableObjectExport | WorkflowExport>;
   /**
    * Environment variables and native Cloudflare Bindings to bind to
    * the Worker. Accepts:
@@ -1209,7 +1218,7 @@ export const LiveWorkerProvider = () =>
                   }
                 : {
                     kind: "effect",
-                    exports: (props.exports ?? {}) as any,
+                    exports: props.exports ?? {},
                   },
               stack: { name: stack.name, stage: stack.stage },
               extraOptions: props.build,
@@ -1923,7 +1932,7 @@ export const LiveWorkerProvider = () =>
         precreate: Effect.fnUntraced(function* ({ id, news, session }) {
           const { accountId } = yield* yield* CloudflareEnvironment;
           const name = yield* createWorkerName(id, news.name);
-          const exportMap = (news.exports ?? {}) as Record<string, unknown>;
+          const exportMap = news.exports ?? {};
           const durableObjects = Object.keys(exportMap)
             .filter((logicalId) => isDurableObjectExport(exportMap[logicalId]))
             .map((logicalId) => ({

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerRuntimeContext.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerRuntimeContext.ts
@@ -6,6 +6,7 @@ import * as Redacted from "effect/Redacted";
 import type { HttpEffect } from "../../Http.ts";
 import * as Output from "../../Output.ts";
 import type * as Serverless from "../../Serverless/index.ts";
+import type { DurableObjectExport } from "./DurableObjectNamespace.ts";
 import { makeRequestHandler } from "./HttpServer.ts";
 import {
   ExportedHandlerMethods,
@@ -13,6 +14,7 @@ import {
   WorkerTypeId,
   type WorkerEvent,
 } from "./Worker.ts";
+import type { WorkflowExport } from "./Workflow.ts";
 
 export interface WorkerRuntimeContext extends Serverless.FunctionContext {
   export(name: string, value: any): Effect.Effect<void>;
@@ -21,7 +23,7 @@ export interface WorkerRuntimeContext extends Serverless.FunctionContext {
 
 export const makeWorkerRuntimeContext = (id: string): WorkerRuntimeContext => {
   const listeners: Effect.Effect<Serverless.FunctionListener>[] = [];
-  const exports: Record<string, any> = {};
+  const exports: Record<string, DurableObjectExport | WorkflowExport> = {};
   const env: Record<string, any> = {};
   let userShape: Record<string, unknown> | undefined;
 


### PR DESCRIPTION
`WorkerProps["exports"]` is an internal-only property that is populated automatically from bindings, but it's listed as just another prop. Added a comment marking it as `@internal` to avoid misleading users.

Additionally, it's typed as `string[]` when it's actually `Record<string, DurableObjectExport | WorkflowExport>`. Removed this and some related `any`s.